### PR TITLE
test(recon): boost branch coverage with utility function tests

### DIFF
--- a/src/infrastructure/recon/services/ReconMatrixTargetRunner.js
+++ b/src/infrastructure/recon/services/ReconMatrixTargetRunner.js
@@ -820,4 +820,13 @@ const reconMatrixTargetRunner = {
   }
 };
 
-module.exports = { reconMatrixTargetRunner, hasOnlyFuturePendingMatches };
+module.exports = {
+  reconMatrixTargetRunner,
+  hasOnlyFuturePendingMatches,
+  resolvePendingMatchTimestamp,
+  isFuturePendingMatch,
+  shouldDeferFuturePendingFromResults,
+  splitDeferredFuturePendingMatches,
+  mergeDeferredPendingMatches,
+  normalizeLeagueName
+};

--- a/tests/unit/ReconMatrixTargetRunner.test.js
+++ b/tests/unit/ReconMatrixTargetRunner.test.js
@@ -538,6 +538,47 @@ describe('ReconMatrixTargetRunner', () => {
     assert.equal(hasOnlyFuturePendingMatches(null), false);
   });
 
+  it('工具函数应正确处理边界情况', () => {
+    const {
+      resolvePendingMatchTimestamp,
+      isFuturePendingMatch,
+      shouldDeferFuturePendingFromResults,
+      splitDeferredFuturePendingMatches,
+      mergeDeferredPendingMatches,
+      normalizeLeagueName
+    } = require('../../src/infrastructure/recon/services/ReconMatrixTargetRunner');
+
+    assert.equal(resolvePendingMatchTimestamp(null), null);
+    assert.equal(resolvePendingMatchTimestamp({ match_date: 'invalid' }), null);
+    assert.ok(resolvePendingMatchTimestamp({ match_date: '2026-04-20T00:00:00.000Z' }) > 0);
+
+    assert.equal(isFuturePendingMatch(null), false);
+    assert.equal(isFuturePendingMatch({ match_date: '2026-04-01T00:00:00.000Z' }), false);
+
+    assert.equal(shouldDeferFuturePendingFromResults('fixtures'), false);
+    assert.equal(shouldDeferFuturePendingFromResults('results', { source: { mode: 'current_fixtures' } }), false);
+    assert.equal(shouldDeferFuturePendingFromResults('results', { source: { mode: 'historical' } }), true);
+
+    const split = splitDeferredFuturePendingMatches([
+      { match_id: 'm1', match_date: '2026-04-01T00:00:00.000Z' },
+      { match_id: 'm2', match_date: '2099-04-20T00:00:00.000Z' }
+    ], 'results', { source: { mode: 'historical' } });
+    assert.equal(split.eligiblePending.length, 1);
+    assert.equal(split.deferredPending.length, 1);
+
+    const merged = mergeDeferredPendingMatches(
+      [{ match_id: 'm1' }, { match_id: 'm2' }],
+      [{ match_id: 'm1', data: 'deferred' }],
+      [{ match_id: 'm2', data: 'remaining' }]
+    );
+    assert.equal(merged.length, 2);
+    assert.equal(merged[0].data, 'deferred');
+
+    assert.equal(normalizeLeagueName('Brasileirão'), 'brasileirao');
+    assert.equal(normalizeLeagueName('J1 League'), 'j1 league');
+    assert.equal(normalizeLeagueName(null), '');
+  });
+
   it('_runPostResultsFallbackRoutes 在 results-only 模式遇到残缺 results source 时应抛错重试', async () => {
     const calls = [];
     const runner = createRunner({


### PR DESCRIPTION
## Summary
彻底攻克 Main 分支覆盖率红线波动问题

## Root Cause
Main 分支 branches 覆盖率在 79.98% 左右波动，缺少安全缓冲，导致任何微小变更都可能触发 80% 红线警报。

## Changes
- 导出 6 个工具函数用于测试
- 新增全面的边界情况测试覆盖
- 目标：branches 79.98% → 82%+ (建立安全缓冲)

## Test Plan
- ✅ 本地门禁通过 (commit + push)
- ✅ 新增测试用例全部通过
- ⏳ 等待远程 Action 验证

Fixes main branch coverage red line

🤖 Generated with [Claude Code](https://claude.com/claude-code)