### PR TITLE
feat: implement smart short-circuit probing and dynamic proxy gateway

### DIFF
--- a/config/active_registry.json
+++ b/config/active_registry.json
@@ -5,7 +5,7 @@
   "registry_id": "REG-CLASH-22",
   "description": "[Genesis.NetworkShield] Active Proxy Registry - 22-Node Clash Verge Integration",
   "registry_config": {
-    "proxy_host": "172.25.16.1",
+    "proxy_host": "host.docker.internal",
     "port_range": {
       "start": 7890,
       "end": 7911

--- a/config/proxy_pool.js
+++ b/config/proxy_pool.js
@@ -5,7 +5,29 @@ const path = require('node:path');
 
 const PROXY_POOL_PATH = path.resolve(__dirname, 'proxy_pool.json');
 const DEFAULT_PROTOCOL = 'http';
-const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PREFERRED_HOST = 'host.docker.internal';
+const DEFAULT_HOST = DEFAULT_PREFERRED_HOST;
+
+function normalizeHost(value) {
+    return typeof value === 'string' && value.trim() !== ''
+        ? value.trim()
+        : '';
+}
+
+function isLegacyBridgeHost(value) {
+    const host = normalizeHost(value);
+    if (!host) {
+        return false;
+    }
+
+    const parts = host.split('.').map(part => Number(part));
+    return parts.length === 4
+        && parts.every(part => Number.isInteger(part) && part >= 0 && part <= 255)
+        && parts[0] === 172
+        && parts[1] === 25
+        && parts[2] === 16
+        && parts[3] === 1;
+}
 
 function parseProxyPorts(value) {
     if (Array.isArray(value)) {
@@ -56,6 +78,9 @@ function readProxyPoolFile() {
 function resolveProxyPoolConfig(env = process.env) {
     const fileConfig = readProxyPoolFile();
     const protocol = env.PROXY_PROTOCOL || fileConfig.protocol || DEFAULT_PROTOCOL;
+    const explicitServerTemplate = typeof env.PROXY_SERVER === 'string' && env.PROXY_SERVER.trim() !== ''
+        ? env.PROXY_SERVER.trim()
+        : '';
 
     const envPorts = parseProxyPorts(env.PROXY_PORTS);
     const rangePorts = envPorts.length === 0
@@ -69,11 +94,13 @@ function resolveProxyPoolConfig(env = process.env) {
     const fileServerTemplate = typeof fileConfig.serverTemplate === 'string'
         ? fileConfig.serverTemplate
         : '';
-    const configuredServerTemplate = env.PROXY_SERVER || fileServerTemplate;
-    const host = env.WSL2_PROXY_HOST
-        || env.PROXY_HOST
-        || extractHost(configuredServerTemplate)
-        || fileConfig.host
+    const configuredServerTemplate = explicitServerTemplate || fileServerTemplate;
+    const fileHost = normalizeHost(fileConfig.host);
+    const host = normalizeHost(env.WSL2_PROXY_HOST)
+        || normalizeHost(env.PROXY_HOST)
+        || normalizeHost(extractHost(explicitServerTemplate))
+        || (isLegacyBridgeHost(fileHost) ? '' : fileHost)
+        || DEFAULT_PREFERRED_HOST
         || DEFAULT_HOST;
 
     const defaultPortCandidate = Number(
@@ -88,7 +115,10 @@ function resolveProxyPoolConfig(env = process.env) {
     const ports = candidatePorts.length > 0
         ? [...candidatePorts]
         : (defaultPort > 0 ? [defaultPort] : []);
-    const serverTemplate = configuredServerTemplate || `${protocol}://${host}:{port}`;
+    const hasExplicitHost = normalizeHost(env.WSL2_PROXY_HOST) || normalizeHost(env.PROXY_HOST);
+    const serverTemplate = configuredServerTemplate && !hasExplicitHost
+        ? configuredServerTemplate
+        : `${protocol}://${host}:{port}`;
 
     return {
         protocol,
@@ -119,6 +149,7 @@ module.exports = {
     PROXY_POOL_PATH,
     buildProxyServer,
     extractHost,
+    isLegacyBridgeHost,
     parseProxyPorts,
     readProxyPoolFile,
     resolveProxyPoolConfig

--- a/config/proxy_pool.json
+++ b/config/proxy_pool.json
@@ -1,6 +1,6 @@
 {
   "protocol": "http",
-  "host": "172.25.16.1",
+  "host": "host.docker.internal",
   "defaultPort": 7891,
   "ports": [
     7891,

--- a/scripts/ops/recon_scanner_impl.js
+++ b/scripts/ops/recon_scanner_impl.js
@@ -253,6 +253,11 @@ class ReconScanner {
       });
     }
 
+    const proxyProvider = this.proxyRotator?.proxyProvider;
+    if (proxyProvider && typeof proxyProvider.initialize === 'function') {
+      await proxyProvider.initialize();
+    }
+
     if (this.healthServer && this.proxyRotator && typeof this.healthServer.registerProxyPoolCheck === 'function') {
       this.healthServer.registerProxyPoolCheck(this.proxyRotator);
     }

--- a/src/config/proxy_settings.py
+++ b/src/config/proxy_settings.py
@@ -12,6 +12,10 @@ from pydantic import BaseModel, Field, field_validator
 from src.config.common import logger
 
 PROXY_POOL_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "proxy_pool.json"
+DEFAULT_PREFERRED_PROXY_HOST = "host.docker.internal"
+IPV4_OCTET_COUNT = 4
+IPV4_OCTET_MAX = 255
+LEGACY_BRIDGE_PROXY_OCTETS = (172, 25, 16, 1)
 
 
 def _read_proxy_pool_file() -> dict[str, Any]:
@@ -74,11 +78,43 @@ def _extract_proxy_host(server_template: str | None) -> str | None:
     return match.group(1) if match else None
 
 
+def _normalize_proxy_host(host: str | None) -> str | None:
+    """清洗代理主机字符串。"""
+    if host is None:
+        return None
+
+    normalized = str(host).strip()
+    return normalized or None
+
+
+def _is_legacy_bridge_proxy_host(host: str | None) -> bool:
+    """识别历史 WSL 网桥地址，避免继续回退到旧桥接 IP。"""
+    normalized = _normalize_proxy_host(host)
+    if not normalized:
+        return False
+
+    parts = normalized.split(".")
+    if len(parts) != IPV4_OCTET_COUNT:
+        return False
+
+    try:
+        octets = [int(part) for part in parts]
+    except ValueError:
+        return False
+
+    return (
+        all(0 <= octet <= IPV4_OCTET_MAX for octet in octets)
+        and tuple(octets) == LEGACY_BRIDGE_PROXY_OCTETS
+    )
+
+
 def resolve_shared_proxy_pool_config() -> dict[str, Any]:
     """解析跨语言共享的代理池配置。"""
     file_config = _read_proxy_pool_file()
     protocol = os.environ.get("PROXY_PROTOCOL") or file_config.get("protocol") or "http"
-    server_template = os.environ.get("PROXY_SERVER") or file_config.get("serverTemplate") or ""
+    explicit_server_template = (os.environ.get("PROXY_SERVER") or "").strip()
+    file_server_template = str(file_config.get("serverTemplate") or "").strip()
+    server_template = explicit_server_template or file_server_template
 
     ports = parse_proxy_ports(os.environ.get("PROXY_PORTS"))
     if not ports:
@@ -89,12 +125,13 @@ def resolve_shared_proxy_pool_config() -> dict[str, Any]:
     if not ports:
         ports = parse_proxy_ports(file_config.get("ports"))
 
+    file_host = _normalize_proxy_host(file_config.get("host"))
     host = (
-        os.environ.get("WSL2_PROXY_HOST")
-        or os.environ.get("PROXY_HOST")
-        or _extract_proxy_host(server_template)
-        or file_config.get("host")
-        or "127.0.0.1"
+        _normalize_proxy_host(os.environ.get("WSL2_PROXY_HOST"))
+        or _normalize_proxy_host(os.environ.get("PROXY_HOST"))
+        or _normalize_proxy_host(_extract_proxy_host(explicit_server_template))
+        or (None if _is_legacy_bridge_proxy_host(file_host) else file_host)
+        or DEFAULT_PREFERRED_PROXY_HOST
     )
 
     try:
@@ -109,7 +146,13 @@ def resolve_shared_proxy_pool_config() -> dict[str, Any]:
     if not ports and default_port:
         ports = [default_port]
 
-    resolved_template = server_template or f"{protocol}://{host}:{{port}}"
+    resolved_template = (
+        server_template
+        if server_template
+        and not os.environ.get("WSL2_PROXY_HOST")
+        and not os.environ.get("PROXY_HOST")
+        else f"{protocol}://{host}:{{port}}"
+    )
 
     return {
         "protocol": protocol,
@@ -127,22 +170,27 @@ def get_shared_proxy_pool_config() -> dict[str, Any]:
 
 
 def default_proxy_host() -> str:
+    """返回默认代理主机。"""
     return str(resolve_shared_proxy_pool_config()["host"])
 
 
 def default_proxy_ports() -> list[int]:
+    """返回默认代理端口列表。"""
     return list(resolve_shared_proxy_pool_config()["ports"])
 
 
 def default_proxy_ports_csv() -> str:
+    """返回默认代理端口 CSV。"""
     return ",".join(str(port) for port in default_proxy_ports())
 
 
 def default_proxy_protocol() -> str:
+    """返回默认代理协议。"""
     return str(resolve_shared_proxy_pool_config()["protocol"])
 
 
 def default_proxy_server_template() -> str:
+    """返回默认代理地址模板。"""
     return str(resolve_shared_proxy_pool_config()["server_template"])
 
 
@@ -194,9 +242,11 @@ class ProxyConfig:
         ]
 
     def is_port_deprecated(self, port: int) -> bool:
+        """判断端口是否已弃用。"""
         return port in self.deprecated_proxy_ports
 
     def validate_port(self, port: int) -> bool:
+        """验证端口是否仍可被使用。"""
         return not self.is_port_deprecated(port) and port in self.proxy_ports
 
 
@@ -220,21 +270,25 @@ class ProxySettingsMixin(BaseModel):
     @field_validator("proxy_wsl2_host", mode="before")
     @classmethod
     def normalize_proxy_wsl2_host(cls, _: Any) -> str:
+        """统一回填共享代理主机。"""
         return default_proxy_host()
 
     @field_validator("proxy_protocol", mode="before")
     @classmethod
     def normalize_proxy_protocol(cls, _: Any) -> str:
+        """统一回填共享代理协议。"""
         return default_proxy_protocol()
 
     @field_validator("proxy_ports", mode="before")
     @classmethod
     def normalize_proxy_ports(cls, _: Any) -> str:
+        """统一回填共享代理端口列表。"""
         return default_proxy_ports_csv()
 
     @field_validator("proxy_server_template", mode="before")
     @classmethod
     def normalize_proxy_server_template(cls, _: Any) -> str:
+        """统一回填共享代理模板。"""
         return default_proxy_server_template()
 
     def build_proxy_config(self) -> ProxyConfig:

--- a/src/infrastructure/network/ProxyProvider.js
+++ b/src/infrastructure/network/ProxyProvider.js
@@ -22,6 +22,7 @@ const DEFAULT_CRITICAL_ERROR_COOLDOWN_MS = 1800000;
 const DEFAULT_MIN_HEALTH_SCORE = 60;
 const DEFAULT_SUCCESS_HEALTH_REWARD = 4;
 const DEFAULT_FAILURE_HEALTH_PENALTY = 10;
+const DEFAULT_GATEWAY_PREFLIGHT_TIMEOUT_MS = 1500;
 
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
@@ -97,6 +98,8 @@ class ProxyProvider extends EventEmitter {
     this.sequence = 0;
     this.healthTimer = null;
     this.started = false;
+    this.initialized = false;
+    this.initializationPromise = null;
   }
 
   _buildConfig(options = {}) {
@@ -111,6 +114,7 @@ class ProxyProvider extends EventEmitter {
       protocol,
       host,
       ports,
+      defaultPort: Number(options.defaultPort) || resolveProxyPoolConfig().defaultPort || ports[0] || 0,
       targetLatencyMs: Number(options.targetLatencyMs) || DEFAULT_TARGET_LATENCY_MS,
       healthCheckIntervalMs: Number(options.healthCheckIntervalMs) || 30000,
       tcpTimeoutMs: Number(options.tcpTimeoutMs) || 1500,
@@ -238,6 +242,31 @@ class ProxyProvider extends EventEmitter {
     });
   }
 
+  async initialize() {
+    if (this.initialized) {
+      return {
+        ok: true,
+        host: this.config.host,
+        port: this._resolvePreflightPort()
+      };
+    }
+
+    if (!this.initializationPromise) {
+      this.initializationPromise = this._runGatewayPreflight()
+        .then((result) => {
+          this.initialized = true;
+          this.start();
+          return result;
+        })
+        .catch((error) => {
+          this.initializationPromise = null;
+          throw error;
+        });
+    }
+
+    return this.initializationPromise;
+  }
+
   start() {
     if (this.started || this.config.healthCheckIntervalMs <= 0) {
       return this;
@@ -253,6 +282,72 @@ class ProxyProvider extends EventEmitter {
     }
 
     return this;
+  }
+
+  _resolvePreflightPort() {
+    const preferredPort = Number(this.config.defaultPort);
+    if (Number.isInteger(preferredPort) && preferredPort > 0) {
+      return preferredPort;
+    }
+
+    return this.config.ports[0] || 0;
+  }
+
+  async _runGatewayPreflight() {
+    const port = this._resolvePreflightPort();
+    if (!Number.isInteger(port) || port <= 0) {
+      return {
+        ok: true,
+        skipped: true,
+        host: this.config.host,
+        port: 0
+      };
+    }
+
+    const result = await this.probes.tcp({
+      port,
+      host: this.config.host
+    }, {
+      ...this.config,
+      tcpTimeoutMs: positiveNumber(this.config.tcpTimeoutMs, DEFAULT_GATEWAY_PREFLIGHT_TIMEOUT_MS)
+    });
+
+    if (result?.ok) {
+      if (typeof this.logger.info === 'function') {
+        this.logger.info('[ProxyProvider] gateway_preflight_passed', {
+          host: this.config.host,
+          port,
+          latencyMs: result.latencyMs
+        });
+      }
+
+      return {
+        ok: true,
+        host: this.config.host,
+        port,
+        latencyMs: result.latencyMs
+      };
+    }
+
+    const reason = String(result?.error || 'tcp_preflight_failed');
+    const error = new Error(
+      `PROXY_GATEWAY_UNREACHABLE: ${this.config.host}:${port} (${reason}). `
+      + '代理网关无法连接，请检查 host.docker.internal 是否可用，或通过 PROXY_HOST 指定正确的宿主机地址'
+    );
+    error.code = 'PROXY_GATEWAY_UNREACHABLE';
+    error.host = this.config.host;
+    error.port = port;
+    error.reason = reason;
+
+    if (typeof this.logger.warn === 'function') {
+      this.logger.warn('[ProxyProvider] gateway_preflight_failed', {
+        host: this.config.host,
+        port,
+        reason
+      });
+    }
+
+    throw error;
   }
 
   stop() {

--- a/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
+++ b/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
@@ -554,147 +554,308 @@ const reconMatrixFlow = {
       return { pendingTotal: 0, linked: 0, mismatched: 0 };
     }
 
-    const selectedSource = await this._selectCandidateSourceWithLocalFallback(
+    const reconRunId = this._createReconRunId(target);
+    const persistLimiter = pLimit(1);
+    const resultsSource = await this._probeResultsCandidateSource(
       runtimeTarget,
       remainingPending,
       effectiveThreshold,
       navigator
     );
-    const candidates = selectedSource.candidates;
-    const seasonMirror = selectedSource.seasonMirror || this.mirrorManager.buildSeasonMirror(candidates);
+    const resultsCandidates = Array.isArray(resultsSource?.candidates) ? resultsSource.candidates : [];
+    const resultsSeasonMirror = resultsSource?.seasonMirror
+      || this.mirrorManager.buildSeasonMirror(resultsCandidates);
+    const scopedPending = this._resolveScopedPendingMatches(
+      remainingPending,
+      remainingMatchLimit,
+      resultsCandidates,
+      effectiveThreshold,
+      resultsSeasonMirror
+    );
 
-    if (!Array.isArray(candidates) || candidates.length === 0) {
-      if (this._canUseLocalDictionaryFallback(runtimeTarget, orderedPending)) {
-        const fallbackPending = Number.isInteger(remainingMatchLimit) && remainingMatchLimit > 0
-          ? remainingPending.slice(0, Math.min(remainingMatchLimit, remainingPending.length))
-          : remainingPending;
-
-        return this._runLocalDictionaryOnlyTarget(runtimeTarget, fallbackPending, {
-          batchSize,
-          confidenceThreshold: effectiveThreshold,
-          sourceSeason: selectedSource?.source?.season || runtimeTarget.dbSeason,
-          sourceUrl: selectedSource?.source?.url || this._buildLocalDictionarySourceUrl(runtimeTarget)
-        });
-      }
-
-      const sourceState = selectedSource?.extractResult?.sourceState || 'SOURCE_EMPTY';
-      const error = new Error(sourceState);
-      error.code = sourceState;
-      error.sourceUrl = selectedSource?.source?.url || target.resultsUrl;
-      error.sourceSeason = selectedSource?.source?.season || this.taskPlanner.formatSeasonForUrl(target.season);
-      throw error;
+    if (!Array.isArray(scopedPending) || scopedPending.length === 0) {
+      return { pendingTotal: 0, linked: 0, mismatched: 0 };
     }
 
-    const selectedPending = this.taskPlanner.selectProcessablePendingMatches(
-      remainingPending,
-      candidates,
-      effectiveThreshold,
-      remainingMatchLimit,
-      seasonMirror
-    );
-    const runtimeTargetWithSource = {
-      ...runtimeTarget,
-      reconSourceUrl: selectedSource?.source?.url || target.resultsUrl,
-      reconSourceSeason: selectedSource?.source?.season || this.taskPlanner.formatSeasonForUrl(target.season)
-    };
-    const reconRunId = this._createReconRunId(target);
     const progress = {
       processed: 0,
       linked: 0,
       mismatched: 0,
-      total: selectedPending.length,
+      total: scopedPending.length,
       startedAt: Date.now()
     };
+    const routeMetadata = {
+      reconRunId,
+      season: target.dbSeason,
+      league: target.league.name,
+      allowMismatchRetry: target?.reconPolicy?.allowMismatchRetry === true
+    };
+    let remainingRoutePending = scopedPending;
+    let totalLinked = 0;
+    let totalMismatched = 0;
+    let totalCandidateCount = 0;
+    let finalSourceSeason = null;
+    let finalSourceUrl = null;
+    let lastSourceState = resultsSource?.extractResult?.sourceState || 'SOURCE_EMPTY';
 
-    const outcomes = await Promise.all(
-      selectedPending.map((l1Match) => limiter(() =>
-        this._reconcilePendingMatch(l1Match, candidates, runtimeTargetWithSource, effectiveThreshold, seasonMirror)
-          .then((outcome) => {
+    const applyRouteResult = (routeResult, routeSource) => {
+      totalLinked += Number(routeResult?.linked || 0);
+      totalMismatched += Number(routeResult?.mismatched || 0);
+      totalCandidateCount += Number(routeSource?.localFallbackCandidateCount || routeSource?.candidates?.length || 0);
+      remainingRoutePending = Array.isArray(routeResult?.remainingPending)
+        ? routeResult.remainingPending
+        : [];
+      finalSourceSeason = routeSource?.source?.season || finalSourceSeason;
+      finalSourceUrl = routeSource?.source?.url || finalSourceUrl;
+      lastSourceState = routeSource?.extractResult?.sourceState || lastSourceState;
+    };
+
+    const processRoute = async (routeKind, routeSource, options = {}) => {
+      const normalizedRouteSource = routeSource || this._buildEmptyRouteSource(routeKind, runtimeTarget, 'SOURCE_EMPTY');
+      const routeResult = await this._processPendingMatchesWithShortCircuit(
+        routeKind,
+        normalizedRouteSource,
+        remainingRoutePending,
+        runtimeTarget,
+        {
+          confidenceThreshold: effectiveThreshold,
+          limiter,
+          persistLimiter,
+          progress,
+          metadata: routeMetadata,
+          finalPass: options.finalPass === true,
+          forceProcessWithoutCandidates: options.forceProcessWithoutCandidates === true
+        }
+      );
+      applyRouteResult(routeResult, normalizedRouteSource);
+    };
+
+    await processRoute('results', resultsSource);
+
+    if (remainingRoutePending.length > 0) {
+      const fixturesSource = await this._probeFixturesCandidateSource(
+        runtimeTarget,
+        remainingRoutePending,
+        effectiveThreshold,
+        navigator,
+        { useDedicatedNavigator: false }
+      );
+      await processRoute('fixtures', fixturesSource || this._buildEmptyRouteSource('fixtures', runtimeTarget, 'ROUTE_SKIPPED_NO_FIXTURES_URL'));
+    }
+
+    const canUseLocalDictionaryFallback = remainingRoutePending.length > 0
+      && this._canUseLocalDictionaryFallback(runtimeTarget, remainingRoutePending);
+
+    if (remainingRoutePending.length > 0) {
+      const searchSource = await this._probeSearchCandidateSource(
+        runtimeTarget,
+        remainingRoutePending,
+        effectiveThreshold,
+        navigator,
+        { useDedicatedNavigator: false }
+      );
+      const searchHasCandidates = Array.isArray(searchSource?.candidates) && searchSource.candidates.length > 0;
+      await processRoute('search', searchSource, {
+        finalPass: canUseLocalDictionaryFallback !== true && (totalCandidateCount > 0 || searchHasCandidates)
+      });
+    }
+
+    if (remainingRoutePending.length > 0 && canUseLocalDictionaryFallback) {
+      await processRoute(
+        'local_dictionary',
+        this._buildLocalDictionarySelectedSource(runtimeTarget, remainingRoutePending, 'LOCAL_DICTIONARY_FALLBACK'),
+        {
+          finalPass: true,
+          forceProcessWithoutCandidates: true
+        }
+      );
+    }
+
+    if (remainingRoutePending.length > 0) {
+      const error = new Error(lastSourceState || 'SOURCE_EMPTY');
+      error.code = lastSourceState || 'SOURCE_EMPTY';
+      error.sourceUrl = finalSourceUrl || target.resultsUrl;
+      error.sourceSeason = finalSourceSeason || this.taskPlanner.formatSeasonForUrl(target.season);
+      throw error;
+    }
+
+    return {
+      pendingTotal: scopedPending.length,
+      linked: totalLinked,
+      mismatched: totalMismatched,
+      sourceSeason: finalSourceSeason || this.taskPlanner.formatSeasonForUrl(target.season),
+      sourceUrl: finalSourceUrl || target.resultsUrl,
+      candidateCount: totalCandidateCount,
+      effectiveConfidenceThreshold: effectiveThreshold
+    };
+  },
+
+  _resolveScopedPendingMatches(pendingMatches, matchLimit, candidates, confidenceThreshold, seasonMirror = null) {
+    const orderedPending = [...(Array.isArray(pendingMatches) ? pendingMatches : [])]
+      .sort((a, b) => String(a.match_id).localeCompare(String(b.match_id)));
+
+    if (!Number.isInteger(matchLimit) || matchLimit <= 0 || orderedPending.length <= matchLimit) {
+      return orderedPending;
+    }
+
+    if (Array.isArray(candidates) && candidates.length > 0) {
+      return this.taskPlanner.selectProcessablePendingMatches(
+        orderedPending,
+        candidates,
+        confidenceThreshold,
+        matchLimit,
+        seasonMirror
+      );
+    }
+
+    return orderedPending.slice(0, Math.min(matchLimit, orderedPending.length));
+  },
+
+  async _processPendingMatchesWithShortCircuit(routeKind, routeSource, pendingMatches, target, options = {}) {
+    const {
+      confidenceThreshold = this.confidenceThreshold,
+      limiter = pLimit(1),
+      persistLimiter = pLimit(1),
+      progress = null,
+      metadata = {},
+      finalPass = false,
+      forceProcessWithoutCandidates = false
+    } = options;
+
+    const candidates = Array.isArray(routeSource?.candidates) ? routeSource.candidates : [];
+    const canProcessMatches = candidates.length > 0 || forceProcessWithoutCandidates === true || finalPass === true;
+    if (!canProcessMatches) {
+      this.logger.info('recon_route_short_circuit', {
+        league: target?.league?.name || null,
+        season: target?.dbSeason || null,
+        routeKind,
+        pendingTotal: pendingMatches.length,
+        linked: 0,
+        mismatched: 0,
+        remainingPending: pendingMatches.length,
+        sourceState: routeSource?.extractResult?.sourceState || 'SOURCE_EMPTY',
+        finalPass
+      });
+      return {
+        linked: 0,
+        mismatched: 0,
+        remainingPending: [...pendingMatches]
+      };
+    }
+
+    const seasonMirror = routeSource?.seasonMirror || this.mirrorManager.buildSeasonMirror(candidates);
+    const runtimeTargetWithSource = {
+      ...target,
+      reconSourceUrl: routeSource?.source?.url || target.resultsUrl,
+      reconSourceSeason: routeSource?.source?.season || this.taskPlanner.formatSeasonForUrl(target.season)
+    };
+    const unresolvedMatches = [];
+    let linked = 0;
+    let mismatched = 0;
+
+    await Promise.all(
+      pendingMatches.map((l1Match) => limiter(async () => {
+        const outcome = await this._reconcilePendingMatch(
+          l1Match,
+          candidates,
+          runtimeTargetWithSource,
+          confidenceThreshold,
+          seasonMirror
+        );
+
+        if (outcome?.status === 'linked' && outcome.mapping) {
+          const persistResult = await persistLimiter(() => this._persistReconOutcomeImmediately(outcome, {
+            ...metadata,
+            sourceSeason: runtimeTargetWithSource.reconSourceSeason,
+            sourceUrl: runtimeTargetWithSource.reconSourceUrl
+          }));
+          linked += Number(persistResult?.linked || 0);
+          if (progress) {
             progress.processed++;
-            if (outcome?.status === 'linked') {
-              progress.linked++;
-            } else if (outcome?.status === 'mismatch') {
-              progress.mismatched++;
-            }
-
+            progress.linked += Number(persistResult?.linked || 0);
             if (this._shouldEmitReconProgressSnapshot(progress)) {
               this._emitReconProgressSnapshot(target, progress);
             }
-
-            return outcome;
-          })
-      ))
-    );
-
-    const mappings = [];
-    const mismatches = [];
-
-    for (const outcome of outcomes) {
-      if (outcome?.status === 'linked' && outcome.mapping) {
-        mappings.push(outcome.mapping);
-      } else if (outcome?.status === 'mismatch' && outcome.matchId) {
-        mismatches.push({
-          match_id: String(outcome.matchId),
-          evidence: outcome.evidence || null
-        });
-      }
-    }
-
-    const deduped = this._dedupeMappingsBySeasonHash(mappings);
-    if (deduped.droppedMatchIds.length > 0) {
-      for (const droppedMatchId of deduped.droppedMatchIds) {
-        if (!mismatches.some((item) => String(item?.match_id || item) === String(droppedMatchId))) {
-          mismatches.push({
-            match_id: String(droppedMatchId),
-            evidence: null
-          });
+          }
+          return;
         }
-      }
 
-      this.logger.warn('recon_mapping_hash_dedup', {
-        season: target.dbSeason,
-        league: target.league.name,
-        droppedCount: deduped.droppedMatchIds.length,
-        droppedMatchIds: deduped.droppedMatchIds.slice(0, 10),
-        truncated: deduped.droppedMatchIds.length > 10
-      });
-    }
+        if (finalPass) {
+          const persistResult = await persistLimiter(() => this._persistReconOutcomeImmediately(outcome, {
+            ...metadata,
+            sourceSeason: runtimeTargetWithSource.reconSourceSeason,
+            sourceUrl: runtimeTargetWithSource.reconSourceUrl
+          }));
+          mismatched += Number(persistResult?.mismatched || 0);
+          if (progress) {
+            progress.processed++;
+            progress.mismatched += Number(persistResult?.mismatched || 0);
+            if (this._shouldEmitReconProgressSnapshot(progress)) {
+              this._emitReconProgressSnapshot(target, progress);
+            }
+          }
+          return;
+        }
 
-    if (deduped.bypassedMatchIds.length > 0) {
-      this.logger.warn('recon_mapping_hash_bypass', {
-        season: target.dbSeason,
-        league: target.league.name,
-        bypassedCount: deduped.bypassedMatchIds.length,
-        bypassedMatchIds: deduped.bypassedMatchIds.slice(0, 10),
-        bypassedHashKeys: deduped.bypassedHashKeys.slice(0, 5),
-        truncated: deduped.bypassedMatchIds.length > 10 || deduped.bypassedHashKeys.length > 5
-      });
-    }
-
-    const persistedMappings = deduped.mappings;
-
-    const persistResult = await this._persistReconBatches(
-      persistedMappings,
-      mismatches,
-      Math.max(1, Number(batchSize)),
-      {
-        reconRunId,
-        season: target.dbSeason,
-        league: target.league.name,
-        sourceSeason: selectedSource?.source?.season || this.taskPlanner.formatSeasonForUrl(target.season),
-        sourceUrl: selectedSource?.source?.url || target.resultsUrl,
-        allowMismatchRetry: target?.reconPolicy?.allowMismatchRetry === true
-      }
+        unresolvedMatches.push(l1Match);
+      }))
     );
+
+    const orderedRemainingPending = unresolvedMatches
+      .sort((left, right) => String(left?.match_id || '').localeCompare(String(right?.match_id || '')));
+
+    this.logger.info('recon_route_short_circuit', {
+      league: target?.league?.name || null,
+      season: target?.dbSeason || null,
+      routeKind,
+      pendingTotal: pendingMatches.length,
+      linked,
+      mismatched,
+      remainingPending: orderedRemainingPending.length,
+      sourceState: routeSource?.extractResult?.sourceState || 'SOURCE_EMPTY',
+      finalPass
+    });
 
     return {
-      pendingTotal: selectedPending.length,
-      linked: Number(persistResult?.linkedApplied || 0),
-      mismatched: Number(persistResult?.mismatchUpdated || 0),
-      sourceSeason: selectedSource?.source?.season || this.taskPlanner.formatSeasonForUrl(target.season),
-      sourceUrl: selectedSource?.source?.url || target.resultsUrl,
-      candidateCount: Number(selectedSource?.localFallbackCandidateCount || (Array.isArray(candidates) ? candidates.length : 0)),
-      effectiveConfidenceThreshold: effectiveThreshold
+      linked,
+      mismatched,
+      remainingPending: orderedRemainingPending
+    };
+  },
+
+  async _persistReconOutcomeImmediately(outcome, metadata = {}) {
+    if (outcome?.status === 'linked' && outcome.mapping) {
+      const persistResult = await this._persistReconBatches(
+        [outcome.mapping],
+        [],
+        1,
+        metadata
+      );
+      return {
+        linked: Number(persistResult?.linkedApplied || 0),
+        mismatched: 0
+      };
+    }
+
+    if (outcome?.matchId) {
+      const persistResult = await this._persistReconBatches(
+        [],
+        [{
+          match_id: String(outcome.matchId),
+          evidence: outcome.evidence || null
+        }],
+        1,
+        metadata
+      );
+      return {
+        linked: 0,
+        mismatched: Number(persistResult?.mismatchUpdated || 0)
+      };
+    }
+
+    return {
+      linked: 0,
+      mismatched: 0
     };
   },
 

--- a/tests/unit/ProxyProvider.test.js
+++ b/tests/unit/ProxyProvider.test.js
@@ -147,7 +147,7 @@ describe('src/infrastructure/network/ProxyProvider', () => {
     assert.ok(provider.getNodeStates().find(item => item.port === blockedPort).healthScore < 60);
   });
 
-  test('WSL2 默认主机应统一解析为 172.25.16.1', () => {
+  test('默认主机应统一解析为 host.docker.internal', () => {
     const provider = getProxyProvider({
       healthCheckIntervalMs: 0
     });
@@ -155,7 +155,53 @@ describe('src/infrastructure/network/ProxyProvider', () => {
     const stats = provider.getStats();
     const nodes = provider.getNodeStates();
 
-    assert.strictEqual(stats.host, '172.25.16.1');
-    assert.ok(nodes.every(node => node.host === '172.25.16.1'));
+    assert.strictEqual(stats.host, 'host.docker.internal');
+    assert.ok(nodes.every(node => node.host === 'host.docker.internal'));
+  });
+
+  test('初始化时应先完成代理网关 TCP 预检', async () => {
+    let tcpProbeCalls = 0;
+    const provider = new ProxyProvider({
+      host: 'host.docker.internal',
+      ports: [7891, 7892],
+      defaultPort: 7891,
+      healthCheckIntervalMs: 0,
+      probes: {
+        tcp: async (node) => {
+          tcpProbeCalls += 1;
+          assert.strictEqual(node.host, 'host.docker.internal');
+          assert.strictEqual(node.port, 7891);
+          return { ok: true, latencyMs: 12 };
+        },
+        http: async () => ({ ok: true, statusCode: 200, latencyMs: 12 })
+      }
+    });
+
+    const result = await provider.initialize();
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.host, 'host.docker.internal');
+    assert.strictEqual(result.port, 7891);
+    assert.strictEqual(tcpProbeCalls, 1);
+
+    await provider.initialize();
+    assert.strictEqual(tcpProbeCalls, 1);
+  });
+
+  test('代理网关 TCP 预检失败时应抛出清晰错误', async () => {
+    const provider = new ProxyProvider({
+      host: 'host.docker.internal',
+      ports: [7891],
+      defaultPort: 7891,
+      healthCheckIntervalMs: 0,
+      probes: {
+        tcp: async () => ({ ok: false, error: 'connect ECONNREFUSED' }),
+        http: async () => ({ ok: true, statusCode: 200, latencyMs: 8 })
+      }
+    });
+
+    await assert.rejects(
+      provider.initialize(),
+      /代理网关无法连接，请检查 host\.docker\.internal 是否可用/
+    );
   });
 });

--- a/tests/unit/ReconEngine.test.js
+++ b/tests/unit/ReconEngine.test.js
@@ -83,18 +83,13 @@ test('ReconEngine 在 navigator 后置注入时必须同步闭合到 taskPlanner
         circuitBreakerKey: 'recon:47:2025/2026:results_archive:2025-2026:0',
         forcePureProtocol: false
       }
-    },
-    {
-      url: 'oddsportal://root/football/england/premier-league-2025-2026/fixtures/',
-      options: {
-        maxPages: 50,
-        timeoutMs: engine.archiveTimeoutMs,
-        preferCurrentSeasonSource: true,
-        circuitBreakerKey: 'recon:47:2025/2026:fixtures:2025/2026',
-        forceDomOnly: true
-      }
     }
   ]);
+  assert.equal(
+    protocolCalls.some((call) => call.url.includes('/fixtures/')),
+    false,
+    'Results 命中并完成即时入库后，不应再继续探测 fixtures fallback'
+  );
   assert.ok(
     protocolCalls.every((call) => !call.url.includes('2024-2025')),
     'navigator 后置注入后仍不得回退到上一赛季 URL'

--- a/tests/unit/ReconMatrixFlow.test.js
+++ b/tests/unit/ReconMatrixFlow.test.js
@@ -35,7 +35,7 @@ describe('ReconMatrixFlow', () => {
         const captured = [];
         const flow = {
             ...reconMatrixFlow,
-            defaultReconConcurrency: 2,
+            defaultReconConcurrency: 1,
             reconBatchSize: 25,
             confidenceThreshold: 0.75,
             logger: { info() {}, warn() {}, error() {} },
@@ -45,11 +45,12 @@ describe('ReconMatrixFlow', () => {
                 selectProcessablePendingMatches: () => {
                     throw new Error('不应进入 selectProcessablePendingMatches');
                 },
+                formatSeasonForUrl: (season) => season,
             },
             _primeLeagueDictionary: async () => [{ remote_name: 'Alpha', local_team_name: 'Alpha' }],
             _canUseLocalDictionaryFallback: () => true,
             _shouldUseLocalDictionaryOnly: () => false,
-            _selectCandidateSourceWithLocalFallback: async () => ({
+            _probeResultsCandidateSource: async () => ({
                 candidates: [],
                 source: {
                     season: '2025/2026',
@@ -58,20 +59,38 @@ describe('ReconMatrixFlow', () => {
                 extractResult: {
                     sourceState: 'SOURCE_EMPTY',
                 },
+                seasonMirror: new Map(),
             }),
-            _runLocalDictionaryOnlyTarget: async (_target, pendingMatches) => {
-                captured.push(pendingMatches.map(match => match.match_id));
+            _probeFixturesCandidateSource: async () => null,
+            _probeSearchCandidateSource: async () => ({
+                candidates: [],
+                source: {
+                    season: '2025/2026',
+                    url: 'https://example.com/search/',
+                },
+                extractResult: {
+                    sourceState: 'SOURCE_EMPTY',
+                },
+                seasonMirror: new Map(),
+            }),
+            _buildLocalDictionarySourceUrl: () => 'dictionary://recon/1/2025%2F2026',
+            _reconcilePendingMatch: async (match, _candidates, target) => {
+                if (String(target?.reconSourceUrl || '').startsWith('dictionary://')) {
+                    captured.push(match.match_id);
+                }
                 return {
-                    pendingTotal: pendingMatches.length,
-                    linked: 0,
-                    mismatched: pendingMatches.length,
-                    sourceSeason: '2025/2026',
-                    sourceUrl: 'dictionary://recon/1/2025%2F2026',
-                    candidateCount: pendingMatches.length,
-                    effectiveConfidenceThreshold: 0.75,
+                    status: 'mismatch',
+                    matchId: match.match_id,
+                    evidence: null,
                 };
             },
-            _buildLocalDictionarySourceUrl: () => 'dictionary://recon/1/2025%2F2026',
+            _persistReconOutcomeImmediately: async () => ({
+                linked: 0,
+                mismatched: 1,
+            }),
+            _createReconRunId: () => 'run-dictionary-limit',
+            _shouldEmitReconProgressSnapshot: () => false,
+            _emitReconProgressSnapshot() {},
         };
 
         const result = await flow._runReconTarget(
@@ -91,7 +110,7 @@ describe('ReconMatrixFlow', () => {
             }
         );
 
-        assert.deepStrictEqual(captured, [['m1', 'm2']]);
+        assert.deepStrictEqual(captured, ['m1', 'm2']);
         assert.strictEqual(result.pendingTotal, 2);
         assert.strictEqual(result.mismatched, 2);
     });
@@ -113,14 +132,12 @@ describe('ReconMatrixFlow', () => {
                     Number.isInteger(matchLimit) && matchLimit > 0
                         ? pendingMatches.slice(0, matchLimit)
                         : pendingMatches,
+                formatSeasonForUrl: (season) => season,
             },
             matchExtractor: reconMatchExtractor,
             _primeLeagueDictionary: async () => [{ remote_name: 'Alpha', local_team_name: 'Alpha' }],
             _canUseLocalDictionaryFallback: () => true,
-            _runLocalDictionaryOnlyTarget: async () => {
-                throw new Error('不应在全量 mismatch 时直接短路到本地字典');
-            },
-            _selectCandidateSourceWithLocalFallback: async (_target, pendingMatches) => {
+            _probeResultsCandidateSource: async (_target, pendingMatches) => {
                 selectedCalls.push(pendingMatches.map(match => match.match_id));
                 return {
                     candidates: [
@@ -140,6 +157,12 @@ describe('ReconMatrixFlow', () => {
                     seasonMirror: new Map(),
                 };
             },
+            _probeFixturesCandidateSource: async () => {
+                throw new Error('results 已命中 limit 后不应继续探测 fixtures');
+            },
+            _probeSearchCandidateSource: async () => {
+                throw new Error('results 已命中 limit 后不应继续探测 search');
+            },
             _findBestCandidate: () => ({
                 candidate: {
                     hash: 'AbCd1234',
@@ -156,12 +179,9 @@ describe('ReconMatrixFlow', () => {
             _createReconRunId: () => 'run-remote-first',
             _shouldEmitReconProgressSnapshot: () => false,
             _emitReconProgressSnapshot() {},
-            _persistReconBatches: async (mappings, mismatches) => {
-                persisted.push({ mappings, mismatches });
-                return {
-                    linkedApplied: mappings.length,
-                    mismatchUpdated: mismatches.length,
-                };
+            _persistReconOutcomeImmediately: async (outcome) => {
+                persisted.push(outcome);
+                return { linked: 1, mismatched: 0 };
             },
         };
 
@@ -196,9 +216,141 @@ describe('ReconMatrixFlow', () => {
 
         assert.deepStrictEqual(selectedCalls, [['m1', 'm2']]);
         assert.strictEqual(persisted.length, 1);
-        assert.strictEqual(persisted[0].mappings.length, 1);
+        assert.strictEqual(persisted[0].mapping.match_id, 'm1');
         assert.strictEqual(result.pendingTotal, 1);
         assert.strictEqual(result.linked, 1);
+    });
+
+    it('results 已缝上的比赛不应再进入 search 路径', async () => {
+        const searchCalls = [];
+        const persisted = [];
+        const flow = {
+            ...reconMatrixFlow,
+            defaultReconConcurrency: 1,
+            reconBatchSize: 25,
+            confidenceThreshold: 0.75,
+            logger: { info() {}, warn() {}, error() {} },
+            mirrorManager: { buildSeasonMirror: () => new Map() },
+            taskPlanner: {
+                resolveReconPolicy: () => ({ effectiveConfidenceThreshold: 0.75 }),
+                formatSeasonForUrl: (season) => season,
+            },
+            _primeLeagueDictionary: async () => [],
+            _canUseLocalDictionaryFallback: () => false,
+            _probeResultsCandidateSource: async () => ({
+                routeKind: 'results',
+                source: {
+                    season: '2025/2026',
+                    url: 'oddsportal://results',
+                },
+                extractResult: {
+                    sourceState: 'SOURCE_READY',
+                },
+                candidates: [{ match_id: 'm1' }],
+                seasonMirror: new Map(),
+            }),
+            _probeFixturesCandidateSource: async () => ({
+                routeKind: 'fixtures',
+                source: {
+                    season: '2025/2026',
+                    url: 'oddsportal://fixtures',
+                },
+                extractResult: {
+                    sourceState: 'SOURCE_EMPTY',
+                },
+                candidates: [],
+                seasonMirror: new Map(),
+            }),
+            _probeSearchCandidateSource: async (_target, pendingMatches) => {
+                searchCalls.push(pendingMatches.map(match => match.match_id));
+                return {
+                    routeKind: 'search',
+                    source: {
+                        season: '2025/2026',
+                        url: 'oddsportal://search',
+                    },
+                    extractResult: {
+                        sourceState: 'SEARCH_SWEEP_READY',
+                    },
+                    candidates: [{ match_id: 'm2' }],
+                    seasonMirror: new Map(),
+                };
+            },
+            _reconcilePendingMatch: async (match, _candidates, target) => {
+                if (target.reconSourceUrl === 'oddsportal://results' && match.match_id === 'm1') {
+                    return {
+                        status: 'linked',
+                        mapping: {
+                            match_id: 'm1',
+                            oddsportal_hash: 'hash-results',
+                            full_url: 'oddsportal://results/m1',
+                            season: '2025/2026',
+                            league_name: 'Test League',
+                            home_team: 'A',
+                            away_team: 'B',
+                        },
+                    };
+                }
+
+                if (target.reconSourceUrl === 'oddsportal://search' && match.match_id === 'm2') {
+                    return {
+                        status: 'linked',
+                        mapping: {
+                            match_id: 'm2',
+                            oddsportal_hash: 'hash-search',
+                            full_url: 'oddsportal://search/m2',
+                            season: '2025/2026',
+                            league_name: 'Test League',
+                            home_team: 'C',
+                            away_team: 'D',
+                        },
+                    };
+                }
+
+                return {
+                    status: 'mismatch',
+                    matchId: match.match_id,
+                    evidence: null,
+                };
+            },
+            _persistReconOutcomeImmediately: async (outcome, metadata) => {
+                persisted.push({
+                    matchId: outcome.mapping?.match_id || outcome.matchId,
+                    sourceUrl: metadata.sourceUrl,
+                });
+                return {
+                    linked: outcome.status === 'linked' ? 1 : 0,
+                    mismatched: outcome.status === 'mismatch' ? 1 : 0,
+                };
+            },
+            _createReconRunId: () => 'run-short-circuit',
+            _shouldEmitReconProgressSnapshot: () => false,
+            _emitReconProgressSnapshot() {},
+        };
+
+        const result = await flow._runReconTarget(
+            {
+                leagueId: 1,
+                dbSeason: '2025/2026',
+                season: '2025/2026',
+                resultsUrl: 'oddsportal://results',
+                league: { id: 1, name: 'Test League' },
+            },
+            {
+                pendingMatches: [
+                    { match_id: 'm1', pipeline_status: 'harvested' },
+                    { match_id: 'm2', pipeline_status: 'harvested' },
+                ],
+            }
+        );
+
+        assert.deepStrictEqual(searchCalls, [['m2']]);
+        assert.deepStrictEqual(persisted, [
+            { matchId: 'm1', sourceUrl: 'oddsportal://results' },
+            { matchId: 'm2', sourceUrl: 'oddsportal://search' },
+        ]);
+        assert.strictEqual(result.linked, 2);
+        assert.strictEqual(result.mismatched, 0);
     });
 
     it('linked 前应先把 h2h 候选洗白为 canonical URL', async () => {

--- a/tests/unit/config_package_test.py
+++ b/tests/unit/config_package_test.py
@@ -113,16 +113,16 @@ def test_proxy_pool_resolution_prefers_environment(monkeypatch, tmp_path):
     assert resolved["host"] == "proxy.local"
     assert resolved["ports"] == [8100, 8101]
     assert resolved["protocol"] == "https"
-    assert resolved["server_template"] == "http://172.25.16.1:{port}"
+    assert resolved["server_template"] == "https://proxy.local:{port}"
 
     snapshot = get_shared_proxy_pool_config()
     assert snapshot["host"] == "proxy.local"
 
     proxy = ProxyConfig(proxy_ports=[8100, 8101], deprecated_proxy_ports=[8101])
-    assert proxy.get_proxy_url(8100) == "http://172.25.16.1:8100"
+    assert proxy.get_proxy_url(8100) == "https://proxy.local:8100"
     assert proxy.get_all_proxy_urls() == [
-        "http://172.25.16.1:8100",
-        "http://172.25.16.1:8101",
+        "https://proxy.local:8100",
+        "https://proxy.local:8101",
     ]
     assert proxy.validate_port(8100) is True
     assert proxy.validate_port(8101) is False
@@ -306,3 +306,30 @@ def test_unified_settings_urls_and_accessors(monkeypatch, tmp_path):
     assert ConfigAccessor().proxy.get_proxy_url(7891) == "http://172.25.16.1:7891"
     accessor.reload()
     assert accessor.database.name == "football_db"
+
+
+def test_proxy_pool_default_host_prefers_host_docker_internal(monkeypatch, tmp_path):
+    """未显式指定 PROXY_HOST 时，应优先回退到 host.docker.internal。"""
+    pool_file = tmp_path / "proxy_pool.json"
+    pool_file.write_text(
+        json.dumps(
+            {
+                "host": "172.25.16.1",
+                "protocol": "http",
+                "ports": [7891, 7892],
+                "defaultPort": 7891,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(proxy_settings, "PROXY_POOL_CONFIG_PATH", pool_file)
+    monkeypatch.delenv("WSL2_PROXY_HOST", raising=False)
+    monkeypatch.delenv("PROXY_HOST", raising=False)
+    monkeypatch.delenv("PROXY_SERVER", raising=False)
+    monkeypatch.delenv("PROXY_PORTS", raising=False)
+    monkeypatch.delenv("PROXY_PORT", raising=False)
+
+    resolved = proxy_settings.resolve_shared_proxy_pool_config()
+    assert resolved["host"] == "host.docker.internal"
+    assert resolved["server_template"] == "http://host.docker.internal:{port}"


### PR DESCRIPTION
## Summary
- replace hardcoded legacy bridge host fallback with dynamic proxy gateway resolution
- add results -> fixtures -> search short-circuit probing with immediate persistence
- align JS/Python proxy config and refresh related unit coverage

## Verification
- npm run gatekeeper -- --mode=push
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconEngine.test.js
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconMatrixFlow.test.js