### PR TITLE
test(recon): add coverage for hasOnlyFuturePendingMatches

### DIFF
--- a/src/infrastructure/recon/services/ReconMatrixTargetRunner.js
+++ b/src/infrastructure/recon/services/ReconMatrixTargetRunner.js
@@ -113,6 +113,8 @@ function buildReconTargetState(target, runtimeTarget, scopedPending, effectiveTh
   };
 }
 
+module.exports.hasOnlyFuturePendingMatches = hasOnlyFuturePendingMatches;
+
 const reconMatrixTargetRunner = {
   _shouldUseTargetDrivenSingleMatch(runtimeTarget = {}, pendingMatches = [], candidates = []) {
     return Number.isInteger(runtimeTarget?.matchLimit)
@@ -818,4 +820,4 @@ const reconMatrixTargetRunner = {
   }
 };
 
-module.exports = { reconMatrixTargetRunner };
+module.exports = { reconMatrixTargetRunner, hasOnlyFuturePendingMatches };

--- a/tests/unit/ReconMatrixTargetRunner.test.js
+++ b/tests/unit/ReconMatrixTargetRunner.test.js
@@ -521,6 +521,23 @@ describe('ReconMatrixTargetRunner', () => {
     }), false);
   });
 
+  it('hasOnlyFuturePendingMatches 应正确识别全部为未来比赛的场景', () => {
+    const { hasOnlyFuturePendingMatches } = require('../../src/infrastructure/recon/services/ReconMatrixTargetRunner');
+
+    assert.equal(hasOnlyFuturePendingMatches([
+      { match_id: 'm1', match_date: '2099-04-19T23:00:00.000Z' },
+      { match_id: 'm2', match_date: '2099-04-20T23:00:00.000Z' }
+    ]), true);
+
+    assert.equal(hasOnlyFuturePendingMatches([
+      { match_id: 'm1', match_date: '2026-04-01T00:00:00.000Z' },
+      { match_id: 'm2', match_date: '2099-04-20T23:00:00.000Z' }
+    ]), false);
+
+    assert.equal(hasOnlyFuturePendingMatches([]), false);
+    assert.equal(hasOnlyFuturePendingMatches(null), false);
+  });
+
   it('_runPostResultsFallbackRoutes 在 results-only 模式遇到残缺 results source 时应抛错重试', async () => {
     const calls = [];
     const runner = createRunner({


### PR DESCRIPTION
## Summary
修复 main 分支门禁失败 (Action #85: branches=79.97% < 80%)

## Root Cause
PR #1097 新增了 `hasOnlyFuturePendingMatches` 函数和相关分支逻辑，但缺少测试覆盖，导致 branches 覆盖率跌破 80% 阈值。

## Changes
- 导出 `hasOnlyFuturePendingMatches` 函数用于测试
- 新增 4 个测试用例，覆盖全部分支场景
- 修复 branches 覆盖率缺口 (79.97% → 80%+)

## Test Plan
- ✅ 本地门禁通过 (commit + push)
- ✅ 新增测试用例全部通过
- ✅ 覆盖率门禁验证通过

Closes #85 (Action failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)