### PR TITLE
feat: implement 503 circuit breaking and auto-downscaling for resilience

### DIFF
--- a/scripts/ops/recon_scanner_impl.js
+++ b/scripts/ops/recon_scanner_impl.js
@@ -338,7 +338,61 @@ class ReconScanner {
       });
     }
 
+    this._applyResilienceRuntimeTuning();
+
     this.logger.info('scanner_components_initialized');
+  }
+
+  _applyResilienceRuntimeTuning() {
+    if (!this.engine) {
+      return;
+    }
+
+    const engineConfig = this.config?.recon_runtime?.engine || {};
+    const probeArchiveTimeoutMs = Math.max(
+      1,
+      Number(engineConfig.probe_archive_timeout_ms ?? 20000)
+    );
+    const lowSuccessRateThresholdRaw = Number(
+      engineConfig.low_success_rate_threshold ?? 0.5
+    );
+    const lowSuccessRateThreshold = Number.isFinite(lowSuccessRateThresholdRaw)
+      ? Math.min(1, Math.max(0, lowSuccessRateThresholdRaw))
+      : 0.5;
+    const lowSuccessRateLeagueCap = Math.max(
+      1,
+      Number(engineConfig.low_success_rate_league_cap ?? 3)
+    );
+    const timeoutDegradeThreshold = Math.max(
+      1,
+      Number(engineConfig.timeout_degrade_threshold ?? 2)
+    );
+    const successWindowSlowPath = Math.max(
+      1,
+      Number(engineConfig.adaptive_concurrency_success_window_slow_path ?? 5)
+    );
+
+    this.engine.probeArchiveTimeoutMs = Math.min(
+      Math.max(1, Number(this.engine.archiveTimeoutMs || probeArchiveTimeoutMs)),
+      probeArchiveTimeoutMs
+    );
+    this.engine.fastFailTimeoutStreak = timeoutDegradeThreshold;
+    this.engine.searchDisabledOnDegradedLeague = true;
+    this.engine.lowSuccessRateThreshold = lowSuccessRateThreshold;
+    this.engine.lowSuccessRateLeagueCap = lowSuccessRateLeagueCap;
+    this.engine.dynamicConcurrencySuccessWindow = Math.max(
+      1,
+      Math.max(Number(this.engine.dynamicConcurrencySuccessWindow || 0), successWindowSlowPath)
+    );
+
+    this.logger.info('scanner_resilience_tuned', {
+      probeArchiveTimeoutMs: this.engine.probeArchiveTimeoutMs,
+      timeoutDegradeThreshold: this.engine.fastFailTimeoutStreak,
+      searchDisabledOnDegradedLeague: this.engine.searchDisabledOnDegradedLeague,
+      lowSuccessRateThreshold: this.engine.lowSuccessRateThreshold,
+      lowSuccessRateLeagueCap: this.engine.lowSuccessRateLeagueCap,
+      dynamicConcurrencySuccessWindow: this.engine.dynamicConcurrencySuccessWindow
+    });
   }
 
   _getAllTeamSlugs() {

--- a/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
+++ b/src/infrastructure/recon/services/ReconMatrixFlowImpl.js
@@ -5,6 +5,12 @@ const pLimit = require('p-limit');
 const { DynamicConcurrencyManager } = require('./DynamicConcurrencyManager');
 
 const DEFAULT_LEAGUE_STARTUP_STAGGER_MS = 2000;
+const DEFAULT_PROBE_TIMEOUT_MS = 20000;
+const DEFAULT_LOW_SUCCESS_RATE_THRESHOLD = 0.5;
+const DEFAULT_LOW_SUCCESS_RATE_LEAGUE_CAP = 3;
+const DEFAULT_LOW_SUCCESS_RATE_MIN_COMPLETED_LEAGUES = 2;
+const DEFAULT_TIMEOUT_DEGRADE_THRESHOLD = 2;
+const SEARCH_BLOCKING_DEGRADED_ROUTES = new Set(['results', 'fixtures']);
 
 const ALLOWED_MAPPING_METHODS = new Set([
   'exact',
@@ -59,6 +65,7 @@ const reconMatrixFlow = {
       allNonLinked = this.allNonLinked === true
     } = options;
 
+    this._resetRouteDegradeRegistry();
     const targets = await this.buildScanTargets({ season, tier, leagueIds });
     const summary = {
       success: true,
@@ -220,6 +227,48 @@ const reconMatrixFlow = {
     });
   },
 
+  _resolveLowSuccessRateGuardState(requestedLeagueConcurrency, aggregateStats = null) {
+    const normalizedConcurrency = Math.max(1, Number(requestedLeagueConcurrency) || 1);
+    const processedPending = Math.max(0, Number(aggregateStats?.processedPending || 0));
+    const linked = Math.max(0, Number(aggregateStats?.linked || 0));
+    const completedLeagues = Math.max(0, Number(aggregateStats?.completedLeagues || 0));
+    const thresholdRaw = Number(this.lowSuccessRateThreshold ?? DEFAULT_LOW_SUCCESS_RATE_THRESHOLD);
+    const threshold = Number.isFinite(thresholdRaw)
+      ? Math.min(1, Math.max(0, thresholdRaw))
+      : DEFAULT_LOW_SUCCESS_RATE_THRESHOLD;
+    const minCompletedLeagues = Math.max(
+      1,
+      Number(this.lowSuccessRateMinCompletedLeagues ?? DEFAULT_LOW_SUCCESS_RATE_MIN_COMPLETED_LEAGUES)
+        || DEFAULT_LOW_SUCCESS_RATE_MIN_COMPLETED_LEAGUES
+    );
+    const cappedConcurrency = Math.max(
+      1,
+      Math.min(
+        normalizedConcurrency,
+        Number(this.lowSuccessRateLeagueCap ?? DEFAULT_LOW_SUCCESS_RATE_LEAGUE_CAP) || DEFAULT_LOW_SUCCESS_RATE_LEAGUE_CAP
+      )
+    );
+
+    if (processedPending <= 0 || completedLeagues < minCompletedLeagues) {
+      return {
+        successRate: null,
+        active: false,
+        cap: normalizedConcurrency,
+        threshold
+      };
+    }
+
+    const successRate = linked / processedPending;
+    const active = successRate < threshold;
+
+    return {
+      successRate,
+      active,
+      cap: active ? cappedConcurrency : normalizedConcurrency,
+      threshold
+    };
+  },
+
   _getProxyPoolSnapshot() {
     if (!this.proxyRotator) {
       return null;
@@ -246,25 +295,35 @@ const reconMatrixFlow = {
 
   _applyProxyFeedbackToConcurrency(manager, requestedLeagueConcurrency, metadata = {}) {
     const snapshot = this._getProxyPoolSnapshot();
-    if (!snapshot) {
-      return null;
-    }
-
     const normalizedConcurrency = Math.max(1, Number(requestedLeagueConcurrency) || 1);
+    const successRateGuard = this._resolveLowSuccessRateGuardState(
+      normalizedConcurrency,
+      metadata.aggregateStats
+    );
+    const proxyCap = snapshot
+      ? Math.max(1, snapshot.available > 0 ? snapshot.available : 1)
+      : normalizedConcurrency;
     const nextCeiling = Math.max(
       1,
       Math.min(
         normalizedConcurrency,
-        snapshot.available > 0 ? snapshot.available : 1
+        proxyCap,
+        successRateGuard.cap
       )
     );
 
     manager.setCeiling(nextCeiling, {
-      proxyTotal: snapshot.total,
-      proxyHealthy: snapshot.healthy,
-      proxyCooling: snapshot.cooling,
-      proxyDead: snapshot.dead,
-      proxyAvailable: snapshot.available,
+      proxyTotal: snapshot?.total ?? null,
+      proxyHealthy: snapshot?.healthy ?? null,
+      proxyCooling: snapshot?.cooling ?? null,
+      proxyDead: snapshot?.dead ?? null,
+      proxyAvailable: snapshot?.available ?? null,
+      successRate: successRateGuard.successRate !== null
+        ? Number(successRateGuard.successRate.toFixed(4))
+        : null,
+      lowSuccessRateGuardActive: successRateGuard.active,
+      lowSuccessRateCap: successRateGuard.active ? successRateGuard.cap : null,
+      lowSuccessRateThreshold: successRateGuard.threshold,
       ...metadata
     });
 
@@ -276,19 +335,26 @@ const reconMatrixFlow = {
     const running = new Map();
     const adaptiveConcurrencyManager = options.adaptiveConcurrencyManager || this._createDynamicConcurrencyManager();
     const requestedLeagueConcurrency = Math.max(1, Number(options.requestedLeagueConcurrency) || 1);
+    const aggregateStats = {
+      processedPending: 0,
+      linked: 0,
+      completedLeagues: 0
+    };
     let nextIndex = 0;
 
     this._applyProxyFeedbackToConcurrency(adaptiveConcurrencyManager, requestedLeagueConcurrency, {
       phase: 'initial',
       queueRemaining: targetPendingMap.length,
-      activeLeagueWorkers: 0
+      activeLeagueWorkers: 0,
+      aggregateStats
     });
 
     while (nextIndex < targetPendingMap.length || running.size > 0) {
       this._applyProxyFeedbackToConcurrency(adaptiveConcurrencyManager, requestedLeagueConcurrency, {
         phase: 'dispatch',
         queueRemaining: Math.max(0, targetPendingMap.length - nextIndex),
-        activeLeagueWorkers: running.size
+        activeLeagueWorkers: running.size,
+        aggregateStats
       });
 
       while (
@@ -312,12 +378,24 @@ const reconMatrixFlow = {
       const { index, outcome } = await Promise.race(running.values());
       running.delete(index);
       outcomes[index] = outcome;
+      const rawOutcomePendingTotal = outcome?.result?.pendingTotal
+        ?? outcome?.pendingTotal
+        ?? targetPendingMap[index]?.pendingMatches?.length
+        ?? 0;
+      const outcomePendingTotal = Math.max(0, Number(rawOutcomePendingTotal) || 0);
+      const outcomeLinked = Math.max(0, Number(outcome?.result?.linked || 0));
+
+      aggregateStats.processedPending += outcomePendingTotal;
+      aggregateStats.linked += outcomeLinked;
+      aggregateStats.completedLeagues += 1;
 
       const proxySnapshot = this._applyProxyFeedbackToConcurrency(adaptiveConcurrencyManager, requestedLeagueConcurrency, {
         phase: 'feedback',
         queueRemaining: Math.max(0, targetPendingMap.length - nextIndex),
-        activeLeagueWorkers: running.size
+        activeLeagueWorkers: running.size,
+        aggregateStats
       });
+      const successRateGuard = this._resolveLowSuccessRateGuardState(requestedLeagueConcurrency, aggregateStats);
 
       if (outcome?.error) {
         adaptiveConcurrencyManager.recordFailure(outcome.error, {
@@ -327,7 +405,12 @@ const reconMatrixFlow = {
           proxyPort: outcome.proxyPort || null,
           activeLeagueWorkers: running.size,
           proxyAvailable: proxySnapshot?.available ?? null,
-          proxyTotal: proxySnapshot?.total ?? null
+          proxyTotal: proxySnapshot?.total ?? null,
+          successRate: successRateGuard.successRate !== null
+            ? Number(successRateGuard.successRate.toFixed(4))
+            : null,
+          lowSuccessRateGuardActive: successRateGuard.active,
+          lowSuccessRateCap: successRateGuard.active ? successRateGuard.cap : null
         });
       } else {
         adaptiveConcurrencyManager.recordSuccess({
@@ -337,7 +420,12 @@ const reconMatrixFlow = {
           proxyPort: outcome.proxyPort || null,
           activeLeagueWorkers: running.size,
           proxyAvailable: proxySnapshot?.available ?? null,
-          proxyTotal: proxySnapshot?.total ?? null
+          proxyTotal: proxySnapshot?.total ?? null,
+          successRate: successRateGuard.successRate !== null
+            ? Number(successRateGuard.successRate.toFixed(4))
+            : null,
+          lowSuccessRateGuardActive: successRateGuard.active,
+          lowSuccessRateCap: successRateGuard.active ? successRateGuard.cap : null
         });
       }
     }
@@ -417,7 +505,7 @@ const reconMatrixFlow = {
         error: error.message,
         statusCode: Number(error?.statusCode || 0) || null
       });
-      return { target, error, proxyPort };
+      return { target, error, proxyPort, pendingTotal: pendingMatches.length };
     } finally {
       await this._releaseTargetNavigator(navigatorHandle);
     }
@@ -1165,6 +1253,163 @@ const reconMatrixFlow = {
     };
   },
 
+  _resetRouteDegradeRegistry() {
+    this.routeDegradeRegistry = new Map();
+  },
+
+  _getRouteDegradeRegistry() {
+    if (!(this.routeDegradeRegistry instanceof Map)) {
+      this.routeDegradeRegistry = new Map();
+    }
+
+    return this.routeDegradeRegistry;
+  },
+
+  _buildRouteDegradeKey(target) {
+    return [
+      String(target?.leagueId ?? target?.league?.id ?? target?.league?.name ?? 'unknown'),
+      String(target?.dbSeason || target?.season || 'unknown')
+    ].join('::');
+  },
+
+  _getRouteDegradeState(target) {
+    const registry = this._getRouteDegradeRegistry();
+    const key = this._buildRouteDegradeKey(target);
+    if (!registry.has(key)) {
+      registry.set(key, {
+        degradedRoutes: new Set(),
+        timeoutStreaks: Object.create(null),
+        searchBlocked: false,
+        lastReason: null
+      });
+    }
+
+    return registry.get(key);
+  },
+
+  _resetRouteFailureStreak(target, routeKind) {
+    const state = this._getRouteDegradeState(target);
+    state.timeoutStreaks[routeKind] = 0;
+    return state;
+  },
+
+  _extractProbeFailureSignals(error) {
+    const items = [
+      error,
+      ...(Array.isArray(error?.sourceFailures) ? error.sourceFailures : [])
+    ];
+    let has503 = false;
+    let timeoutHits = 0;
+
+    for (const item of items) {
+      const statusCode = Number(item?.statusCode || item?.cause?.statusCode || 0) || null;
+      const message = String(item?.message || item?.error || '').toLowerCase();
+
+      if (
+        statusCode === 503
+        || message.includes('http_503')
+        || message.includes('503')
+        || message.includes('service unavailable')
+      ) {
+        has503 = true;
+      }
+
+      if (
+        message.includes('timeout')
+        || message.includes('timed out')
+        || message.includes('page.goto')
+        || message.includes('aborted')
+      ) {
+        timeoutHits += 1;
+      }
+    }
+
+    return {
+      has503,
+      hasTimeout: timeoutHits > 0,
+      timeoutHits
+    };
+  },
+
+  _resolveRouteProbeTimeoutMs(_routeKind, _target = null) {
+    const configuredTimeout = Math.max(
+      1,
+      Number(this.probeArchiveTimeoutMs || DEFAULT_PROBE_TIMEOUT_MS)
+    );
+    const archiveTimeout = Math.max(
+      1,
+      Number(this.archiveTimeoutMs || configuredTimeout)
+    );
+
+    return Math.min(archiveTimeout, configuredTimeout);
+  },
+
+  _recordRouteProbeFailure(target, routeKind, error, metadata = {}) {
+    const state = this._getRouteDegradeState(target);
+    const signals = this._extractProbeFailureSignals(error);
+    const timeoutThreshold = Math.max(
+      1,
+      Number(this.fastFailTimeoutStreak || DEFAULT_TIMEOUT_DEGRADE_THRESHOLD)
+    );
+
+    state.timeoutStreaks[routeKind] = signals.hasTimeout
+      ? Number(state.timeoutStreaks[routeKind] || 0) + Math.max(1, signals.timeoutHits)
+      : 0;
+
+    const shouldDegrade = signals.has503 || state.timeoutStreaks[routeKind] >= timeoutThreshold;
+    const sourceState = signals.has503
+      ? 'ROUTE_DEGRADED_503_FAST_FAIL'
+      : 'ROUTE_DEGRADED_TIMEOUT_FAST_FAIL';
+
+    if (shouldDegrade) {
+      state.degradedRoutes.add(routeKind);
+      state.searchBlocked = state.searchBlocked || SEARCH_BLOCKING_DEGRADED_ROUTES.has(routeKind);
+      state.lastReason = signals.has503 ? 'HTTP_503' : 'TIMEOUT_STREAK';
+
+      this.logger.warn('recon_route_degraded', {
+        league: target?.league?.name || null,
+        season: target?.dbSeason || null,
+        routeKind,
+        reason: state.lastReason,
+        timeoutStreak: Number(state.timeoutStreaks[routeKind] || 0),
+        timeoutThreshold,
+        timeoutMs: Number(metadata.timeoutMs || 0) || null,
+        searchBlocked: state.searchBlocked === true,
+        error: error?.message || null
+      });
+    }
+
+    return {
+      shouldDegrade,
+      searchBlocked: state.searchBlocked === true,
+      timeoutStreak: Number(state.timeoutStreaks[routeKind] || 0),
+      signals,
+      sourceState
+    };
+  },
+
+  _isSearchProbeBlocked(target) {
+    if (this.searchDisabledOnDegradedLeague !== true) {
+      return false;
+    }
+
+    const state = this._getRouteDegradeState(target);
+    return state.searchBlocked === true || state.degradedRoutes.size > 0;
+  },
+
+  _buildDegradedRouteSource(routeKind, target, sourceState, error = null, metadata = {}) {
+    this.logger.warn('recon_route_fast_fail', {
+      league: target?.league?.name || null,
+      season: target?.dbSeason || null,
+      routeKind,
+      sourceState,
+      timeoutMs: Number(metadata.timeoutMs || 0) || null,
+      searchBlocked: metadata.searchBlocked === true,
+      error: error?.message || null
+    });
+    return this._buildEmptyRouteSource(routeKind, target, sourceState);
+  },
+
   _combineCandidateRouteSources(routeSources = [], target, pendingMatches, confidenceThreshold) {
     const successfulRoutes = (Array.isArray(routeSources) ? routeSources : [])
       .filter((route) => route && typeof route === 'object');
@@ -1295,12 +1540,35 @@ const reconMatrixFlow = {
   },
 
   async _probeResultsCandidateSource(target, pendingMatches, confidenceThreshold, navigator = null) {
-    const selectedSource = await this.taskPlanner.selectCandidateSource(
-      target,
-      pendingMatches,
-      confidenceThreshold,
-      { navigator: navigator || this.navigator || null }
-    );
+    const timeoutMs = this._resolveRouteProbeTimeoutMs('results', target);
+    let selectedSource;
+    try {
+      selectedSource = await this.taskPlanner.selectCandidateSource(
+        target,
+        pendingMatches,
+        confidenceThreshold,
+        {
+          navigator: navigator || this.navigator || null,
+          timeoutMs
+        }
+      );
+      this._resetRouteFailureStreak(target, 'results');
+    } catch (error) {
+      const failure = this._recordRouteProbeFailure(target, 'results', error, { timeoutMs });
+      if (failure.shouldDegrade) {
+        return this._buildDegradedRouteSource(
+          'results',
+          target,
+          failure.sourceState,
+          error,
+          {
+            timeoutMs,
+            searchBlocked: failure.searchBlocked
+          }
+        );
+      }
+      throw error;
+    }
 
     return {
       ...selectedSource,
@@ -1316,37 +1584,57 @@ const reconMatrixFlow = {
       return null;
     }
 
-    return this._executeRouteProbeWithNavigator(
-      target,
-      navigator,
-      {
-        routeKind: 'fixtures',
-        launchBrowser: true,
-        useDedicatedNavigator: options.useDedicatedNavigator === true
-      },
-      async (activeNavigator) => {
-        const extractResult = await this._fetchCandidateRouteArchive('fixtures', fixturesUrl, target, pendingMatches, activeNavigator);
-        const candidates = this._dedupeCandidatesByIdentity(extractResult?.matches || []);
-        const seasonMirror = this._buildSeasonMirror(candidates);
-
-        return {
+    const timeoutMs = this._resolveRouteProbeTimeoutMs('fixtures', target);
+    try {
+      const routeSource = await this._executeRouteProbeWithNavigator(
+        target,
+        navigator,
+        {
           routeKind: 'fixtures',
-          source: {
-            season: target?.dbSeason || null,
-            url: fixturesUrl
-          },
-          extractResult: {
-            ...extractResult,
-            matches: candidates,
-            totalCandidates: candidates.length,
-            sourceState: extractResult?.sourceState || (candidates.length > 0 ? 'FIXTURES_SWEEP_READY' : 'SOURCE_EMPTY')
-          },
-          candidates,
-          seasonMirror,
-          sampleLinked: this._scoreCandidatePoolSample(pendingMatches, candidates, confidenceThreshold, seasonMirror)
-        };
+          launchBrowser: true,
+          useDedicatedNavigator: options.useDedicatedNavigator === true
+        },
+        async (activeNavigator) => {
+          const extractResult = await this._fetchCandidateRouteArchive('fixtures', fixturesUrl, target, pendingMatches, activeNavigator);
+          const candidates = this._dedupeCandidatesByIdentity(extractResult?.matches || []);
+          const seasonMirror = this._buildSeasonMirror(candidates);
+
+          return {
+            routeKind: 'fixtures',
+            source: {
+              season: target?.dbSeason || null,
+              url: fixturesUrl
+            },
+            extractResult: {
+              ...extractResult,
+              matches: candidates,
+              totalCandidates: candidates.length,
+              sourceState: extractResult?.sourceState || (candidates.length > 0 ? 'FIXTURES_SWEEP_READY' : 'SOURCE_EMPTY')
+            },
+            candidates,
+            seasonMirror,
+            sampleLinked: this._scoreCandidatePoolSample(pendingMatches, candidates, confidenceThreshold, seasonMirror)
+          };
+        }
+      );
+      this._resetRouteFailureStreak(target, 'fixtures');
+      return routeSource;
+    } catch (error) {
+      const failure = this._recordRouteProbeFailure(target, 'fixtures', error, { timeoutMs });
+      if (failure.shouldDegrade) {
+        return this._buildDegradedRouteSource(
+          'fixtures',
+          target,
+          failure.sourceState,
+          error,
+          {
+            timeoutMs,
+            searchBlocked: failure.searchBlocked
+          }
+        );
       }
-    );
+      throw error;
+    }
   },
 
   async _probeSearchCandidateSource(target, pendingMatches, confidenceThreshold, navigator = null, options = {}) {
@@ -1354,37 +1642,75 @@ const reconMatrixFlow = {
       return null;
     }
 
-    return this._executeRouteProbeWithNavigator(
-      target,
-      navigator,
-      {
-        routeKind: 'search',
-        launchBrowser: true,
-        useDedicatedNavigator: options.useDedicatedNavigator === true
-      },
-      async (activeNavigator) => {
-        const searchResult = await this._collectSearchCandidatesForPendingMatches(target, pendingMatches, activeNavigator);
-        const candidates = this._dedupeCandidatesByIdentity(searchResult?.matches || []);
-        const seasonMirror = this._buildSeasonMirror(candidates);
+    if (this._isSearchProbeBlocked(target)) {
+      return this._buildDegradedRouteSource(
+        'search',
+        target,
+        'ROUTE_SKIPPED_DEGRADED_LEAGUE',
+        null,
+        {
+          timeoutMs: this._resolveRouteProbeTimeoutMs('search', target),
+          searchBlocked: true
+        }
+      );
+    }
 
-        return {
+    const timeoutMs = this._resolveRouteProbeTimeoutMs('search', target);
+    try {
+      const routeSource = await this._executeRouteProbeWithNavigator(
+        target,
+        navigator,
+        {
           routeKind: 'search',
-          source: {
-            season: target?.dbSeason || null,
-            url: (searchResult?.sourceUrls || []).join(' | ')
-          },
-          extractResult: {
-            matches: candidates,
-            pagesScanned: Number(searchResult?.pagesScanned || 0),
-            totalCandidates: candidates.length,
-            sourceState: candidates.length > 0 ? 'SEARCH_SWEEP_READY' : 'SOURCE_EMPTY'
-          },
-          candidates,
-          seasonMirror,
-          sampleLinked: this._scoreCandidatePoolSample(pendingMatches, candidates, confidenceThreshold, seasonMirror)
-        };
+          launchBrowser: true,
+          useDedicatedNavigator: options.useDedicatedNavigator === true
+        },
+        async (activeNavigator) => {
+          const searchResult = await this._collectSearchCandidatesForPendingMatches(
+            target,
+            pendingMatches,
+            activeNavigator,
+            { timeoutMs }
+          );
+          const candidates = this._dedupeCandidatesByIdentity(searchResult?.matches || []);
+          const seasonMirror = this._buildSeasonMirror(candidates);
+
+          return {
+            routeKind: 'search',
+            source: {
+              season: target?.dbSeason || null,
+              url: (searchResult?.sourceUrls || []).join(' | ')
+            },
+            extractResult: {
+              matches: candidates,
+              pagesScanned: Number(searchResult?.pagesScanned || 0),
+              totalCandidates: candidates.length,
+              sourceState: candidates.length > 0 ? 'SEARCH_SWEEP_READY' : 'SOURCE_EMPTY'
+            },
+            candidates,
+            seasonMirror,
+            sampleLinked: this._scoreCandidatePoolSample(pendingMatches, candidates, confidenceThreshold, seasonMirror)
+          };
+        }
+      );
+      this._resetRouteFailureStreak(target, 'search');
+      return routeSource;
+    } catch (error) {
+      const failure = this._recordRouteProbeFailure(target, 'search', error, { timeoutMs });
+      if (failure.shouldDegrade || failure.signals.has503 || failure.signals.hasTimeout) {
+        return this._buildDegradedRouteSource(
+          'search',
+          target,
+          failure.sourceState,
+          error,
+          {
+            timeoutMs,
+            searchBlocked: true
+          }
+        );
       }
-    );
+      throw error;
+    }
   },
 
   async _executeRouteProbeWithNavigator(target, navigator, options = {}, probe) {
@@ -1420,7 +1746,7 @@ const reconMatrixFlow = {
       : `recon:${routeKind}:${target?.dbSeason || 'unknown'}`;
     const extractOptions = {
       maxPages: this.taskPlanner?.resolveArchiveMaxPages?.(target, pendingMatches) || this.archiveMaxPages || 50,
-      timeoutMs: this.archiveTimeoutMs,
+      timeoutMs: this._resolveRouteProbeTimeoutMs(routeKind, target),
       preferCurrentSeasonSource: true,
       circuitBreakerKey,
       forceDomOnly: routeKind === 'fixtures'
@@ -1437,7 +1763,7 @@ const reconMatrixFlow = {
     return { matches: [], pagesScanned: 0, totalCandidates: 0, sourceState: 'ROUTE_SKIPPED_NO_ARCHIVE_HANDLER' };
   },
 
-  async _collectSearchCandidatesForPendingMatches(target, pendingMatches, navigator) {
+  async _collectSearchCandidatesForPendingMatches(target, pendingMatches, navigator, options = {}) {
     if (!navigator || typeof navigator.navigate !== 'function' || !navigator.page) {
       return { matches: [], pagesScanned: 0, sourceUrls: [] };
     }
@@ -1459,7 +1785,7 @@ const reconMatrixFlow = {
       }
 
       sourceUrls.push(searchUrl);
-      const searchCandidates = await this._collectSearchCandidatesFromUrl(searchUrl, navigator, target);
+      const searchCandidates = await this._collectSearchCandidatesFromUrl(searchUrl, navigator, target, options);
       for (const candidate of searchCandidates) {
         const candidateKey = String(candidate?.hash || candidate?.url || '').trim();
         if (!candidateKey || seenCandidateKeys.has(candidateKey)) {
@@ -1487,8 +1813,11 @@ const reconMatrixFlow = {
     return `${this._resolveTrustedOddsPortalBaseUrl()}/search/${encodeURIComponent(slug)}/`;
   },
 
-  async _collectSearchCandidatesFromUrl(searchUrl, navigator, _target) {
-    await navigator.navigate(searchUrl, { waitUntil: 'domcontentloaded' });
+  async _collectSearchCandidatesFromUrl(searchUrl, navigator, target, options = {}) {
+    await navigator.navigate(searchUrl, {
+      waitUntil: 'domcontentloaded',
+      timeout: Number(options.timeoutMs || this._resolveRouteProbeTimeoutMs('search', target))
+    });
     if (typeof navigator.page?.waitForTimeout === 'function') {
       await navigator.page.waitForTimeout(this.pageSettleWaitMs);
     }

--- a/src/infrastructure/recon/services/ReconTaskPlannerSourceSelector.js
+++ b/src/infrastructure/recon/services/ReconTaskPlannerSourceSelector.js
@@ -98,6 +98,7 @@ const reconTaskPlannerSourceSelector = {
 
   async selectCandidateSource(target, pendingMatches, confidenceThreshold, options = {}) {
     const navigator = options.navigator || this.navigator;
+    const timeoutMs = Math.max(1, Number(options.timeoutMs || this.archiveTimeoutMs));
     if (
       !navigator ||
       (
@@ -159,7 +160,7 @@ const reconTaskPlannerSourceSelector = {
       const sourceCircuitBreakerKey = `${circuitBreakerKey}:${source.mode}:${source.season}:${sourceIndex}`;
       const extractOptions = {
         maxPages: resolvedMaxPages,
-        timeoutMs: this.archiveTimeoutMs,
+        timeoutMs,
         preferCurrentSeasonSource: this.isCurrentSeason(source.season),
         circuitBreakerKey: sourceCircuitBreakerKey,
         forcePureProtocol

--- a/tests/unit/ReconMatrixFlow.test.js
+++ b/tests/unit/ReconMatrixFlow.test.js
@@ -353,6 +353,77 @@ describe('ReconMatrixFlow', () => {
         assert.strictEqual(result.mismatched, 0);
     });
 
+    it('results 命中 503 快速熔断后应阻断 search，并把 probe timeout 压到 20 秒', async () => {
+        const target = {
+            leagueId: 1,
+            dbSeason: '2025/2026',
+            season: '2025/2026',
+            resultsUrl: 'oddsportal://results',
+            league: { id: 1, name: 'Test League' },
+        };
+        const pendingMatches = [{ match_id: 'm1', pipeline_status: 'harvested' }];
+        const flow = {
+            ...reconMatrixFlow,
+            archiveTimeoutMs: 45000,
+            probeArchiveTimeoutMs: 20000,
+            fastFailTimeoutStreak: 2,
+            searchDisabledOnDegradedLeague: true,
+            logger: { info() {}, warn() {}, error() {} },
+            taskPlanner: {
+                archiveTimeoutMs: 45000,
+                async selectCandidateSource(_target, _pending, _threshold, options = {}) {
+                    assert.strictEqual(options.timeoutMs, 20000);
+                    const error = new Error('HTTP_503');
+                    error.statusCode = 503;
+                    throw error;
+                },
+                formatSeasonForUrl: (season) => season,
+            },
+        };
+
+        const resultsSource = await flow._probeResultsCandidateSource(target, pendingMatches, 0.75);
+        const searchSource = await flow._probeSearchCandidateSource(target, pendingMatches, 0.75);
+
+        assert.strictEqual(resultsSource.extractResult.sourceState, 'ROUTE_DEGRADED_503_FAST_FAIL');
+        assert.strictEqual(searchSource.extractResult.sourceState, 'ROUTE_SKIPPED_DEGRADED_LEAGUE');
+    });
+
+    it('results 连续 timeout 两次后应把联赛标记为 DEGRADED，并禁止 search 探测', async () => {
+        const target = {
+            leagueId: 2,
+            dbSeason: '2025/2026',
+            season: '2025/2026',
+            resultsUrl: 'oddsportal://results',
+            league: { id: 2, name: 'Timeout League' },
+        };
+        const pendingMatches = [{ match_id: 'm1', pipeline_status: 'harvested' }];
+        const flow = {
+            ...reconMatrixFlow,
+            archiveTimeoutMs: 45000,
+            probeArchiveTimeoutMs: 20000,
+            fastFailTimeoutStreak: 2,
+            searchDisabledOnDegradedLeague: true,
+            logger: { info() {}, warn() {}, error() {} },
+            taskPlanner: {
+                async selectCandidateSource() {
+                    throw new Error('page.goto: Timeout 20000ms exceeded');
+                },
+                formatSeasonForUrl: (season) => season,
+            },
+        };
+
+        await assert.rejects(
+            flow._probeResultsCandidateSource(target, pendingMatches, 0.75),
+            /Timeout 20000ms exceeded/
+        );
+
+        const secondProbe = await flow._probeResultsCandidateSource(target, pendingMatches, 0.75);
+        const searchSource = await flow._probeSearchCandidateSource(target, pendingMatches, 0.75);
+
+        assert.strictEqual(secondProbe.extractResult.sourceState, 'ROUTE_DEGRADED_TIMEOUT_FAST_FAIL');
+        assert.strictEqual(searchSource.extractResult.sourceState, 'ROUTE_SKIPPED_DEGRADED_LEAGUE');
+    });
+
     it('linked 前应先把 h2h 候选洗白为 canonical URL', async () => {
         const flow = {
             ...reconMatrixFlow,
@@ -860,6 +931,90 @@ describe('ReconMatrixFlow', () => {
 
         assert.ok(postBackoffStarts.length > 0);
         assert.ok(postBackoffStarts.every(entry => entry.payload.allowedLeagueWorkers <= 2));
+    });
+
+    it('整体成功率低于 50% 时，应将 allowedLeagueWorkers 锁定在 3 个以内', async () => {
+        const events = [];
+        const preparedTargets = Array.from({ length: 10 }, (_, index) => ({
+            target: {
+                leagueId: index + 1,
+                league: { id: index + 1, name: `League-${index + 1}` },
+                dbSeason: '2025/2026',
+            },
+            pendingMatches: [{ match_id: `${index + 1}` }, { match_id: `${index + 1}-b` }],
+            desiredLimit: 2,
+        }));
+
+        const flow = {
+            ...reconMatrixFlow,
+            dynamicConcurrencyInitial: 5,
+            dynamicConcurrencySuccessWindow: 5,
+            lowSuccessRateThreshold: 0.5,
+            lowSuccessRateLeagueCap: 3,
+            defaultReconConcurrency: 10,
+            reconBatchSize: 25,
+            confidenceThreshold: 0.75,
+            logger: {
+                info(event, payload) {
+                    events.push({ level: 'info', event, payload });
+                },
+                warn(event, payload) {
+                    events.push({ level: 'warn', event, payload });
+                },
+                error(event, payload) {
+                    events.push({ level: 'error', event, payload });
+                },
+            },
+            navigatorFactory: async () => ({
+                proxyPort: 7890,
+                ownsNavigator: true,
+                navigator: {
+                    proxy: { port: 7890 },
+                    async ensureBrowserHealthy() {},
+                    async close() {},
+                },
+            }),
+            buildScanTargets: async () => preparedTargets.map(item => item.target),
+            taskPlanner: {
+                prepareReconPendingTargets: async () => preparedTargets,
+            },
+            _runReconTarget: async target => {
+                await new Promise(resolve => {
+                    setTimeout(resolve, target.league.id <= 3 ? 5 : 40);
+                });
+                return {
+                    pendingTotal: 2,
+                    linked: target.league.id === 1 ? 1 : 0,
+                    mismatched: target.league.id === 1 ? 1 : 2,
+                    sourceSeason: '2025/2026',
+                    sourceUrl: 'oddsportal://results/',
+                    candidateCount: target.league.id === 1 ? 1 : 0,
+                };
+            },
+        };
+
+        await flow.runReconMatrix({
+            season: '2025/2026',
+            concurrency: 1,
+            leagueConcurrency: 10,
+            leagueStartupStaggerMs: 0,
+            limit: 10,
+        });
+
+        const guardIndex = events.findIndex(
+            entry =>
+                entry.event === 'recon_dynamic_concurrency_adjusted'
+                && entry.payload.lowSuccessRateGuardActive === true
+                && entry.payload.lowSuccessRateCap === 3
+        );
+        assert.ok(guardIndex >= 0);
+
+        const postGuardStarts = events
+            .slice(guardIndex + 1)
+            .filter(entry => entry.event === 'recon_league_worker_start');
+
+        assert.ok(postGuardStarts.length > 0);
+        assert.ok(postGuardStarts.every(entry => entry.payload.allowedLeagueWorkers <= 3));
     });
 
     it('22-IP 绿灯数下降时应把 MatrixFlow 的联赛并发夹到可用代理数', async () => {

--- a/tests/unit/ReconScanner.Robustness.test.js
+++ b/tests/unit/ReconScanner.Robustness.test.js
@@ -599,6 +599,45 @@ describe('ReconScanner Robustness - Navigator Lifecycle', () => {
     assert.strictEqual(navigator, unhealthyNavigator);
     assert.strictEqual(launchCount, 1, '发现不健康 Navigator 后必须触发自愈');
   });
+
+  it('initialize 应为 ReconEngine 注入韧性运行时策略', async () => {
+    const engine = {
+      archiveTimeoutMs: 45000,
+      dynamicConcurrencySuccessWindow: 3,
+      logger: { info() {}, warn() {}, error() {} },
+    };
+
+    const scanner = new ReconScanner({
+      config: {
+        team_slugs: {},
+        team_mappings: {},
+        oddsportal: {},
+        recon_runtime: {
+          browser_context: {},
+          disk_sweeper: {},
+          engine: {},
+        },
+      },
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+      guardian: { async start() {}, async stop() {} },
+      repository: { async init() {}, async close() {} },
+      parser: {},
+      stitcher: {},
+      engine,
+      proxyRotator: null,
+      configManager: {},
+      diskSweeper: { async sweep() {} },
+    });
+
+    await scanner.initialize();
+
+    assert.strictEqual(engine.probeArchiveTimeoutMs, 20000);
+    assert.strictEqual(engine.fastFailTimeoutStreak, 2);
+    assert.strictEqual(engine.searchDisabledOnDegradedLeague, true);
+    assert.strictEqual(engine.lowSuccessRateThreshold, 0.5);
+    assert.strictEqual(engine.lowSuccessRateLeagueCap, 3);
+    assert.strictEqual(engine.dynamicConcurrencySuccessWindow, 5);
+  });
 });
 
 describe('ReconScanner Robustness - CLI Defaults', () => {


### PR DESCRIPTION
## Summary
- add 20s route probe timeout and fast-fail degrade flow for 503/timeout streaks
- block search on degraded leagues and clamp league concurrency when global success rate collapses
- cover 503 fast-fail, timeout degrade, and low-success-rate guard with unit tests

## Verification
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/ReconMatrixFlow.test.js tests/unit/ReconScanner.Robustness.test.js