### PR TITLE
fix: honor requested league concurrency in recon matrix

### DIFF
--- a/scripts/ops/ReconCLIHandler.js
+++ b/scripts/ops/ReconCLIHandler.js
@@ -364,6 +364,7 @@ async function main(argv = process.argv.slice(2), dependencies = {}) {
           season: args.season,
           leagueIds: leagues.map((league) => Number(league.id)),
           concurrency: Number.isInteger(args.concurrency) && args.concurrency > 0 ? args.concurrency : 5,
+          leagueConcurrency: Number.isInteger(args.concurrency) && args.concurrency > 0 ? args.concurrency : 5,
           limit: args.limit,
           confidenceThreshold: Number.isFinite(args.threshold) ? args.threshold : scanner.engine.confidenceThreshold,
           currentSeasonOnly: args.currentSeasonOnly,

--- a/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
+++ b/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
@@ -27,10 +27,16 @@ const reconMatrixFlow = {
   },
 
   async runReconMatrix(options = {}) {
+    const requestedConcurrency = Number.isInteger(options.concurrency) && options.concurrency > 0
+      ? options.concurrency
+      : this.defaultReconConcurrency;
+    const requestedLeagueConcurrency = Number.isInteger(options.leagueConcurrency) && options.leagueConcurrency > 0
+      ? options.leagueConcurrency
+      : requestedConcurrency;
     const {
       season,
-      concurrency = this.defaultReconConcurrency,
-      leagueConcurrency = this.leagueParallelism || concurrency,
+      concurrency = requestedConcurrency,
+      leagueConcurrency = requestedLeagueConcurrency,
       tier = null,
       leagueIds = null,
       batchSize = this.reconBatchSize,

--- a/tests/unit/ReconMatrixFlow.test.js
+++ b/tests/unit/ReconMatrixFlow.test.js
@@ -312,4 +312,64 @@ describe('ReconMatrixFlow', () => {
     assert.equal(result.scannedLeagues, 3);
     assert.equal(result.linked, 3);
   });
+
+  it('未显式传入 leagueConcurrency 时，应默认复用请求的 concurrency 而不是退回配置值', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    const preparedTargets = Array.from({ length: 6 }, (_, index) => ({
+      target: {
+        leagueId: index + 1,
+        league: { id: index + 1, name: `League-${index + 1}` },
+        dbSeason: '2025/2026'
+      },
+      pendingMatches: [{ match_id: `${index + 1}` }],
+      desiredLimit: 1
+    }));
+
+    const flow = {
+      ...reconMatrixFlow,
+      defaultReconConcurrency: 5,
+      leagueParallelism: 2,
+      reconBatchSize: 25,
+      confidenceThreshold: 0.75,
+      logger: { info() {}, warn() {}, error() {} },
+      navigatorFactory: async () => ({
+        proxyPort: null,
+        ownsNavigator: true,
+        navigator: {
+          async ensureBrowserHealthy() {},
+          async close() {}
+        }
+      }),
+      buildScanTargets: async () => preparedTargets.map((item) => item.target),
+      taskPlanner: {
+        prepareReconPendingTargets: async () => preparedTargets
+      },
+      _runReconTarget: async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => {
+          setTimeout(resolve, 25);
+        });
+        active--;
+        return {
+          pendingTotal: 1,
+          linked: 1,
+          mismatched: 0,
+          sourceSeason: '2025/2026',
+          sourceUrl: 'oddsportal://results/',
+          candidateCount: 1
+        };
+      }
+    };
+
+    await flow.runReconMatrix({
+      season: '2025/2026',
+      concurrency: 6,
+      limit: 6
+    });
+
+    assert.equal(maxActive, 6);
+  });
 });


### PR DESCRIPTION
## Summary
- make recon matrix default `leagueConcurrency` to the requested `concurrency` when no explicit override is provided
- explicitly pass `leagueConcurrency` from the recon scanner CLI into matrix execution
- add regression coverage so CLI-style 22-concurrency runs cannot silently fall back to the config default of 5 league workers

## Validation
- npm run gatekeeper -- --mode=push
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconMatrixFlow.test.js
- local 25s recon startup probe confirmed `leagueConcurrency: 22` and multi-port worker fan-out
