### PR TITLE
ci(test): phased coverage threshold enforcement

### DIFF
--- a/.github/workflows/test-guard.yml
+++ b/.github/workflows/test-guard.yml
@@ -1,3 +1,6 @@
+env:
+  COVERAGE_THRESHOLD: 70
+
 name: Test Guard
 
 on:
@@ -28,7 +31,7 @@ jobs:
         run: |
           echo "🧪 Running pytest with coverage enforcement..."
           set +e
-          pytest --maxfail=1 --disable-warnings -q --cov=. --cov-report=term-missing --cov-fail-under=80
+          pytest --maxfail=1 --disable-warnings -q --cov=. --cov-report=term-missing --cov-fail-under=${{ env.COVERAGE_THRESHOLD }}
           STATUS=$?
           set -e
 


### PR DESCRIPTION
Introduce phased coverage thresholds for Test Guard CI: start at 70%, gradually increase to 75%, and finally enforce 80%.