### PR TITLE
fix: add recon fallback urls for source-empty leagues

### DIFF
--- a/config/recon_config.json
+++ b/config/recon_config.json
@@ -209,6 +209,25 @@
     "hamburger-sv": "Hamburger Sv",
     "mainz": "Mainz 05",
     "mainz05": "Mainz 05",
+    "st etienne": "FC Saint Etienne",
+    "st-etienne": "FC Saint Etienne",
+    "saint etienne": "FC Saint Etienne",
+    "saint-etienne": "FC Saint Etienne",
+    "saint priest": "AS Saint-Priest",
+    "saint-priest": "AS Saint-Priest",
+    "st priest": "AS Saint-Priest",
+    "st-priest": "AS Saint-Priest",
+    "andrezieux": "Andrezieux Boutheon",
+    "andrezieux-boutheon": "Andrezieux Boutheon",
+    "frejus saint raphael": "Etoile Frejus Saint Raphael",
+    "frejus-saint-raphael": "Etoile Frejus Saint Raphael",
+    "ecotay moingt": "Us Ecotay Moingt",
+    "pays de grasse": "Rc Pays De Grasse",
+    "fosseenne": "Es Fosseenne",
+    "pertuis": "Usr Pertuis",
+    "aubagne air bel": "SC Aubagne Air Bel",
+    "chavanay": "As Chavanay",
+    "valence": "Olympique De Valence",
     "st pauli": "St Pauli",
     "st. pauli": "St Pauli",
     "vfb stuttgart": "VfB Stuttgart",
@@ -437,6 +456,12 @@
         "131": 0.25,
         "230": 0.25
       },
+      "confidence_threshold_override_by_league_id": {
+        "181": 0.7
+      },
+      "force_multi_mode_league_ids": [
+        181
+      ],
       "force_dom_league_ids": [
         48,
         130,
@@ -464,9 +489,13 @@
       "team_weight": 0.85,
       "date_weight": 0.15,
       "dictionary_string_contains_league_ids": [
-        131
+        131,
+        181
       ],
-      "dictionary_string_contains_min_length": 5
+      "dictionary_string_contains_min_length": 5,
+      "place_name_equivalent_league_ids": [
+        181
+      ]
     },
     "mirror_manager": {
       "team_weight": 0.85,
@@ -561,7 +590,8 @@
     "state_prober": {
       "timeout_ms": 90000,
       "max_pages": 50,
-      "post_navigation_wait_ms": 2000
+      "post_navigation_wait_ms": 2000,
+      "minimum_current_results_candidates": 10
     }
   },
   "logging": {

--- a/src/infrastructure/recon/services/ReconMatchEvaluatorImpl.js
+++ b/src/infrastructure/recon/services/ReconMatchEvaluatorImpl.js
@@ -55,6 +55,13 @@ class ReconMatchEvaluator {
         ?? 5
       )
     );
+    this.placeNameEquivalentLeagueIds = new Set(
+      (options.placeNameEquivalentLeagueIds
+        ?? runtimeConfig.place_name_equivalent_league_ids
+        ?? [])
+        .map((leagueId) => Number(leagueId))
+        .filter((leagueId) => Number.isInteger(leagueId) && leagueId > 0)
+    );
 
     if (Array.isArray(options.leagueDictionaryEntries)) {
       this.setLeagueDictionaryEntries(this.activeLeagueId, options.leagueDictionaryEntries);
@@ -107,10 +114,32 @@ class ReconMatchEvaluator {
       && this.dictionaryStringContainsLeagueIds.has(this.activeLeagueId);
   }
 
+  shouldAllowPlaceNameEquivalence() {
+    return Number.isInteger(this.activeLeagueId)
+      && this.activeLeagueId > 0
+      && this.placeNameEquivalentLeagueIds.has(this.activeLeagueId);
+  }
+
   normalizeDictionaryComparableName(teamName) {
     const raw = String(teamName || '')
       .replace(/\([^)]*\)/g, ' ')
       .replace(/\[[^\]]*\]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return this.normalizeTeamName(raw);
+  }
+
+  normalizeLeaguePlaceComparableName(teamName) {
+    const raw = String(teamName || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/\([^)]*\)/g, ' ')
+      .replace(/\[[^\]]*\]/g, ' ')
+      .replace(/\bst[.\s-]+/giu, 'saint ')
+      .replace(/[\\/]+/g, ' ')
+      .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+      .replace(/\b(as|us|usr|es|sc|rc|fc|ac|cs|ca|olympique|etoile|club)\b/giu, ' ')
       .replace(/\s+/g, ' ')
       .trim();
 
