### PR TITLE
STITCHER UPGRADE: Deploying Arbitration Strategy and Concurrency Guard

### DIFF
--- a/src/infrastructure/recon/ReconStitcher.js
+++ b/src/infrastructure/recon/ReconStitcher.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ReconDistributedLock } = require('./ReconDistributedLock');
+const { ReconArbitrationStrategy } = require('./services/ReconArbitrationStrategy');
 const { reconMatchValidator } = require('./services/ReconMatchValidator');
 const { reconStitcherPersistence } = require('./services/ReconStitcherPersistence');
 const { reconStitcherFlow } = require('./services/ReconStitcherFlow');
@@ -27,6 +28,9 @@ class ReconStitcher {
       }
     }
 
+    this.arbitrationStrategy = options.arbitrationStrategy || new ReconArbitrationStrategy({
+      logger: this.logger
+    });
     this.processedHashes = new Set();
     this.unmatchedCache = [];
   }

--- a/src/infrastructure/recon/services/ReconArbitrationStrategy.js
+++ b/src/infrastructure/recon/services/ReconArbitrationStrategy.js
@@ -1,0 +1,345 @@
+'use strict';
+
+function clampConfidence(value) {
+  return Math.max(0, Math.min(1, Number(value || 0)));
+}
+
+function roundConfidence(value) {
+  return Number(clampConfidence(value).toFixed(3));
+}
+
+function pickFirstNonEmpty(values = []) {
+  for (const value of values) {
+    const normalized = String(value || '').trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return '';
+}
+
+/**
+ * ReconArbitrationStrategy
+ *
+ * Responsibilities:
+ * 1. Absorb source noise before DB persistence.
+ * 2. Rank duplicate fixtures with kickoff-aware scoring.
+ * 3. Classify safe hash rollover vs. suspicious overwrite.
+ *
+ * High-risk area:
+ * This strategy runs immediately before match_id binding and mapping persistence.
+ * A bad decision here becomes a wrong canonical link downstream.
+ */
+class ReconArbitrationStrategy {
+  /**
+   * @param {Object} [options]
+   * @param {number} [options.teamSimilarityThreshold=0.75]
+   * @param {number} [options.kickoffToleranceMs=300000]
+   * @param {number} [options.kickoffSoftWindowMs=7200000]
+   * @param {number} [options.kickoffHardRejectMs=43200000]
+   * @param {Object} [options.logger]
+   */
+  constructor(options = {}) {
+    this.logger = options.logger || { info() {}, warn() {}, error() {} };
+    this.teamSimilarityThreshold = Number.isFinite(Number(options.teamSimilarityThreshold))
+      ? Number(options.teamSimilarityThreshold)
+      : 0.75;
+    this.kickoffToleranceMs = Number.isFinite(Number(options.kickoffToleranceMs))
+      ? Number(options.kickoffToleranceMs)
+      : 5 * 60 * 1000;
+    this.kickoffSoftWindowMs = Number.isFinite(Number(options.kickoffSoftWindowMs))
+      ? Number(options.kickoffSoftWindowMs)
+      : 2 * 60 * 60 * 1000;
+    this.kickoffHardRejectMs = Number.isFinite(Number(options.kickoffHardRejectMs))
+      ? Number(options.kickoffHardRejectMs)
+      : 12 * 60 * 60 * 1000;
+  }
+
+  /**
+   * @param {string|Date|null} value
+   * @returns {number|null}
+   */
+  toTimestamp(value) {
+    const timestamp = new Date(value || '').getTime();
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+
+  /**
+   * @param {string|Date|null} sourceDate
+   * @param {string|Date|null} candidateDate
+   * @returns {{known: boolean, diffMs: number|null, withinTolerance: boolean, withinSoftWindow: boolean, hardReject: boolean}}
+   */
+  evaluateKickoffDelta(sourceDate, candidateDate) {
+    const sourceTs = this.toTimestamp(sourceDate);
+    const candidateTs = this.toTimestamp(candidateDate);
+
+    if (sourceTs === null || candidateTs === null) {
+      return {
+        known: false,
+        diffMs: null,
+        withinTolerance: false,
+        withinSoftWindow: false,
+        hardReject: false
+      };
+    }
+
+    const diffMs = Math.abs(sourceTs - candidateTs);
+    return {
+      known: true,
+      diffMs,
+      withinTolerance: diffMs <= this.kickoffToleranceMs,
+      withinSoftWindow: diffMs <= this.kickoffSoftWindowMs,
+      hardReject: diffMs > this.kickoffHardRejectMs
+    };
+  }
+
+  /**
+   * @param {{known: boolean, withinTolerance: boolean, withinSoftWindow: boolean, diffMs: number|null}} kickoff
+   * @returns {number|null}
+   */
+  resolveKickoffScore(kickoff) {
+    if (!kickoff.known) {
+      return null;
+    }
+
+    if (kickoff.withinTolerance) {
+      return 1;
+    }
+
+    if (kickoff.withinSoftWindow) {
+      return 0.92;
+    }
+
+    return 0.45;
+  }
+
+  /**
+   * @param {string} fallbackMethod
+   * @param {{known: boolean, withinTolerance: boolean, withinSoftWindow: boolean, diffMs: number|null}} kickoff
+   * @returns {string}
+   */
+  resolveKickoffMethod(fallbackMethod, kickoff) {
+    if (kickoff.known && kickoff.withinTolerance && kickoff.diffMs > 0) {
+      return `${fallbackMethod}_kickoff_tolerance`;
+    }
+
+    if (kickoff.known && kickoff.withinSoftWindow && kickoff.diffMs > this.kickoffToleranceMs) {
+      return `${fallbackMethod}_kickoff_window`;
+    }
+
+    return fallbackMethod;
+  }
+
+  /**
+   * @param {Object} input
+   * @param {Object} [input.match]
+   * @param {Object} [input.leagueConfig]
+   * @param {Object|null} [input.existingMapping]
+   * @returns {string}
+   */
+  resolveLeagueName({ match = {}, leagueConfig = {}, existingMapping = null }) {
+    return pickFirstNonEmpty([
+      leagueConfig?.name,
+      match?.leagueName,
+      match?.league_name,
+      existingMapping?.league_name,
+      'Unknown League'
+    ]);
+  }
+
+  /**
+   * @param {Object} input
+   * @param {Object} input.sourceMatch
+   * @param {Object} input.candidateMatch
+   * @param {string} input.homeTeam
+   * @param {string} input.awayTeam
+   * @param {Function} input.similarityFn
+   * @param {string} [input.fallbackMethod='exact']
+   * @returns {Object|null}
+   */
+  scoreCandidateMatch({
+    sourceMatch,
+    candidateMatch,
+    homeTeam,
+    awayTeam,
+    similarityFn,
+    fallbackMethod = 'exact'
+  }) {
+    const directHome = similarityFn(homeTeam, candidateMatch.home_team);
+    const directAway = similarityFn(awayTeam, candidateMatch.away_team);
+    const reverseHome = similarityFn(homeTeam, candidateMatch.away_team);
+    const reverseAway = similarityFn(awayTeam, candidateMatch.home_team);
+
+    const directScore = (directHome + directAway) / 2;
+    const reverseScore = (reverseHome + reverseAway) / 2;
+    const orientationScore = Math.max(directScore, reverseScore);
+
+    if (orientationScore < this.teamSimilarityThreshold) {
+      return null;
+    }
+
+    const kickoff = this.evaluateKickoffDelta(
+      sourceMatch?.matchDate || sourceMatch?.date || sourceMatch?.match_date,
+      candidateMatch?.match_date
+    );
+
+    if (kickoff.hardReject) {
+      return null;
+    }
+
+    const kickoffScore = this.resolveKickoffScore(kickoff);
+
+    const score = kickoffScore === null
+      ? orientationScore
+      : ((orientationScore * 0.8) + (kickoffScore * 0.2));
+    const method = this.resolveKickoffMethod(fallbackMethod, kickoff);
+
+    return {
+      matchId: candidateMatch.match_id,
+      dbHome: candidateMatch.home_team,
+      dbAway: candidateMatch.away_team,
+      matchDate: candidateMatch.match_date || null,
+      confidence: roundConfidence(score),
+      method,
+      kickoffDeltaMs: kickoff.diffMs,
+      orientationScore: roundConfidence(orientationScore)
+    };
+  }
+
+  /**
+   * @param {Object} input
+   * @param {Object} input.sourceMatch
+   * @param {Object[]} input.candidates
+   * @param {string} input.homeTeam
+   * @param {string} input.awayTeam
+   * @param {Function} input.similarityFn
+   * @param {string} [input.fallbackMethod='exact']
+   * @returns {Object|null}
+   */
+  chooseBestMatchCandidate({
+    sourceMatch = {},
+    candidates = [],
+    homeTeam,
+    awayTeam,
+    similarityFn,
+    fallbackMethod = 'exact'
+  }) {
+    const ranked = candidates
+      .map((candidateMatch) => this.scoreCandidateMatch({
+        sourceMatch,
+        candidateMatch,
+        homeTeam,
+        awayTeam,
+        similarityFn,
+        fallbackMethod
+      }))
+      .filter(Boolean)
+      .sort((left, right) => {
+        if (right.confidence !== left.confidence) {
+          return right.confidence - left.confidence;
+        }
+
+        const leftKickoff = Number.isFinite(left.kickoffDeltaMs) ? left.kickoffDeltaMs : Number.MAX_SAFE_INTEGER;
+        const rightKickoff = Number.isFinite(right.kickoffDeltaMs) ? right.kickoffDeltaMs : Number.MAX_SAFE_INTEGER;
+        if (leftKickoff !== rightKickoff) {
+          return leftKickoff - rightKickoff;
+        }
+
+        return String(left.matchId).localeCompare(String(right.matchId));
+      });
+
+    if (ranked.length === 0) {
+      return null;
+    }
+
+    const sourceHasKickoff = this.toTimestamp(
+      sourceMatch?.matchDate || sourceMatch?.date || sourceMatch?.match_date
+    ) !== null;
+    if (!sourceHasKickoff && ranked.length > 1) {
+      const best = ranked[0];
+      const runnerUp = ranked[1];
+      if (Math.abs(best.confidence - runnerUp.confidence) < 0.02) {
+        this.logger.warn('stitch_candidate_ambiguous_without_kickoff', {
+          bestMatchId: String(best.matchId),
+          runnerUpMatchId: String(runnerUp.matchId),
+          bestConfidence: best.confidence,
+          runnerUpConfidence: runnerUp.confidence
+        });
+        return null;
+      }
+    }
+
+    return ranked[0];
+  }
+
+  /**
+   * @param {Object} match
+   * @param {Object} leagueConfig
+   * @returns {string[]}
+   */
+  collectDegradedFields(match, leagueConfig) {
+    const degradedFields = [];
+
+    if (!String(leagueConfig?.name || '').trim()) {
+      degradedFields.push('league_name');
+    }
+    if (this.toTimestamp(match?.matchDate || match?.date || match?.match_date) === null) {
+      degradedFields.push('match_date');
+    }
+
+    return degradedFields;
+  }
+
+  /**
+   * @param {Object} existingMapping
+   * @param {Object} match
+   * @returns {{changed: boolean, previousHash: string|null, incomingHash: string|null}}
+   */
+  buildHashLifecycle(existingMapping, match) {
+    return {
+      changed: Boolean(
+        existingMapping?.oddsportal_hash
+        && match?.hash
+        && String(existingMapping.oddsportal_hash) !== String(match.hash)
+      ),
+      previousHash: existingMapping?.oddsportal_hash ? String(existingMapping.oddsportal_hash) : null,
+      incomingHash: match?.hash ? String(match.hash) : null
+    };
+  }
+
+  /**
+   * @param {Object} input
+   * @param {Object} input.match
+   * @param {Object} input.matchInfo
+   * @param {Object} input.leagueConfig
+   * @param {Object|null} input.existingMapping
+   * @returns {{leagueName: string, mappingMethod: string, matchConfidence: number, degradedFields: string[], hashLifecycle: Object, kickoffDeltaMs: number|null}}
+   */
+  buildMappingDecision({ match = {}, matchInfo = {}, leagueConfig = {}, existingMapping = null }) {
+    const leagueName = this.resolveLeagueName({ match, leagueConfig, existingMapping });
+    const degradedFields = this.collectDegradedFields(match, leagueConfig);
+    const hashLifecycle = this.buildHashLifecycle(existingMapping, match);
+    const kickoff = this.evaluateKickoffDelta(
+      match?.matchDate || match?.date || match?.match_date,
+      matchInfo?.matchDate || matchInfo?.match_date
+    );
+
+    return {
+      leagueName,
+      mappingMethod: hashLifecycle.changed
+        ? 'sequential_hash_rollover'
+        : String(matchInfo.method || 'exact'),
+      matchConfidence: roundConfidence(
+        Number.isFinite(Number(matchInfo.confidence))
+          ? Number(matchInfo.confidence)
+          : 0.75
+      ),
+      degradedFields,
+      hashLifecycle,
+      kickoffDeltaMs: kickoff.diffMs
+    };
+  }
+}
+
+module.exports = { ReconArbitrationStrategy };

--- a/src/infrastructure/recon/services/ReconStitcherFlow.js
+++ b/src/infrastructure/recon/services/ReconStitcherFlow.js
@@ -6,10 +6,23 @@ const { RECON_CONFIG } = require('./ReconServiceConfig');
 const BASE_URL = RECON_CONFIG.oddsportal.base_url;
 
 const reconStitcherFlow = {
+  /**
+   * Run the legacy stitcher over a page candidate set.
+   *
+   * High-risk area:
+   * This method orchestrates all fallback passes. If counters drift here, the
+   * follow-up set-closure and sniper phases receive corrupted unmatched state.
+   *
+   * @param {Object[]} matches
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @returns {Promise<Object>}
+   */
   async stitch(matches, season, leagueConfig) {
+    const dbSeason = this.formatSeasonForDb(season);
     this.logger.info('stitch_start', {
       matchCount: matches.length,
-      season,
+      season: dbSeason,
       league: leagueConfig.name
     });
 
@@ -19,7 +32,7 @@ const reconStitcherFlow = {
     this.unmatchedCache = [];
 
     for (const match of matches) {
-      const result = await this.stitchSingle(match, season, leagueConfig);
+      const result = await this.stitchSingle(match, dbSeason, leagueConfig);
       if (result.status === 'inserted') inserted++;
       else if (result.status === 'skipped') skipped++;
       else {
@@ -33,7 +46,7 @@ const reconStitcherFlow = {
         unmatchedCount: this.unmatchedCache.length
       });
 
-      const closureResult = await this.performSetClosure(season, leagueConfig);
+      const closureResult = await this.performSetClosure(dbSeason, leagueConfig);
       inserted += closureResult.inserted;
       unmatched -= closureResult.inserted;
     }
@@ -41,7 +54,7 @@ const reconStitcherFlow = {
     if (this.unmatchedCache.length > 0) {
       this.logger.info('starting_sniper_fill', { remaining: this.unmatchedCache.length });
 
-      const sniperResult = await this.sniperFill(season, leagueConfig);
+      const sniperResult = await this.sniperFill(dbSeason, leagueConfig);
       inserted += sniperResult.inserted;
       unmatched -= sniperResult.inserted;
     }
@@ -51,7 +64,7 @@ const reconStitcherFlow = {
       : '0%';
 
     this.logger.info('stitch_complete', {
-      season,
+      season: dbSeason,
       league: leagueConfig.name,
       inserted,
       skipped,
@@ -68,71 +81,111 @@ const reconStitcherFlow = {
     };
   },
 
+  /**
+   * Stitch a single source match into one canonical match_id.
+   *
+   * High-risk area:
+   * This is the only place where source parsing, idempotency, kickoff-aware DB
+   * selection and persistence all meet. A silent fallback here causes wrong links.
+   *
+   * @param {Object} match
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @returns {Promise<Object>}
+   */
   async stitchSingle(match, season, leagueConfig) {
-    if (match.hash && this.processedHashes.has(match.hash)) {
-      return { status: 'skipped', details: { reason: 'idempotent_cache' } };
+    const dbSeason = this.formatSeasonForDb(season);
+    const lock = await this.acquireHashGuard(match?.hash, {
+      leagueName: leagueConfig?.name,
+      season: dbSeason
+    });
+    if (lock?.contended) {
+      return { status: 'skipped', details: { reason: 'lock_contended' } };
     }
 
-    const existing = await this.checkExistingMapping(match.hash, season);
-    if (existing) {
-      return { status: 'skipped', details: { reason: 'already_exists' } };
-    }
-
-    let teams = null;
-
-    if (this.parser) {
-      teams = this.parser.extractTeamsFromSlug(match.slug);
-    }
-
-    if ((!teams || teams.awayTeam === 'Unknown') && match.rawText) {
-      const textTeams = this.extractTeamsFromText(match.rawText);
-      if (textTeams) teams = textTeams;
-    }
-
-    if (teams && teams.homeTeam !== 'Unknown' && teams.awayTeam === 'Unknown') {
-      const dateMatch = await this.findMatchByHomeAndDate(
-        teams.homeTeam, match.date, season, leagueConfig.name
-      );
-      if (dateMatch) {
-        teams.awayTeam = dateMatch.awayTeam;
-      }
-    }
-
-    if (!teams || teams.homeTeam === 'Unknown' || teams.awayTeam === 'Unknown') {
-      return { status: 'unmatched', details: { reason: 'parse_failed', teams } };
-    }
-
-    const matchInfo = await this.findMatchInDb(teams.homeTeam, teams.awayTeam, season);
-
-    if (!matchInfo) {
-      return { status: 'unmatched', details: { reason: 'db_not_found', teams } };
-    }
-
-    let result;
     try {
-      result = await this.saveMapping(match, teams, matchInfo, season, leagueConfig);
-    } catch (error) {
-      if (error.code === 'ORIENTATION_UNCERTAIN') {
-        this.logger.warn('orientation_uncertain', {
-          hash: match.hash,
-          season,
-          league: leagueConfig.name,
-          teams
-        });
-        return { status: 'unmatched', details: { reason: 'orientation_uncertain', teams } };
+      if (match.hash && this.processedHashes.has(match.hash)) {
+        return { status: 'skipped', details: { reason: 'idempotent_cache' } };
       }
 
-      throw error;
-    }
+      const existing = await this.checkExistingMapping(match.hash, dbSeason);
+      if (existing) {
+        return { status: 'skipped', details: { reason: 'already_exists' } };
+      }
 
-    if (result.success) {
-      this.processedHashes.add(match.hash);
-      return { status: 'inserted', details: { matchId: result.matchId } };
-    }
+      let teams = null;
 
-    return { status: 'skipped', details: { reason: 'save_failed' } };
+      if (this.parser) {
+        teams = this.parser.extractTeamsFromSlug(match.slug);
+      }
+
+      if ((!teams || teams.awayTeam === 'Unknown') && match.rawText) {
+        const textTeams = this.extractTeamsFromText(match.rawText);
+        if (textTeams) teams = textTeams;
+      }
+
+      if (teams && teams.homeTeam !== 'Unknown' && teams.awayTeam === 'Unknown') {
+        const dateMatch = await this.findMatchByHomeAndDate(
+          teams.homeTeam,
+          match.date || match.matchDate || match.match_date || null,
+          dbSeason,
+          leagueConfig.name
+        );
+        if (dateMatch) {
+          teams.awayTeam = dateMatch.awayTeam;
+        }
+      }
+
+      if (!teams || teams.homeTeam === 'Unknown' || teams.awayTeam === 'Unknown') {
+        return { status: 'unmatched', details: { reason: 'parse_failed', teams } };
+      }
+
+      const matchInfo = await this.findMatchInDb(teams.homeTeam, teams.awayTeam, dbSeason, {
+        match: {
+          ...match,
+          matchDate: match.date || match.matchDate || match.match_date || null
+        }
+      });
+
+      if (!matchInfo) {
+        return { status: 'unmatched', details: { reason: 'db_not_found', teams } };
+      }
+
+      let result;
+      try {
+        result = await this.saveMapping(match, teams, matchInfo, dbSeason, leagueConfig);
+      } catch (error) {
+        if (error.code === 'ORIENTATION_UNCERTAIN') {
+          this.logger.warn('orientation_uncertain', {
+            hash: match.hash,
+            season: dbSeason,
+            league: leagueConfig.name,
+            teams
+          });
+          return { status: 'unmatched', details: { reason: 'orientation_uncertain', teams } };
+        }
+
+        throw error;
+      }
+
+      if (result.success) {
+        this.processedHashes.add(match.hash);
+        return { status: 'inserted', details: { matchId: result.matchId } };
+      }
+
+      return { status: 'skipped', details: { reason: 'save_failed' } };
+    } finally {
+      await this.releaseHashGuard(lock, match?.hash);
+    }
   },
 
+  /**
+   * Secondary pass that reconciles page leftovers with the DB unmatched set.
+   *
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @returns {Promise<{inserted: number}>}
+   */
   async performSetClosure(season, leagueConfig) {
     let inserted = 0;
 
@@ -180,7 +233,10 @@ const reconStitcherFlow = {
             const matchInfo = {
               matchId: dbMatch.match_id,
               confidence: 0.75,
-              method: 'set_closure'
+              method: 'set_closure',
+              dbHome: dbMatch.home_team,
+              dbAway: dbMatch.away_team,
+              matchDate: dbMatch.match_date || null
             };
 
             const result = await this.saveMapping(match, teams, matchInfo, season, leagueConfig);
@@ -211,6 +267,13 @@ const reconStitcherFlow = {
     return { inserted };
   },
 
+  /**
+   * Placeholder for search-based recovery of still-unmatched fixtures.
+   *
+   * @param {string} _season
+   * @param {Object} _leagueConfig
+   * @returns {Promise<{inserted: number}>}
+   */
   async sniperFill(_season, _leagueConfig) {
     const inserted = 0;
 
@@ -226,6 +289,19 @@ const reconStitcherFlow = {
     return { inserted };
   },
 
+  /**
+   * Hash-oriented fast path for already-resolved web matches.
+   *
+   * High-risk area:
+   * The method name promises locking. Without a real guard this path degenerates
+   * into concurrent upsert contention, so each hash now attempts row-level gating.
+   *
+   * @param {Object[]} interceptedMatches
+   * @param {Object[]} l1Matches
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @returns {Promise<{inserted: number, skipped: number, unmatched: number}>}
+   */
   async stitchWithHashLock(interceptedMatches, l1Matches, season, leagueConfig) {
     this.logger.info('hash_lock_start', {
       intercepted: interceptedMatches.length,
@@ -244,6 +320,15 @@ const reconStitcherFlow = {
     }
 
     for (const rawMatch of interceptedMatches) {
+      const lock = await this.acquireHashGuard(rawMatch?.hash, {
+        leagueName: leagueConfig?.name,
+        season: dbSeason
+      });
+      if (lock?.contended) {
+        skipped++;
+        continue;
+      }
+
       try {
         const match = this._resolveWebMatchTeams(rawMatch, l1Matches);
         if (match.hash && this.processedHashes.has(match.hash)) {
@@ -251,7 +336,7 @@ const reconStitcherFlow = {
           continue;
         }
 
-        const existing = await this.checkExistingMapping(match.hash, season);
+        const existing = await this.checkExistingMapping(match.hash, dbSeason);
         if (existing) {
           this.processedHashes.add(match.hash);
           skipped++;
@@ -315,12 +400,23 @@ const reconStitcherFlow = {
       } catch (error) {
         this.logger.error('hash_lock_error', { hash: rawMatch?.hash, error: error.message });
         unmatched++;
+      } finally {
+        await this.releaseHashGuard(lock, rawMatch?.hash);
       }
     }
 
     return { inserted, skipped, unmatched };
   },
 
+  /**
+   * Cardinality-based reconciliation fallback for near-complete sets.
+   *
+   * @param {Object[]} webMatches
+   * @param {Object[]} l1Matches
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @returns {Promise<{inserted: number, unmatched: number}>}
+   */
   async setReconciliation(webMatches, l1Matches, season, leagueConfig) {
     this.logger.info('set_reconciliation_start', {
       webCount: webMatches.length,
@@ -329,6 +425,7 @@ const reconStitcherFlow = {
 
     let inserted = 0;
     let unmatched = 0;
+    const dbSeason = this.formatSeasonForDb(season);
 
     const pendingWeb = webMatches.filter((match) => !this.processedHashes.has(match.hash));
     const pendingL1 = l1Matches.filter((match) => !this.processedHashes.has(match.match_id));
@@ -373,7 +470,7 @@ const reconStitcherFlow = {
               match_id: bestMatch.match_id,
               oddsportal_hash: webMatch.hash,
               full_url: webMatch.url,
-              season: season.replace('-', '/'),
+              season: dbSeason,
               league_name: leagueConfig.name,
               home_team: bestMatch.home_team,
               away_team: bestMatch.away_team,
@@ -416,6 +513,54 @@ const reconStitcherFlow = {
     }
 
     return { inserted, unmatched };
+  },
+
+  /**
+   * Acquire a best-effort per-hash distributed guard.
+   *
+   * @param {string|null} hash
+   * @param {Object} context
+   * @returns {Promise<{lock: Object|null, contended: boolean}>}
+   */
+  async acquireHashGuard(hash, context = {}) {
+    if (!hash || !this.enableLocking || !this.lockManager?.acquireRowLock) {
+      return { lock: null, contended: false };
+    }
+
+    try {
+      const lock = await this.lockManager.acquireRowLock(hash);
+      return { lock, contended: false };
+    } catch (error) {
+      this.logger.warn('stitch_hash_lock_contended', {
+        hash,
+        season: context.season || null,
+        league: context.leagueName || null,
+        error: error.message
+      });
+      return { lock: null, contended: true };
+    }
+  },
+
+  /**
+   * Release the distributed guard acquired for a hash.
+   *
+   * @param {{lock: Object|null, contended: boolean}|null} guard
+   * @param {string|null} hash
+   * @returns {Promise<void>}
+   */
+  async releaseHashGuard(guard, hash) {
+    if (!guard?.lock?.release) {
+      return;
+    }
+
+    try {
+      await guard.lock.release();
+    } catch (error) {
+      this.logger.warn('stitch_hash_lock_release_failed', {
+        hash: hash || null,
+        error: error.message
+      });
+    }
   }
 };
 

--- a/src/infrastructure/recon/services/ReconStitcherPersistence.js
+++ b/src/infrastructure/recon/services/ReconStitcherPersistence.js
@@ -1,8 +1,20 @@
 'use strict';
 
 const reconStitcherPersistence = {
+  /**
+   * Fetch unmatched L1 fixtures for the target league/season.
+   *
+   * High-risk area:
+   * This method defines the set-closure search space. A wrong season format here
+   * silently removes valid reconciliation candidates.
+   *
+   * @param {string} season
+   * @param {string} leagueName
+   * @returns {Promise<Object[]>}
+   */
   async getDbUnstitchedMatches(season, leagueName) {
     try {
+      const dbSeason = this.formatSeasonForDb(season);
       const client = await this.repository.dbPool.connect();
       try {
         const query = `
@@ -18,7 +30,7 @@ const reconStitcherPersistence = {
           ORDER BY m.match_date;
         `;
 
-        const result = await client.query(query, [leagueName, season]);
+        const result = await client.query(query, [leagueName, dbSeason]);
         return result.rows;
       } finally {
         client.release();
@@ -29,6 +41,20 @@ const reconStitcherPersistence = {
     }
   },
 
+  /**
+   * Persist a stitched mapping after orientation and arbitration checks.
+   *
+   * High-risk area:
+   * This is the last write gate before `matches_oddsportal_mapping`. League/name
+   * degradation and hash rollover classification both happen here.
+   *
+   * @param {Object} match
+   * @param {{homeTeam: string, awayTeam: string}} teams
+   * @param {Object} matchInfo
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @returns {Promise<Object>}
+   */
   async saveMapping(match, teams, matchInfo, season, leagueConfig) {
     const l1HomeTeam = matchInfo.dbHome || teams.homeTeam;
     const l1AwayTeam = matchInfo.dbAway || teams.awayTeam;
@@ -45,17 +71,52 @@ const reconStitcherPersistence = {
       throw error;
     }
 
+    const dbSeason = this.formatSeasonForDb(season);
+    const existingMapping = await this.findExistingMappingForMatch(matchInfo.matchId, dbSeason);
+    const decision = this.arbitrationStrategy
+      ? this.arbitrationStrategy.buildMappingDecision({
+        match,
+        matchInfo,
+        leagueConfig,
+        existingMapping
+      })
+      : {
+        leagueName: leagueConfig?.name,
+        mappingMethod: matchInfo.method || 'exact',
+        matchConfidence: matchInfo.confidence || 0.75,
+        degradedFields: [],
+        hashLifecycle: { changed: false }
+      };
+
+    if (decision.hashLifecycle?.changed) {
+      this.logger.warn('stitch_hash_rollover_detected', {
+        matchId: String(matchInfo.matchId),
+        previousHash: decision.hashLifecycle.previousHash,
+        incomingHash: decision.hashLifecycle.incomingHash,
+        season: dbSeason
+      });
+    }
+
+    if (decision.degradedFields?.length > 0) {
+      this.logger.warn('stitch_field_degradation_applied', {
+        matchId: String(matchInfo.matchId),
+        hash: match?.hash || null,
+        degradedFields: decision.degradedFields,
+        leagueName: decision.leagueName
+      });
+    }
+
     const mappingData = {
       match_id: matchInfo.matchId,
       oddsportal_hash: match.hash,
       full_url: match.url,
-      season: season.replace('-', '/'),
-      league_name: leagueConfig.name,
+      season: dbSeason,
+      league_name: decision.leagueName,
       home_team: l1HomeTeam,
       away_team: l1AwayTeam,
       is_reversed: orientation.isReversed,
-      match_confidence: matchInfo.confidence || 0.75,
-      mapping_method: matchInfo.method || 'exact',
+      match_confidence: decision.matchConfidence,
+      mapping_method: decision.mappingMethod,
       status: 'pending'
     };
 
@@ -64,65 +125,141 @@ const reconStitcherPersistence = {
     });
   },
 
-  async findMatchInDb(homeTeam, awayTeam, season) {
-    const matchInfo = await this.repository.findMatchByTeams(homeTeam, awayTeam, season);
-    if (matchInfo) return matchInfo;
+  /**
+   * Find the most plausible L1 match for parsed web teams.
+   *
+   * High-risk area:
+   * Team equality is not sufficient in cup/league double-headers. Kickoff-aware
+   * arbitration is mandatory when duplicate team pairs exist.
+   *
+   * @param {string} homeTeam
+   * @param {string} awayTeam
+   * @param {string} season
+   * @param {Object} [arbitrationContext]
+   * @returns {Promise<Object|null>}
+   */
+  async findMatchInDb(homeTeam, awayTeam, season, arbitrationContext = {}) {
+    const dbSeason = this.formatSeasonForDb(season);
+    const sourceMatch = arbitrationContext.match || {
+      matchDate: arbitrationContext.matchDate || null
+    };
+    const exactCandidates = await this.findMatchesByTeams(homeTeam, awayTeam, dbSeason);
+    if (Array.isArray(exactCandidates) && exactCandidates.length > 0) {
+      const exactMatch = this.arbitrationStrategy
+        ? this.arbitrationStrategy.chooseBestMatchCandidate({
+          sourceMatch,
+          candidates: exactCandidates,
+          homeTeam,
+          awayTeam,
+          similarityFn: (left, right) => this._calculateTeamSimilarity(left, right),
+          fallbackMethod: 'exact'
+        })
+        : null;
+      if (exactMatch) {
+        return exactMatch;
+      }
+    }
 
     if (this.parser) {
-      return this.findWithFuzzyMatch(homeTeam, awayTeam, season);
+      return this.findWithFuzzyMatch(homeTeam, awayTeam, dbSeason, arbitrationContext);
     }
 
     return null;
   },
 
-  async findWithFuzzyMatch(homeTeam, awayTeam, season) {
+  /**
+   * Fuzzy-match source teams against the full season candidate pool.
+   *
+   * @param {string} homeTeam
+   * @param {string} awayTeam
+   * @param {string} season
+   * @param {Object} [arbitrationContext]
+   * @returns {Promise<Object|null>}
+   */
+  async findWithFuzzyMatch(homeTeam, awayTeam, season, arbitrationContext = {}) {
     const candidates = await this.repository.findMatchesBySeason(season);
     if (!candidates || candidates.length === 0) return null;
 
-    const homeCandidates = candidates.map((match) => match.home_team);
-    const homeMatch = this.parser.findBestMatch(homeTeam, homeCandidates, 0.75);
-
-    if (!homeMatch) return null;
-
-    const awayCandidates = candidates.map((match) => match.away_team);
-    const awayMatch = this.parser.findBestMatch(awayTeam, awayCandidates, 0.75);
-
-    if (!awayMatch) return null;
-
-    const matchedGame = candidates.find((match) =>
-      match.home_team === homeMatch.team && match.away_team === awayMatch.team
-    );
-
-    if (matchedGame) {
-      return {
-        matchId: matchedGame.match_id,
-        confidence: (homeMatch.confidence + awayMatch.confidence) / 2,
-        method: 'fuzzy'
-      };
+    if (this.arbitrationStrategy) {
+      return this.arbitrationStrategy.chooseBestMatchCandidate({
+        sourceMatch: arbitrationContext.match || {
+          matchDate: arbitrationContext.matchDate || null
+        },
+        candidates,
+        homeTeam,
+        awayTeam,
+        similarityFn: (left, right) => this._calculateTeamSimilarity(left, right),
+        fallbackMethod: 'fuzzy'
+      });
     }
 
     return null;
   },
 
-  async findMatchByHomeAndDate(homeTeam, _dateStr, season, _leagueName) {
+  /**
+   * Recover the away team when only the home side is reliably parsed.
+   *
+   * @param {string} homeTeam
+   * @param {string|null} dateStr
+   * @param {string} season
+   * @param {string} _leagueName
+   * @returns {Promise<Object|null>}
+   */
+  async findMatchByHomeAndDate(homeTeam, dateStr, season, _leagueName) {
     if (!this.repository.findMatchesBySeason) return null;
 
     try {
-      const candidates = await this.repository.findMatchesBySeason(season);
+      const dbSeason = this.formatSeasonForDb(season);
+      const candidates = await this.repository.findMatchesBySeason(dbSeason);
       if (!candidates) return null;
 
-      const homeMatches = candidates.filter((match) => {
-        const similarity = this.parser
-          ? this.parser.calculateSimilarity(match.home_team, homeTeam)
-          : this.simpleSimilarity(match.home_team, homeTeam);
-        return similarity > 0.75;
-      });
+      const sourceTs = this.arbitrationStrategy?.toTimestamp(dateStr) ?? null;
+      const homeMatches = candidates
+        .map((match) => {
+          const similarity = this.parser
+            ? this.parser.calculateSimilarity(match.home_team, homeTeam)
+            : this.simpleSimilarity(match.home_team, homeTeam);
+          const kickoff = this.arbitrationStrategy
+            ? this.arbitrationStrategy.evaluateKickoffDelta(dateStr, match.match_date)
+            : {
+              known: false,
+              diffMs: null,
+              hardReject: false
+            };
 
-      if (homeMatches.length === 1) {
+          return {
+            match,
+            similarity,
+            kickoff
+          };
+        })
+        .filter((entry) => entry.similarity > 0.75 && !entry.kickoff.hardReject)
+        .sort((left, right) => {
+          const leftKickoff = Number.isFinite(left.kickoff.diffMs) ? left.kickoff.diffMs : Number.MAX_SAFE_INTEGER;
+          const rightKickoff = Number.isFinite(right.kickoff.diffMs) ? right.kickoff.diffMs : Number.MAX_SAFE_INTEGER;
+          if (leftKickoff !== rightKickoff) {
+            return leftKickoff - rightKickoff;
+          }
+
+          if (right.similarity !== left.similarity) {
+            return right.similarity - left.similarity;
+          }
+
+          return String(left.match.match_id).localeCompare(String(right.match.match_id));
+        });
+
+      if (!sourceTs && homeMatches.length !== 1) {
+        return null;
+      }
+
+      if (homeMatches.length >= 1) {
+        const bestMatch = homeMatches[0].match;
         return {
-          matchId: homeMatches[0].match_id,
-          awayTeam: homeMatches[0].away_team,
-          confidence: 0.85
+          matchId: bestMatch.match_id,
+          awayTeam: bestMatch.away_team,
+          confidence: Number((homeMatches[0].similarity * 0.9).toFixed(3)),
+          matchDate: bestMatch.match_date || null,
+          method: 'home_date_fill'
         };
       }
 
@@ -133,14 +270,142 @@ const reconStitcherPersistence = {
     }
   },
 
+  /**
+   * Check whether the incoming season/hash already exists.
+   *
+   * @param {string} hash
+   * @param {string} season
+   * @returns {Promise<Object|null>}
+   */
   async checkExistingMapping(hash, season) {
     try {
-      if (this.repository.findMappingByHash) {
-        return await this.repository.findMappingByHash(hash, season.replace('-', '/'));
+      if (!hash) {
+        return null;
       }
-      return null;
+
+      const dbSeason = this.formatSeasonForDb(season);
+      if (this.repository.findMappingByHash) {
+        return await this.repository.findMappingByHash(hash, dbSeason);
+      }
+
+      if (!this.repository?.dbPool?.connect) {
+        return null;
+      }
+
+      const client = await this.repository.dbPool.connect();
+      try {
+        const result = await client.query(`
+          SELECT match_id, oddsportal_hash, season, league_name, full_url, updated_at
+          FROM matches_oddsportal_mapping
+          WHERE season = $1
+            AND oddsportal_hash = $2
+          LIMIT 1
+        `, [dbSeason, String(hash)]);
+
+        return result.rows[0] || null;
+      } finally {
+        client.release();
+      }
     } catch {
       return null;
+    }
+  },
+
+  /**
+   * Find the currently stored mapping for a specific match_id/season.
+   *
+   * @param {string} matchId
+   * @param {string} season
+   * @returns {Promise<Object|null>}
+   */
+  async findExistingMappingForMatch(matchId, season) {
+    try {
+      if (!matchId) {
+        return null;
+      }
+
+      if (this.repository.findMappingByMatchIdAndSeason) {
+        return await this.repository.findMappingByMatchIdAndSeason(matchId, season);
+      }
+
+      if (!this.repository?.dbPool?.connect) {
+        return null;
+      }
+
+      const client = await this.repository.dbPool.connect();
+      try {
+        const result = await client.query(`
+          SELECT match_id, oddsportal_hash, season, league_name, full_url, updated_at
+          FROM matches_oddsportal_mapping
+          WHERE match_id = $1
+            AND season = $2
+          LIMIT 1
+        `, [String(matchId), String(season)]);
+
+        return result.rows[0] || null;
+      } finally {
+        client.release();
+      }
+    } catch {
+      return null;
+    }
+  },
+
+  /**
+   * Fetch all exact team-pair candidates inside a season.
+   *
+   * @param {string} homeTeam
+   * @param {string} awayTeam
+   * @param {string} season
+   * @returns {Promise<Object[]>}
+   */
+  async findMatchesByTeams(homeTeam, awayTeam, season) {
+    if (this.repository.findMatchesByTeams) {
+      const matches = await this.repository.findMatchesByTeams(homeTeam, awayTeam, season);
+      if (Array.isArray(matches)) {
+        return matches;
+      }
+
+      if (matches) {
+        return [{
+          match_id: matches.matchId,
+          home_team: matches.dbHome || homeTeam,
+          away_team: matches.dbAway || awayTeam,
+          match_date: matches.matchDate || matches.match_date || null
+        }];
+      }
+    }
+
+    if (!this.repository?.dbPool?.connect) {
+      const singleMatch = await this.repository.findMatchByTeams(homeTeam, awayTeam, season);
+      if (!singleMatch) {
+        return [];
+      }
+
+      return [{
+        match_id: singleMatch.matchId,
+        home_team: singleMatch.dbHome || homeTeam,
+        away_team: singleMatch.dbAway || awayTeam,
+        match_date: singleMatch.matchDate || singleMatch.match_date || null
+      }];
+    }
+
+    const client = await this.repository.dbPool.connect();
+    try {
+      const result = await client.query(`
+        SELECT match_id, home_team, away_team, match_date
+        FROM matches
+        WHERE season = $1
+          AND (
+            (LOWER(home_team) = LOWER($2) AND LOWER(away_team) = LOWER($3))
+            OR (LOWER(home_team) = LOWER($3) AND LOWER(away_team) = LOWER($2))
+          )
+        ORDER BY match_date ASC, match_id ASC
+      `, [season, homeTeam, awayTeam]);
+
+      return result.rows || [];
+    } finally {
+      client.release();
     }
   }
 };

--- a/tests/unit/ReconStitcherFlow.test.js
+++ b/tests/unit/ReconStitcherFlow.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ReconStitcher } = require('../../src/infrastructure/recon/ReconStitcher');
+
+const silentLogger = {
+  info() {},
+  warn() {},
+  error() {}
+};
+
+function normalizeName(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function createParser(teams) {
+  return {
+    extractTeamsFromSlug() {
+      return teams;
+    },
+    calculateSimilarity(left, right) {
+      return normalizeName(left) === normalizeName(right) ? 1 : 0;
+    }
+  };
+}
+
+test('ReconStitcher 应在 5 分钟内的开球漂移中命中正确 match_id', async () => {
+  const savedMappings = [];
+  let requestedSeason = null;
+
+  const stitcher = new ReconStitcher({
+    repository: {
+      async findMatchesByTeams(_homeTeam, _awayTeam, season) {
+        requestedSeason = season;
+        return [
+          {
+            match_id: '54_20252026_4824901',
+            home_team: 'Bayern Munich',
+            away_team: 'RB Leipzig',
+            match_date: '2025-08-22T18:30:00.000Z'
+          },
+          {
+            match_id: '54_20252026_4999999',
+            home_team: 'Bayern Munich',
+            away_team: 'RB Leipzig',
+            match_date: '2025-09-12T18:30:00.000Z'
+          }
+        ];
+      },
+      async findMappingByHash() {
+        return null;
+      },
+      async findMappingByMatchIdAndSeason() {
+        return null;
+      },
+      async saveOddsPortalMapping(mapping) {
+        savedMappings.push(mapping);
+        return { success: true, matchId: mapping.match_id };
+      }
+    },
+    parser: createParser({
+      homeTeam: 'Bayern Munich',
+      awayTeam: 'RB Leipzig'
+    }),
+    logger: silentLogger,
+    enableLocking: false
+  });
+
+  const result = await stitcher.stitchSingle({
+    hash: 'correct-date-hash',
+    slug: 'bayern-munich-rb-leipzig-correct-date',
+    url: 'oddsportal://correct-date',
+    date: '2025-08-22T18:35:00.000Z'
+  }, '2025-2026', { name: 'Bundesliga' });
+
+  assert.equal(result.status, 'inserted');
+  assert.equal(requestedSeason, '2025/2026');
+  assert.equal(savedMappings.length, 1);
+  assert.equal(savedMappings[0].match_id, '54_20252026_4824901');
+  assert.equal(savedMappings[0].mapping_method, 'exact_kickoff_tolerance');
+});
+
+test('ReconStitcher 应在 LeagueName 缺失时回退到 source leagueName', async () => {
+  const savedMappings = [];
+
+  const stitcher = new ReconStitcher({
+    repository: {
+      async findMatchesByTeams() {
+        return [{
+          match_id: '55_20252026_4001',
+          home_team: 'Juventus',
+          away_team: 'Inter',
+          match_date: '2025-09-01T18:45:00.000Z'
+        }];
+      },
+      async findMappingByHash() {
+        return null;
+      },
+      async findMappingByMatchIdAndSeason() {
+        return null;
+      },
+      async saveOddsPortalMapping(mapping) {
+        savedMappings.push(mapping);
+        return { success: true, matchId: mapping.match_id };
+      }
+    },
+    parser: createParser({
+      homeTeam: 'Juventus',
+      awayTeam: 'Inter'
+    }),
+    logger: silentLogger,
+    enableLocking: false
+  });
+
+  const result = await stitcher.stitchSingle({
+    hash: 'serie-a-hash',
+    slug: 'juventus-inter-serie-a-hash',
+    url: 'oddsportal://serie-a',
+    date: '2025-09-01T18:45:00.000Z',
+    leagueName: 'Serie A'
+  }, '2025-2026', {});
+
+  assert.equal(result.status, 'inserted');
+  assert.equal(savedMappings.length, 1);
+  assert.equal(savedMappings[0].league_name, 'Serie A');
+});
+
+test('ReconStitcher 应在同一 match_id 的 hash 变化时标记 sequential_hash_rollover', async () => {
+  const savedMappings = [];
+  const warnLogs = [];
+
+  const stitcher = new ReconStitcher({
+    repository: {
+      async findMatchesByTeams() {
+        return [{
+          match_id: '47_20252026_4813435',
+          home_team: 'AFC Bournemouth',
+          away_team: 'Fulham',
+          match_date: '2025-10-03T19:00:00.000Z'
+        }];
+      },
+      async findMappingByHash() {
+        return null;
+      },
+      async findMappingByMatchIdAndSeason() {
+        return {
+          match_id: '47_20252026_4813435',
+          season: '2025/2026',
+          league_name: 'Premier League',
+          oddsportal_hash: 'old-hash'
+        };
+      },
+      async saveOddsPortalMapping(mapping) {
+        savedMappings.push(mapping);
+        return { success: true, matchId: mapping.match_id };
+      }
+    },
+    parser: createParser({
+      homeTeam: 'AFC Bournemouth',
+      awayTeam: 'Fulham'
+    }),
+    logger: {
+      ...silentLogger,
+      warn(message, payload) {
+        warnLogs.push({ message, payload });
+      }
+    },
+    enableLocking: false
+  });
+
+  const result = await stitcher.stitchSingle({
+    hash: 'new-hash',
+    slug: 'bournemouth-fulham-new-hash',
+    url: 'oddsportal://new-hash',
+    date: '2025-10-03T19:00:00.000Z'
+  }, '2025-2026', { name: 'Premier League' });
+
+  assert.equal(result.status, 'inserted');
+  assert.equal(savedMappings.length, 1);
+  assert.equal(savedMappings[0].mapping_method, 'sequential_hash_rollover');
+  assert.ok(warnLogs.some((entry) => entry.message === 'stitch_hash_rollover_detected'));
+});
+
+test('ReconStitcher 应在 hash 锁争用时跳过当前缝合而非继续写库', async () => {
+  let repositoryTouched = false;
+
+  const stitcher = new ReconStitcher({
+    repository: {
+      async findMappingByHash() {
+        repositoryTouched = true;
+        return null;
+      },
+      async saveOddsPortalMapping() {
+        repositoryTouched = true;
+        return { success: true };
+      }
+    },
+    parser: createParser({
+      homeTeam: 'Arsenal',
+      awayTeam: 'Chelsea'
+    }),
+    logger: silentLogger,
+    enableLocking: true,
+    lockManager: {
+      async acquireRowLock() {
+        throw new Error('redis_busy');
+      }
+    }
+  });
+
+  const result = await stitcher.stitchSingle({
+    hash: 'lock-busy-hash',
+    slug: 'arsenal-chelsea-lock-busy-hash',
+    url: 'oddsportal://lock-busy-hash',
+    date: '2025-08-18T19:00:00.000Z'
+  }, '2025-2026', { name: 'Premier League' });
+
+  assert.equal(result.status, 'skipped');
+  assert.deepEqual(result.details, { reason: 'lock_contended' });
+  assert.equal(repositoryTouched, false);
+});


### PR DESCRIPTION
## Summary
- extract ReconArbitrationStrategy for kickoff drift, field degradation, and hash rollover decisions
- wire distributed hash guard into ReconStitcher legacy flow
- add targeted tests for time drift, league fallback, hash change, and lock contention