### PR TITLE
ci(test): enforce no TODO placeholders in tests

### DIFF
--- a/.github/workflows/test-guard.yml
+++ b/.github/workflows/test-guard.yml
@@ -65,3 +65,7 @@ jobs:
 # 修改方法:
 #   直接在上方 env 中调整 COVERAGE_THRESHOLD 的值
 # ----------------------------------------------------------
+
+      - name: Check for TODO placeholders in tests
+        run: |
+          python scripts/check_todo_tests.py

--- a/scripts/check_todo_tests.py
+++ b/scripts/check_todo_tests.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+errors = []
+for f in Path("tests").rglob("test_*.py"):
+    text = f.read_text(encoding="utf-8")
+    for i, line in enumerate(text.splitlines(), start=1):
+        if "TODO" in line:
+            errors.append(f"{f}:{i}: Found TODO placeholder → {line.strip()}")
+
+if errors:
+    print("❌ Found TODO placeholders in test files:")
+    for e in errors:
+        print("   ", e)
+    print("\n请替换 TODO 为真实断言后再提交！")
+    sys.exit(1)
+else:
+    print("✅ No TODO placeholders found in tests.")


### PR DESCRIPTION
Introduce a CI check to detect TODO placeholders in pytest files under tests/. Ensures all test cases use real assertions before merging.