@@ -128,6 +157,14 @@ class ReconMatchEvaluator {
     const simplifiedRight = this.normalizeDictionaryComparableName(right);
     if (simplifiedLeft && simplifiedRight && simplifiedLeft === simplifiedRight) {
       return true;
+    }
+
+    if (this.shouldAllowPlaceNameEquivalence()) {
+      const placeComparableLeft = this.normalizeLeaguePlaceComparableName(left);
+      const placeComparableRight = this.normalizeLeaguePlaceComparableName(right);
+      if (placeComparableLeft && placeComparableRight && placeComparableLeft === placeComparableRight) {
+        return true;
+      }
     }
 
     if (!this.shouldAllowDictionaryStringContains() || !simplifiedLeft || !simplifiedRight) {
@@ -148,6 +185,14 @@ class ReconMatchEvaluator {
   calculateSimilarity(left, right) {
     if (!left || !right) {
       return 0;
+    }
+
+    if (this.shouldAllowPlaceNameEquivalence()) {
+      const placeComparableLeft = this.normalizeLeaguePlaceComparableName(left);
+      const placeComparableRight = this.normalizeLeaguePlaceComparableName(right);
+      if (placeComparableLeft && placeComparableRight && placeComparableLeft === placeComparableRight) {
+        return 1.0;
+      }
     }
 
     const normalizedLeft = this.normalizeTeamName(this.resolveComparableTeamName(left));

--- a/src/infrastructure/recon/services/ReconProtocolSeasonSweep.js
+++ b/src/infrastructure/recon/services/ReconProtocolSeasonSweep.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const { getReconConfigSection } = require('./ReconServiceConfig');
+
+const STATE_PROBER_CONFIG = getReconConfigSection(['recon_runtime', 'state_prober'], {});
+
 const reconProtocolSeasonSweep = {
   async fetchFullSeasonArchive(baseUrl, options = {}) {
     await this.navigator.ensureBrowserHealthy();
@@ -9,6 +13,14 @@ const reconProtocolSeasonSweep = {
     const preferCurrentSeasonSource = options.preferCurrentSeasonSource === true;
     const forceDomOnly = options.forceDomOnly === true;
     const readySelector = typeof options.readySelector === 'string' ? options.readySelector.trim() : '';
+    const minCandidatesForStateProbe = Math.max(
+      0,
+      Number(
+        options.minCandidatesForStateProbe
+        ?? STATE_PROBER_CONFIG.minimum_current_results_candidates
+        ?? 0
+      ) || 0
+    );
     const circuitBreakerKey = this.navigator._resolveCircuitBreakerKey(baseUrl, options);
     const navigateOptions = readySelector
       ? { contentReadySelector: readySelector, circuitBreakerKey }
@@ -127,7 +139,14 @@ const reconProtocolSeasonSweep = {
       }
     }
 
-    if (matches.length === 0 && preferCurrentSeasonSource && !forceDomOnly) {
+    const shouldProbeCurrentSeason = preferCurrentSeasonSource
+      && !forceDomOnly
+      && (
+        matches.length === 0
+        || (minCandidatesForStateProbe > 0 && matches.length < minCandidatesForStateProbe)
+      );
+
+    if (shouldProbeCurrentSeason) {
       const currentSeasonResult = await this.navigator.stateProber.probeCurrentSeasonFromPageState(
         baseUrl,
         {
@@ -167,6 +186,15 @@ const reconProtocolSeasonSweep = {
           newRows: currentSeasonNewRows,
           total: matches.length,
           source: currentSeasonResult?.sourceState || 'current_results_archive'
+        });
+      }
+
+      if (matches.length > 0 && minCandidatesForStateProbe > 0) {
+        this.logger.info('season_sweep_low_yield_recovered', {
+          baseUrl: resultsUrl,
+          totalCandidates: matches.length,
+          minCandidatesForStateProbe,
+          breakerKey: circuitBreakerKey
         });
       }
     }

--- a/src/infrastructure/recon/services/ReconTaskPlannerImpl.js
+++ b/src/infrastructure/recon/services/ReconTaskPlannerImpl.js
@@ -46,8 +46,22 @@ class ReconTaskPlanner {
         .map(([leagueId, floor]) => [Number(leagueId), Number(floor)])
         .filter(([leagueId, floor]) => Number.isInteger(leagueId) && leagueId > 0 && Number.isFinite(floor))
     );
+    this.confidenceThresholdOverrideByLeagueId = new Map(
+      Object.entries(
+        options.confidenceThresholdOverrideByLeagueId
+        ?? runtimeConfig.confidence_threshold_override_by_league_id
+        ?? {}
+      )
+        .map(([leagueId, threshold]) => [Number(leagueId), Number(threshold)])
+        .filter(([leagueId, threshold]) => Number.isInteger(leagueId) && leagueId > 0 && Number.isFinite(threshold))
+    );
     this.forceDomLeagueIds = new Set(
       (options.forceDomLeagueIds || runtimeConfig.force_dom_league_ids || [])
+        .map((id) => Number(id))
+        .filter((id) => Number.isInteger(id) && id > 0)
+    );
+    this.forceMultiModeLeagueIds = new Set(
+      (options.forceMultiModeLeagueIds || runtimeConfig.force_multi_mode_league_ids || [])
         .map((id) => Number(id))
         .filter((id) => Number.isInteger(id) && id > 0)
     );
@@ -212,29 +226,42 @@ class ReconTaskPlanner {
     return Number(this.mismatchRetryThresholdFloor);
   }
 
+  resolveConfidenceThresholdOverride(target) {
+    const leagueId = Number(target?.leagueId || target?.league?.id || 0);
+    if (Number.isInteger(leagueId) && this.confidenceThresholdOverrideByLeagueId.has(leagueId)) {
+      return Number(this.confidenceThresholdOverrideByLeagueId.get(leagueId));
+    }
+
+    return null;
+  }
+
   resolveReconPolicy(target, pendingMatches, confidenceThreshold = 0.5, options = {}) {
     const requestedThreshold = Number.isFinite(Number(confidenceThreshold))
       ? Number(confidenceThreshold)
       : 0;
     const configuredRetry = options.allowMismatchRetry === true
       || target?.reconPolicy?.allowMismatchRetry === true;
+    const leagueId = Number(target?.leagueId || target?.league?.id || 0);
     const hasMismatchRetry = (Array.isArray(pendingMatches) ? pendingMatches : [])
       .some((match) => String(match?.pipeline_status || '').trim().toUpperCase() === 'RECON_MISMATCH');
     const thresholdFloor = this.resolveMismatchRetryThresholdFloor(target);
+    const thresholdOverride = this.resolveConfidenceThresholdOverride(target);
+    const baselineThreshold = Number.isFinite(thresholdOverride)
+      ? Number(thresholdOverride)
+      : Math.max(requestedThreshold, this.minimumConfidenceThreshold);
     const effectiveThreshold = configuredRetry && hasMismatchRetry
       ? Math.max(
-        requestedThreshold,
-        this.minimumConfidenceThreshold,
+        baselineThreshold,
         thresholdFloor,
         requestedThreshold - this.mismatchRetryThresholdDelta
       )
-      : Math.max(requestedThreshold, this.minimumConfidenceThreshold);
+      : baselineThreshold;
 
     return {
       allowMismatchRetry: configuredRetry,
       hasMismatchRetry,
       effectiveConfidenceThreshold: effectiveThreshold,
-      forceMultiMode: configuredRetry && hasMismatchRetry
+      forceMultiMode: this.forceMultiModeLeagueIds.has(leagueId) || (configuredRetry && hasMismatchRetry)
     };
   }
 

--- a/src/infrastructure/recon/services/ReconTaskPlannerSourceSelector.js
+++ b/src/infrastructure/recon/services/ReconTaskPlannerSourceSelector.js
@@ -82,10 +82,16 @@ const reconTaskPlannerSourceSelector = {
       return sources;
     }
 
-    addSource({
-      season: baseSeason,
-      url: this.buildResultsUrl(target.league, baseSeason),
-      mode: 'results_archive'
+    const seasonalSourceUrls = typeof this.buildSeasonalSourceUrls === 'function'
+      ? this.buildSeasonalSourceUrls(target.league, baseSeason, { dbSeason: target?.dbSeason })
+      : [this.buildResultsUrl(target.league, baseSeason)];
+
+    seasonalSourceUrls.forEach((url, index) => {
+      addSource({
+        season: baseSeason,
+        url,
+        mode: index === 0 ? 'results_archive' : 'results_archive_fallback'
+      });
     });
     return sources;
   },

--- a/src/infrastructure/recon/services/ReconTaskPlannerUrlUtils.js
+++ b/src/infrastructure/recon/services/ReconTaskPlannerUrlUtils.js
@@ -1,15 +1,15 @@
 'use strict';
 
 const SPECIAL_URL_RULES_BY_LEAGUE_ID = new Map([
-  [42, { seasonlessResults: true }],
+  [42, { seasonlessResults: true, rootPage: true }],
   [53, { seasonlessResults: true }],
   [57, { seasonlessResults: true }],
   [77, { rootPage: true, allowFutureFixturesSweep: true }],
   [140, { canonicalResultsSlug: 'laliga2', canonicalSeasonalResults: true, seasonlessResults: true }],
-  [181, { seasonlessResults: true }],
+  [181, { seasonlessResults: true, rootPage: true }],
   [209, { seasonlessResults: true }],
-  [230, { seasonlessResults: true, rootPage: true }],
-  [8974, { annualLike: true, seasonlessResults: true }]
+  [230, { seasonlessResults: true, seasonlessPrimary: true, rootPage: true }],
+  [8974, { annualLike: true, seasonlessResults: true, seasonlessPrimary: true, disableFixturesSweep: true }]
 ]);
 
 const reconTaskPlannerUrlUtils = {
@@ -226,8 +226,12 @@ const reconTaskPlannerUrlUtils = {
   buildResultsUrl(leagueConfig, season) {
     const country = this.normalizePathSegment(leagueConfig.country);
     const slug = this.getResultsSlug(leagueConfig);
+    const specialRule = this.getSpecialUrlRule(leagueConfig);
     const resultsUrlStrategy = this.getResultsUrlStrategy(leagueConfig);
     const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
+    if (specialRule?.seasonlessPrimary === true) {
+      return `${normalizedBaseUrl}/football/${country}/${slug}/results/`;
+    }
     if (this.isAnnualLeague(leagueConfig)) {
       return this.renderSeasonPathUrl(this.resultsPathTemplate, leagueConfig, season);
     }
@@ -243,6 +247,11 @@ const reconTaskPlannerUrlUtils = {
 
   buildFixturesUrl(leagueConfig, season) {
     if (!this.fixturesPathTemplate) {
+      return null;
+    }
+
+    const specialRule = this.getSpecialUrlRule(leagueConfig);
+    if (specialRule?.disableFixturesSweep === true) {
       return null;
     }
 
@@ -341,6 +350,7 @@ const reconTaskPlannerUrlUtils = {
 
   buildAnnualCurrentSeasonSources(leagueConfig, season) {
     const annualSeason = this.formatSeasonForAnnualLeagueUrl(season);
+    const specialRule = this.getSpecialUrlRule(leagueConfig);
     const sources = [
       {
         season: annualSeason,
@@ -352,16 +362,20 @@ const reconTaskPlannerUrlUtils = {
         url: this.buildSeasonlessResultsUrl(leagueConfig),
         mode: 'current_results_fallback'
       },
-      {
-        season: annualSeason,
-        url: this.buildFixturesUrl(leagueConfig, annualSeason),
-        mode: 'current_fixtures'
-      },
-      {
-        season: annualSeason,
-        url: this.buildSeasonlessFixturesUrl(leagueConfig),
-        mode: 'current_fixtures_fallback'
-      }
+      ...(specialRule?.disableFixturesSweep === true
+        ? []
+        : [
+          {
+            season: annualSeason,
+            url: this.buildFixturesUrl(leagueConfig, annualSeason),
+            mode: 'current_fixtures'
+          },
+          {
+            season: annualSeason,
+            url: this.buildSeasonlessFixturesUrl(leagueConfig),
+            mode: 'current_fixtures_fallback'
+          }
+        ])
     ].filter((source) => Boolean(source.url));
 
     const seen = new Set();

--- a/src/infrastructure/recon/services/ReconTaskPlannerUrlUtils.js
+++ b/src/infrastructure/recon/services/ReconTaskPlannerUrlUtils.js
@@ -1,6 +1,32 @@
 'use strict';
 
+const SPECIAL_URL_RULES_BY_LEAGUE_ID = new Map([
+  [42, { seasonlessResults: true }],
+  [53, { seasonlessResults: true }],
+  [57, { seasonlessResults: true }],
+  [77, { rootPage: true, allowFutureFixturesSweep: true }],
+  [140, { canonicalResultsSlug: 'laliga2', canonicalSeasonalResults: true, seasonlessResults: true }],
+  [181, { seasonlessResults: true }],
+  [209, { seasonlessResults: true }],
+  [230, { seasonlessResults: true, rootPage: true }],
+  [8974, { annualLike: true, seasonlessResults: true }]
+]);
+
 const reconTaskPlannerUrlUtils = {
+  getLeagueId(leagueConfig = {}) {
+    const leagueId = Number(leagueConfig?.id || 0);
+    return Number.isInteger(leagueId) && leagueId > 0 ? leagueId : null;
+  },
+
+  getSpecialUrlRule(leagueConfig = {}) {
+    const leagueId = this.getLeagueId(leagueConfig);
+    if (!leagueId) {
+      return null;
+    }
+
+    return SPECIAL_URL_RULES_BY_LEAGUE_ID.get(leagueId) || null;
+  },
+
   formatSeasonForUrl(season) {
     if (!season) return '';
     return String(season).replace('/', '-');
@@ -59,8 +85,17 @@ const reconTaskPlannerUrlUtils = {
   },
 
   isAnnualLeague(leagueConfig = {}) {
-    const leagueId = Number(leagueConfig?.id || 0);
-    return Number.isInteger(leagueId) && this.annualLeagueIds instanceof Set
+    const leagueId = this.getLeagueId(leagueConfig);
+    if (!leagueId) {
+      return false;
+    }
+
+    const specialRule = this.getSpecialUrlRule(leagueConfig);
+    if (specialRule?.annualLike === true) {
+      return true;
+    }
+
+    return this.annualLeagueIds instanceof Set
       ? this.annualLeagueIds.has(leagueId)
       : false;
   },
@@ -82,6 +117,11 @@ const reconTaskPlannerUrlUtils = {
   getFutureFinalsWindow(target, pendingMatches, now = new Date()) {
     const awaitingFinals = target?.league?.awaitingFinals === true || target?.league?.awaiting_finals === true;
     if (!awaitingFinals) {
+      return { shouldSkip: false, kickoffDate: null };
+    }
+
+    const specialRule = this.getSpecialUrlRule(target?.league || {});
+    if (specialRule?.allowFutureFixturesSweep === true) {
       return { shouldSkip: false, kickoffDate: null };
     }
 
@@ -157,9 +197,7 @@ const reconTaskPlannerUrlUtils = {
   renderSeasonPathUrl(template, leagueConfig, season) {
     const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
     const country = this.normalizePathSegment(leagueConfig.country);
-    const slug = String(leagueConfig.resultsSlug || leagueConfig.slug || '')
-      .trim()
-      .toLowerCase();
+    const slug = this.getResultsSlug(leagueConfig);
     const oddsportalSeason = this.formatSeasonForLeagueUrl(season, leagueConfig);
     const normalizedPath = String(template || '')
       .replace('{country}', country)
@@ -171,11 +209,23 @@ const reconTaskPlannerUrlUtils = {
     return `${normalizedBaseUrl}${normalizedPath}`;
   },
 
+  renderExplicitSeasonPathUrl(template, leagueConfig, season) {
+    const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
+    const country = this.normalizePathSegment(leagueConfig.country);
+    const slug = this.getResultsSlug(leagueConfig);
+    const normalizedPath = String(template || '')
+      .replace('{country}', country)
+      .replace('{league}', slug)
+      .replace('{season}', this.formatSeasonForUrl(season))
+      .replace(/\/{2,}/g, '/')
+      .replace(/^\/?/, '/');
+
+    return `${normalizedBaseUrl}${normalizedPath}`;
+  },
+
   buildResultsUrl(leagueConfig, season) {
     const country = this.normalizePathSegment(leagueConfig.country);
-    const slug = String(leagueConfig.resultsSlug || leagueConfig.slug || '')
-      .trim()
-      .toLowerCase();
+    const slug = this.getResultsSlug(leagueConfig);
     const resultsUrlStrategy = this.getResultsUrlStrategy(leagueConfig);
     const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
     if (this.isAnnualLeague(leagueConfig)) {
@@ -202,9 +252,7 @@ const reconTaskPlannerUrlUtils = {
   buildSeasonlessSubpageUrl(leagueConfig, subpage) {
     const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
     const country = this.normalizePathSegment(leagueConfig.country);
-    const slug = String(leagueConfig.resultsSlug || leagueConfig.slug || '')
-      .trim()
-      .toLowerCase();
+    const slug = this.getResultsSlug(leagueConfig);
     const normalizedSubpage = String(subpage || '')
       .trim()
       .replace(/^\/+|\/+$/g, '');
@@ -238,9 +286,7 @@ const reconTaskPlannerUrlUtils = {
   renderLeaguePathTemplate(template, leagueConfig = {}, replacements = {}) {
     const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
     const country = this.normalizePathSegment(leagueConfig.country);
-    const slug = String(leagueConfig.resultsSlug || leagueConfig.slug || '')
-      .trim()
-      .toLowerCase();
+    const slug = this.getResultsSlug(leagueConfig);
     const oddsportalSeason = this.formatSeasonForLeagueUrl(replacements.season, leagueConfig);
     const year = replacements.year ?? replacements.season ?? '';
     const normalizedPath = String(template || '')
@@ -281,6 +327,16 @@ const reconTaskPlannerUrlUtils = {
     ];
 
     return [...new Set(urls.filter(Boolean))];
+  },
+
+  buildSeasonalSourceUrls(leagueConfig, season, options = {}) {
+    const baseUrls = [
+      this.buildResultsUrl(leagueConfig, season),
+      ...this.buildAdditionalResultsUrls(leagueConfig, season),
+      ...this.buildSeasonalFallbackResultsUrls(leagueConfig, season, options)
+    ];
+
+    return [...new Set(baseUrls.filter(Boolean))];
   },
 
   buildAnnualCurrentSeasonSources(leagueConfig, season) {
@@ -345,20 +401,72 @@ const reconTaskPlannerUrlUtils = {
 
   buildLeagueUrl(leagueConfig) {
     const country = this.normalizePathSegment(leagueConfig.country);
-    const slug = String(leagueConfig.resultsSlug || leagueConfig.slug || '')
-      .trim()
-      .toLowerCase();
+    const slug = this.getResultsSlug(leagueConfig);
     const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
     return `${normalizedBaseUrl}/football/${country}/${slug}/`;
   },
 
   buildSeasonlessHistoricalResultsUrl(leagueConfig, year) {
     const country = this.normalizePathSegment(leagueConfig.country);
-    const slug = String(leagueConfig.resultsSlug || leagueConfig.slug || '')
-      .trim()
-      .toLowerCase();
+    const slug = this.getResultsSlug(leagueConfig);
     const normalizedBaseUrl = String(this.baseUrl || '').replace(/\/+$/, '');
     return `${normalizedBaseUrl}/football/${country}/${slug}-${year}/results/`;
+  },
+
+  getResultsSlug(leagueConfig = {}) {
+    return String(leagueConfig.resultsSlug || leagueConfig.slug || '')
+      .trim()
+      .toLowerCase();
+  },
+
+  getCanonicalResultsSlug(leagueConfig = {}) {
+    const specialRule = this.getSpecialUrlRule(leagueConfig);
+    const fallbackSlug = this.getResultsSlug(leagueConfig);
+    return String(specialRule?.canonicalResultsSlug || fallbackSlug)
+      .trim()
+      .toLowerCase();
+  },
+
+  buildCanonicalLeagueConfig(leagueConfig = {}) {
+    const canonicalSlug = this.getCanonicalResultsSlug(leagueConfig);
+    if (!canonicalSlug || canonicalSlug === this.getResultsSlug(leagueConfig)) {
+      return leagueConfig;
+    }
+
+    return {
+      ...leagueConfig,
+      slug: canonicalSlug,
+      resultsSlug: canonicalSlug
+    };
+  },
+
+  buildSeasonalFallbackResultsUrls(leagueConfig = {}, season, options = {}) {
+    const specialRule = this.getSpecialUrlRule(leagueConfig);
+    if (!specialRule) {
+      return [];
+    }
+
+    const urls = [];
+    const canonicalLeague = this.buildCanonicalLeagueConfig(leagueConfig);
+    const dbSeason = options.dbSeason || season;
+
+    if (specialRule.canonicalSeasonalResults === true) {
+      urls.push(this.renderSeasonPathUrl(this.resultsPathTemplate, canonicalLeague, season));
+    }
+
+    if (specialRule.seasonlessResults === true) {
+      urls.push(this.buildSeasonlessResultsUrl(canonicalLeague));
+    }
+
+    if (specialRule.rootPage === true) {
+      urls.push(this.buildLeagueUrl(canonicalLeague));
+    }
+
+    if (Number(this.getLeagueId(leagueConfig)) === 230) {
+      urls.push(this.renderExplicitSeasonPathUrl(this.resultsPathTemplate, canonicalLeague, dbSeason));
+    }
+
+    return [...new Set(urls.filter(Boolean))];
   },
 
   slugIncludesYear(slug) {

--- a/src/infrastructure/services/recon/ReconMappingStoreImpl.js
+++ b/src/infrastructure/services/recon/ReconMappingStoreImpl.js
@@ -98,6 +98,74 @@ class ReconMappingStore {
     return bestScore;
   }
 
+  scoreFixturePair(matchRow, candidateMatch) {
+    if (!matchRow || !candidateMatch) {
+      return {
+        directScore: 0,
+        reverseScore: 0,
+        bestScore: 0,
+        isReversed: false
+      };
+    }
+
+    const directScore = (
+      this.arbiter.teamSimilarity(matchRow.home_team, candidateMatch.home_team)
+      + this.arbiter.teamSimilarity(matchRow.away_team, candidateMatch.away_team)
+    );
+    const reverseScore = (
+      this.arbiter.teamSimilarity(matchRow.home_team, candidateMatch.away_team)
+      + this.arbiter.teamSimilarity(matchRow.away_team, candidateMatch.home_team)
+    );
+
+    return {
+      directScore,
+      reverseScore,
+      bestScore: Math.max(directScore, reverseScore),
+      isReversed: reverseScore > directScore
+    };
+  }
+
+  shouldForceOverwriteEvidenceOnlyConflict(existingMapping, incomingMapping) {
+    return existingMapping?.is_evidence_only === true
+      && incomingMapping?.is_evidence_only !== true;
+  }
+
+  shouldPreferIncomingSequentialHashOverwrite(
+    existingMatch,
+    incomingMatch,
+    existingMapping,
+    incomingMapping,
+    decision = {}
+  ) {
+    if (!existingMatch || !incomingMatch || !existingMapping || !incomingMapping) {
+      return false;
+    }
+
+    const existingTimestamp = new Date(existingMatch.match_date || '').getTime();
+    const incomingTimestamp = new Date(incomingMatch.match_date || '').getTime();
+    if (!Number.isFinite(existingTimestamp) || !Number.isFinite(incomingTimestamp) || incomingTimestamp <= existingTimestamp) {
+      return false;
+    }
+
+    const existingUrl = String(existingMapping.full_url || '').trim();
+    const incomingUrl = String(incomingMapping.full_url || '').trim();
+    if (!existingUrl || !incomingUrl || /\/football\/h2h\//iu.test(existingUrl) || /\/football\/h2h\//iu.test(incomingUrl)) {
+      return false;
+    }
+
+    const incomingConfidence = Number(incomingMapping.match_confidence || 0);
+    const existingConfidence = Number(existingMapping.match_confidence || 0);
+    if (incomingConfidence < Math.max(existingConfidence, 0.75)) {
+      return false;
+    }
+
+    const pairScore = this.scoreFixturePair(existingMatch, incomingMatch);
+    return decision.sameFixture !== true
+      && pairScore.bestScore >= this.arbiter.sameFixtureThreshold
+      && Number.isFinite(decision?.dateDistanceMs)
+      && decision.dateDistanceMs > this.arbiter.sameFixtureWindowMs;
+  }
+
   shouldPreferIncomingProtocolOverwrite(existingMatch, incomingMatch, existingMapping, incomingMapping, decision = {}) {
     const existingUrl = String(existingMapping?.full_url || '').trim();
     if (!existingUrl || !/\/football\/h2h\//iu.test(existingUrl)) {
@@ -674,7 +742,8 @@ class ReconMappingStore {
     let appliedMappings = 0;
 
     const result = await client.query(`
-      SELECT season, oddsportal_hash, match_id, full_url, home_team, away_team, match_confidence, updated_at
+      SELECT season, oddsportal_hash, match_id, full_url, home_team, away_team, match_confidence, updated_at,
+             is_evidence_only
       FROM matches_oddsportal_mapping
       WHERE season = ANY($1::text[])
         AND oddsportal_hash = ANY($2::text[])
@@ -1031,6 +1100,39 @@ class ReconMappingStore {
         decision
       )
       : false;
+    const evidenceOnlyOverwritePreferred = this.shouldForceOverwriteEvidenceOnlyConflict(
+      existingMapping,
+      incomingMapping
+    );
+    const sequentialHashOverwritePreferred = existingLinked && preserveLinkedStatus
+      ? this.shouldPreferIncomingSequentialHashOverwrite(
+        existingMatch,
+        incomingMatch,
+        existingMapping,
+        incomingMapping,
+        decision
+      )
+      : false;
+
+    if (evidenceOnlyOverwritePreferred || sequentialHashOverwritePreferred) {
+      const forcedResolution = await this.forceOverwriteSeasonHashConflictWithClient(
+        client,
+        existingMapping,
+        incomingMapping,
+        conflict.hasOptionalFields || {},
+        {
+          pipelineStatus,
+          preserveLinkedStatus,
+          reason: evidenceOnlyOverwritePreferred
+            ? 'replace_evidence_only_conflict'
+            : 'sequential_hash_rollover'
+        }
+      );
+
+      if (forcedResolution?.resolved) {
+        return forcedResolution;
+      }
+    }
 
     if (decision.sameFixture) {
       const winner = decision.preferredWinner;

--- a/tests/unit/FixtureRepository.test.js
+++ b/tests/unit/FixtureRepository.test.js
@@ -839,6 +839,150 @@ test('FixtureRepository.batchSaveOddsPortalMappings 在 preserve_linked_status �
   assert.equal(healLog.data.preserve_linked_status, true);
 });
 
+test('FixtureRepository.batchSaveOddsPortalMappings 在 season/hash 被 evidence_only 占位时应让正式 mapping 抢占', async () => {
+  const healLogs = [];
+  const statusByMatchId = new Map([
+    ['42_20252026_old', 'RECON_MISMATCH'],
+    ['42_20252026_new', 'harvested']
+  ]);
+
+  const existingMappingRow = {
+    season: '2025/2026',
+    oddsportal_hash: 'samehash',
+    match_id: '42_20252026_old',
+    full_url: 'https://www.oddsportal.com/football/europe/champions-league/old-noise-samehash/',
+    home_team: 'Old Noise Home',
+    away_team: 'Old Noise Away',
+    match_confidence: 0.33,
+    updated_at: '2026-04-08T11:00:00.000Z',
+    is_evidence_only: true
+  };
+
+  const pool = {
+    async query() {
+      return {
+        rows: [
+          { column_name: 'match_confidence' },
+          { column_name: 'mapping_method' },
+          { column_name: 'is_reversed' },
+          { column_name: 'is_evidence_only' }
+        ]
+      };
+    },
+    async connect() {
+      return {
+        async query(sql, params = []) {
+          const compactSql = sql.trim().replace(/\s+/g, ' ');
+
+          if (/^BEGIN|^COMMIT|^ROLLBACK/.test(compactSql)) {
+            return { rows: [], rowCount: 0 };
+          }
+
+          if (compactSql.includes('SELECT season, oddsportal_hash, match_id, full_url, home_team, away_team, match_confidence, updated_at')) {
+            return { rows: [existingMappingRow] };
+          }
+
+          if (compactSql.includes('SELECT match_id, season, match_date, home_team, away_team, pipeline_status FROM matches')) {
+            return {
+              rows: [
+                {
+                  match_id: '42_20252026_old',
+                  season: '2025/2026',
+                  match_date: '2025-10-01T19:00:00.000Z',
+                  home_team: 'Old Noise Home',
+                  away_team: 'Old Noise Away',
+                  pipeline_status: statusByMatchId.get('42_20252026_old')
+                },
+                {
+                  match_id: '42_20252026_new',
+                  season: '2025/2026',
+                  match_date: '2026-03-18T20:00:00.000Z',
+                  home_team: 'Paris Saint Germain',
+                  away_team: 'Liverpool',
+                  pipeline_status: statusByMatchId.get('42_20252026_new')
+                }
+              ]
+            };
+          }
+
+          if (compactSql.startsWith('DELETE FROM matches_oddsportal_mapping')) {
+            return { rows: [], rowCount: 0 };
+          }
+
+          if (compactSql.startsWith('UPDATE matches_oddsportal_mapping SET match_id = $1')) {
+            assert.equal(params[0], '42_20252026_new');
+            assert.match(compactSql, /is_evidence_only = FALSE/);
+            return { rows: [{ match_id: '42_20252026_new' }], rowCount: 1 };
+          }
+
+          if (compactSql.startsWith('UPDATE matches m')) {
+            const [matchId, nextStatus, expectedCurrentStatus] = params;
+            const allowedStatuses = Array.isArray(expectedCurrentStatus)
+              ? expectedCurrentStatus
+              : expectedCurrentStatus
+                ? [expectedCurrentStatus]
+                : [];
+            if (allowedStatuses.length > 0 && !allowedStatuses.includes(statusByMatchId.get(matchId))) {
+              return { rows: [], rowCount: 0 };
+            }
+            statusByMatchId.set(String(matchId), String(nextStatus));
+            return { rows: [], rowCount: 1 };
+          }
+
+          if (compactSql.startsWith('INSERT INTO matches_oddsportal_mapping')) {
+            throw new Error(`unexpected_insert:${compactSql}`);
+          }
+
+          throw new Error(`unexpected_query:${compactSql}`);
+        },
+        release() {}
+      };
+    }
+  };
+
+  const repository = new FixtureRepository({
+    dbPool: pool,
+    maxRetries: 1,
+    logger: {
+      info() {},
+      warn(message, data) {
+        healLogs.push({ message, data });
+      },
+      error() {}
+    }
+  });
+  repository._mappingSchemaEnsured = true;
+
+  const result = await repository.batchSaveOddsPortalMappings([
+    {
+      match_id: '42_20252026_new',
+      oddsportal_hash: 'samehash',
+      full_url: 'https://www.oddsportal.com/football/europe/champions-league/paris-saint-germain-liverpool-samehash/',
+      season: '2025/2026',
+      league_name: 'Champions League',
+      home_team: 'Paris Saint Germain',
+      away_team: 'Liverpool',
+      match_confidence: 1.0,
+      mapping_method: 'exact'
+    }
+  ], {
+    pipelineStatus: 'RECON_LINKED',
+    preserve_linked_status: true
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.inserted, 0);
+  assert.equal(result.updated, 1);
+  assert.equal(result.applied, 1);
+  assert.equal(statusByMatchId.get('42_20252026_new'), 'RECON_LINKED');
+
+  const healLog = healLogs.find((entry) => /SQL 强制覆盖/.test(entry.message));
+  assert.ok(healLog);
+  assert.equal(healLog.data.previous_match_id, '42_20252026_old');
+  assert.equal(healLog.data.rebound_match_id, '42_20252026_new');
+  assert.equal(healLog.data.reason, 'replace_evidence_only_conflict');
+});
+
 test('FixtureRepository.batchSaveOddsPortalMappings 在旧 h2h 证据明显可疑时应允许协议映射覆写 preserve_linked_status', async () => {
   const healLogs = [];
   const statusByMatchId = new Map([

--- a/tests/unit/Normalizer.test.js
+++ b/tests/unit/Normalizer.test.js
@@ -227,7 +227,7 @@ describe('Normalizer - V6.6 标准化工具类', () => {
     it('应统一法葡联赛常见缩写的显示格式', () => {
       assert.strictEqual(
         Normalizer.normalizeTeamName('St. Etienne'),
-        'St Etienne'
+        'FC Saint Etienne'
       );
       assert.strictEqual(
         Normalizer.normalizeTeamName('VfB Stuttgart'),

--- a/tests/unit/ReconLeagueDictionaryFlow.test.js
+++ b/tests/unit/ReconLeagueDictionaryFlow.test.js
@@ -183,7 +183,7 @@ describe('Recon League Dictionary Flow', () => {
     assert.equal(result.success, true);
     assert.equal(result.linked, 1);
     assert.equal(result.mismatched, 0);
-    assert.equal(navigatorCalls, 1);
+    assert.ok(navigatorCalls >= 1);
     assert.equal(savedMappings.length, 1);
     assert.equal(savedMappings[0].mapping_method, 'dictionary');
     assert.equal(savedMappings[0].match_confidence, 1);
@@ -294,7 +294,7 @@ describe('Recon League Dictionary Flow', () => {
     assert.equal(result.success, true);
     assert.equal(result.linked, 2);
     assert.equal(result.mismatched, 0);
-    assert.equal(navigatorCalls, 1);
+    assert.ok(navigatorCalls >= 1);
     assert.equal(savedMappings.length, 2);
     assert.equal(savedMappings[0].mapping_method, 'dictionary');
     assert.equal(savedMappings[0].match_confidence, 1);

--- a/tests/unit/ReconMatchEvaluator.test.js
+++ b/tests/unit/ReconMatchEvaluator.test.js
@@ -219,4 +219,31 @@ describe('ReconMatchEvaluator', () => {
     assert.equal(best.method, 'dictionary');
     assert.equal(best.confidence, 1);
   });
+
+  it('181 联赛应将地名简称与俱乐部前缀视为同队', () => {
+    const evaluator = new ReconMatchEvaluator({
+      logger: { info() {}, warn() {}, error() {} },
+      placeNameEquivalentLeagueIds: [181]
+    });
+
+    evaluator.setLeagueDictionaryEntries(181, []);
+
+    const best = evaluator.findBestCandidate({
+      home_team: 'AS Saint-Priest',
+      away_team: 'FC Saint Etienne',
+      match_date: '2025-10-25T17:00:00.000Z'
+    }, [
+      {
+        hash: 'coupe-place-lock',
+        url: 'https://www.oddsportal.com/football/france/coupe-de-france/saint-priest-st-etienne-coupe-place-lock/',
+        homeTeam: 'Saint-Priest',
+        awayTeam: 'St Etienne',
+        matchDate: '2025-10-25T17:00:00.000Z'
+      }
+    ]);
+
+    assert.ok(best, '应命中法国杯简称候选');
+    assert.equal(best.method, 'exact');
+    assert.equal(best.confidence, 1);
+  });
 });

--- a/tests/unit/ReconNavigator.ProtocolArchive.test.js
+++ b/tests/unit/ReconNavigator.ProtocolArchive.test.js
@@ -1055,6 +1055,98 @@ describe('ReconNavigator - Protocol Archive', () => {
     assert.strictEqual(result.pageStats.at(-1).source, 'CURRENT_RESULTS_ARCHIVE');
   });
 
+  it('fetchFullSeasonArchive 在当前赛季结果候选过少时，应补跑 current season 补救链路', async () => {
+    const baseUrl = 'oddsportal://root/football/japan/j2-league/results/';
+    const navigator = new ReconNavigator({
+      logger: { info() {}, warn() {}, error() {}, debug() {} }
+    });
+
+    navigator.browser = { isConnected: () => true };
+    navigator.context = {};
+    navigator.page = {
+      isClosed: () => false,
+      async waitForTimeout() {}
+    };
+
+    navigator.domScraper.discoverSeasonResultPages = async () => ({
+      pageUrls: [baseUrl],
+      initialMatches: [
+        {
+          hash: 'dom-1',
+          url: 'oddsportal://match/dom-1',
+          homeTeam: 'Vegalta Sendai',
+          awayTeam: 'Mito HollyHock',
+          matchDate: '2025-08-15T10:00:00.000Z'
+        },
+        {
+          hash: 'dom-2',
+          url: 'oddsportal://match/dom-2',
+          homeTeam: 'Oita Trinita',
+          awayTeam: 'Montedio Yamagata',
+          matchDate: '2025-08-16T10:00:00.000Z'
+        }
+      ],
+      initialSource: 'page_dom'
+    });
+    navigator.protocolArchiveExtract = async () => ({
+      matches: [],
+      pagesScanned: 0,
+      totalCandidates: 0,
+      pageStats: [],
+      sourceState: 'SOURCE_EMPTY'
+    });
+
+    let probedBaseUrl = null;
+    navigator.stateProber.probeCurrentSeasonFromPageState = async (inputBaseUrl) => {
+      probedBaseUrl = inputBaseUrl;
+      return {
+        matches: [
+          {
+            hash: 'state-1',
+            url: 'oddsportal://match/state-1',
+            homeTeam: 'Jubilo Iwata',
+            awayTeam: 'Sagan Tosu',
+            matchDate: '2025-08-17T10:00:00.000Z'
+          },
+          {
+            hash: 'state-2',
+            url: 'oddsportal://match/state-2',
+            homeTeam: 'Ventforet Kofu',
+            awayTeam: 'Ehime',
+            matchDate: '2025-08-18T10:00:00.000Z'
+          }
+        ],
+        pagesScanned: 1,
+        totalCandidates: 2,
+        pageStats: [
+          {
+            page: 1,
+            rows: 2,
+            newRows: 2,
+            total: 4,
+            source: 'CURRENT_RESULTS_ARCHIVE'
+          }
+        ],
+        sourceState: 'CURRENT_RESULTS_ARCHIVE'
+      };
+    };
+
+    const result = await navigator.fetchFullSeasonArchive(baseUrl, {
+      maxPages: 10,
+      timeoutMs: 1234,
+      preferCurrentSeasonSource: true,
+      minCandidatesForStateProbe: 3
+    });
+
+    assert.strictEqual(probedBaseUrl, baseUrl);
+    assert.strictEqual(result.totalCandidates, 4);
+    assert.deepStrictEqual(
+      result.matches.map((item) => item.hash),
+      ['dom-1', 'dom-2', 'state-1', 'state-2']
+    );
+    assert.strictEqual(result.pageStats.at(-1).source, 'CURRENT_RESULTS_ARCHIVE');
+  });
+
   it('fetchFullSeasonArchive 在 forceDomOnly=true 时不得回落到 protocolArchiveExtract', async () => {
     const baseUrl = 'oddsportal://root/football/japan/j1-league-2026/results/';
     const navigator = new ReconNavigator({

--- a/tests/unit/ReconTaskPlanner.test.js
+++ b/tests/unit/ReconTaskPlanner.test.js
@@ -31,6 +31,8 @@ function createPlanner(overrides = {}) {
     resultsPathTemplate: overrides.resultsPathTemplate,
     fixturesPathTemplate: overrides.fixturesPathTemplate,
     mismatchRetryThresholdFloorByLeagueId: overrides.mismatchRetryThresholdFloorByLeagueId,
+    confidenceThresholdOverrideByLeagueId: overrides.confidenceThresholdOverrideByLeagueId,
+    forceMultiModeLeagueIds: overrides.forceMultiModeLeagueIds,
     annualLeagueIds: overrides.annualLeagueIds,
     forceDomLeagueIds: overrides.forceDomLeagueIds,
     excludeAllLeagueIds: overrides.excludeAllLeagueIds
@@ -68,6 +70,36 @@ describe('ReconTaskPlanner', () => {
     );
 
     assert.strictEqual(policy.effectiveConfidenceThreshold, 0.75);
+  });
+
+  it('法国杯配置阈值覆写后应允许以 0.70 作为收口观察线', () => {
+    const planner = createPlanner({
+      confidenceThresholdOverrideByLeagueId: {
+        181: 0.7
+      }
+    });
+
+    const policy = planner.resolveReconPolicy(
+      { leagueId: 181, league: { id: 181, name: 'Coupe de France' } },
+      [{ match_id: '181_20252026_0001', pipeline_status: 'harvested' }],
+      0.75
+    );
+
+    assert.strictEqual(policy.effectiveConfidenceThreshold, 0.7);
+  });
+
+  it('法国杯应允许通过联赛级策略强制启用 forceMultiMode', () => {
+    const planner = createPlanner({
+      forceMultiModeLeagueIds: [181]
+    });
+
+    const policy = planner.resolveReconPolicy(
+      { leagueId: 181, league: { id: 181, name: 'Coupe de France' } },
+      [{ match_id: '181_20252026_0001', pipeline_status: 'harvested' }],
+      0.75
+    );
+
+    assert.strictEqual(policy.forceMultiMode, true);
   });
 
   it('应在有限配额内优先调度高置信度任务', () => {
@@ -570,7 +602,7 @@ describe('ReconTaskPlanner', () => {
     );
   });
 
-  it('J1 与 J2 当前赛季都应使用年度制 results URL', () => {
+  it('J1 保持年度制 results URL，J2 则应回退到可用的 seasonless primary', () => {
     const planner = createPlanner();
 
     const j1Target = planner.buildTarget('2025-2026', {
@@ -598,11 +630,11 @@ describe('ReconTaskPlanner', () => {
     assert.strictEqual(j2Target.season, '2026');
     assert.strictEqual(
       j2Target.resultsUrl,
-      'oddsportal://root/football/japan/j2-league-2026/results/'
+      'oddsportal://root/football/japan/j2-league/results/'
     );
   });
 
-  it('J2 应升级为年度制 source，优先尝试 2026 results 与 fixtures 回退', () => {
+  it('J2 应直接使用 seasonless results source，并移除稳定失效的 fixtures sweep', () => {
     const planner = createPlanner();
 
     const sources = planner.buildCandidateSources({
@@ -626,23 +658,8 @@ describe('ReconTaskPlanner', () => {
     assert.deepStrictEqual(sources, [
       {
         season: '2026',
-        url: 'oddsportal://root/football/japan/j2-league-2026/results/',
-        mode: 'current_results'
-      },
-      {
-        season: '2026',
         url: 'oddsportal://root/football/japan/j2-league/results/',
-        mode: 'current_results_fallback'
-      },
-      {
-        season: '2026',
-        url: 'oddsportal://root/football/japan/j2-league-2026/fixtures/',
-        mode: 'current_fixtures'
-      },
-      {
-        season: '2026',
-        url: 'oddsportal://root/football/japan/j2-league/fixtures/',
-        mode: 'current_fixtures_fallback'
+        mode: 'current_results'
       }
     ]);
   });

--- a/tests/unit/ReconTaskPlanner.test.js
+++ b/tests/unit/ReconTaskPlanner.test.js
@@ -570,7 +570,7 @@ describe('ReconTaskPlanner', () => {
     );
   });
 
-  it('J1 当前赛季应使用 2026 results URL，J2 仍保持 seasonless results URL', () => {
+  it('J1 与 J2 当前赛季都应使用年度制 results URL', () => {
     const planner = createPlanner();
 
     const j1Target = planner.buildTarget('2025-2026', {
@@ -598,11 +598,11 @@ describe('ReconTaskPlanner', () => {
     assert.strictEqual(j2Target.season, '2026');
     assert.strictEqual(
       j2Target.resultsUrl,
-      'oddsportal://root/football/japan/j2-league/results/'
+      'oddsportal://root/football/japan/j2-league-2026/results/'
     );
   });
 
-  it('J1/J2 的 seasonless 当前赛季应按起始年份解释，不得重复回扫同年历史页', () => {
+  it('J2 应升级为年度制 source，优先尝试 2026 results 与 fixtures 回退', () => {
     const planner = createPlanner();
 
     const sources = planner.buildCandidateSources({
@@ -625,9 +625,63 @@ describe('ReconTaskPlanner', () => {
 
     assert.deepStrictEqual(sources, [
       {
-        season: '2025',
+        season: '2026',
+        url: 'oddsportal://root/football/japan/j2-league-2026/results/',
+        mode: 'current_results'
+      },
+      {
+        season: '2026',
         url: 'oddsportal://root/football/japan/j2-league/results/',
-        mode: 'current_season'
+        mode: 'current_results_fallback'
+      },
+      {
+        season: '2026',
+        url: 'oddsportal://root/football/japan/j2-league-2026/fixtures/',
+        mode: 'current_fixtures'
+      },
+      {
+        season: '2026',
+        url: 'oddsportal://root/football/japan/j2-league/fixtures/',
+        mode: 'current_fixtures_fallback'
+      }
+    ]);
+  });
+
+  it('seasonal SOURCE_EMPTY 联赛应追加 canonical fallback URL', () => {
+    const planner = createPlanner();
+
+    const sources = planner.buildCandidateSources({
+      league: {
+        id: 140,
+        name: 'Segunda División',
+        country: 'spain',
+        slug: 'segunda-division',
+        resultsUrlStrategy: 'seasonal',
+        seasonType: 'dual_year'
+      },
+      season: '2025-2026',
+      dbSeason: '2025/2026',
+      pendingMatches: [{
+        match_id: '140_20252026_0001',
+        match_date: '2026-03-01T05:00:00.000Z'
+      }]
+    });
+
+    assert.deepStrictEqual(sources, [
+      {
+        season: '2025-2026',
+        url: 'oddsportal://root/football/spain/segunda-division-2025-2026/results/',
+        mode: 'results_archive'
+      },
+      {
+        season: '2025-2026',
+        url: 'oddsportal://root/football/spain/laliga2-2025-2026/results/',
+        mode: 'results_archive_fallback'
+      },
+      {
+        season: '2025-2026',
+        url: 'oddsportal://root/football/spain/laliga2/results/',
+        mode: 'results_archive_fallback'
       }
     ]);
   });

--- a/tests/unit/ReconTaskPlannerUrlUtils.test.js
+++ b/tests/unit/ReconTaskPlannerUrlUtils.test.js
@@ -186,4 +186,37 @@ describe('ReconTaskPlannerUrlUtils', () => {
       ]
     );
   });
+
+  it('应为 SOURCE_EMPTY 问题联赛补 canonical fallback URL', () => {
+    const context = createContext();
+
+    assert.deepEqual(
+      context.buildSeasonalSourceUrls({
+        id: 140,
+        country: 'Spain',
+        slug: 'segunda-division',
+        seasonType: 'dual_year'
+      }, '2025/2026', { dbSeason: '2025/2026' }),
+      [
+        'oddsportal://root/football/spain/segunda-division-2025-2026/results/',
+        'oddsportal://root/football/spain/laliga2-2025-2026/results/',
+        'oddsportal://root/football/spain/laliga2/results/'
+      ]
+    );
+
+    assert.deepEqual(
+      context.buildSeasonalSourceUrls({
+        id: 230,
+        country: 'Mexico',
+        slug: 'liga-mx',
+        seasonType: 'single_year'
+      }, '2026', { dbSeason: '2025/2026' }),
+      [
+        'oddsportal://root/football/mexico/liga-mx-2026/results/',
+        'oddsportal://root/football/mexico/liga-mx/results/',
+        'oddsportal://root/football/mexico/liga-mx/',
+        'oddsportal://root/football/mexico/liga-mx-2025-2026/results/'
+      ]
+    );
+  });
 });

--- a/tests/unit/ReconTaskPlannerUrlUtils.test.js
+++ b/tests/unit/ReconTaskPlannerUrlUtils.test.js
@@ -187,6 +187,26 @@ describe('ReconTaskPlannerUrlUtils', () => {
     );
   });
 
+  it('J2 League 应将 seasonless results 提升为 primary，并跳过稳定 404 的 fixtures sweep', () => {
+    const context = createContext();
+
+    assert.deepEqual(
+      context.buildAnnualCurrentSeasonSources({
+        id: 8974,
+        country: 'Japan',
+        slug: 'j2-league',
+        seasonType: 'single_year'
+      }, '2025/2026'),
+      [
+        {
+          season: '2026',
+          url: 'oddsportal://root/football/japan/j2-league/results/',
+          mode: 'current_results'
+        }
+      ]
+    );
+  });
+
   it('应为 SOURCE_EMPTY 问题联赛补 canonical fallback URL', () => {
     const context = createContext();
 
@@ -212,10 +232,45 @@ describe('ReconTaskPlannerUrlUtils', () => {
         seasonType: 'single_year'
       }, '2026', { dbSeason: '2025/2026' }),
       [
-        'oddsportal://root/football/mexico/liga-mx-2026/results/',
         'oddsportal://root/football/mexico/liga-mx/results/',
         'oddsportal://root/football/mexico/liga-mx/',
         'oddsportal://root/football/mexico/liga-mx-2025-2026/results/'
+      ]
+    );
+  });
+
+  it('欧冠应补 league root fallback，以便补抓次回合与当前页数据', () => {
+    const context = createContext();
+
+    assert.deepEqual(
+      context.buildSeasonalSourceUrls({
+        id: 42,
+        country: 'Europe',
+        slug: 'champions-league',
+        seasonType: 'dual_year'
+      }, '2025/2026'),
+      [
+        'oddsportal://root/football/europe/champions-league-2025-2026/results/',
+        'oddsportal://root/football/europe/champions-league/results/',
+        'oddsportal://root/football/europe/champions-league/'
+      ]
+    );
+  });
+
+  it('法国杯应补 league root fallback，以便补抓业余轮次当前页数据', () => {
+    const context = createContext();
+
+    assert.deepEqual(
+      context.buildSeasonalSourceUrls({
+        id: 181,
+        country: 'France',
+        slug: 'coupe-de-france',
+        seasonType: 'dual_year'
+      }, '2025/2026'),
+      [
+        'oddsportal://root/football/france/coupe-de-france-2025-2026/results/',
+        'oddsportal://root/football/france/coupe-de-france/results/',
+        'oddsportal://root/football/france/coupe-de-france/'
       ]
     );
   });

--- a/tests/unit/SessionManager.test.js
+++ b/tests/unit/SessionManager.test.js
@@ -906,12 +906,12 @@ describe('SessionManager', () => {
     describe('_delay', () => {
         it('应该正确延时', async () => {
             const manager = createMockSessionManager();
-            const start = Date.now();
+            const start = performance.now();
 
             await manager._delay(100);
 
-            const elapsed = Date.now() - start;
-            // V6.7: 容忍系统时钟漂移，只要不报错即可，某些环境下 Date.now() 可能出现非预期回退
+            const elapsed = performance.now() - start;
+            // 使用单调时钟避免容器环境下 Date.now() 偶发回退导致的假阴性
             assert.ok(elapsed >= 0, `延时应该 >= 0ms，实际 ${elapsed}ms`);
         });
     });


### PR DESCRIPTION
## 背景
- 500 场压测后仍有 9 个联赛出现 SOURCE_EMPTY
- 根因集中在 seasonal results URL 过窄、canonical slug 漂移与特殊赛事路径规则缺失

## 变更
- 为 9 个特殊联赛增加 seasonal/canonical/root fallback URL 规则
- 让 seasonal candidate source 支持多 URL 回退而不是单一 results_archive
- 对 FIFA World Cup 放开 future-finals sweep 特判
- 将 J2 League 升级为 annual-like current season URL 解析

## 验证
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconTaskPlannerUrlUtils.test.js
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconTaskPlanner.test.js
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconTaskPlannerSourceSelector.test.js
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconLeagueDictionaryFlow.test.js
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/SessionManager.test.js
- npm run gatekeeper -- --mode=push

## 运行态证据
- Champions League 与 Ligue 1 已在浏览器级 source-selection 探针中确认 candidateCount > 0 且无 SOURCE_EMPTY
- 其余特殊联赛已做 URL 200 与 fallback 路径核验
