### PR TITLE
Turbo Stitcher: batch recon persistence and fixture lookup preload

### DIFF
--- a/src/infrastructure/recon/services/ReconScanModes.js
+++ b/src/infrastructure/recon/services/ReconScanModes.js
@@ -359,7 +359,8 @@ const reconScanModes = {
 
       this.logger.info('dom_extract_complete', { candidates: domMatches.length });
 
-      let inserted = 0;
+      const matchPairs = [];
+      let unmatched = 0;
       for (const l1Match of unstitched) {
         const matched = domMatches.find((domMatch) => {
           const text = domMatch.rawText.toLowerCase();
@@ -367,25 +368,30 @@ const reconScanModes = {
         });
 
         if (matched && this.stitcher) {
-          try {
-            const result = await this.stitcher.stitchWithHashLock(
-              [{
-                ...matched,
-                homeTeam: l1Match.home_team,
-                awayTeam: l1Match.away_team
-              }],
-              [l1Match],
-              dbSeason,
-              leagueConfig
-            );
-            inserted += result.inserted || 0;
-          } catch (error) {
-            this.logger.warn('dom_stitch_failed', { matchId: l1Match.match_id, error: error.message });
-          }
+          matchPairs.push({
+            rawMatch: {
+              ...matched,
+              homeTeam: l1Match.home_team,
+              awayTeam: l1Match.away_team
+            },
+            l1Match,
+            method: 'hash_lock',
+            confidence: 0.9
+          });
+        } else {
+          unmatched++;
         }
       }
 
-      this.logger.info('dom_fallback_scan_complete', { inserted, candidates: domMatches.length });
+      const result = matchPairs.length > 0 && this.stitcher
+        ? await this.stitcher.stitchBatch(matchPairs, dbSeason, leagueConfig, {
+          l1Matches: unstitched
+        })
+        : { inserted: 0, unmatched: 0 };
+      const inserted = Number(result?.inserted || 0);
+      unmatched += Number(result?.unmatched || 0);
+
+      this.logger.info('dom_fallback_scan_complete', { inserted, unmatched, candidates: domMatches.length });
 
       return {
         success: true,
@@ -402,7 +408,7 @@ const reconScanModes = {
   },
 
   async _matchAndStitch(candidates, l1Matches, season, leagueConfig) {
-    let inserted = 0;
+    const matchedPairs = [];
     let unmatched = 0;
     const usedCandidates = new Set();
 
@@ -423,24 +429,49 @@ const reconScanModes = {
       }
 
       if (matched && this.stitcher) {
-        try {
-          const result = await this.stitcher.stitchWithHashLock(
-            [matched],
-            [l1Match],
-            season,
-            leagueConfig
-          );
-          inserted += result.inserted || 0;
-        } catch (error) {
-          this.logger.error('stitch_failed', { matchId: l1Match.match_id, error: error.message });
-          unmatched++;
-        }
+        matchedPairs.push({
+          rawMatch: matched,
+          l1Match,
+          method: 'hash_lock',
+          confidence: 0.9
+        });
       } else {
         unmatched++;
       }
     }
 
-    return { inserted, unmatched };
+    if (!this.stitcher || matchedPairs.length === 0) {
+      return { inserted: 0, unmatched };
+    }
+
+    try {
+      const result = typeof this.stitcher.stitchBatch === 'function'
+        ? await this.stitcher.stitchBatch(matchedPairs, season, leagueConfig, {
+          l1Matches
+        })
+        : await this.stitcher.stitchWithHashLock(
+          matchedPairs.map((pair) => pair.rawMatch),
+          l1Matches,
+          season,
+          leagueConfig
+        );
+
+      return {
+        inserted: Number(result?.inserted || 0),
+        unmatched: unmatched + Number(result?.unmatched || 0)
+      };
+    } catch (error) {
+      this.logger.error('stitch_batch_failed', {
+        league: leagueConfig?.name || null,
+        season,
+        pairCount: matchedPairs.length,
+        error: error.message
+      });
+      return {
+        inserted: 0,
+        unmatched: unmatched + matchedPairs.length
+      };
+    }
   },
 
   _isStrictMatch(candidate, l1Match) {

--- a/src/infrastructure/recon/services/ReconStitcherFlow.js
+++ b/src/infrastructure/recon/services/ReconStitcherFlow.js
@@ -20,6 +20,7 @@ const reconStitcherFlow = {
    */
   async stitch(matches, season, leagueConfig) {
     const dbSeason = this.formatSeasonForDb(season);
+    const fixtureLookup = await this.createFixtureLookupContext(dbSeason);
     this.logger.info('stitch_start', {
       matchCount: matches.length,
       season: dbSeason,
@@ -32,7 +33,9 @@ const reconStitcherFlow = {
     this.unmatchedCache = [];
 
     for (const match of matches) {
-      const result = await this.stitchSingle(match, dbSeason, leagueConfig);
+      const result = await this.stitchSingle(match, dbSeason, leagueConfig, {
+        fixtureLookup
+      });
       if (result.status === 'inserted') inserted++;
       else if (result.status === 'skipped') skipped++;
       else {
@@ -102,9 +105,10 @@ const reconStitcherFlow = {
    * @param {Object} match
    * @param {string} season
    * @param {Object} leagueConfig
+   * @param {Object} [runtimeContext]
    * @returns {Promise<Object>}
    */
-  async stitchSingle(match, season, leagueConfig) {
+  async stitchSingle(match, season, leagueConfig, runtimeContext = {}) {
     const dbSeason = this.formatSeasonForDb(season);
     const lock = await this.acquireHashGuard(match?.hash, {
       leagueName: leagueConfig?.name,
@@ -157,7 +161,10 @@ const reconStitcherFlow = {
           teams.homeTeam,
           match.date || match.matchDate || match.match_date || null,
           dbSeason,
-          leagueConfig.name
+          leagueConfig.name,
+          {
+            fixtureLookup: runtimeContext.fixtureLookup || null
+          }
         );
         if (dateMatch) {
           teams.awayTeam = dateMatch.awayTeam;
@@ -172,7 +179,8 @@ const reconStitcherFlow = {
         match: {
           ...match,
           matchDate: match.date || match.matchDate || match.match_date || null
-        }
+        },
+        fixtureLookup: runtimeContext.fixtureLookup || null
       });
 
       if (!matchInfo) {
@@ -325,6 +333,276 @@ const reconStitcherFlow = {
     return { inserted };
   },
 
+  _buildHashLockL1Index(l1Matches = []) {
+    const l1Index = new Map();
+
+    for (const l1Match of Array.isArray(l1Matches) ? l1Matches : []) {
+      const key = `${this._normalizeTeamName(l1Match.home_team)}_${this._normalizeTeamName(l1Match.away_team)}`;
+      if (!l1Index.has(key)) {
+        l1Index.set(key, []);
+      }
+      l1Index.get(key).push(l1Match);
+    }
+
+    return l1Index;
+  },
+
+  _resolveHashLockTargetMatch(match, l1Matches = [], l1Index = new Map()) {
+    const exactKey = `${this._normalizeTeamName(match.homeTeam)}_${this._normalizeTeamName(match.awayTeam)}`;
+    const reversedKey = `${this._normalizeTeamName(match.awayTeam)}_${this._normalizeTeamName(match.homeTeam)}`;
+    const indexedCandidates = [
+      ...(l1Index.get(exactKey) || []),
+      ...(l1Index.get(reversedKey) || [])
+    ];
+
+    for (const candidate of indexedCandidates) {
+      const orientation = this._resolveOrientation(
+        match.homeTeam,
+        match.awayTeam,
+        candidate.home_team,
+        candidate.away_team
+      );
+      if (orientation.directMatch || orientation.swappedMatch) {
+        return { targetL1: candidate, orientation };
+      }
+    }
+
+    for (const l1Match of Array.isArray(l1Matches) ? l1Matches : []) {
+      const orientation = this._resolveOrientation(
+        match.homeTeam,
+        match.awayTeam,
+        l1Match.home_team,
+        l1Match.away_team
+      );
+      if (orientation.directMatch || orientation.swappedMatch) {
+        return { targetL1: l1Match, orientation };
+      }
+    }
+
+    return { targetL1: null, orientation: null };
+  },
+
+  async _persistPreparedMappings(preparedMappings, season, leagueConfig) {
+    if (!Array.isArray(preparedMappings) || preparedMappings.length === 0) {
+      return { inserted: 0, skipped: 0, unmatched: 0 };
+    }
+
+    if (typeof this.repository.batchSaveOddsPortalMappings === 'function') {
+      const result = await this.repository.batchSaveOddsPortalMappings(
+        preparedMappings.map((entry) => entry.mappingData),
+        {
+          pipelineStatus: 'RECON_LINKED',
+          preserve_linked_status: true
+        }
+      );
+      const inserted = Number(result?.applied ?? result?.inserted ?? 0);
+
+      for (const entry of preparedMappings) {
+        this.processedHashes.add(entry.match.hash);
+        this.logStitchSuccess(entry.match, entry.matchId, season, leagueConfig?.name, {
+          mappingMethod: entry.decision?.mappingMethod || 'hash_lock',
+          phase: 'hash_lock_batch'
+        });
+      }
+
+      return {
+        inserted,
+        skipped: Math.max(0, preparedMappings.length - inserted),
+        unmatched: 0
+      };
+    }
+
+    let inserted = 0;
+    let skipped = 0;
+    let unmatched = 0;
+
+    for (const entry of preparedMappings) {
+      try {
+        const result = await this.repository.saveOddsPortalMapping(entry.mappingData, {
+          pipelineStatus: 'RECON_LINKED'
+        });
+        if (result?.success) {
+          this.processedHashes.add(entry.match.hash);
+          this.logStitchSuccess(entry.match, entry.matchId, season, leagueConfig?.name, {
+            mappingMethod: entry.decision?.mappingMethod || 'hash_lock',
+            phase: 'hash_lock_batch'
+          });
+          inserted++;
+        } else {
+          skipped++;
+        }
+      } catch (error) {
+        this.logger.error('hash_lock_batch_save_error', {
+          hash: entry.match?.hash || null,
+          matchId: String(entry.matchId || ''),
+          error: error.message
+        });
+        unmatched++;
+      }
+    }
+
+    return { inserted, skipped, unmatched };
+  },
+
+  /**
+   * Bulk stitch pre-matched source/L1 pairs with a single persistence phase.
+   *
+   * High-risk area:
+   * This method deliberately holds per-hash locks across batch persistence to
+   * trade small lock lifetimes for far fewer DB round-trips.
+   *
+   * @param {Object[]} matchPairs
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @param {Object} [runtimeContext]
+   * @returns {Promise<{inserted: number, skipped: number, unmatched: number}>}
+   */
+  async stitchBatch(matchPairs, season, leagueConfig, runtimeContext = {}) {
+    const dbSeason = this.formatSeasonForDb(season);
+    const normalizedPairs = Array.isArray(matchPairs) ? matchPairs : [];
+    const l1Matches = runtimeContext.l1Matches || normalizedPairs
+      .map((pair) => pair?.l1Match)
+      .filter(Boolean);
+    const l1Index = runtimeContext.l1Index || this._buildHashLockL1Index(l1Matches);
+    const existingByHash = await this.findExistingMappingsByHashes(
+      normalizedPairs.map((pair) => pair?.rawMatch?.hash || pair?.match?.hash).filter(Boolean),
+      dbSeason
+    );
+    const existingByMatchId = await this.findExistingMappingsByMatchIds(
+      normalizedPairs.map((pair) => pair?.l1Match?.match_id).filter(Boolean),
+      dbSeason
+    );
+    const heldGuards = [];
+    const queuedHashes = new Set();
+    const preparedMappings = [];
+    let skipped = 0;
+    let unmatched = 0;
+
+    this.logger.info('stitch_batch_start', {
+      season: dbSeason,
+      league: leagueConfig?.name || null,
+      pairCount: normalizedPairs.length
+    });
+
+    try {
+      for (const pair of normalizedPairs) {
+        const rawMatch = pair?.rawMatch || pair?.match || null;
+        if (!rawMatch) {
+          unmatched++;
+          continue;
+        }
+
+        let targetL1 = pair?.l1Match || null;
+        const resolvedMatch = pair?.match || this._resolveWebMatchTeams(rawMatch, targetL1 ? [targetL1] : l1Matches);
+        let orientation = pair?.orientation || null;
+
+        if (!targetL1 || !orientation) {
+          const resolvedTarget = this._resolveHashLockTargetMatch(resolvedMatch, l1Matches, l1Index);
+          targetL1 = targetL1 || resolvedTarget.targetL1;
+          orientation = orientation || resolvedTarget.orientation;
+        }
+
+        if (!targetL1 || !orientation || (!orientation.directMatch && !orientation.swappedMatch)) {
+          unmatched++;
+          continue;
+        }
+
+        const guard = await this.acquireHashGuard(resolvedMatch?.hash, {
+          leagueName: leagueConfig?.name,
+          season: dbSeason
+        });
+        if (guard?.contended) {
+          skipped++;
+          continue;
+        }
+
+        let keepGuard = false;
+        try {
+          const hashKey = String(resolvedMatch?.hash || '').trim();
+          if (!hashKey) {
+            unmatched++;
+            continue;
+          }
+
+          if (this.processedHashes.has(hashKey) || queuedHashes.has(hashKey)) {
+            skipped++;
+            continue;
+          }
+
+          if (existingByHash.has(hashKey)) {
+            this.processedHashes.add(hashKey);
+            skipped++;
+            continue;
+          }
+
+          const prepared = this.buildMappingPayload(
+            resolvedMatch,
+            {
+              homeTeam: resolvedMatch.homeTeam,
+              awayTeam: resolvedMatch.awayTeam
+            },
+            {
+              matchId: targetL1.match_id,
+              dbHome: targetL1.home_team,
+              dbAway: targetL1.away_team,
+              matchDate: targetL1.match_date || null,
+              confidence: pair?.confidence ?? 0.9,
+              method: pair?.method || 'hash_lock'
+            },
+            dbSeason,
+            leagueConfig,
+            {
+              existingMapping: existingByMatchId.get(String(targetL1.match_id)) || null
+            }
+          );
+
+          preparedMappings.push({
+            ...prepared,
+            match: resolvedMatch,
+            matchId: String(targetL1.match_id)
+          });
+          queuedHashes.add(hashKey);
+          keepGuard = true;
+          heldGuards.push({ hash: hashKey, guard });
+        } catch (error) {
+          if (error.code === 'ORIENTATION_UNCERTAIN') {
+            this.logger.warn('orientation_uncertain', {
+              hash: resolvedMatch?.hash || null,
+              season: dbSeason,
+              league: leagueConfig?.name || null,
+              teams: {
+                homeTeam: resolvedMatch?.homeTeam || null,
+                awayTeam: resolvedMatch?.awayTeam || null
+              }
+            });
+          } else {
+            this.logger.error('hash_lock_prepare_error', {
+              hash: resolvedMatch?.hash || null,
+              matchId: String(targetL1?.match_id || ''),
+              error: error.message
+            });
+          }
+          unmatched++;
+        } finally {
+          if (!keepGuard) {
+            await this.releaseHashGuard(guard, resolvedMatch?.hash);
+          }
+        }
+      }
+
+      const persisted = await this._persistPreparedMappings(preparedMappings, dbSeason, leagueConfig);
+      return {
+        inserted: persisted.inserted,
+        skipped: skipped + Number(persisted.skipped || 0),
+        unmatched: unmatched + Number(persisted.unmatched || 0)
+      };
+    } finally {
+      for (const { hash, guard } of heldGuards) {
+        await this.releaseHashGuard(guard, hash);
+      }
+    }
+  },
+
   /**
    * Hash-oriented fast path for already-resolved web matches.
    *
@@ -344,108 +622,43 @@ const reconStitcherFlow = {
       l1Total: l1Matches.length
     });
 
-    let inserted = 0;
-    let skipped = 0;
     let unmatched = 0;
-    const dbSeason = this.formatSeasonForDb(season);
-
-    const l1Map = new Map();
-    for (const match of l1Matches) {
-      const key = `${this._normalizeTeamName(match.home_team)}_${this._normalizeTeamName(match.away_team)}`;
-      l1Map.set(key, match);
-    }
+    const l1Index = this._buildHashLockL1Index(l1Matches);
+    const matchPairs = [];
 
     for (const rawMatch of interceptedMatches) {
-      const lock = await this.acquireHashGuard(rawMatch?.hash, {
-        leagueName: leagueConfig?.name,
-        season: dbSeason
-      });
-      if (lock?.contended) {
-        skipped++;
-        continue;
-      }
-
       try {
         const match = this._resolveWebMatchTeams(rawMatch, l1Matches);
-        if (match.hash && this.processedHashes.has(match.hash)) {
-          skipped++;
-          continue;
-        }
-
-        const existing = await this.checkExistingMapping(match.hash, dbSeason);
-        if (existing) {
-          this.processedHashes.add(match.hash);
-          skipped++;
-          continue;
-        }
-
-        let targetL1 = null;
-        let orientation = null;
-        const exactKey = `${this._normalizeTeamName(match.homeTeam)}_${this._normalizeTeamName(match.awayTeam)}`;
-        targetL1 = l1Map.get(exactKey);
-        if (targetL1) {
-          orientation = this._resolveOrientation(match.homeTeam, match.awayTeam, targetL1.home_team, targetL1.away_team);
-        }
-
-        if (!targetL1) {
-          const reversedKey = `${this._normalizeTeamName(match.awayTeam)}_${this._normalizeTeamName(match.homeTeam)}`;
-          targetL1 = l1Map.get(reversedKey);
-          if (targetL1) {
-            orientation = this._resolveOrientation(match.homeTeam, match.awayTeam, targetL1.home_team, targetL1.away_team);
-          }
-        }
-
-        if (!targetL1) {
-          for (const [, l1] of l1Map.entries()) {
-            const candidateOrientation = this._resolveOrientation(match.homeTeam, match.awayTeam, l1.home_team, l1.away_team);
-            if (candidateOrientation.directMatch || candidateOrientation.swappedMatch) {
-              targetL1 = l1;
-              orientation = candidateOrientation;
-              break;
-            }
-          }
-        }
-
-        if (!targetL1 || !orientation || (!orientation.directMatch && !orientation.swappedMatch)) {
+        const resolvedTarget = this._resolveHashLockTargetMatch(match, l1Matches, l1Index);
+        if (!resolvedTarget.targetL1) {
           unmatched++;
           continue;
         }
 
-        const result = await this.repository.saveOddsPortalMapping({
-          match_id: targetL1.match_id,
-          oddsportal_hash: match.hash,
-          full_url: match.url,
-          season: dbSeason,
-          league_name: leagueConfig.name,
-          home_team: targetL1.home_team,
-          away_team: targetL1.away_team,
-          is_reversed: orientation.isReversed,
-          match_confidence: 0.9,
-          mapping_method: 'hash_lock',
-          status: 'pending'
-        }, {
-          pipelineStatus: 'RECON_LINKED'
+        matchPairs.push({
+          rawMatch,
+          match,
+          l1Match: resolvedTarget.targetL1,
+          orientation: resolvedTarget.orientation,
+          method: 'hash_lock',
+          confidence: 0.9
         });
-
-        if (result.success) {
-          this.processedHashes.add(match.hash);
-          this.logStitchSuccess(match, targetL1.match_id, dbSeason, leagueConfig?.name, {
-            mappingMethod: 'hash_lock',
-            phase: 'hash_lock'
-          });
-          inserted++;
-        } else {
-          skipped++;
-        }
       } catch (error) {
         this.logger.error('hash_lock_error', { hash: rawMatch?.hash, error: error.message });
         unmatched++;
-      } finally {
-        await this.releaseHashGuard(lock, rawMatch?.hash);
       }
     }
 
-    return { inserted, skipped, unmatched };
+    const stitched = await this.stitchBatch(matchPairs, season, leagueConfig, {
+      l1Matches,
+      l1Index
+    });
+
+    return {
+      inserted: stitched.inserted,
+      skipped: stitched.skipped,
+      unmatched: unmatched + stitched.unmatched
+    };
   },
 
   /**

--- a/src/infrastructure/recon/services/ReconStitcherPersistence.js
+++ b/src/infrastructure/recon/services/ReconStitcherPersistence.js
@@ -56,6 +56,44 @@ const reconStitcherPersistence = {
    * @returns {Promise<Object>}
    */
   async saveMapping(match, teams, matchInfo, season, leagueConfig) {
+    const dbSeason = this.formatSeasonForDb(season);
+    const existingMapping = await this.findExistingMappingForMatch(matchInfo.matchId, dbSeason);
+    const prepared = this.buildMappingPayload(
+      match,
+      teams,
+      matchInfo,
+      dbSeason,
+      leagueConfig,
+      { existingMapping }
+    );
+
+    const result = await this.repository.saveOddsPortalMapping(prepared.mappingData, {
+      pipelineStatus: 'RECON_LINKED'
+    });
+
+    return {
+      ...result,
+      mappingMethod: prepared.decision?.mappingMethod || null
+    };
+  },
+
+  /**
+   * Build a persistence-ready mapping payload without writing to the DB.
+   *
+   * High-risk area:
+   * Batch flows reuse this helper to keep arbitration consistent with single
+   * writes. Any drift here creates divergent match_id binding behaviour.
+   *
+   * @param {Object} match
+   * @param {{homeTeam: string, awayTeam: string}} teams
+   * @param {Object} matchInfo
+   * @param {string} season
+   * @param {Object} leagueConfig
+   * @param {Object} [options]
+   * @param {Object|null} [options.existingMapping=null]
+   * @returns {{mappingData: Object, decision: Object, orientation: Object}}
+   */
+  buildMappingPayload(match, teams, matchInfo, season, leagueConfig, options = {}) {
     const l1HomeTeam = matchInfo.dbHome || teams.homeTeam;
     const l1AwayTeam = matchInfo.dbAway || teams.awayTeam;
     const orientation = this._resolveOrientation(
@@ -72,7 +110,7 @@ const reconStitcherPersistence = {
     }
 
     const dbSeason = this.formatSeasonForDb(season);
-    const existingMapping = await this.findExistingMappingForMatch(matchInfo.matchId, dbSeason);
+    const existingMapping = options.existingMapping || null;
     const decision = this.arbitrationStrategy
       ? this.arbitrationStrategy.buildMappingDecision({
         match,
@@ -106,23 +144,227 @@ const reconStitcherPersistence = {
       });
     }
 
-    const mappingData = {
-      match_id: matchInfo.matchId,
-      oddsportal_hash: match.hash,
-      full_url: match.url,
-      season: dbSeason,
-      league_name: decision.leagueName,
-      home_team: l1HomeTeam,
-      away_team: l1AwayTeam,
-      is_reversed: orientation.isReversed,
-      match_confidence: decision.matchConfidence,
-      mapping_method: decision.mappingMethod,
-      status: 'pending'
+    return {
+      orientation,
+      decision,
+      mappingData: {
+        match_id: matchInfo.matchId,
+        oddsportal_hash: match.hash,
+        full_url: match.url,
+        season: dbSeason,
+        league_name: decision.leagueName,
+        home_team: l1HomeTeam,
+        away_team: l1AwayTeam,
+        is_reversed: orientation.isReversed,
+        match_confidence: decision.matchConfidence,
+        mapping_method: decision.mappingMethod,
+        status: 'pending'
+      }
+    };
+  },
+
+  _buildFixtureLookupPairKey(homeTeam, awayTeam) {
+    const normalizedHome = this._normalizeTeamName(homeTeam);
+    const normalizedAway = this._normalizeTeamName(awayTeam);
+
+    if (!normalizedHome || !normalizedAway) {
+      return null;
+    }
+
+    return `${normalizedHome}__${normalizedAway}`;
+  },
+
+  buildFixtureLookup(matches = []) {
+    const fixtureLookup = {
+      matches: [],
+      pairIndex: new Map(),
+      homeIndex: new Map()
     };
 
-    return this.repository.saveOddsPortalMapping(mappingData, {
-      pipelineStatus: 'RECON_LINKED'
-    });
+    for (const match of Array.isArray(matches) ? matches : []) {
+      fixtureLookup.matches.push(match);
+
+      const pairKey = this._buildFixtureLookupPairKey(match.home_team, match.away_team);
+      if (pairKey) {
+        if (!fixtureLookup.pairIndex.has(pairKey)) {
+          fixtureLookup.pairIndex.set(pairKey, []);
+        }
+        fixtureLookup.pairIndex.get(pairKey).push(match);
+      }
+
+      const homeKey = this._normalizeTeamName(match.home_team);
+      if (homeKey) {
+        if (!fixtureLookup.homeIndex.has(homeKey)) {
+          fixtureLookup.homeIndex.set(homeKey, []);
+        }
+        fixtureLookup.homeIndex.get(homeKey).push(match);
+      }
+    }
+
+    return fixtureLookup;
+  },
+
+  /**
+   * Preload season fixtures into in-memory lookup maps for batch matching.
+   *
+   * @param {string} season
+   * @param {Object} [options]
+   * @param {Object[]} [options.preloadedMatches]
+   * @returns {Promise<Object|null>}
+   */
+  async createFixtureLookupContext(season, options = {}) {
+    const preloadedMatches = Array.isArray(options.preloadedMatches)
+      ? options.preloadedMatches
+      : null;
+    const candidates = preloadedMatches || (
+      typeof this.repository.findMatchesBySeason === 'function'
+        ? await this.repository.findMatchesBySeason(season)
+        : null
+    );
+
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      return null;
+    }
+
+    return this.buildFixtureLookup(candidates);
+  },
+
+  _getExactCandidatesFromFixtureLookup(homeTeam, awayTeam, fixtureLookup = null) {
+    if (!(fixtureLookup?.pairIndex instanceof Map)) {
+      return null;
+    }
+
+    const direct = fixtureLookup.pairIndex.get(
+      this._buildFixtureLookupPairKey(homeTeam, awayTeam)
+    ) || [];
+    const reversed = fixtureLookup.pairIndex.get(
+      this._buildFixtureLookupPairKey(awayTeam, homeTeam)
+    ) || [];
+
+    return [...direct, ...reversed];
+  },
+
+  _getHomeCandidatesFromFixtureLookup(homeTeam, fixtureLookup = null) {
+    if (!(fixtureLookup?.homeIndex instanceof Map)) {
+      return null;
+    }
+
+    return fixtureLookup.homeIndex.get(this._normalizeTeamName(homeTeam)) || [];
+  },
+
+  _normalizeRepositoryTeamMatch(match, homeTeam, awayTeam) {
+    if (!match) {
+      return [];
+    }
+
+    if (Array.isArray(match)) {
+      return match;
+    }
+
+    return [{
+      match_id: match.matchId,
+      home_team: match.dbHome || homeTeam,
+      away_team: match.dbAway || awayTeam,
+      match_date: match.matchDate || match.match_date || null
+    }];
+  },
+
+  async _findMatchesByTeamsFromRepository(homeTeam, awayTeam, season) {
+    if (typeof this.repository.findMatchesByTeams === 'function') {
+      const matches = await this.repository.findMatchesByTeams(homeTeam, awayTeam, season);
+      return this._normalizeRepositoryTeamMatch(matches, homeTeam, awayTeam);
+    }
+
+    if (typeof this.repository.findMatchByTeams === 'function') {
+      const match = await this.repository.findMatchByTeams(homeTeam, awayTeam, season);
+      return this._normalizeRepositoryTeamMatch(match, homeTeam, awayTeam);
+    }
+
+    return null;
+  },
+
+  /**
+   * Preload existing season/hash mappings into memory for batch dedupe.
+   *
+   * @param {string[]} hashes
+   * @param {string} season
+   * @returns {Promise<Map<string, Object>>}
+   */
+  async findExistingMappingsByHashes(hashes = [], season) {
+    const normalizedHashes = [...new Set(
+      (Array.isArray(hashes) ? hashes : [])
+        .map((hash) => String(hash || '').trim())
+        .filter(Boolean)
+    )];
+
+    if (normalizedHashes.length === 0) {
+      return new Map();
+    }
+
+    const dbSeason = this.formatSeasonForDb(season);
+    if (!this.repository?.dbPool?.connect) {
+      const rows = await Promise.all(normalizedHashes.map(async (hash) => [
+        hash,
+        await this.checkExistingMapping(hash, dbSeason)
+      ]));
+      return new Map(rows.filter(([, mapping]) => mapping));
+    }
+
+    const client = await this.repository.dbPool.connect();
+    try {
+      const result = await client.query(`
+        SELECT match_id, oddsportal_hash, season, league_name, full_url, updated_at
+        FROM matches_oddsportal_mapping
+        WHERE season = $1
+          AND oddsportal_hash = ANY($2::text[])
+      `, [dbSeason, normalizedHashes]);
+
+      return new Map((result.rows || []).map((row) => [String(row.oddsportal_hash), row]));
+    } finally {
+      client.release();
+    }
+  },
+
+  /**
+   * Preload existing match_id/season mappings into memory for hash rollover arbitration.
+   *
+   * @param {string[]} matchIds
+   * @param {string} season
+   * @returns {Promise<Map<string, Object>>}
+   */
+  async findExistingMappingsByMatchIds(matchIds = [], season) {
+    const normalizedMatchIds = [...new Set(
+      (Array.isArray(matchIds) ? matchIds : [])
+        .map((matchId) => String(matchId || '').trim())
+        .filter(Boolean)
+    )];
+
+    if (normalizedMatchIds.length === 0) {
+      return new Map();
+    }
+
+    const dbSeason = this.formatSeasonForDb(season);
+    if (!this.repository?.dbPool?.connect) {
+      const rows = await Promise.all(normalizedMatchIds.map(async (matchId) => [
+        matchId,
+        await this.findExistingMappingForMatch(matchId, dbSeason)
+      ]));
+      return new Map(rows.filter(([, mapping]) => mapping));
+    }
+
+    const client = await this.repository.dbPool.connect();
+    try {
+      const result = await client.query(`
+        SELECT match_id, oddsportal_hash, season, league_name, full_url, updated_at
+        FROM matches_oddsportal_mapping
+        WHERE season = $1
+          AND match_id = ANY($2::text[])
+      `, [dbSeason, normalizedMatchIds]);
+
+      return new Map((result.rows || []).map((row) => [String(row.match_id), row]));
+    } finally {
+      client.release();
+    }
   },
 
   /**
@@ -143,7 +385,9 @@ const reconStitcherPersistence = {
     const sourceMatch = arbitrationContext.match || {
       matchDate: arbitrationContext.matchDate || null
     };
-    const exactCandidates = await this.findMatchesByTeams(homeTeam, awayTeam, dbSeason);
+    const exactCandidates = await this.findMatchesByTeams(homeTeam, awayTeam, dbSeason, {
+      fixtureLookup: arbitrationContext.fixtureLookup || null
+    });
     if (Array.isArray(exactCandidates) && exactCandidates.length > 0) {
       const exactMatch = this.arbitrationStrategy
         ? this.arbitrationStrategy.chooseBestMatchCandidate({
@@ -177,7 +421,8 @@ const reconStitcherPersistence = {
    * @returns {Promise<Object|null>}
    */
   async findWithFuzzyMatch(homeTeam, awayTeam, season, arbitrationContext = {}) {
-    const candidates = await this.repository.findMatchesBySeason(season);
+    const candidates = arbitrationContext.fixtureLookup?.matches
+      || await this.repository.findMatchesBySeason(season);
     if (!candidates || candidates.length === 0) return null;
 
     if (this.arbitrationStrategy) {
@@ -205,12 +450,16 @@ const reconStitcherPersistence = {
    * @param {string} _leagueName
    * @returns {Promise<Object|null>}
    */
-  async findMatchByHomeAndDate(homeTeam, dateStr, season, _leagueName) {
-    if (!this.repository.findMatchesBySeason) return null;
-
+  async findMatchByHomeAndDate(homeTeam, dateStr, season, _leagueName, options = {}) {
     try {
       const dbSeason = this.formatSeasonForDb(season);
-      const candidates = await this.repository.findMatchesBySeason(dbSeason);
+      const fixtureLookup = options.fixtureLookup || null;
+      const candidates = this._getHomeCandidatesFromFixtureLookup(homeTeam, fixtureLookup)
+        || (
+          typeof this.repository.findMatchesBySeason === 'function'
+            ? await this.repository.findMatchesBySeason(dbSeason)
+            : null
+        );
       if (!candidates) return null;
 
       const sourceTs = this.arbitrationStrategy?.toTimestamp(dateStr) ?? null;
@@ -359,35 +608,23 @@ const reconStitcherPersistence = {
    * @param {string} season
    * @returns {Promise<Object[]>}
    */
-  async findMatchesByTeams(homeTeam, awayTeam, season) {
-    if (this.repository.findMatchesByTeams) {
-      const matches = await this.repository.findMatchesByTeams(homeTeam, awayTeam, season);
-      if (Array.isArray(matches)) {
-        return matches;
-      }
+  async findMatchesByTeams(homeTeam, awayTeam, season, options = {}) {
+    const exactCandidatesFromLookup = this._getExactCandidatesFromFixtureLookup(
+      homeTeam,
+      awayTeam,
+      options.fixtureLookup || null
+    );
+    if (Array.isArray(exactCandidatesFromLookup)) {
+      return exactCandidatesFromLookup;
+    }
 
-      if (matches) {
-        return [{
-          match_id: matches.matchId,
-          home_team: matches.dbHome || homeTeam,
-          away_team: matches.dbAway || awayTeam,
-          match_date: matches.matchDate || matches.match_date || null
-        }];
-      }
+    const repositoryMatches = await this._findMatchesByTeamsFromRepository(homeTeam, awayTeam, season);
+    if (Array.isArray(repositoryMatches)) {
+      return repositoryMatches;
     }
 
     if (!this.repository?.dbPool?.connect) {
-      const singleMatch = await this.repository.findMatchByTeams(homeTeam, awayTeam, season);
-      if (!singleMatch) {
-        return [];
-      }
-
-      return [{
-        match_id: singleMatch.matchId,
-        home_team: singleMatch.dbHome || homeTeam,
-        away_team: singleMatch.dbAway || awayTeam,
-        match_date: singleMatch.matchDate || singleMatch.match_date || null
-      }];
+      return [];
     }
 
     const client = await this.repository.dbPool.connect();

--- a/src/infrastructure/services/FixtureRepository.js
+++ b/src/infrastructure/services/FixtureRepository.js
@@ -728,7 +728,15 @@ class FixtureRepository {
       }
     }, 'getMappingStats');
   }
-  async close() { if (this.dbPool && typeof this.dbPool.end === 'function') { await this.dbPool.end(); this.logger.info('[Repository] 数据库连接池已关闭'); } }
+  async close() {
+    const pool = this.dbPool;
+    this.dbPool = null;
+
+    if (pool && typeof pool.end === 'function') {
+      await pool.end();
+      this.logger.info('[Repository] 数据库连接池已关闭');
+    }
+  }
 }
 
 module.exports = { FixtureRepository, RepositoryError };

--- a/src/infrastructure/services/FotMobExtractor.js
+++ b/src/infrastructure/services/FotMobExtractor.js
@@ -11,6 +11,12 @@
 
 'use strict';
 
+const {
+  buildDomScanPayload,
+  dedupeById,
+  extractPrimaryLeagueData
+} = require('../shared/helpers/fotMobExtractionHelpers');
+
 /**
  * FotMob 数据提取器
  * @class FotMobExtractor
@@ -120,38 +126,13 @@ class FotMobExtractor {
         throw new Error(`JSON 解析错误: ${nextData.error}`);
       }
       
-      // 🔥 数据提取逻辑
-      const pageProps = nextData.props?.pageProps;
-      let extractedData = null;
-      let matchCount = 0;
-      
-      // 路径 1: fallback 中的联赛数据
-      const fallback = pageProps?.fallback;
-      if (fallback && typeof fallback === 'object') {
-        const leagueKey = Object.keys(fallback).find(key => 
-          key.includes('/api/leagues') || key.includes('leagues')
-        );
-        
-        if (leagueKey && fallback[leagueKey]) {
-          extractedData = fallback[leagueKey];
-          matchCount = this._countMatches(extractedData);
-          this.logger.info(`[HOUND-SOUL] ✅ 从 fallback["${leagueKey}"] 提取 ${matchCount} 场数据`);
-        }
-      }
-      
-      // 路径 2: 直接从 pageProps 提取
-      if (!extractedData && pageProps) {
-        if (pageProps.fixtures || pageProps.allMatches) {
-          extractedData = {
-            fixtures: pageProps.fixtures || pageProps.allMatches,
-            leagueId: leagueId,
-            season: season,
-            ...pageProps
-          };
-          matchCount = this._countMatches(extractedData);
-          this.logger.info(`[HOUND-SOUL] ✅ 从 pageProps 提取 ${matchCount} 场数据`);
-        }
-      }
+      const { data: extractedData, matchCount } = extractPrimaryLeagueData(
+        nextData.props?.pageProps,
+        leagueId,
+        season,
+        (data) => this._countMatches(data),
+        this.logger
+      );
       
       // 🔥 V6.7.9: 如果数据量不足，尝试使用捕获的真实 API 端点
       if (!extractedData || matchCount < 200) {
@@ -182,12 +163,7 @@ class FotMobExtractor {
         
         if (domData && domData.length > matchCount) {
           this.logger.info(`[HOUND-SOUL] ✅ DOM 扫描发现 ${domData.length} 场，覆盖原有数据`);
-          return {
-            fixtures: { allMatches: domData },
-            leagueId: leagueId,
-            season: season,
-            _source: 'dom_scan'
-          };
+          return buildDomScanPayload(domData, leagueId, season);
         }
       }
       
@@ -368,24 +344,8 @@ class FotMobExtractor {
       return data;
     });
 
-    // 去重
-    const uniqueLeagues = [];
-    const seenLeagues = new Set();
-    results.leagues.forEach(l => {
-      if (!seenLeagues.has(l.id)) {
-        seenLeagues.add(l.id);
-        uniqueLeagues.push(l);
-      }
-    });
-
-    const uniqueTeams = [];
-    const seenTeams = new Set();
-    results.teams.forEach(t => {
-      if (!seenTeams.has(t.id)) {
-        seenTeams.add(t.id);
-        uniqueTeams.push(t);
-      }
-    });
+    const uniqueLeagues = dedupeById(results.leagues);
+    const uniqueTeams = dedupeById(results.teams);
 
     if (uniqueLeagues.length === 0 && uniqueTeams.length === 0) {
       throw new Error('DOM 搜索未返回结果');

--- a/src/infrastructure/shared/helpers/fotMobExtractionHelpers.js
+++ b/src/infrastructure/shared/helpers/fotMobExtractionHelpers.js
@@ -1,0 +1,100 @@
+'use strict';
+
+function normalizeLeagueId(value) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function extractLeagueIdFromFallbackKey(key) {
+  const rawKey = String(key || '').trim();
+  if (!rawKey || !/leagues/i.test(rawKey)) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(rawKey, 'https://www.fotmob.com');
+    const queryLeagueId = normalizeLeagueId(parsed.searchParams.get('id') || parsed.searchParams.get('leagueId'));
+    if (queryLeagueId) {
+      return queryLeagueId;
+    }
+
+    const pathMatch = parsed.pathname.match(/\/leagues\/(\d+)(?:\/|$)/i);
+    return pathMatch ? normalizeLeagueId(pathMatch[1]) : null;
+  } catch {
+    const queryMatch = rawKey.match(/[?&](?:id|leagueId)=(\d+)(?:&|$)/i);
+    if (queryMatch) {
+      return normalizeLeagueId(queryMatch[1]);
+    }
+
+    const pathMatch = rawKey.match(/\/leagues\/(\d+)(?:\/|$)/i);
+    return pathMatch ? normalizeLeagueId(pathMatch[1]) : null;
+  }
+}
+
+function resolveFallbackLeagueKey(fallback, leagueId) {
+  const normalizedLeagueId = normalizeLeagueId(leagueId);
+  if (!fallback || typeof fallback !== 'object' || !normalizedLeagueId) {
+    return '';
+  }
+
+  return Object.keys(fallback).find((key) => extractLeagueIdFromFallbackKey(key) === normalizedLeagueId) || '';
+}
+
+function extractPrimaryLeagueData(pageProps, leagueId, season, countMatches, logger = console) {
+  const fallback = pageProps?.fallback;
+  if (fallback && typeof fallback === 'object') {
+    const leagueKey = resolveFallbackLeagueKey(fallback, leagueId);
+
+    if (leagueKey && fallback[leagueKey]) {
+      const data = fallback[leagueKey];
+      const matchCount = countMatches(data);
+      logger.info(`[HOUND-SOUL] ✅ 从 fallback["${leagueKey}"] 提取 ${matchCount} 场数据`);
+      return { data, matchCount };
+    }
+  }
+
+  if (pageProps?.fixtures || pageProps?.allMatches) {
+    const data = {
+      fixtures: pageProps.fixtures || pageProps.allMatches,
+      leagueId,
+      season,
+      ...pageProps
+    };
+    const matchCount = countMatches(data);
+    logger.info(`[HOUND-SOUL] ✅ 从 pageProps 提取 ${matchCount} 场数据`);
+    return { data, matchCount };
+  }
+
+  return { data: null, matchCount: 0 };
+}
+
+function buildDomScanPayload(domData, leagueId, season) {
+  return {
+    fixtures: { allMatches: domData },
+    leagueId,
+    season,
+    _source: 'dom_scan'
+  };
+}
+
+function dedupeById(entries = []) {
+  const results = [];
+  const seen = new Set();
+
+  for (const entry of entries) {
+    if (seen.has(entry.id)) {
+      continue;
+    }
+
+    seen.add(entry.id);
+    results.push(entry);
+  }
+
+  return results;
+}
+
+module.exports = {
+  buildDomScanPayload,
+  dedupeById,
+  extractPrimaryLeagueData
+};

--- a/tests/unit/FixtureRepository.test.js
+++ b/tests/unit/FixtureRepository.test.js
@@ -11,6 +11,24 @@ const reconConfig = require('../../config/recon_config.json');
 const { ReconMappingStore } = require('../../src/infrastructure/services/recon/ReconMappingStore');
 const { ReconSchemaJanitor } = require('../../src/infrastructure/services/recon/ReconSchemaJanitor');
 
+test('FixtureRepository.close 应关闭连接池并将 dbPool 置空', async () => {
+  let endCalls = 0;
+  const pool = {
+    async end() {
+      endCalls += 1;
+    }
+  };
+  const repository = new FixtureRepository({
+    dbPool: pool,
+    logger: { info() {}, warn() {}, error() {} }
+  });
+
+  await repository.close();
+
+  assert.equal(endCalls, 1);
+  assert.equal(repository.dbPool, null);
+});
+
 test('FixtureRepository.batchUpdateMatchPipelineStatus 应在竞争更新下只允许一个任务将 harvested 改为 RECON_MISMATCH', async () => {
   const state = {
     status: 'harvested',

--- a/tests/unit/ReconBulkFlow.test.js
+++ b/tests/unit/ReconBulkFlow.test.js
@@ -393,6 +393,40 @@ describe('ReconEngine - Bulk Flow TDD', () => {
     ]);
   });
 
+  it('严格匹配热路径应聚合同联赛命中并只调用一次 stitchBatch', async () => {
+    const l1Matches = createPendingMatches(3);
+    const candidates = createWebCandidates(l1Matches);
+    const stitchBatchCalls = [];
+
+    const engine = new ReconEngine({
+      matchEvaluator: {
+        isStrictMatch(candidate, l1Match) {
+          return candidate.homeTeam === l1Match.home_team && candidate.awayTeam === l1Match.away_team;
+        }
+      },
+      stitcher: {
+        async stitchBatch(matchPairs, season, leagueConfig, runtimeContext) {
+          stitchBatchCalls.push({ matchPairs, season, leagueConfig, runtimeContext });
+          return { inserted: matchPairs.length, skipped: 0, unmatched: 0 };
+        }
+      },
+      logger: { info() {}, warn() {}, error() {} }
+    });
+
+    const result = await engine._matchAndStitch(
+      candidates,
+      l1Matches,
+      '2024/2025',
+      { name: 'Premier League' }
+    );
+
+    assert.equal(result.inserted, 3);
+    assert.equal(result.unmatched, 0);
+    assert.equal(stitchBatchCalls.length, 1);
+    assert.equal(stitchBatchCalls[0].matchPairs.length, 3);
+    assert.equal(stitchBatchCalls[0].season, '2024/2025');
+  });
+
   it('低于阈值时应保留最佳落选候选证据，便于 mismatch 归因', async () => {
     const engine = new ReconEngine({
       parser: { calculateSimilarity: () => 0.6 },

--- a/tests/unit/ReconScanner.Elite.test.js
+++ b/tests/unit/ReconScanner.Elite.test.js
@@ -194,10 +194,13 @@ describe('ReconScanner Elite - Circuit Breaker', () => {
     cb.trip('test trip');
     assert.strictEqual(cb.getStatus().state, 'OPEN');
     
-    await new Promise((resolve) => {
-      setTimeout(resolve, 150);
-    });
-    
+    const deadline = Date.now() + 500;
+    while (cb.getStatus().state === 'OPEN' && Date.now() < deadline) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+
     let enteredHalfOpen = false;
     try {
       await cb.execute(async () => {

--- a/tests/unit/ReconStitcherFlow.test.js
+++ b/tests/unit/ReconStitcherFlow.test.js
@@ -367,3 +367,151 @@ test('ReconStitcher 应在 slug 解析失败时回退到结构化 homeTeam/awayT
   assert.equal(savedMappings.length, 1);
   assert.equal(savedMappings[0].match_id, '130_20252026_9010');
 });
+
+test('ReconStitcher.stitch 应只预热一次赛季 fixture lookup 并复用到整批缝合', async () => {
+  const savedMappings = [];
+  let seasonLookupLoads = 0;
+
+  const stitcher = new ReconStitcher({
+    repository: {
+      async findMatchesBySeason() {
+        seasonLookupLoads++;
+        return [
+          {
+            match_id: '47_20252026_1000',
+            home_team: 'Arsenal',
+            away_team: 'Chelsea',
+            match_date: '2025-08-16T14:00:00.000Z'
+          },
+          {
+            match_id: '47_20252026_1001',
+            home_team: 'Liverpool',
+            away_team: 'Everton',
+            match_date: '2025-08-17T14:00:00.000Z'
+          }
+        ];
+      },
+      async findMappingByHash() {
+        return null;
+      },
+      async findMappingByMatchIdAndSeason() {
+        return null;
+      },
+      async saveOddsPortalMapping(mapping) {
+        savedMappings.push(mapping);
+        return { success: true, matchId: mapping.match_id };
+      }
+    },
+    parser: {
+      extractTeamsFromSlug() {
+        return { homeTeam: 'Unknown', awayTeam: 'Unknown' };
+      },
+      normalizeTeamName(value) {
+        return String(value || '').trim();
+      },
+      calculateSimilarity(left, right) {
+        return normalizeName(left) === normalizeName(right) ? 1 : 0;
+      }
+    },
+    logger: silentLogger,
+    enableLocking: false
+  });
+
+  const result = await stitcher.stitch([
+    {
+      hash: 'batch-stitch-hash-1',
+      slug: 'arsenal-chelsea',
+      url: 'oddsportal://arsenal-chelsea',
+      homeTeam: 'Arsenal',
+      awayTeam: 'Chelsea',
+      date: '2025-08-16T14:00:00.000Z'
+    },
+    {
+      hash: 'batch-stitch-hash-2',
+      slug: 'liverpool-everton',
+      url: 'oddsportal://liverpool-everton',
+      homeTeam: 'Liverpool',
+      awayTeam: 'Everton',
+      date: '2025-08-17T14:00:00.000Z'
+    }
+  ], '2025-2026', { name: 'Premier League' });
+
+  assert.equal(result.inserted, 2);
+  assert.equal(savedMappings.length, 2);
+  assert.equal(seasonLookupLoads, 1);
+});
+
+test('ReconStitcher.stitchBatch 应把多场命中压缩为一次 batchSaveOddsPortalMappings', async () => {
+  const batchCalls = [];
+  let singleSaveCalls = 0;
+
+  const stitcher = new ReconStitcher({
+    repository: {
+      async findMappingByHash() {
+        return null;
+      },
+      async findMappingByMatchIdAndSeason() {
+        return null;
+      },
+      async batchSaveOddsPortalMappings(mappings, options) {
+        batchCalls.push({ mappings, options });
+        return {
+          success: true,
+          inserted: mappings.length,
+          applied: mappings.length
+        };
+      },
+      async saveOddsPortalMapping() {
+        singleSaveCalls++;
+        return { success: true };
+      }
+    },
+    parser: createParser({
+      homeTeam: 'Arsenal',
+      awayTeam: 'Chelsea'
+    }),
+    logger: silentLogger,
+    enableLocking: false
+  });
+
+  const result = await stitcher.stitchBatch([
+    {
+      rawMatch: {
+        hash: 'bulk-hash-1',
+        url: 'oddsportal://bulk-1',
+        homeTeam: 'Arsenal',
+        awayTeam: 'Chelsea'
+      },
+      l1Match: {
+        match_id: '47_20252026_1000',
+        home_team: 'Arsenal',
+        away_team: 'Chelsea',
+        match_date: '2025-08-16T14:00:00.000Z'
+      }
+    },
+    {
+      rawMatch: {
+        hash: 'bulk-hash-2',
+        url: 'oddsportal://bulk-2',
+        homeTeam: 'Liverpool',
+        awayTeam: 'Everton'
+      },
+      l1Match: {
+        match_id: '47_20252026_1001',
+        home_team: 'Liverpool',
+        away_team: 'Everton',
+        match_date: '2025-08-17T14:00:00.000Z'
+      }
+    }
+  ], '2025-2026', { name: 'Premier League' });
+
+  assert.equal(result.inserted, 2);
+  assert.equal(result.unmatched, 0);
+  assert.equal(batchCalls.length, 1);
+  assert.equal(batchCalls[0].mappings.length, 2);
+  assert.deepEqual(batchCalls[0].options, {
+    pipelineStatus: 'RECON_LINKED',
+    preserve_linked_status: true
+  });
+  assert.equal(singleSaveCalls, 0);
+});

--- a/tests/unit/fotMobExtractionHelpers.test.js
+++ b/tests/unit/fotMobExtractionHelpers.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  extractPrimaryLeagueData
+} = require('../../src/infrastructure/shared/helpers/fotMobExtractionHelpers');
+
+test('extractPrimaryLeagueData 应只提取与目标 leagueId 匹配的 fallback 数据', () => {
+  const logs = [];
+  const logger = {
+    info(message) {
+      logs.push(message);
+    }
+  };
+  const pageProps = {
+    fallback: {
+      'https://www.fotmob.com/api/data/leagues?id=47&season=20242025': {
+        fixtures: [{ id: 'wrong-league' }]
+      },
+      'https://www.fotmob.com/api/data/leagues?id=54&season=20242025': {
+        fixtures: [{ id: 'target-league' }, { id: 'target-league-2' }]
+      }
+    }
+  };
+
+  const result = extractPrimaryLeagueData(
+    pageProps,
+    54,
+    '2024/2025',
+    (data) => Array.isArray(data?.fixtures) ? data.fixtures.length : 0,
+    logger
+  );
+
+  assert.equal(result.matchCount, 2);
+  assert.deepEqual(result.data, {
+    fixtures: [{ id: 'target-league' }, { id: 'target-league-2' }]
+  });
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /id=54/);
+});
+
+test('extractPrimaryLeagueData 在 fallback 无匹配 leagueId 时应回退到 pageProps fixtures', () => {
+  const pageProps = {
+    fallback: {
+      'https://www.fotmob.com/api/data/leagues?id=47&season=20242025': {
+        fixtures: [{ id: 'wrong-league' }]
+      }
+    },
+    fixtures: [{ id: 'page-props-1' }, { id: 'page-props-2' }],
+    marker: 'page-props-fallback'
+  };
+
+  const result = extractPrimaryLeagueData(
+    pageProps,
+    54,
+    '2024/2025',
+    (data) => Array.isArray(data?.fixtures) ? data.fixtures.length : 0,
+    { info() {} }
+  );
+
+  assert.equal(result.matchCount, 2);
+  assert.equal(result.data.leagueId, 54);
+  assert.equal(result.data.season, '2024/2025');
+  assert.equal(result.data.marker, 'page-props-fallback');
+});


### PR DESCRIPTION
## Summary\n- batch strict-match stitching into a single stitchBatch persistence phase\n- preload season fixture lookups and existing mapping caches to cut DB round-trips\n- include validated FixtureRepository/FotMob helper hardening assets and tests\n\n## Verification\n- npm run lint\n- node --test tests/unit/FixtureRepository.test.js\n- node --test tests/unit/fotMobExtractionHelpers.test.js\n- node --test tests/unit/ReconScanner.Elite.test.js\n- node --test tests/unit/ReconStitcherFlow.test.js tests/unit/ReconDirectionality.test.js tests/unit/ReconBulkFlow.test.js\n- gatekeeper commit/push hooks passed