### PR TITLE
fix: harden recon proxy durability and stealth

### DIFF
--- a/src/infrastructure/harvesters/ProxyRotator.js
+++ b/src/infrastructure/harvesters/ProxyRotator.js
@@ -35,8 +35,12 @@ const USER_AGENTS = [
 class ProxyRotator {
   constructor(options = {}) {
     this.strategy = options.strategy || 'round-robin';
-    this.cooldownMs = options.cooldownMs || 60000;
-    this.maxFailures = options.maxFailures || 3;
+    this.cooldownMs = Number.isFinite(Number(options.cooldownMs)) && Number(options.cooldownMs) > 0
+      ? Number(options.cooldownMs)
+      : 90000;
+    this.maxFailures = Number.isFinite(Number(options.maxFailures)) && Number(options.maxFailures) > 0
+      ? Number(options.maxFailures)
+      : 8;
     this.consumer = options.consumer || 'recon-engine';
     this.proxyProvider = options.proxyProvider || getProxyProvider();
     this.sequence = 0;
@@ -198,6 +202,14 @@ class ProxyRotator {
 
       const node = this._getProviderNode(port);
       const failCount = node?.failureCount || 0;
+      if (String(errorType) === '503' && !node?.cooling && failCount < this.maxFailures) {
+        this.logger.warn('👀 代理进入 503 观察期', {
+          port,
+          failCount,
+          observationThreshold: this.maxFailures,
+          reason: errorType
+        });
+      }
       if (this._isCoolingNode(node, failCount)) {
         this.logger.warn('❌ 代理进入冷却', {
           port,

--- a/src/infrastructure/network/ProxyProvider.js
+++ b/src/infrastructure/network/ProxyProvider.js
@@ -13,6 +13,10 @@ const DEFAULT_PROTOCOL = 'http';
 const DEFAULT_TARGET_LATENCY_MS = 1500;
 const DEFAULT_SUCCESS_RATE = 0.95;
 const DEFAULT_HEARTBEAT_URL = 'https://httpbin.org/ip';
+const DEFAULT_FAILURE_COOLDOWN_MS = 60000;
+const DEFAULT_HTTP_503_COOLDOWN_MS = 90000;
+const DEFAULT_FAILURE_THRESHOLD = 6;
+const DEFAULT_HTTP_503_OBSERVATION_THRESHOLD = 3;
 
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
@@ -28,6 +32,11 @@ function extractStatusCode(reason = '') {
   const message = String(reason || '');
   const match = message.match(/\b(4\d{2}|5\d{2})\b/);
   return match ? Number(match[1]) : null;
+}
+
+function positiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 class ProxyProvider extends EventEmitter {
@@ -57,6 +66,7 @@ class ProxyProvider extends EventEmitter {
     const ports = Array.isArray(options.ports) && options.ports.length > 0
       ? [...options.ports]
       : ProxyProvider.resolvePorts();
+    const failureThreshold = positiveNumber(options.failureThreshold, DEFAULT_FAILURE_THRESHOLD);
 
     return {
       protocol,
@@ -68,9 +78,14 @@ class ProxyProvider extends EventEmitter {
       httpTimeoutMs: Number(options.httpTimeoutMs) || 4000,
       heartbeatUrl: String(options.heartbeatUrl || process.env.PROXY_HEARTBEAT_URL || DEFAULT_HEARTBEAT_URL),
       rateLimitIsolationMs: Number(options.rateLimitIsolationMs) || 300000,
-      failureCooldownMs: Number(options.failureCooldownMs) || 3000,
-      heartbeatFailureCooldownMs: Number(options.heartbeatFailureCooldownMs) || 5000,
-      failureThreshold: Number(options.failureThreshold) || 2,
+      failureCooldownMs: positiveNumber(options.failureCooldownMs, DEFAULT_FAILURE_COOLDOWN_MS),
+      http503CooldownMs: positiveNumber(options.http503CooldownMs, DEFAULT_HTTP_503_COOLDOWN_MS),
+      heartbeatFailureCooldownMs: positiveNumber(options.heartbeatFailureCooldownMs, 5000),
+      failureThreshold,
+      http503ObservationThreshold: positiveNumber(
+        options.http503ObservationThreshold,
+        Math.max(DEFAULT_HTTP_503_OBSERVATION_THRESHOLD, Math.ceil(failureThreshold / 2))
+      ),
       successEwmaAlpha: Number(options.successEwmaAlpha) || 0.25,
       latencyEwmaAlpha: Number(options.latencyEwmaAlpha) || 0.2,
       baseWeight: Number(options.baseWeight) || 1
@@ -346,17 +361,51 @@ class ProxyProvider extends EventEmitter {
       return true;
     }
 
-    if (statusCode === 403 || statusCode >= 500 || node.consecutiveFailures >= this.config.failureThreshold) {
-      node.cooldownUntil = now + this.config.failureCooldownMs;
+    if (
+      statusCode === 503
+      && node.consecutiveFailures < this.config.http503ObservationThreshold
+    ) {
+      this._emitAlert('proxy_under_observation', node, {
+        statusCode,
+        reason,
+        consecutiveFailures: node.consecutiveFailures,
+        observationThreshold: this.config.http503ObservationThreshold
+      });
+      return true;
+    }
+
+    if (this._shouldCooldownNode(statusCode, node)) {
+      const cooldownMs = this._resolveFailureCooldownMs(statusCode);
+      node.cooldownUntil = now + cooldownMs;
       this._emitAlert('proxy_cooled_down', node, {
         statusCode,
         reason,
         cooldownUntil: node.cooldownUntil,
+        cooldownMs,
         consecutiveFailures: node.consecutiveFailures
       });
     }
 
     return true;
+  }
+
+  _shouldCooldownNode(statusCode, node) {
+    if (statusCode === 403) {
+      return true;
+    }
+    if (statusCode === 503) {
+      return node.consecutiveFailures >= this.config.http503ObservationThreshold;
+    }
+    if (statusCode >= 500) {
+      return true;
+    }
+    return node.consecutiveFailures >= this.config.failureThreshold;
+  }
+
+  _resolveFailureCooldownMs(statusCode) {
+    return statusCode === 503
+      ? this.config.http503CooldownMs
+      : this.config.failureCooldownMs;
   }
 
   getStats() {

--- a/src/infrastructure/recon/services/ReconBrowserContext.js
+++ b/src/infrastructure/recon/services/ReconBrowserContext.js
@@ -1,6 +1,14 @@
 'use strict';
 
 const { chromium: playwrightChromium } = require('playwright');
+const {
+  getAntiDetectionScripts,
+  getEnhancedStealthConfig
+} = require('../../network/enhanced_stealth_config');
+const {
+  FIXED_FINGERPRINT,
+  generateStealthHeaders
+} = require('../../network/StealthFingerprint');
 const { ReconBookmakerUnlocker } = require('./ReconBookmakerUnlocker');
 const {
   ReconStealthProvider,
@@ -23,6 +31,57 @@ const DEFAULT_READY_SELECTORS = [
   'body'
 ];
 const BACKEND_FETCH_FAILED_RE = /backend fetch failed|guru meditation/i;
+const MODERN_CHROME_UA_RE = /\bChrome\/(13[1-9]|\d{3,})\b/;
+
+function deriveStealthWorkerId(traceId = '', proxy = null) {
+  const port = Number(proxy?.port || 0);
+  if (Number.isInteger(port) && port > 0) {
+    return port;
+  }
+
+  let hash = 0;
+  for (const character of String(traceId || 'recon-stealth')) {
+    hash = ((hash * 31) + character.charCodeAt(0)) % 10000;
+  }
+  return hash + 1;
+}
+
+function buildStealthIdentity(traceId = '', proxy = null) {
+  const workerId = deriveStealthWorkerId(traceId, proxy);
+  const enhancedConfig = getEnhancedStealthConfig({ platform: 'win32' });
+  const fixedHeaders = generateStealthHeaders(true);
+
+  return {
+    workerId,
+    userAgent: String(fixedHeaders.userAgent || enhancedConfig.userAgent || FIXED_FINGERPRINT.userAgent),
+    viewport: enhancedConfig.viewport || fixedHeaders.viewport || FIXED_FINGERPRINT.viewport,
+    locale: FIXED_FINGERPRINT.locale || 'en-US',
+    timezoneId: FIXED_FINGERPRINT.timezoneId || 'Europe/London',
+    platform: enhancedConfig.platform || FIXED_FINGERPRINT.platform || 'Win32',
+    deviceScaleFactor: Number(enhancedConfig.deviceScaleFactor ?? FIXED_FINGERPRINT.deviceScaleFactor ?? 1) || 1,
+    hasTouch: enhancedConfig.hasTouch === true,
+    isMobile: enhancedConfig.isMobile === true,
+    extraHTTPHeaders: {
+      ...(fixedHeaders.extraHTTPHeaders || {})
+    },
+    antiDetectionScript: getAntiDetectionScripts(workerId)
+  };
+}
+
+function buildStealthLaunchArgs(baseArgs = [], viewport = FIXED_FINGERPRINT.viewport, locale = 'en-US') {
+  return Array.from(new Set([
+    ...baseArgs,
+    '--disable-blink-features=AutomationControlled',
+    '--disable-dev-shm-usage',
+    `--window-size=${viewport.width},${viewport.height}`,
+    `--lang=${String(locale || 'en-US').split(',')[0]}`
+  ]));
+}
+
+function resolveContextUserAgent(candidate, fallback) {
+  const value = String(candidate || '').trim();
+  return MODERN_CHROME_UA_RE.test(value) ? value : fallback;
+}
 
 function resolveList(primary, secondary, fallback) {
   if (Array.isArray(primary) && primary.length > 0) {
@@ -48,6 +107,7 @@ class ReconBrowserContext {
     const runtimeConfig = getReconConfigSection(['recon_runtime', 'browser_context'], {});
     const networkMonitorConfig = getReconConfigSection(['recon_runtime', 'network_monitor'], {});
     const unlockStrategiesConfig = getReconConfigSection(['recon_runtime', 'unlock_strategies'], {});
+    const stealthIdentity = buildStealthIdentity(options.traceId, options.proxy);
 
     this.logger = options.logger || console;
     this.traceId = options.traceId || 'trace-unknown';
@@ -60,13 +120,21 @@ class ReconBrowserContext {
     this.isClosed = false;
     this.launchTimeoutMs = Number(options.launchTimeoutMs ?? runtimeConfig.launch_timeout_ms);
     this.navigationTimeoutMs = Number(options.navigationTimeoutMs ?? runtimeConfig.navigation_timeout_ms);
-    this.userAgent = options.userAgent || runtimeConfig.user_agent;
-    this.viewport = options.viewport || runtimeConfig.viewport;
-    this.launchArgs = Array.isArray(options.launchArgs)
+    this.stealthIdentity = stealthIdentity;
+    this.userAgent = resolveContextUserAgent(
+      options.userAgent || runtimeConfig.user_agent,
+      this.stealthIdentity.userAgent
+    );
+    this.viewport = options.viewport || this.stealthIdentity.viewport || runtimeConfig.viewport;
+    this.launchArgs = buildStealthLaunchArgs(
+      Array.isArray(options.launchArgs)
       ? options.launchArgs
       : Array.isArray(runtimeConfig.launch_args)
         ? runtimeConfig.launch_args
-        : [];
+        : [],
+      this.viewport,
+      options.locale || this.stealthIdentity.locale || runtimeConfig.locale || 'en-US'
+    );
     this.warmupDelayMs = Number(options.warmupDelayMs ?? runtimeConfig.warmup_delay_ms);
     this.scrollIterations = Number(options.scrollIterations ?? runtimeConfig.scroll_iterations);
     this.scrollStepPx = Number(options.scrollStepPx ?? runtimeConfig.scroll_step_px);
@@ -93,13 +161,30 @@ class ReconBrowserContext {
       || ''
     ).trim();
     this.homeWarmupWaitMs = Number(options.homeWarmupWaitMs ?? networkMonitorConfig.home_warmup_wait_ms ?? 5000);
-    this.acceptLanguage = String(options.acceptLanguage || runtimeConfig.accept_language || DEFAULT_ACCEPT_LANGUAGE);
-    this.locale = String(options.locale || runtimeConfig.locale || 'en-US');
-    this.timezoneId = String(options.timezoneId || runtimeConfig.timezone_id || 'Asia/Tokyo');
+    this.acceptLanguage = String(
+      options.acceptLanguage
+      || this.stealthIdentity.extraHTTPHeaders['accept-language']
+      || runtimeConfig.accept_language
+      || DEFAULT_ACCEPT_LANGUAGE
+    );
+    this.locale = String(options.locale || this.stealthIdentity.locale || runtimeConfig.locale || 'en-US');
+    this.timezoneId = String(
+      options.timezoneId
+      || this.stealthIdentity.timezoneId
+      || runtimeConfig.timezone_id
+      || 'Europe/London'
+    );
     this.hardwareConcurrency = Number(options.hardwareConcurrency ?? runtimeConfig.hardware_concurrency ?? 8);
     this.deviceMemory = Number(options.deviceMemory ?? runtimeConfig.device_memory ?? 8);
-    this.platform = String(options.platform || runtimeConfig.platform || 'MacIntel');
-    this.enableStealthFingerprint = options.enableStealthFingerprint ?? runtimeConfig.enable_stealth_fingerprint ?? false;
+    this.platform = String(options.platform || this.stealthIdentity.platform || runtimeConfig.platform || 'Win32');
+    this.deviceScaleFactor = Number(options.deviceScaleFactor ?? this.stealthIdentity.deviceScaleFactor ?? 1) || 1;
+    this.hasTouch = options.hasTouch ?? this.stealthIdentity.hasTouch ?? false;
+    this.isMobile = options.isMobile ?? this.stealthIdentity.isMobile ?? false;
+    this.stealthExtraHTTPHeaders = {
+      ...this.stealthIdentity.extraHTTPHeaders
+    };
+    this.antiDetectionScript = String(this.stealthIdentity.antiDetectionScript || '');
+    this.enableStealthFingerprint = true;
     this.externalSessionPath = String(options.externalSessionPath || runtimeConfig.external_session_path || '');
     this.preferFullChromium = options.preferFullChromium ?? runtimeConfig.prefer_full_chromium ?? false;
     this.persistentProfileEnabled = options.persistentProfileEnabled ?? runtimeConfig.persistent_profile_enabled ?? true;
@@ -183,8 +268,8 @@ class ReconBrowserContext {
     const launchOptions = options.launchOptions || this.buildLaunchOptions(options);
     const externalSession = this.sessionManager.load();
     const sessionHeaders = externalSession?.extraHTTPHeaders || {};
-    const contextUserAgent = externalSession?.userAgent || this.userAgent;
-    const acceptLanguage = sessionHeaders['accept-language'] || this.acceptLanguage;
+    const contextUserAgent = resolveContextUserAgent(externalSession?.userAgent, this.userAgent);
+    const acceptLanguage = this.acceptLanguage;
 
     let browser = null;
     let context = null;
@@ -197,8 +282,13 @@ class ReconBrowserContext {
         viewport: this.viewport,
         locale: this.locale,
         timezoneId: this.timezoneId,
+        deviceScaleFactor: this.deviceScaleFactor,
+        screen: this.viewport,
+        hasTouch: this.hasTouch,
+        isMobile: this.isMobile,
         extraHTTPHeaders: {
           ...sessionHeaders,
+          ...this.stealthExtraHTTPHeaders,
           'accept-language': acceptLanguage,
           ...(contextUserAgent ? { 'user-agent': contextUserAgent } : {})
         }
@@ -224,6 +314,9 @@ class ReconBrowserContext {
       await this.injectExternalSession(context, externalSession);
       page = await context.newPage();
       await this.stealthProvider.applyStealthFingerprint(page, this.enableStealthFingerprint);
+      if (this.antiDetectionScript && typeof page.addInitScript === 'function') {
+        await page.addInitScript(this.antiDetectionScript);
+      }
 
       this.browser = browser;
       this.context = context;

--- a/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
+++ b/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
@@ -3,6 +3,8 @@
 const crypto = require('crypto');
 const pLimit = require('p-limit');
 
+const DEFAULT_LEAGUE_STARTUP_STAGGER_MS = 2000;
+
 const ALLOWED_MAPPING_METHODS = new Set([
   'exact',
   'fuzzy',
@@ -17,6 +19,12 @@ const ALLOWED_MAPPING_METHODS = new Set([
   'V5.5_HARVESTER',
   'v41_186_auto'
 ]);
+
+function sleep(delayMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
 
 const reconMatrixFlow = {
   async buildScanTargets(options = {}) {
@@ -37,6 +45,7 @@ const reconMatrixFlow = {
       season,
       concurrency = requestedConcurrency,
       leagueConcurrency = requestedLeagueConcurrency,
+      leagueStartupStaggerMs = this.leagueStartupStaggerMs ?? DEFAULT_LEAGUE_STARTUP_STAGGER_MS,
       tier = null,
       leagueIds = null,
       batchSize = this.reconBatchSize,
@@ -61,60 +70,64 @@ const reconMatrixFlow = {
 
     const leagueLimiter = pLimit(Math.max(1, Number(leagueConcurrency)));
     const outcomes = await Promise.all(
-      targetPendingMap.map(({ target, pendingMatches, desiredLimit = null }) => leagueLimiter(async () => {
-        let navigatorHandle = null;
-        let proxyPort = null;
+      targetPendingMap.map(({ target, pendingMatches, desiredLimit = null }, index) => (async () => {
+        await this._delayLeagueWorkerStart(target, index, { leagueStartupStaggerMs });
+        return leagueLimiter(async () => {
+          let navigatorHandle = null;
+          let proxyPort = null;
 
-        try {
-          navigatorHandle = await this._acquireTargetNavigator(target, {
-            launchBrowser: forcePureProtocol !== true
-          });
-          proxyPort = Number(navigatorHandle?.proxyPort || navigatorHandle?.navigator?.proxy?.port || 0) || null;
+          try {
+            navigatorHandle = await this._acquireTargetNavigator(target, {
+              launchBrowser: forcePureProtocol !== true
+            });
+            proxyPort = Number(navigatorHandle?.proxyPort || navigatorHandle?.navigator?.proxy?.port || 0) || null;
 
-          this.logger.info('recon_league_worker_start', {
-            league: target.league.name,
-            season: target.dbSeason,
-            pendingTotal: pendingMatches.length,
-            desiredLimit,
-            proxyPort,
-            leagueConcurrency: Math.max(1, Number(leagueConcurrency)),
-            matchConcurrency: Math.max(1, Number(concurrency))
-          });
+            this.logger.info('recon_league_worker_start', {
+              league: target.league.name,
+              season: target.dbSeason,
+              pendingTotal: pendingMatches.length,
+              desiredLimit,
+              proxyPort,
+              leagueConcurrency: Math.max(1, Number(leagueConcurrency)),
+              leagueStartupStaggerMs: Math.max(0, Number(leagueStartupStaggerMs) || 0),
+              matchConcurrency: Math.max(1, Number(concurrency))
+            });
 
-          const result = await this._runReconTarget(target, {
-            concurrency,
-            batchSize,
-            confidenceThreshold,
-            forceDomMode,
-            forceJsonExtract,
-            forcePureProtocol,
-            pendingMatches,
-            matchLimit: desiredLimit,
-            navigator: navigatorHandle?.navigator || null
-          });
+            const result = await this._runReconTarget(target, {
+              concurrency,
+              batchSize,
+              confidenceThreshold,
+              forceDomMode,
+              forceJsonExtract,
+              forcePureProtocol,
+              pendingMatches,
+              matchLimit: desiredLimit,
+              navigator: navigatorHandle?.navigator || null
+            });
 
-          this.logger.info('recon_league_worker_complete', {
-            league: target.league.name,
-            season: target.dbSeason,
-            proxyPort,
-            linked: result.linked,
-            mismatched: result.mismatched,
-            pendingTotal: result.pendingTotal
-          });
+            this.logger.info('recon_league_worker_complete', {
+              league: target.league.name,
+              season: target.dbSeason,
+              proxyPort,
+              linked: result.linked,
+              mismatched: result.mismatched,
+              pendingTotal: result.pendingTotal
+            });
 
-          return { target, result };
-        } catch (error) {
-          this.logger.error('recon_matrix_target_failed', {
-            league: target.league.name,
-            season,
-            proxyPort,
-            error: error.message
-          });
-          return { target, error };
-        } finally {
-          await this._releaseTargetNavigator(navigatorHandle);
-        }
-      }))
+            return { target, result };
+          } catch (error) {
+            this.logger.error('recon_matrix_target_failed', {
+              league: target.league.name,
+              season,
+              proxyPort,
+              error: error.message
+            });
+            return { target, error };
+          } finally {
+            await this._releaseTargetNavigator(navigatorHandle);
+          }
+        });
+      })())
     );
 
     for (const outcome of outcomes) {
@@ -191,6 +204,33 @@ const reconMatrixFlow = {
     if (typeof handle.navigator.close === 'function') {
       await handle.navigator.close();
     }
+  },
+
+  _resolveLeagueWorkerStartupDelay(index, options = {}) {
+    const stepMs = Number(options.leagueStartupStaggerMs);
+    const normalizedStep = Number.isFinite(stepMs) && stepMs >= 0
+      ? stepMs
+      : DEFAULT_LEAGUE_STARTUP_STAGGER_MS;
+    return Math.max(0, Number(index) || 0) * normalizedStep;
+  },
+
+  async _delayLeagueWorkerStart(target, index, options = {}) {
+    const delayMs = this._resolveLeagueWorkerStartupDelay(index, options);
+    if (delayMs <= 0) {
+      return 0;
+    }
+
+    this.logger.info('recon_league_worker_stagger', {
+      league: target?.league?.name || null,
+      workerIndex: Number(index) || 0,
+      delayMs
+    });
+    await this._sleep(delayMs);
+    return delayMs;
+  },
+
+  async _sleep(delayMs) {
+    await sleep(delayMs);
   },
 
   async _runReconTarget(target, options = {}) {

--- a/tests/unit/ProxyProvider.test.js
+++ b/tests/unit/ProxyProvider.test.js
@@ -46,14 +46,16 @@ describe('src/infrastructure/network/ProxyProvider', () => {
     assert.strictEqual(provider.getStats().activeLeases, 0);
   });
 
-  test('连续 503 应在 3 秒冷却窗内剔除节点并触发告警', async () => {
+  test('连续 503 应在观察窗后进入 90 秒冷却并触发告警', async () => {
     let now = 1_000;
     const alerts = [];
     const provider = new ProxyProvider({
       now: () => now,
       healthCheckIntervalMs: 0,
-      failureCooldownMs: 3000,
-      failureThreshold: 2
+      failureCooldownMs: 60000,
+      http503CooldownMs: 90000,
+      failureThreshold: 6,
+      http503ObservationThreshold: 3
     });
 
     provider.on('alert', payload => {
@@ -70,10 +72,19 @@ describe('src/infrastructure/network/ProxyProvider', () => {
     await provider.reportFailure(lease.id, { statusCode: 503, reason: 'HTTP 503' });
 
     let node = provider.getNodeStates().find(item => item.port === lease.proxy.port);
+    assert.strictEqual(node.cooling, false);
+    assert.ok(alerts.some(item => item.type === 'proxy_under_observation' && item.port === lease.proxy.port));
+
+    await provider.reportFailure(lease.id, { statusCode: 503, reason: 'HTTP 503' });
+    node = provider.getNodeStates().find(item => item.port === lease.proxy.port);
     assert.strictEqual(node.cooling, true);
     assert.ok(alerts.some(item => item.type === 'proxy_cooled_down' && item.port === lease.proxy.port));
 
-    now += 3001;
+    now += 89_999;
+    node = provider.getNodeStates().find(item => item.port === lease.proxy.port);
+    assert.strictEqual(node.cooling, true);
+
+    now += 2;
     node = provider.getNodeStates().find(item => item.port === lease.proxy.port);
     assert.strictEqual(node.cooling, false);
   });

--- a/tests/unit/ReconBrowserContext.test.js
+++ b/tests/unit/ReconBrowserContext.test.js
@@ -56,16 +56,35 @@ describe('ReconBrowserContext', () => {
       userDataDir: browserContext.userDataDir,
       options: {
         headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-blink-features=AutomationControlled',
+          '--disable-dev-shm-usage',
+          '--window-size=1920,1080',
+          '--lang=en-US'
+        ],
         timeout: 4321,
-        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
         viewport: { width: 1920, height: 1080 },
         locale: 'en-US',
-        timezoneId: 'Asia/Tokyo',
+        timezoneId: 'Europe/London',
+        deviceScaleFactor: 1,
+        screen: { width: 1920, height: 1080 },
+        hasTouch: false,
+        isMobile: false,
         proxy: { server: 'http://127.0.0.1:8899' },
         extraHTTPHeaders: {
-          'accept-language': 'en-US,en;q=0.9,ja-JP;q=0.8,ja;q=0.7',
-          'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+          'sec-ch-ua': '"Chromium";v="131", "Google Chrome";v="131", "Not-A.Brand";v="99"',
+          'sec-ch-ua-mobile': '?0',
+          'sec-ch-ua-platform': '"Windows"',
+          'sec-fetch-dest': 'document',
+          'sec-fetch-mode': 'navigate',
+          'sec-fetch-site': 'none',
+          'sec-fetch-user': '?1',
+          'accept-language': 'en-US,en;q=0.9',
+          'accept-encoding': 'gzip, deflate, br',
+          'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
         }
       }
     });
@@ -81,7 +100,7 @@ describe('ReconBrowserContext', () => {
     assert.strictEqual(events[2], 'context.close');
   });
 
-  it('启用高仿真指纹时才应注入 addInitScript', async () => {
+  it('应同时注入基础 stealth 指纹与增强反检测脚本', async () => {
     const events = [];
     const page = {
       async addInitScript(fn) {
@@ -118,7 +137,10 @@ describe('ReconBrowserContext', () => {
 
     await browserContext.launch({ timeout: 4321 });
 
-    assert.deepStrictEqual(events, [{ type: 'addInitScript', value: 'function' }]);
+    assert.deepStrictEqual(events, [
+      { type: 'addInitScript', value: 'function' },
+      { type: 'addInitScript', value: 'string' }
+    ]);
   });
 
   it('启用 preferFullChromium 时应把完整 Chromium executablePath 注入 launchOptions', async () => {
@@ -162,7 +184,7 @@ describe('ReconBrowserContext', () => {
     assert.strictEqual(events[0].executablePath, '/tmp/playwright/chromium/chrome');
   });
 
-  it('launch 后应自动注入 external session cookies，并用外部 UA 对齐 context', async () => {
+  it('launch 后应自动注入 external session cookies，并保持 Chrome 131 stealth UA', async () => {
     const events = [];
     const page = {
       async addInitScript() {}
@@ -222,8 +244,14 @@ describe('ReconBrowserContext', () => {
     await browserContext.launch();
 
     assert.strictEqual(events[0].type, 'launchPersistentContext');
-    assert.strictEqual(events[0].options.userAgent, 'External-UA/1.0');
-    assert.strictEqual(events[0].options.extraHTTPHeaders['user-agent'], 'External-UA/1.0');
+    assert.strictEqual(
+      events[0].options.userAgent,
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    );
+    assert.strictEqual(
+      events[0].options.extraHTTPHeaders['user-agent'],
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    );
     assert.strictEqual(events[1].type, 'addCookies');
     assert.strictEqual(events[1].cookies.length, 1);
     assert.strictEqual(events[1].cookies[0].name, 'session-cookie');

--- a/tests/unit/ReconMatrixFlow.test.js
+++ b/tests/unit/ReconMatrixFlow.test.js
@@ -300,6 +300,7 @@ describe('ReconMatrixFlow', () => {
       season: '2025/2026',
       concurrency: 1,
       leagueConcurrency: 2,
+      leagueStartupStaggerMs: 0,
       limit: 3
     });
 
@@ -367,9 +368,64 @@ describe('ReconMatrixFlow', () => {
     await flow.runReconMatrix({
       season: '2025/2026',
       concurrency: 6,
+      leagueStartupStaggerMs: 0,
       limit: 6
     });
 
     assert.equal(maxActive, 6);
+  });
+
+  it('runReconMatrix 应按 index * 2000ms 对联赛 worker 启动错峰', async () => {
+    const delays = [];
+    const preparedTargets = ['Premier League', 'Serie A', 'Bundesliga'].map((leagueName, index) => ({
+      target: {
+        leagueId: index + 1,
+        league: { id: index + 1, name: leagueName },
+        dbSeason: '2025/2026'
+      },
+      pendingMatches: [{ match_id: `${index + 1}` }],
+      desiredLimit: 1
+    }));
+
+    const flow = {
+      ...reconMatrixFlow,
+      defaultReconConcurrency: 22,
+      reconBatchSize: 25,
+      confidenceThreshold: 0.75,
+      logger: { info() {}, warn() {}, error() {} },
+      _sleep: async (delayMs) => {
+        delays.push(delayMs);
+      },
+      navigatorFactory: async () => ({
+        proxyPort: 7890,
+        ownsNavigator: true,
+        navigator: {
+          proxy: { port: 7890 },
+          async ensureBrowserHealthy() {},
+          async close() {}
+        }
+      }),
+      buildScanTargets: async () => preparedTargets.map((item) => item.target),
+      taskPlanner: {
+        prepareReconPendingTargets: async () => preparedTargets
+      },
+      _runReconTarget: async () => ({
+        pendingTotal: 1,
+        linked: 1,
+        mismatched: 0,
+        sourceSeason: '2025/2026',
+        sourceUrl: 'oddsportal://results/',
+        candidateCount: 1
+      })
+    };
+
+    await flow.runReconMatrix({
+      season: '2025/2026',
+      concurrency: 1,
+      leagueConcurrency: 3,
+      limit: 3
+    });
+
+    assert.deepStrictEqual(delays, [2000, 4000]);
   });
 });

--- a/tests/unit/ReconServiceConfig.test.js
+++ b/tests/unit/ReconServiceConfig.test.js
@@ -19,7 +19,7 @@ const { ReconNetworkMonitor } = require('../../src/infrastructure/recon/services
 const { ReconDomScraper } = require('../../src/infrastructure/recon/services/ReconDomScraper');
 const { ReconStateProber } = require('../../src/infrastructure/recon/services/ReconStateProber');
 
-test('Recon services 应默认从 recon_config.json 读取运行时参数', async () => {
+test('Recon services 应默认从 recon_config.json 读取运行时参数，并对 BrowserContext 注入工业 stealth 基线', async () => {
   const mirrorManager = new ReconMirrorManager();
   const matchEvaluator = new ReconMatchEvaluator();
   const taskPlanner = new ReconTaskPlanner();
@@ -34,7 +34,10 @@ test('Recon services 应默认从 recon_config.json 读取运行时参数', asyn
   assert.equal(taskPlanner.resultsPathTemplate, config.recon_runtime.task_planner.results_path);
   assert.equal(browserContext.warmupDelayMs, config.recon_runtime.browser_context.warmup_delay_ms);
   assert.deepEqual(browserContext.viewport, config.recon_runtime.browser_context.viewport);
-  assert.equal(browserContext.enableStealthFingerprint, config.recon_runtime.browser_context.enable_stealth_fingerprint);
+  assert.equal(browserContext.enableStealthFingerprint, true);
+  assert.match(browserContext.userAgent, /Chrome\/131\.0\.0\.0/);
+  assert.equal(browserContext.locale, 'en-US');
+  assert.equal(browserContext.timezoneId, 'Europe/London');
   assert.equal(browserContext.homeWarmupEnabled, config.recon_runtime.network_monitor.home_warmup_enabled);
   assert.equal(networkMonitor.scriptEvalTimeoutMs, config.recon_runtime.network_monitor.script_eval_timeout_ms);
   assert.equal(networkMonitor.fetchTimeoutMs, config.recon_runtime.network_monitor.fetch_timeout_ms);


### PR DESCRIPTION
## Summary
- harden proxy failure tolerance for transient 503 storms and lengthen cooldown windows
- stagger league worker startup to avoid synchronized navigation spikes
- force Recon browser contexts onto the Chrome 131 stealth baseline with enhanced anti-detection scripts

## Validation
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ProxyProvider.test.js tests/unit/ReconBrowserContext.test.js tests/unit/ReconMatrixFlow.test.js
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconServiceConfig.test.js
- npm run gatekeeper -- --mode=push