### PR TITLE
security(gatekeeper): permanently lock local main commit and push paths

### DIFF
--- a/scripts/devops/gatekeeper.sh
+++ b/scripts/devops/gatekeeper.sh
@@ -29,6 +29,10 @@ log() {
   printf '[Gatekeeper] %s\n' "$*"
 }
 
+warn() {
+  printf '[Gatekeeper] WARN: %s\n' "$*" >&2
+}
+
 fail() {
   printf '[Gatekeeper] ERROR: %s\n' "$*" >&2
   exit 1
@@ -62,6 +66,150 @@ resolve_auto_mode() {
   fi
 
   printf 'push\n'
+}
+
+is_ci_gatekeeper_context() {
+  [[ -n "${GITHUB_ACTIONS:-}" || "${CI:-}" == "true" ]]
+}
+
+git_current_branch() {
+  git symbolic-ref --quiet --short HEAD 2>/dev/null || true
+}
+
+git_branch_is_protected() {
+  local branch="$1"
+  case "$branch" in
+    main|master)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+git_branch_is_preferred_workspace() {
+  local branch="$1"
+  case "$branch" in
+    security/*|feat/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+resolve_branch_upstream_ref() {
+  local branch="$1"
+  local upstream_ref=''
+
+  upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+  if [[ -n "$upstream_ref" ]]; then
+    printf '%s\n' "$upstream_ref"
+    return 0
+  fi
+
+  if [[ -n "$branch" ]] && git rev-parse --verify "origin/${branch}" >/dev/null 2>&1; then
+    printf 'origin/%s\n' "$branch"
+    return 0
+  fi
+
+  return 1
+}
+
+collect_significant_status_lines() {
+  local line=''
+  local file=''
+
+  git status --short 2>/dev/null | while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    file="${line:3}"
+
+    case "$file" in
+      src/*|scripts/*|config/*|database/*|.github/*|.githooks/*|docker-compose*.yml|package.json|package-lock.json|Makefile|requirements*.txt|pytest.ini)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done
+}
+
+run_branch_workspace_preflight() {
+  local current_branch=''
+  local upstream_ref=''
+  local ahead_count=0
+  local ahead_merge_count=0
+  local merge_subject=''
+  local important_status=()
+  local line=''
+  local limit=10
+  local index=0
+
+  if [[ "${GATEKEEPER_HOST_PREFLIGHT_DONE:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+
+  current_branch="$(git_current_branch)"
+  [[ -n "$current_branch" ]] || return 0
+
+  if ! is_ci_gatekeeper_context && git_branch_is_protected "$current_branch"; then
+    if [[ "$MODE" == "commit" ]]; then
+      fail '本地主干禁写协议触发！严禁在本地 main 编写或合并代码。请前往 feature 分支并通过 GitHub PR 流程操作。'
+    fi
+
+    if [[ "$MODE" == "push" ]]; then
+      upstream_ref="$(resolve_branch_upstream_ref "$current_branch" || true)"
+      if [[ -n "$upstream_ref" ]]; then
+        ahead_count="$(git rev-list --count "${upstream_ref}..HEAD" 2>/dev/null | tr -d '[:space:]')"
+        ahead_merge_count="$(git rev-list --count --merges "${upstream_ref}..HEAD" 2>/dev/null | tr -d '[:space:]')"
+      fi
+
+      if [[ -n "$ahead_count" ]] && (( ahead_count > 0 )); then
+        if [[ -n "$ahead_merge_count" ]] && (( ahead_merge_count > 0 )); then
+          merge_subject="$(git log --format=%s --merges -1 "${upstream_ref}..HEAD" 2>/dev/null || true)"
+          warn "检测到 ${ahead_merge_count} 个尚未推送到远端的 Merge Commit（范围 ${upstream_ref}..HEAD）。"
+          [[ -n "$merge_subject" ]] && warn "最近一次本地 Merge Commit: ${merge_subject}"
+        else
+          warn "检测到主干分支 ${current_branch} 存在 ${ahead_count} 个尚未推送的本地提交。"
+        fi
+        fail '本地主干禁写协议触发！严禁在本地 main 编写或合并代码。请前往 feature 分支并通过 GitHub PR 流程操作。'
+      fi
+    fi
+  fi
+
+  if is_ci_gatekeeper_context; then
+    return 0
+  fi
+
+  if [[ "$MODE" != "commit" && "$MODE" != "push" && "$MODE" != "pr" ]]; then
+    return 0
+  fi
+
+  if git_branch_is_protected "$current_branch" || git_branch_is_preferred_workspace "$current_branch"; then
+    return 0
+  fi
+
+  mapfile -t important_status < <(collect_significant_status_lines)
+  if [[ "${#important_status[@]}" -eq 0 ]]; then
+    return 0
+  fi
+
+  warn "当前分支 ${current_branch} 不属于规范工作分支（security/* 或 feat/*），但检测到 ${#important_status[@]} 个重要改动："
+  for line in "${important_status[@]}"; do
+    printf '[Gatekeeper] WARN:   %s\n' "$line" >&2
+    index=$((index + 1))
+    if (( index >= limit )); then
+      break
+    fi
+  done
+
+  if (( ${#important_status[@]} > limit )); then
+    warn "... 还有 $(( ${#important_status[@]} - limit )) 个重要改动未展开。"
+  fi
 }
 
 if [[ "${GATEKEEPER_IN_CONTAINER:-0}" != "1" ]]; then
@@ -99,6 +247,8 @@ if [[ "${GATEKEEPER_IN_CONTAINER:-0}" != "1" ]]; then
     log "自动选择门禁模式: ${MODE}"
   fi
 
+  run_branch_workspace_preflight
+
   UP_ARGS=(-d)
   if [[ "${GATEKEEPER_BUILD:-0}" == "1" ]]; then
     UP_ARGS=(-d --build)
@@ -112,7 +262,7 @@ if [[ "${GATEKEEPER_IN_CONTAINER:-0}" != "1" ]]; then
   log '切入 dev 容器执行门禁。'
   "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" exec -T "$DEV_SERVICE" \
     env GATEKEEPER_IN_CONTAINER=1 GATEKEEPER_MODE="$MODE" GATEKEEPER_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
-    GITHUB_ACTIONS="${GITHUB_ACTIONS:-}" CI="${CI:-}" \
+    GATEKEEPER_HOST_PREFLIGHT_DONE=1 GITHUB_ACTIONS="${GITHUB_ACTIONS:-}" CI="${CI:-}" \
     bash "$CONTAINER_GATEKEEPER_PATH"
   exit $?
 fi
@@ -193,6 +343,37 @@ collect_scan_files() {
           ! -name '*.md' \
           ! -name '*.disabled' \
           ! -path '*/tests/*' \
+          ! -path '*/node_modules/*' \
+          ! -path '*/docs/*' \
+          ! -path '*/archive_vault_2026/*' \
+          ! -path '*/logs/*' \
+          ! -path '*/tmp/*' \
+          ! -path '*/__pycache__/*'
+      )
+    fi
+  done
+
+  printf '%s\n' "${files[@]}" | sort -u
+}
+
+collect_no_verify_scan_files() {
+  local roots=(scripts .githooks .github Makefile package.json)
+  local files=()
+  local root
+
+  for root in "${roots[@]}"; do
+    if [[ -f "$root" ]]; then
+      files+=("$root")
+      continue
+    fi
+
+    if [[ -d "$root" ]]; then
+      while IFS= read -r file; do
+        files+=("$file")
+      done < <(
+        find "$root" -type f \
+          ! -name '*.md' \
+          ! -name '*.disabled' \
           ! -path '*/node_modules/*' \
           ! -path '*/docs/*' \
           ! -path '*/archive_vault_2026/*' \
@@ -355,6 +536,35 @@ run_optional_grep() {
   fi
 
   return 0
+}
+
+run_no_verify_backdoor_guard() {
+  log '执行 Git Hook 逃逸参数扫描。'
+
+  mapfile -t scan_files < <(collect_no_verify_scan_files)
+  if [[ "${#scan_files[@]}" -eq 0 ]]; then
+    fail '未找到可用于扫描 Hook 逃逸参数的脚本文件。'
+  fi
+
+  local findings=()
+  local line=''
+  local no_verify_word='no'
+  local no_verify_long='--no'
+  local pattern=''
+  no_verify_word+='-verify'
+  no_verify_long+='-verify'
+  pattern="(^|[^[:alnum:]_-])(${no_verify_long}|${no_verify_word})([^[:alnum:]_-]|$)"
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    findings+=("$line")
+  done < <(run_optional_grep "$pattern" "${scan_files[@]}")
+
+  if [[ "${#findings[@]}" -gt 0 ]]; then
+    printf '[Gatekeeper] 命中 Hook 逃逸参数字面量:\n' >&2
+    printf '  %s\n' "${findings[@]}" >&2
+    fail '检测到绕过 Gatekeeper 的 Hook 逃逸参数，请立即移除。'
+  fi
 }
 
 assert_quality_tooling() {
@@ -981,27 +1191,27 @@ run_remote_merge_enforcement() {
   fi
 
   local current_branch
-  current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  current_branch="$(git_current_branch)"
 
-  if [[ "$current_branch" != "main" && "$current_branch" != "master" ]]; then
+  if ! git_branch_is_protected "$current_branch"; then
     return 0
   fi
 
-  local last_commit_parents
-  last_commit_parents="$(git log -1 --format=%P HEAD 2>/dev/null || true)"
-
-  if [[ -z "$last_commit_parents" ]]; then
+  local upstream_ref
+  upstream_ref="$(resolve_branch_upstream_ref "$current_branch" || true)"
+  if [[ -z "$upstream_ref" ]]; then
     return 0
   fi
 
-  local parent_count
-  parent_count="$(echo "$last_commit_parents" | wc -w | tr -d '[:space:]')"
+  local merge_count
+  merge_count="$(git rev-list --count --merges "${upstream_ref}..HEAD" 2>/dev/null | tr -d '[:space:]')"
 
-  if (( parent_count > 1 )); then
+  if [[ -n "$merge_count" ]] && (( merge_count > 0 )); then
     printf '[Gatekeeper] ERROR: 检测到本地合并提交推送到主干分支 %s\n' "$current_branch" >&2
-    printf '[Gatekeeper] 最后一次提交有 %s 个父提交，疑似本地 merge\n' "$parent_count" >&2
-    printf '[Gatekeeper] 提交哈希: %s\n' "$(git log -1 --format=%H HEAD)" >&2
-    printf '[Gatekeeper] 提交信息: %s\n' "$(git log -1 --format=%s HEAD)" >&2
+    printf '[Gatekeeper] 命中 %s 个尚未推送的本地 Merge Commit，范围: %s..HEAD\n' "$merge_count" "$upstream_ref" >&2
+    printf '[Gatekeeper] 最近一次 Merge Commit: %s %s\n' \
+      "$(git log --format=%H --merges -1 "${upstream_ref}..HEAD")" \
+      "$(git log --format=%s --merges -1 "${upstream_ref}..HEAD")" >&2
     fail '禁止在本地合并代码推送到主干，请通过 GitHub PR 在云端完成合并！'
   fi
 }
@@ -1033,11 +1243,13 @@ run_commit_smoke_tests() {
 main() {
   log "进入门禁容器执行阶段（mode=${MODE}）。"
 
+  run_branch_workspace_preflight
   ensure_git_context
   bootstrap_node_dependencies
   bootstrap_python_dependencies
   assert_quality_tooling
 
+  run_no_verify_backdoor_guard
   validate_proxy_pool_file
   validate_cross_language_proxy_source
   run_secret_ip_leak_check


### PR DESCRIPTION
## Summary\n- permanently block local commit/push activity on protected branches  and \n- fail push mode when protected branches contain unpushed local merge commits or direct local commits\n- scan scripts, hooks, workflow files and entrypoints for  escape hatches\n- warn immediately when important changes happen outside  or  work branches\n\n## Validation\n- \n- [Gatekeeper] 准备开发容器（mode=commit）...
[Gatekeeper] 切入 dev 容器执行门禁。
[Gatekeeper] 进入门禁容器执行阶段（mode=commit）。
[Gatekeeper] 执行 Git Hook 逃逸参数扫描。
[Gatekeeper] 校验共享代理池配置文件。
[Gatekeeper] proxy_pool.json OK host=127.0.0.1 ports=40
[Gatekeeper] 校验 JS/Python 代理真相源一致性。
[Gatekeeper] 跨语言代理配置一致: host=192.168.65.254 ports=40
[Gatekeeper] 执行硬编码 IP/端口泄漏扫描。
[Gatekeeper] 执行 ProxyProvider 契约检查。
[Gatekeeper] 执行 Python 代理契约检查。
[Gatekeeper] 执行 src.config_unified 兼容壳收口检查。
[Gatekeeper] 执行 Python 架构体量检查。
[Gatekeeper] 未检测到本次变更涉及 Python 目标文件，跳过巨石文件检查。
[Gatekeeper] 执行静态质量检查。

> footballprediction-v451@4.51.2-TOTAL-WAR lint
> eslint "src/**/*.js" "config/**/*.js" "scripts/ops/**/*.js" "scripts/maintenance/**/*.js" "scripts/test/**/*.js" --cache --cache-location .eslintcache

[Gatekeeper] 未检测到本次变更涉及 Python 目标文件，跳过 Python 风格与类型检查。
[Gatekeeper] 执行 [GATE-COLD-START] 冷启动蓝图校验。
[GATE-COLD-START] PASS - 空库回放成功 - 临时库 gatekeeper_cold_start_1776929968821_ca6e6332，蓝图 10 个文件
[Gatekeeper] 执行仓库卫生扫描。
[REPO-HYGIENE] WARN - 疑似脱离主流程的 scripts/ops 脚本 15 个: scripts/ops/bulk_import_matches.js, scripts/ops/cleanup_csv_bulk_loader_import.js, scripts/ops/fixture_harvester_l1.js, scripts/ops/generate_bundesliga_fixtures.js, scripts/ops/gold_pilot_50.js, scripts/ops/l3_stitch_worker.js, scripts/ops/master_inventory.js, scripts/ops/purge_ghost_data.js ... 还有 7 个
[REPO-HYGIENE] PASS - 仓库卫生检查通过
[Gatekeeper] 执行 ProxyProvider 契约单测。
TAP version 13
# [ProxyProvider] proxy_under_observation {
#   type: 'proxy_under_observation',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   consecutiveFailures: 1,
#   observationThreshold: 3
# }
# [ProxyProvider] proxy_under_observation {
#   type: 'proxy_under_observation',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   consecutiveFailures: 2,
#   observationThreshold: 3
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   cooldownUntil: 91000,
#   cooldownMs: 90000,
#   consecutiveFailures: 3
# }
# [ProxyProvider] proxy_health_score_blocked {
#   type: 'proxy_health_score_blocked',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   healthScore: 40,
#   minHealthScore: 60
# }
# [ProxyProvider] rate_limit_isolation {
#   type: 'rate_limit_isolation',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:20.000Z',
#   statusCode: 429,
#   reason: 'Too Many Requests',
#   isolatedUntil: 1220000,
#   cooldownUntil: 1220000,
#   cooldownMs: 1200000
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:20.000Z',
#   statusCode: 429,
#   reason: 'Too Many Requests',
#   cooldownUntil: 1220000,
#   cooldownMs: 1200000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:30.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   cooldownUntil: 1230000,
#   cooldownMs: 1200000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:10.000Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   cooldownUntil: 1810000,
#   cooldownMs: 1800000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_health_score_blocked {
#   type: 'proxy_health_score_blocked',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:10.000Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   healthScore: 55,
#   minHealthScore: 60
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '2026-04-23T07:39:47.391Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   cooldownUntil: 1776931787391,
#   cooldownMs: 1800000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_health_score_blocked {
#   type: 'proxy_health_score_blocked',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '2026-04-23T07:39:47.391Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   healthScore: 55,
#   minHealthScore: 60
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:05.000Z',
#   statusCode: null,
#   reason: 'page.goto: net::ERR_EMPTY_RESPONSE',
#   failureClass: 'upstream_block',
#   cooldownUntil: 10000,
#   cooldownMs: 5000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:08.000Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 9000,
#   cooldownMs: 1000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:09.100Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 11100,
#   cooldownMs: 2000,
#   consecutiveFailures: 2
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:10.200Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 13200,
#   cooldownMs: 3000,
#   consecutiveFailures: 3
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:11.300Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 14300,
#   cooldownMs: 3000,
#   consecutiveFailures: 4
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:12.400Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 15400,
#   cooldownMs: 3000,
#   consecutiveFailures: 5
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:13.500Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 16500,
#   cooldownMs: 3000,
#   consecutiveFailures: 6
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:14.600Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 17600,
#   cooldownMs: 3000,
#   consecutiveFailures: 7
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:15.700Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 18700,
#   cooldownMs: 3000,
#   consecutiveFailures: 8
# }
# [ProxyProvider] gateway_preflight_failed {
#   host: 'host.docker.internal',
#   port: 7891,
#   reason: 'connect ECONNREFUSED'
# }
# [ProxyProvider] gateway_preflight_passed { host: 'host.docker.internal', port: 7891, latencyMs: 12 }
# Subtest: src/infrastructure/network/ProxyProvider
    # Subtest: 100 次并发租约应在当前可用端口间近似均衡分布
    ok 1 - 100 次并发租约应在当前可用端口间近似均衡分布
      ---
      duration_ms: 5.038046
      ...
    # Subtest: 连续 503 应在观察窗后进入 90 秒冷却并触发告警
    ok 2 - 连续 503 应在观察窗后进入 90 秒冷却并触发告警
      ---
      duration_ms: 3.469266
      ...
    # Subtest: 429 应在首次命中后立即隔离并进入 20 分钟冷却
    ok 3 - 429 应在首次命中后立即隔离并进入 20 分钟冷却
      ---
      duration_ms: 1.227727
      ...
    # Subtest: 503 在 observationThreshold=1 时应首次命中立即进入 20 分钟冷却
    ok 4 - 503 在 observationThreshold=1 时应首次命中立即进入 20 分钟冷却
      ---
      duration_ms: 0.757259
      ...
    # Subtest: 403 应立即触发 30 分钟关键冷却并跌破健康分租用阈值
    ok 5 - 403 应立即触发 30 分钟关键冷却并跌破健康分租用阈值
      ---
      duration_ms: 0.932953
      ...
    # Subtest: 健康分低于 60 的端口不得再次被租用
    ok 6 - 健康分低于 60 的端口不得再次被租用
      ---
      duration_ms: 0.506208
      ...
    # Subtest: 默认主机应统一解析为 127.0.0.1
    ok 7 - 默认主机应统一解析为 127.0.0.1
      ---
      duration_ms: 0.313554
      ...
    # Subtest: ERR_EMPTY_RESPONSE 应触发软退避而不是判定代理物理死亡
    ok 8 - ERR_EMPTY_RESPONSE 应触发软退避而不是判定代理物理死亡
      ---
      duration_ms: 0.534884
      ...
    # Subtest: 软故障连续出现时不得将节点健康分打穿到不可租用
    ok 9 - 软故障连续出现时不得将节点健康分打穿到不可租用
      ---
      duration_ms: 0.891591
      ...
    # Subtest: 初始化时应先完成代理网关 TCP 预检
    ok 10 - 初始化时应先完成代理网关 TCP 预检
      ---
      duration_ms: 0.608409
      ...
    # Subtest: 代理网关 TCP 预检失败时应抛出清晰错误
    ok 11 - 代理网关 TCP 预检失败时应抛出清晰错误
      ---
      duration_ms: 0.532442
      ...
    1..11
ok 1 - src/infrastructure/network/ProxyProvider
  ---
  duration_ms: 15.832225
  type: 'suite'
  ...
1..1
# tests 11
# suites 1
# pass 11
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 100.09102
[Gatekeeper] 执行 Commit 模式核心单测烟雾检查。
[Gatekeeper] 运行烟雾测试: tests/unit/EntityMapper.test.js
TAP version 13
# Subtest: normalizeBookmakerName 应识别亚洲博彩公司预留别名
ok 1 - normalizeBookmakerName 应识别亚洲博彩公司预留别名
  ---
  duration_ms: 3.47787
  ...
# Subtest: normalizeBookmakerName 对未预置庄家应保持原值
ok 2 - normalizeBookmakerName 对未预置庄家应保持原值
  ---
  duration_ms: 0.647244
  ...
# Subtest: normalizeLeagueName 应识别 LaLiga 别名
ok 3 - normalizeLeagueName 应识别 LaLiga 别名
  ---
  duration_ms: 1.008449
  ...
# Subtest: normalizeTeamName 应识别五大联赛常见别名
ok 4 - normalizeTeamName 应识别五大联赛常见别名
  ---
  duration_ms: 0.444004
  ...
1..4
# tests 4
# suites 0
# pass 4
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 47.24587
[Gatekeeper] 运行烟雾测试: tests/unit/helpers/euroLeagueAdapters.test.js
TAP version 13
# Subtest: normalizeText - 应正确规范化文本
ok 1 - normalizeText - 应正确规范化文本
  ---
  duration_ms: 2.572229
  ...
# Subtest: resolveCsvField - 应支持显式列别名回退
ok 2 - resolveCsvField - 应支持显式列别名回退
  ---
  duration_ms: 0.099983
  ...
# Subtest: resolveCsvField - 应跳过空值
ok 3 - resolveCsvField - 应跳过空值
  ---
  duration_ms: 0.535214
  ...
# Subtest: toCsvCell - 应正确转义 CSV 单元格
ok 4 - toCsvCell - 应正确转义 CSV 单元格
  ---
  duration_ms: 0.157891
  ...
# Subtest: formatCsvLine - 应正确格式化 CSV 行
ok 5 - formatCsvLine - 应正确格式化 CSV 行
  ---
  duration_ms: 0.073567
  ...
# Subtest: formatCsvLine - 应处理包含特殊字符的行
ok 6 - formatCsvLine - 应处理包含特殊字符的行
  ---
  duration_ms: 0.049922
  ...
# Subtest: parseFootballDataDateTime - 应正确解析日期时间
ok 7 - parseFootballDataDateTime - 应正确解析日期时间
  ---
  duration_ms: 0.404881
  ...
# Subtest: parseFootballDataDateTime - 应处理无效输入
ok 8 - parseFootballDataDateTime - 应处理无效输入
  ---
  duration_ms: 0.082021
  ...
# Subtest: extractOddsValues - 应正确提取赔率值
ok 9 - extractOddsValues - 应正确提取赔率值
  ---
  duration_ms: 0.609496
  ...
# Subtest: extractOddsValues - 应处理缺失列
ok 10 - extractOddsValues - 应处理缺失列
  ---
  duration_ms: 0.115239
  ...
# Subtest: hasAnyOddsValue - 应正确检测是否有任何赔率值
ok 11 - hasAnyOddsValue - 应正确检测是否有任何赔率值
  ---
  duration_ms: 0.129097
  ...
# Subtest: hasCompleteOddsTriplet - 应正确检测完整赔率三元组
ok 12 - hasCompleteOddsTriplet - 应正确检测完整赔率三元组
  ---
  duration_ms: 0.097244
  ...
# Subtest: resolveLineValue - 应正确解析盘口值
ok 13 - resolveLineValue - 应正确解析盘口值
  ---
  duration_ms: 0.101817
  ...
# Subtest: resolveLineValue - 应处理缺失盘口
ok 14 - resolveLineValue - 应处理缺失盘口
  ---
  duration_ms: 0.073375
  ...
# Subtest: mapOutcomeColumns - 应正确映射结果列
ok 15 - mapOutcomeColumns - 应正确映射结果列
  ---
  duration_ms: 0.061255
  ...
# Subtest: mapOutcomeColumns - 应处理缺失值
ok 16 - mapOutcomeColumns - 应处理缺失值
  ---
  duration_ms: 0.080102
  ...
# Subtest: buildExpandedOddsRows - 应正确构建扩展赔率行
ok 17 - buildExpandedOddsRows - 应正确构建扩展赔率行
  ---
  duration_ms: 0.142081
  ...
# Subtest: buildExpandedOddsRows - 应跳过无赔率的市场
ok 18 - buildExpandedOddsRows - 应跳过无赔率的市场
  ---
  duration_ms: 0.127839
  ...
# Subtest: buildExpandedOddsRows - 应标记低质量数据源
ok 19 - buildExpandedOddsRows - 应标记低质量数据源
  ---
  duration_ms: 0.075806
  ...
1..19
# tests 19
# suites 0
# pass 19
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 54.108101
[Gatekeeper] 门禁通过（mode=commit）。\n- simulated local  commit interception in an isolated temporary clone\n- [Gatekeeper] 自动选择门禁模式: pr
[Gatekeeper] 准备开发容器（mode=pr）...
[Gatekeeper] 切入 dev 容器执行门禁。
[Gatekeeper] 进入门禁容器执行阶段（mode=pr）。
[Gatekeeper] 执行 Git Hook 逃逸参数扫描。
[Gatekeeper] 校验共享代理池配置文件。
[Gatekeeper] proxy_pool.json OK host=127.0.0.1 ports=40
[Gatekeeper] 校验 JS/Python 代理真相源一致性。
[Gatekeeper] 跨语言代理配置一致: host=192.168.65.254 ports=40
[Gatekeeper] 执行硬编码 IP/端口泄漏扫描。
[Gatekeeper] 执行 ProxyProvider 契约检查。
[Gatekeeper] 执行 Python 代理契约检查。
[Gatekeeper] 执行 src.config_unified 兼容壳收口检查。
[Gatekeeper] 执行 Python 架构体量检查。
[Gatekeeper] 未检测到本次变更涉及 Python 目标文件，跳过巨石文件检查。
[Gatekeeper] 执行静态质量检查。

> footballprediction-v451@4.51.2-TOTAL-WAR lint
> eslint "src/**/*.js" "config/**/*.js" "scripts/ops/**/*.js" "scripts/maintenance/**/*.js" "scripts/test/**/*.js" --cache --cache-location .eslintcache

[Gatekeeper] 未检测到本次变更涉及 Python 目标文件，跳过 Python 风格与类型检查。
[Gatekeeper] 执行 [GATE-COLD-START] 冷启动蓝图校验。
[GATE-COLD-START] PASS - 空库回放成功 - 临时库 gatekeeper_cold_start_1776929993474_6450cff6，蓝图 10 个文件
[Gatekeeper] 执行仓库卫生扫描。
[REPO-HYGIENE] WARN - 疑似脱离主流程的 scripts/ops 脚本 15 个: scripts/ops/bulk_import_matches.js, scripts/ops/cleanup_csv_bulk_loader_import.js, scripts/ops/fixture_harvester_l1.js, scripts/ops/generate_bundesliga_fixtures.js, scripts/ops/gold_pilot_50.js, scripts/ops/l3_stitch_worker.js, scripts/ops/master_inventory.js, scripts/ops/purge_ghost_data.js ... 还有 7 个
[REPO-HYGIENE] PASS - 仓库卫生检查通过
[Gatekeeper] 执行 ProxyProvider 契约单测。
TAP version 13
# [ProxyProvider] proxy_under_observation {
#   type: 'proxy_under_observation',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   consecutiveFailures: 1,
#   observationThreshold: 3
# }
# [ProxyProvider] proxy_under_observation {
#   type: 'proxy_under_observation',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   consecutiveFailures: 2,
#   observationThreshold: 3
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   cooldownUntil: 91000,
#   cooldownMs: 90000,
#   consecutiveFailures: 3
# }
# [ProxyProvider] proxy_health_score_blocked {
#   type: 'proxy_health_score_blocked',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:01.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   healthScore: 40,
#   minHealthScore: 60
# }
# [ProxyProvider] rate_limit_isolation {
#   type: 'rate_limit_isolation',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:20.000Z',
#   statusCode: 429,
#   reason: 'Too Many Requests',
#   isolatedUntil: 1220000,
#   cooldownUntil: 1220000,
#   cooldownMs: 1200000
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:20.000Z',
#   statusCode: 429,
#   reason: 'Too Many Requests',
#   cooldownUntil: 1220000,
#   cooldownMs: 1200000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:30.000Z',
#   statusCode: 503,
#   reason: 'HTTP 503',
#   cooldownUntil: 1230000,
#   cooldownMs: 1200000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:10.000Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   cooldownUntil: 1810000,
#   cooldownMs: 1800000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_health_score_blocked {
#   type: 'proxy_health_score_blocked',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:10.000Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   healthScore: 55,
#   minHealthScore: 60
# }
# [ProxyProvider] proxy_cooled_down {
#   type: 'proxy_cooled_down',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '2026-04-23T07:40:12.276Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   cooldownUntil: 1776931812276,
#   cooldownMs: 1800000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_health_score_blocked {
#   type: 'proxy_health_score_blocked',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '2026-04-23T07:40:12.276Z',
#   statusCode: 403,
#   reason: 'Forbidden',
#   healthScore: 55,
#   minHealthScore: 60
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:05.000Z',
#   statusCode: null,
#   reason: 'page.goto: net::ERR_EMPTY_RESPONSE',
#   failureClass: 'upstream_block',
#   cooldownUntil: 10000,
#   cooldownMs: 5000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:08.000Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 9000,
#   cooldownMs: 1000,
#   consecutiveFailures: 1
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:09.100Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 11100,
#   cooldownMs: 2000,
#   consecutiveFailures: 2
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:10.200Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 13200,
#   cooldownMs: 3000,
#   consecutiveFailures: 3
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:11.300Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 14300,
#   cooldownMs: 3000,
#   consecutiveFailures: 4
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:12.400Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 15400,
#   cooldownMs: 3000,
#   consecutiveFailures: 5
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:13.500Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 16500,
#   cooldownMs: 3000,
#   consecutiveFailures: 6
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:14.600Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 17600,
#   cooldownMs: 3000,
#   consecutiveFailures: 7
# }
# [ProxyProvider] proxy_soft_backoff {
#   type: 'proxy_soft_backoff',
#   port: 10001,
#   host: '127.0.0.1',
#   server: 'socks5://127.0.0.1:10001',
#   timestamp: '1970-01-01T00:00:15.700Z',
#   statusCode: null,
#   reason: 'page.evaluate: Execution context was destroyed',
#   failureClass: 'browser_context_transient',
#   cooldownUntil: 18700,
#   cooldownMs: 3000,
#   consecutiveFailures: 8
# }
# [ProxyProvider] gateway_preflight_failed {
#   host: 'host.docker.internal',
#   port: 7891,
#   reason: 'connect ECONNREFUSED'
# }
# [ProxyProvider] gateway_preflight_passed { host: 'host.docker.internal', port: 7891, latencyMs: 12 }
# Subtest: src/infrastructure/network/ProxyProvider
    # Subtest: 100 次并发租约应在当前可用端口间近似均衡分布
    ok 1 - 100 次并发租约应在当前可用端口间近似均衡分布
      ---
      duration_ms: 4.897982
      ...
    # Subtest: 连续 503 应在观察窗后进入 90 秒冷却并触发告警
    ok 2 - 连续 503 应在观察窗后进入 90 秒冷却并触发告警
      ---
      duration_ms: 3.220128
      ...
    # Subtest: 429 应在首次命中后立即隔离并进入 20 分钟冷却
    ok 3 - 429 应在首次命中后立即隔离并进入 20 分钟冷却
      ---
      duration_ms: 0.680631
      ...
    # Subtest: 503 在 observationThreshold=1 时应首次命中立即进入 20 分钟冷却
    ok 4 - 503 在 observationThreshold=1 时应首次命中立即进入 20 分钟冷却
      ---
      duration_ms: 0.540603
      ...
    # Subtest: 403 应立即触发 30 分钟关键冷却并跌破健康分租用阈值
    ok 5 - 403 应立即触发 30 分钟关键冷却并跌破健康分租用阈值
      ---
      duration_ms: 0.558863
      ...
    # Subtest: 健康分低于 60 的端口不得再次被租用
    ok 6 - 健康分低于 60 的端口不得再次被租用
      ---
      duration_ms: 0.464323
      ...
    # Subtest: 默认主机应统一解析为 127.0.0.1
    ok 7 - 默认主机应统一解析为 127.0.0.1
      ---
      duration_ms: 0.307122
      ...
    # Subtest: ERR_EMPTY_RESPONSE 应触发软退避而不是判定代理物理死亡
    ok 8 - ERR_EMPTY_RESPONSE 应触发软退避而不是判定代理物理死亡
      ---
      duration_ms: 0.596561
      ...
    # Subtest: 软故障连续出现时不得将节点健康分打穿到不可租用
    ok 9 - 软故障连续出现时不得将节点健康分打穿到不可租用
      ---
      duration_ms: 1.045775
      ...
    # Subtest: 初始化时应先完成代理网关 TCP 预检
    ok 10 - 初始化时应先完成代理网关 TCP 预检
      ---
      duration_ms: 0.691143
      ...
    # Subtest: 代理网关 TCP 预检失败时应抛出清晰错误
    ok 11 - 代理网关 TCP 预检失败时应抛出清晰错误
      ---
      duration_ms: 0.615204
      ...
    1..11
ok 1 - src/infrastructure/network/ProxyProvider
  ---
  duration_ms: 14.542959
  type: 'suite'
  ...
1..1
# tests 11
# suites 1
# pass 11
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 93.95245
[Gatekeeper] 执行增量 JS 测试门禁。
[TEST-GATE] 增量门禁执行: 变更文件 1 个，命中测试 4 个。
TAP version 13
# Subtest: src/infrastructure/services/BrowserProvider
    # Subtest: 应完成初始化、预热、页面操作与关闭流程
    ok 1 - 应完成初始化、预热、页面操作与关闭流程
      ---
      duration_ms: 3.650125
      ...
    # Subtest: 接入 ProxyProvider 后应携带代理启动并在关闭时释放租约
    ok 2 - 接入 ProxyProvider 后应携带代理启动并在关闭时释放租约
      ---
      duration_ms: 0.844874
      ...
    # Subtest: 初始化失败与页面预热失败时应记录错误/告警
    ok 3 - 初始化失败与页面预热失败时应记录错误/告警
      ---
      duration_ms: 2.309124
      ...
    # Subtest: 预热失败后应废弃失败页并创建干净页
    ok 4 - 预热失败后应废弃失败页并创建干净页
      ---
      duration_ms: 1.046115
      ...
    # Subtest: fetch/evaluate 应覆盖超时与空页面分支
    ok 5 - fetch/evaluate 应覆盖超时与空页面分支
      ---
      duration_ms: 1.023143
      ...
    # Subtest: fetch 在未初始化时应自动拉起浏览器
    ok 6 - fetch 在未初始化时应自动拉起浏览器
      ---
      duration_ms: 0.866634
      ...
    # Subtest: 页面级软故障应上报为轻量失败分类，并支持页面恢复
    ok 7 - 页面级软故障应上报为轻量失败分类，并支持页面恢复
      ---
      duration_ms: 1.420379
      ...
    # Subtest: recoverPage 在 browser 已断连时应阻断 newPage 并重建 Browser 实例
    ok 8 - recoverPage 在 browser 已断连时应阻断 newPage 并重建 Browser 实例
      ---
      duration_ms: 1.0525
      ...
    # Subtest: recoverPage 在 newPage 命中关闭竞态时应回收旧实例并重建 Browser
    ok 9 - recoverPage 在 newPage 命中关闭竞态时应回收旧实例并重建 Browser
      ---
      duration_ms: 1.109606
      ...
    # Subtest: 共享 page 的导航与 fetch 应串行执行，避免恢复导航打断并发请求
    ok 10 - 共享 page 的导航与 fetch 应串行执行，避免恢复导航打断并发请求
      ---
      duration_ms: 5.102978
      ...
    # Subtest: 懒初始化与浏览器内 fetch 分支应覆盖默认 logger、HTTP 错误、HTML 响应和异常响应
    ok 11 - 懒初始化与浏览器内 fetch 分支应覆盖默认 logger、HTTP 错误、HTML 响应和异常响应
      ---
      duration_ms: 1.502714
      ...
    1..11
ok 1 - src/infrastructure/services/BrowserProvider
  ---
  duration_ms: 21.396454
  type: 'suite'
  ...
# [DB] 重试 1/2，等待 9ms...
# Subtest: config/database
    # Subtest: 应按环境变量构建 DB_CONFIG，并缓存连接池单例
    ok 1 - 应按环境变量构建 DB_CONFIG，并缓存连接池单例
      ---
      duration_ms: 1.573663
      ...
    # Subtest: 测试辅助器应恢复未定义环境变量，并允许默认 fake client 执行 query/release
    ok 2 - 测试辅助器应恢复未定义环境变量，并允许默认 fake client 执行 query/release
      ---
      duration_ms: 0.580145
      ...
    # Subtest: withRetry 应支持旧签名、对象签名与命名签名的退避重试
    ok 3 - withRetry 应支持旧签名、对象签名与命名签名的退避重试
      ---
      duration_ms: 0.981846
      ...
    # Subtest: withRetry 应在不可重试错误时立即抛出，并在重试耗尽后返回最后一次错误
    ok 4 - withRetry 应在不可重试错误时立即抛出，并在重试耗尽后返回最后一次错误
      ---
      duration_ms: 1.369607
      ...
    # Subtest: isRetryableError、checkHealth 与 closePool 应覆盖成功和失败分支
    ok 5 - isRetryableError、checkHealth 与 closePool 应覆盖成功和失败分支
      ---
      duration_ms: 0.799025
      ...
    1..5
ok 2 - config/database
  ---
  duration_ms: 6.116624
  type: 'suite'
  ...
# Subtest: HttpClient
    # Subtest: 遇到 429 时应执行指数退避后重试成功
    ok 1 - 遇到 429 时应执行指数退避后重试成功
      ---
      duration_ms: 2.311188
      ...
    # Subtest: 纯净 URL 仍失败时应抛出错误
    ok 2 - 纯净 URL 仍失败时应抛出错误
      ---
      duration_ms: 0.638867
      ...
    # Subtest: 返回 details.id 与请求 providerId 不一致时应抛出 IDENTITY_MISMATCH
    ok 3 - 返回 details.id 与请求 providerId 不一致时应抛出 IDENTITY_MISMATCH
      ---
      duration_ms: 0.875543
      ...
    # Subtest: 浏览器返回空数据时应触发真正的上下文重建后重试
    ok 4 - 浏览器返回空数据时应触发真正的上下文重建后重试
      ---
      duration_ms: 0.54219
      ...
    # Subtest: 已带 ccode3 的 URL 不应重复追加地区参数
    ok 5 - 已带 ccode3 的 URL 不应重复追加地区参数
      ---
      duration_ms: 0.149104
      ...
    # Subtest: 原生 HTTP 403 响应时应抛出带上下文的错误
    ok 6 - 原生 HTTP 403 响应时应抛出带上下文的错误
      ---
      duration_ms: 10.367711
      ...
    # Subtest: 原生 HTTP 404 响应时应抛出带上下文的错误
    ok 7 - 原生 HTTP 404 响应时应抛出带上下文的错误
      ---
      duration_ms: 3.760016
      ...
    # Subtest: 原生 HTTP 502 响应时应抛出带上下文的错误
    ok 8 - 原生 HTTP 502 响应时应抛出带上下文的错误
      ---
      duration_ms: 3.504182
      ...
    # Subtest: 原生 HTTP 503 响应时应抛出带上下文的错误
    ok 9 - 原生 HTTP 503 响应时应抛出带上下文的错误
      ---
      duration_ms: 3.146666
      ...
    # Subtest: 原生 HTTP 返回畸形 JSON 时应抛出解析错误
    ok 10 - 原生 HTTP 返回畸形 JSON 时应抛出解析错误
      ---
      duration_ms: 2.540334
      ...
    # Subtest: 原生 HTTP timeout 时应抛出超时错误并保留上下文
    ok 11 - 原生 HTTP timeout 时应抛出超时错误并保留上下文
      ---
      duration_ms: 0.521817
      ...
    # Subtest: 浏览器 fetch timeout 时应退避重试并强制重建上下文
    ok 12 - 浏览器 fetch timeout 时应退避重试并强制重建上下文
      ---
      duration_ms: 0.425279
      ...
    # Subtest: ERR_EMPTY_RESPONSE 应触发页面级恢复而不是整 Context 重建
    ok 13 - ERR_EMPTY_RESPONSE 应触发页面级恢复而不是整 Context 重建
      ---
      duration_ms: 0.333842
      ...
    # Subtest: Failed to fetch 应视为上游阻断并触发页面级恢复
    ok 14 - Failed to fetch 应视为上游阻断并触发页面级恢复
      ---
      duration_ms: 0.382734
      ...
    # Subtest: 连续软故障第二次起应升级为整 Context 重建以便换代理
    ok 15 - 连续软故障第二次起应升级为整 Context 重建以便换代理
      ---
      duration_ms: 0.341435
      ...
    # Subtest: 并发 stealth 请求应串行执行整个重试与自愈周期
    ok 16 - 并发 stealth 请求应串行执行整个重试与自愈周期
      ---
      duration_ms: 15.935032
      ...
    # Subtest: 内部 helper 应覆盖 redirect、fallback leagueId、retryable 与 sleep 分支
    ok 17 - 内部 helper 应覆盖 redirect、fallback leagueId、retryable 与 sleep 分支
      ---
      duration_ms: 0.78944
      ...
    1..17
ok 3 - HttpClient
  ---
  duration_ms: 47.627428
  type: 'suite'
  ...
# Subtest: ReconBrowserContext
    # Subtest: 应独立完成 launch 与 close 生命周期
    ok 1 - 应独立完成 launch 与 close 生命周期
      ---
      duration_ms: 12.01567
      ...
    # Subtest: 应同时注入基础 stealth 指纹与增强反检测脚本
    ok 2 - 应同时注入基础 stealth 指纹与增强反检测脚本
      ---
      duration_ms: 1.258165
      ...
    # Subtest: resetContext 应在批次切换时销毁旧 context 并注入全新指纹
    ok 3 - resetContext 应在批次切换时销毁旧 context 并注入全新指纹
      ---
      duration_ms: 0.9242
      ...
    # Subtest: 启用 preferFullChromium 时应把完整 Chromium executablePath 注入 launchOptions
    ok 4 - 启用 preferFullChromium 时应把完整 Chromium executablePath 注入 launchOptions
      ---
      duration_ms: 0.803637
      ...
    # Subtest: launch 后应自动注入 external session cookies，并保持 Chrome 131 stealth UA
    ok 5 - launch 后应自动注入 external session cookies，并保持 Chrome 131 stealth UA
      ---
      duration_ms: 0.694342
      ...
    # Subtest: 应独立处理 consent 按钮点击
    ok 6 - 应独立处理 consent 按钮点击
      ---
      duration_ms: 0.467084
      ...
    # Subtest: navigate 默认应使用 domcontentloaded 并等待显式选择器
    ok 7 - navigate 默认应使用 domcontentloaded 并等待显式选择器
      ---
      duration_ms: 0.765278
      ...
    # Subtest: 启用首页预热时应先访问首页并等待指定时长
    ok 8 - 启用首页预热时应先访问首页并等待指定时长
      ---
      duration_ms: 0.727654
      ...
    # Subtest: navigate 成功后应刷新运行期会话快照，供后续 context 复用
    ok 9 - navigate 成功后应刷新运行期会话快照，供后续 context 复用
      ---
      duration_ms: 0.682926
      ...
    # Subtest: navigate 命中 503 Backend fetch failed 页面时应抛出显式 HTTP_503
    ok 10 - navigate 命中 503 Backend fetch failed 页面时应抛出显式 HTTP_503
      ---
      duration_ms: 0.773574
      ...
    # Subtest: contentReadySelector 应按联赛配置等待可见内容
    ok 11 - contentReadySelector 应按联赛配置等待可见内容
      ---
      duration_ms: 0.694971
      ...
    # Subtest: force_unlock_j1 命中且 myBookmakers 变化时应重触发 archive 请求
    ok 12 - force_unlock_j1 命中且 myBookmakers 变化时应重触发 archive 请求
      ---
      duration_ms: 0.630084
      ...
    # Subtest: close() 遇到挂死 context 时必须强制 SIGKILL 浏览器进程
    ok 13 - close() 遇到挂死 context 时必须强制 SIGKILL 浏览器进程
      ---
      duration_ms: 10.9566
      ...
    # Subtest: close() 遇到 SIGKILL 权限错误时也必须继续 cleanupUserDataDir
    ok 14 - close() 遇到 SIGKILL 权限错误时也必须继续 cleanupUserDataDir
      ---
      duration_ms: 11.04603
      ...
    1..14
ok 4 - ReconBrowserContext
  ---
  duration_ms: 43.512314
  type: 'suite'
  ...
1..4
# tests 47
# suites 4
# pass 47
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 20671.78827
[TEST-GATE] 增量 JS 测试通过，用时 20.70s。
[Gatekeeper] 执行 Recon 核心独立覆盖率门禁（行覆盖率 >= 90%）。

> footballprediction-v451@4.51.2-TOTAL-WAR test:coverage:recon-core
> rm -rf reports/coverage/recon-core && c8 --all --include=src/infrastructure/recon/services/ReconDecryptorSourceExtractor.js --include=src/infrastructure/recon/services/ReconSourceProber.js --include=src/infrastructure/recon/services/ReconMatrixTargetRunner.js --include=src/infrastructure/recon/ReconDistributedLock.js --include=src/infrastructure/recon/services/ReconPureDecryptorRuntime.js --reporter=text-summary --reporter=json-summary --reports-dir reports/coverage/recon-core node scripts/test/run_test_suite.js recon-core && node scripts/test/check_recon_core_coverage.js

TAP version 13
# Subtest: ReconDecryptor
    # Subtest: 页面已关闭时应快速退出，避免记录 decryptor_extraction_failed
    ok 1 - 页面已关闭时应快速退出，避免记录 decryptor_extraction_failed
      ---
      duration_ms: 0.961355
      ...
    # Subtest: 样本验证失败时不应接受 app bundle 的未验证候选函数
    ok 2 - 样本验证失败时不应接受 app bundle 的未验证候选函数
      ---
      duration_ms: 2826.862603
      ...
    # Subtest: 启用 best-effort 模式时，应允许回退到 ai 导出函数
    ok 3 - 启用 best-effort 模式时，应允许回退到 ai 导出函数
      ---
      duration_ms: 0.855724
      ...
    # Subtest: 首样本无效时应复用缓存样本做交叉验证并成功提取
    ok 4 - 首样本无效时应复用缓存样本做交叉验证并成功提取
      ---
      duration_ms: 1748.910337
      ...
    # Subtest: app script 导入失败时应回退到 pure runtime decryptor
    ok 5 - app script 导入失败时应回退到 pure runtime decryptor
      ---
      duration_ms: 0.741978
      ...
    # Subtest: bundle 页面内抓取失败时应回退到 Node fetch
    ok 6 - bundle 页面内抓取失败时应回退到 Node fetch
      ---
      duration_ms: 0.308972
      ...
    # Subtest: 应在页面 app-*.js 失效时回退到根页面 live bundle
    ok 7 - 应在页面 app-*.js 失效时回退到根页面 live bundle
      ---
      duration_ms: 52.799584
      ...
    # Subtest: module 页面内抓取失败时应回退到 Node fetch
    ok 8 - module 页面内抓取失败时应回退到 Node fetch
      ---
      duration_ms: 0.466126
      ...
    # Subtest: 页面绑定 loader 回跳旧 app bundle 时应重映射到 live bundle
    ok 9 - 页面绑定 loader 回跳旧 app bundle 时应重映射到 live bundle
      ---
      duration_ms: 0.311357
      ...
    # Subtest: 样本本身是伪 404 payload 时，不应启用 best-effort 回退
    ok 10 - 样本本身是伪 404 payload 时，不应启用 best-effort 回退
      ---
      duration_ms: 3822.321816
      ...
    # Subtest: malformed payload 应在调用解密函数前 fail-fast
    ok 11 - malformed payload 应在调用解密函数前 fail-fast
      ---
      duration_ms: 0.451241
      ...
    # Subtest: 应优先从 bundle 函数体特征中识别 ai 解密导出
    ok 12 - 应优先从 bundle 函数体特征中识别 ai 解密导出
      ---
      duration_ms: 4.757441
      ...
    1..12
ok 1 - ReconDecryptor
  ---
  duration_ms: 8461.1179
  type: 'suite'
  ...
# app_script_candidate_rejected {
#   traceId: 'trace-app-script',
#   source: 'input_candidate',
#   url: 'https://www.oddsportal.com/build/assets/app-missing.js',
#   statusCode: 404,
#   error: 'HTTP_404:https://www.oddsportal.com/build/assets/app-missing.js'
# }
# app_script_candidate_rejected {
#   traceId: 'trace-app-script',
#   source: 'input_candidate',
#   url: 'https://www.oddsportal.com/build/assets/app-dup.js',
#   statusCode: null,
#   error: 'FETCH_UNAVAILABLE'
# }
# app_script_bundle_fetch_success {
#   traceId: 'trace-app-script',
#   source: 'build_manifest',
#   url: 'https://www.oddsportal.com/build/assets/app-live-654321.js',
#   statusCode: 200
# }
# Subtest: ReconDecryptorSourceExtractor
    # Subtest: findLatestAppScript 应在 HTML 候选失效后回落到 manifest 中的最新 app bundle
    ok 1 - findLatestAppScript 应在 HTML 候选失效后回落到 manifest 中的最新 app bundle
      ---
      duration_ms: 47.622996
      ...
    # Subtest: findLatestAppScript 在候选全部失效时应返回 unresolved
    ok 2 - findLatestAppScript 在候选全部失效时应返回 unresolved
      ---
      duration_ms: 5.210727
      ...
    # Subtest: findLatestAppScript 应覆盖 malformed baseUrl、缺失 fetch 与 manifest 杂质分支
    ok 3 - findLatestAppScript 应覆盖 malformed baseUrl、缺失 fetch 与 manifest 杂质分支
      ---
      duration_ms: 3.486049
      ...
    # Subtest: findLatestAppScript 应跳过 manifest 中的非 JS、非 entry 与畸形资源
    ok 4 - findLatestAppScript 应跳过 manifest 中的非 JS、非 entry 与畸形资源
      ---
      duration_ms: 8.814384
      ...
    # Subtest: _readPageCookieHeader 应返回 cookie，并在 evaluate 失败时降级为空串
    ok 5 - _readPageCookieHeader 应返回 cookie，并在 evaluate 失败时降级为空串
      ---
      duration_ms: 0.391941
      ...
    # Subtest: _resolveLiveAppScript 应携带页面 cookie 并缓存最新的 app script 解析结果
    ok 6 - _resolveLiveAppScript 应携带页面 cookie 并缓存最新的 app script 解析结果
      ---
      duration_ms: 5.537879
      ...
    # Subtest: _fetchBundleSource 应优先复用 live resolution 中已经拿到的 bundle
    ok 7 - _fetchBundleSource 应优先复用 live resolution 中已经拿到的 bundle
      ---
      duration_ms: 0.180643
      ...
    # Subtest: _fetchBundleSource 在页面抓取失败时应回落到 Node fetch
    ok 8 - _fetchBundleSource 在页面抓取失败时应回落到 Node fetch
      ---
      duration_ms: 0.16714
      ...
    # Subtest: _waitForDecryptorReady 应吞掉 readiness 超时并记录 debug 事件
    ok 9 - _waitForDecryptorReady 应吞掉 readiness 超时并记录 debug 事件
      ---
      duration_ms: 0.806163
      ...
    # Subtest: _waitForDecryptorReady 在 otCode/pageOutrights 命中时应允许成功返回
    ok 10 - _waitForDecryptorReady 在 otCode/pageOutrights 命中时应允许成功返回
      ---
      duration_ms: 4.602031
      ...
    # Subtest: _readSerializableRuntimeState 应提取 window.pageVar 与 pageOutrightsVar 的可序列化子集
    ok 11 - _readSerializableRuntimeState 应提取 window.pageVar 与 pageOutrightsVar 的可序列化子集
      ---
      duration_ms: 6.272166
      ...
    # Subtest: _readSerializableRuntimeState 应覆盖空页面、坏 JSON 与异常降级
    ok 12 - _readSerializableRuntimeState 应覆盖空页面、坏 JSON 与异常降级
      ---
      duration_ms: 2.994023
      ...
    # Subtest: _readPageHtml 在 page.content 失败后应回退到 documentElement.outerHTML
    ok 13 - _readPageHtml 在 page.content 失败后应回退到 documentElement.outerHTML
      ---
      duration_ms: 4.047854
      ...
    # Subtest: _readPageHtml 应覆盖空页面、无 evaluate 与 evaluate 失败分支
    ok 14 - _readPageHtml 应覆盖空页面、无 evaluate 与 evaluate 失败分支
      ---
      duration_ms: 0.182154
      ...
    # Subtest: _createPageBoundModuleLoader 应支持页面内抓取、manifest remap 与 unavailable 终态
    ok 15 - _createPageBoundModuleLoader 应支持页面内抓取、manifest remap 与 unavailable 终态
      ---
      duration_ms: 3.148618
      ...
    # Subtest: _extractFromPureRuntime 应构建可调用的包装 decrypt 函数并透传元信息
    ok 16 - _extractFromPureRuntime 应构建可调用的包装 decrypt 函数并透传元信息
      ---
      duration_ms: 0.42382
      ...
    # Subtest: _extractFromPureRuntime 应覆盖空输入、空 bundle 与 load 失败分支
    ok 17 - _extractFromPureRuntime 应覆盖空输入、空 bundle 与 load 失败分支
      ---
      duration_ms: 0.312202
      ...
    # Subtest: _extractFromInlineScripts 应识别 inline decryptor，并在后续调用时执行页面内函数
    ok 18 - _extractFromInlineScripts 应识别 inline decryptor，并在后续调用时执行页面内函数
      ---
      duration_ms: 14.885501
      ...
    # Subtest: _extractFromInlineScripts 应覆盖未命中、函数缺失与 page closed 分支
    ok 19 - _extractFromInlineScripts 应覆盖未命中、函数缺失与 page closed 分支
      ---
      duration_ms: 9.45792
      ...
    # Subtest: _extractFromGlobalScope 应优先匹配常见名称并返回页面绑定函数
    ok 20 - _extractFromGlobalScope 应优先匹配常见名称并返回页面绑定函数
      ---
      duration_ms: 8.442543
      ...
    # Subtest: _extractFromGlobalScope 应覆盖 heuristic、未命中与 page closed 分支
    ok 21 - _extractFromGlobalScope 应覆盖 heuristic、未命中与 page closed 分支
      ---
      duration_ms: 12.241112
      ...
    1..21
ok 2 - ReconDecryptorSourceExtractor
  ---
  duration_ms: 140.348829
  type: 'suite'
  ...
# Subtest: src/infrastructure/recon/ReconDistributedLock
    # Subtest: 应获取单锁、包装 release、报告状态并处理 release 异常
    ok 1 - 应获取单锁、包装 release、报告状态并处理 release 异常
      ---
      duration_ms: 3.772931
      ...
    # Subtest: 应按排序批量获取锁，并在超时或中途失败时释放已获得的锁
    ok 2 - 应按排序批量获取锁，并在超时或中途失败时释放已获得的锁
      ---
      duration_ms: 1.672946
      ...
    # Subtest: 应处理批量释放、强制释放全部锁、断开连接与获取失败包装
    ok 3 - 应处理批量释放、强制释放全部锁、断开连接与获取失败包装
      ---
      duration_ms: 1.239209
      ...
    1..3
ok 3 - src/infrastructure/recon/ReconDistributedLock
  ---
  duration_ms: 7.635279
  type: 'suite'
  ...
# Subtest: ReconMatrixFlow
    # Subtest: 应将 season_mirror 与 pure_protocol source 归一化为 protocol_extract
    ok 1 - 应将 season_mirror 与 pure_protocol source 归一化为 protocol_extract
      ---
      duration_ms: 0.779307
      ...
    # Subtest: 应保留数据库白名单中的 mapping_method
    ok 2 - 应保留数据库白名单中的 mapping_method
      ---
      duration_ms: 0.112182
      ...
    # Subtest: SOURCE_EMPTY 回退到本地字典时应尊重 matchLimit
    ok 3 - SOURCE_EMPTY 回退到本地字典时应尊重 matchLimit
      ---
      duration_ms: 6.625674
      ...
    # Subtest: 全量 RECON_MISMATCH 也应先回源选择 source，不得被本地字典短路
    ok 4 - 全量 RECON_MISMATCH 也应先回源选择 source，不得被本地字典短路
      ---
      duration_ms: 0.879423
      ...
    # Subtest: results 已缝上的比赛不应再进入 search 路径
    ok 5 - results 已缝上的比赛不应再进入 search 路径
      ---
      duration_ms: 0.654282
      ...
    # Subtest: Matrix mode 下 results 为空时应直接终结，不再探测 fixtures/search
    ok 6 - Matrix mode 下 results 为空时应直接终结，不再探测 fixtures/search
      ---
      duration_ms: 0.750185
      ...
    # Subtest: Matrix mode 下 results 命中 50% sample 后应停止 fixtures/search 并终结剩余 pending
    ok 7 - Matrix mode 下 results 命中 50% sample 后应停止 fixtures/search 并终结剩余 pending
      ---
      duration_ms: 0.566009
      ...
    # Subtest: results 命中 503 快速熔断后应阻断 search，并把 probe timeout 压到 20 秒
    ok 8 - results 命中 503 快速熔断后应阻断 search，并把 probe timeout 压到 20 秒
      ---
      duration_ms: 0.775871
      ...
    # Subtest: results 连续 timeout 两次后应把联赛标记为 DEGRADED，并禁止 search 探测
    ok 9 - results 连续 timeout 两次后应把联赛标记为 DEGRADED，并禁止 search 探测
      ---
      duration_ms: 0.240709
      ...
    # Subtest: linked 前应先把 h2h 候选洗白为 canonical URL
    ok 10 - linked 前应先把 h2h 候选洗白为 canonical URL
      ---
      duration_ms: 3.358182
      ...
    # Subtest: 应将 results、fixtures、search 三路候选合并为统一候选池
    ok 11 - 应将 results、fixtures、search 三路候选合并为统一候选池
      ---
      duration_ms: 0.928731
      ...
    # Subtest: results 与 fixtures 已满足 sample 时不应再触发 search 探测
    ok 12 - results 与 fixtures 已满足 sample 时不应再触发 search 探测
      ---
      duration_ms: 0.281599
      ...
    # Subtest: runReconMatrix 应默认启用 Matrix 剪枝、禁用 search，并下发 45 秒联赛预算
    ok 13 - runReconMatrix 应默认启用 Matrix 剪枝、禁用 search，并下发 45 秒联赛预算
      ---
      duration_ms: 0.81391
      ...
    # Subtest: perpetualReconMode 开启后只要仍有 pending 且代理可用就应继续下一轮
    ok 14 - perpetualReconMode 开启后只要仍有 pending 且代理可用就应继续下一轮
      ---
      duration_ms: 0.370267
      ...
    # Subtest: runReconMatrix 应在联赛级扇出中分配独立 navigator 端口并受 p-limit 限流
    ok 15 - runReconMatrix 应在联赛级扇出中分配独立 navigator 端口并受 p-limit 限流
      ---
      duration_ms: 54.750178
      ...
    # Subtest: 未显式传入 leagueConcurrency 时，应以 5 冷启动并把请求 concurrency 作为动态上限
    ok 16 - 未显式传入 leagueConcurrency 时，应以 5 冷启动并把请求 concurrency 作为动态上限
      ---
      duration_ms: 54.130662
      ...
    # Subtest: runReconMatrix 应按 index * 2000ms 对联赛 worker 启动错峰
    ok 17 - runReconMatrix 应按 index * 2000ms 对联赛 worker 启动错峰
      ---
      duration_ms: 0.826924
      ...
    # Subtest: runReconMatrix 遇到 503 时应将联赛级动态并发从 5 立刻削减到 2
    ok 18 - runReconMatrix 遇到 503 时应将联赛级动态并发从 5 立刻削减到 2
      ---
      duration_ms: 129.383694
      ...
    # Subtest: 整体成功率低于 50% 时，应将 allowedLeagueWorkers 锁定在 3 个以内
    ok 19 - 整体成功率低于 50% 时，应将 allowedLeagueWorkers 锁定在 3 个以内
      ---
      duration_ms: 128.166812
      ...
    # Subtest: 22-IP 绿灯数下降时应把 MatrixFlow 的联赛并发夹到可用代理数
    ok 20 - 22-IP 绿灯数下降时应把 MatrixFlow 的联赛并发夹到可用代理数
      ---
      duration_ms: 44.736316
      ...
    1..20
ok 4 - ReconMatrixFlow
  ---
  duration_ms: 430.442745
  type: 'suite'
  ...
# Subtest: ReconMatrixTargetRunner
    # Subtest: _prepareReconTargetState 应构建运行时目标与短路阈值
    ok 1 - _prepareReconTargetState 应构建运行时目标与短路阈值
      ---
      duration_ms: 5.122317
      ...
    # Subtest: _prepareReconTargetState 遇到 future pending 时应放开 fixtures/search fallback
    ok 2 - _prepareReconTargetState 遇到 future pending 时应放开 fixtures/search fallback
      ---
      duration_ms: 0.244752
      ...
    # Subtest: _prepareReconTargetState 应尊重 MISMATCH 重试路径下探后的有效阈值
    ok 3 - _prepareReconTargetState 应尊重 MISMATCH 重试路径下探后的有效阈值
      ---
      duration_ms: 0.802641
      ...
    # Subtest: _prepareReconTargetState 在无待处理或 scopedPending 为空时应返回 null
    ok 4 - _prepareReconTargetState 在无待处理或 scopedPending 为空时应返回 null
      ---
      duration_ms: 0.240495
      ...
    # Subtest: _resolveRouteShortCircuitThreshold 应在 Matrix 模式下按比例计算并做边界收敛
    ok 5 - _resolveRouteShortCircuitThreshold 应在 Matrix 模式下按比例计算并做边界收敛
      ---
      duration_ms: 0.110096
      ...
    # Subtest: _assertLeagueBudget 在超时且尚未产出时应抛出 LEAGUE_TIMEOUT
    ok 6 - _assertLeagueBudget 在超时且尚未产出时应抛出 LEAGUE_TIMEOUT
      ---
      duration_ms: 0.336355
      ...
    # Subtest: _assertLeagueBudget 在已有产出时应返回 true 并记录告警
    ok 7 - _assertLeagueBudget 在已有产出时应返回 true 并记录告警
      ---
      duration_ms: 0.094423
      ...
    # Subtest: _shouldFinalizeAfterResults 应在 Matrix 剪枝命中时提前收口
    ok 8 - _shouldFinalizeAfterResults 应在 Matrix 剪枝命中时提前收口
      ---
      duration_ms: 0.371959
      ...
    # Subtest: _handlePostResultsFlow 在预算耗尽时应立即 finalize
    ok 9 - _handlePostResultsFlow 在预算耗尽时应立即 finalize
      ---
      duration_ms: 0.86559
      ...
    # Subtest: _runPostResultsFallbackRoutes 在禁用 search 时应记录日志并走结果终态
    ok 10 - _runPostResultsFallbackRoutes 在禁用 search 时应记录日志并走结果终态
      ---
      duration_ms: 0.306498
      ...
    # Subtest: _runPostResultsFallbackRoutes 在 results-only 模式时应跳过全部慢速路径
    ok 11 - _runPostResultsFallbackRoutes 在 results-only 模式时应跳过全部慢速路径
      ---
      duration_ms: 0.1354
      ...
    # Subtest: _shouldShortCircuitResultsToSearch 应识别 J1 与带重音的 Brasileirão
    ok 12 - _shouldShortCircuitResultsToSearch 应识别 J1 与带重音的 Brasileirão
      ---
      duration_ms: 0.169662
      ...
    # Subtest: _runPostResultsFallbackRoutes 对 J1 results 超时空源应跳过 fixtures 直切 search
    ok 13 - _runPostResultsFallbackRoutes 对 J1 results 超时空源应跳过 fixtures 直切 search
      ---
      duration_ms: 0.242166
      ...
    # Subtest: _processReconRoute 在 results 路径上应跳过 future pending，交由慢速 fallback 处理
    ok 14 - _processReconRoute 在 results 路径上应跳过 future pending，交由慢速 fallback 处理
      ---
      duration_ms: 0.383536
      ...
    # Subtest: _shouldFinalizeAfterResults 在 future pending 存在时不应提前收口
    ok 15 - _shouldFinalizeAfterResults 在 future pending 存在时不应提前收口
      ---
      duration_ms: 0.084603
      ...
    # Subtest: hasOnlyFuturePendingMatches 应正确识别全部为未来比赛的场景
    ok 16 - hasOnlyFuturePendingMatches 应正确识别全部为未来比赛的场景
      ---
      duration_ms: 0.102542
      ...
    # Subtest: 工具函数应正确处理边界情况
    ok 17 - 工具函数应正确处理边界情况
      ---
      duration_ms: 0.223779
      ...
    # Subtest: _runPostResultsFallbackRoutes 在 results-only 模式遇到残缺 results source 时应抛错重试
    ok 18 - _runPostResultsFallbackRoutes 在 results-only 模式遇到残缺 results source 时应抛错重试
      ---
      duration_ms: 0.405497
      ...
    # Subtest: _applyReconRouteResult 应累计 route 结果并刷新最终源信息
    ok 19 - _applyReconRouteResult 应累计 route 结果并刷新最终源信息
      ---
      duration_ms: 0.129558
      ...
    # Subtest: target-driven 与残缺源辅助方法应输出收敛后的结果
    ok 20 - target-driven 与残缺源辅助方法应输出收敛后的结果
      ---
      duration_ms: 0.246359
      ...
    # Subtest: finalize 辅助方法应在预算与本地字典分支下正确收口
    ok 21 - finalize 辅助方法应在预算与本地字典分支下正确收口
      ---
      duration_ms: 0.207872
      ...
    # Subtest: search 与 local dictionary 路由应透传 finalPass 和兜底选项
    ok 22 - search 与 local dictionary 路由应透传 finalPass 和兜底选项
      ---
      duration_ms: 0.27827
      ...
    # Subtest: _runReconTargetRoutes、_assertReconTargetResolved 与 _buildReconTargetResult 应覆盖尾部收口分支
    ok 23 - _runReconTargetRoutes、_assertReconTargetResolved 与 _buildReconTargetResult 应覆盖尾部收口分支
      ---
      duration_ms: 0.470926
      ...
    # Subtest: _runReconTarget 在 prepare 返回 null 时应直接返回零结果
    ok 24 - _runReconTarget 在 prepare 返回 null 时应直接返回零结果
      ---
      duration_ms: 0.13126
      ...
    # Subtest: _processReconRoute 应为缺失 routeSource 兜底空源并透传终态选项
    ok 25 - _processReconRoute 应为缺失 routeSource 兜底空源并透传终态选项
      ---
      duration_ms: 0.150413
      ...
    # Subtest: _runReconTarget 应产出最终结果，未收口时应抛出带源信息的错误
    ok 26 - _runReconTarget 应产出最终结果，未收口时应抛出带源信息的错误
      ---
      duration_ms: 0.27463
      ...
    # Subtest: _buildTargetDrivenResultsSource 应优先缩窄单场候选并保留最佳匹配信息
    ok 27 - _buildTargetDrivenResultsSource 应优先缩窄单场候选并保留最佳匹配信息
      ---
      duration_ms: 0.279524
      ...
    # Subtest: _prepareReconTargetState 在单场剪枝且预算超时下应启用 budget grace 告警
    ok 28 - _prepareReconTargetState 在单场剪枝且预算超时下应启用 budget grace 告警
      ---
      duration_ms: 0.362361
      ...
    # Subtest: _finalizeRemainingPending 与 _runReconFixturesRoute 应覆盖空 pending 与空 fixtures 兜底
    ok 29 - _finalizeRemainingPending 与 _runReconFixturesRoute 应覆盖空 pending 与空 fixtures 兜底
      ---
      duration_ms: 0.249689
      ...
    # Subtest: _processReconRoute 在 results 路由仅剩 future pending 时应延后并保持待处理集合
    ok 30 - _processReconRoute 在 results 路由仅剩 future pending 时应延后并保持待处理集合
      ---
      duration_ms: 0.147115
      ...
    # Subtest: _runPostResultsFallbackRoutes 应覆盖 incomplete source 与短路 search/local-dictionary 路径
    ok 31 - _runPostResultsFallbackRoutes 应覆盖 incomplete source 与短路 search/local-dictionary 路径
      ---
      duration_ms: 0.365958
      ...
    1..31
ok 5 - ReconMatrixTargetRunner
  ---
  duration_ms: 15.135147
  type: 'suite'
  ...
# Subtest: ReconPureDecryptorRuntime
    # Subtest: 测试 helper 应覆盖 restoreGlobals 与 unsetGlobalIfPossible 的防御分支
    ok 1 - 测试 helper 应覆盖 restoreGlobals 与 unsetGlobalIfPossible 的防御分支
      ---
      duration_ms: 0.873752
      ...
    # Subtest: 应补齐浏览器沙盒所需的全局对象与 \#app 根节点
    ok 2 - 应补齐浏览器沙盒所需的全局对象与 \#app 根节点
      ---
      duration_ms: 1.055278
      ...
    # Subtest: 应为语言动态导入准备本地 fallback 模板
    ok 3 - 应为语言动态导入准备本地 fallback 模板
      ---
      duration_ms: 7.384627
      ...
    # Subtest: installGlobal 遇到只读全局属性时应通过 defineProperty 强制覆盖
    ok 4 - installGlobal 遇到只读全局属性时应通过 defineProperty 强制覆盖
      ---
      duration_ms: 0.345166
      ...
    # Subtest: 浏览器沙盒 stub 应提供 storage、event、DOM 与 history 能力
    ok 5 - 浏览器沙盒 stub 应提供 storage、event、DOM 与 history 能力
      ---
      duration_ms: 1.848482
      ...
    # Subtest: 缺失浏览器全局时应安装 fallback 对象并回填 pageVar/pageOutrightsVar
    ok 6 - 缺失浏览器全局时应安装 fallback 对象并回填 pageVar/pageOutrightsVar
      ---
      duration_ms: 1.701207
      ...
    # Subtest: 语言 fallback 准备失败时应写 debug 日志而不是抛错
    ok 7 - 语言 fallback 准备失败时应写 debug 日志而不是抛错
      ---
      duration_ms: 1.408126
      ...
    # Subtest: 应能从 bundle 下载模块树并装载 pure decryptor 导出
    ok 8 - 应能从 bundle 下载模块树并装载 pure decryptor 导出
      ---
      duration_ms: 9.93648
      ...
    # Subtest: 应支持通过 bundleSource/sourceLoader 与 DOM fallback 解析入口模块
    ok 9 - 应支持通过 bundleSource/sourceLoader 与 DOM fallback 解析入口模块
      ---
      duration_ms: 68.426782
      ...
    # Subtest: 候选导出选择应跳过异常函数并在无样本时回退首个候选
    ok 10 - 候选导出选择应跳过异常函数并在无样本时回退首个候选
      ---
      duration_ms: 0.295177
      ...
    # Subtest: 模块 specifier 提取与 fetchText 重试应按预期工作
    ok 11 - 模块 specifier 提取与 fetchText 重试应按预期工作
      ---
      duration_ms: 0.246613
      ...
    # Subtest: fetchText 请求 OddsPortal bundle 时应自动补 referer
    ok 12 - fetchText 请求 OddsPortal bundle 时应自动补 referer
      ---
      duration_ms: 0.269491
      ...
    # Subtest: materialize/download 应处理入口缺失、visited 命中与非 JS specifier 跳过
    ok 13 - materialize/download 应处理入口缺失、visited 命中与非 JS specifier 跳过
      ---
      duration_ms: 5.860513
      ...
    # Subtest: fetchText 在重试耗尽后应抛出最终错误
    ok 14 - fetchText 在重试耗尽后应抛出最终错误
      ---
      duration_ms: 0.181505
      ...
    1..14
ok 6 - ReconPureDecryptorRuntime
  ---
  duration_ms: 100.953821
  type: 'suite'
  ...
# Subtest: ReconSourceProber
    # Subtest: _dedupeCandidatesByIdentity 应按 hash/url 去重并忽略空候选
    ok 1 - _dedupeCandidatesByIdentity 应按 hash/url 去重并忽略空候选
      ---
      duration_ms: 2.005077
      ...
    # Subtest: _canRunParallelRouteProbes 应要求 navigatorFactory 与足够代理
    ok 2 - _canRunParallelRouteProbes 应要求 navigatorFactory 与足够代理
      ---
      duration_ms: 0.139241
      ...
    # Subtest: _combineCandidateRouteSources 应整合成功路由并保留元信息
    ok 3 - _combineCandidateRouteSources 应整合成功路由并保留元信息
      ---
      duration_ms: 0.415435
      ...
    # Subtest: _combineCandidateRouteSources 在无成功路由时应回退到空结果源
    ok 4 - _combineCandidateRouteSources 在无成功路由时应回退到空结果源
      ---
      duration_ms: 0.144711
      ...
    # Subtest: _probeCandidateRoutes 在 Matrix 剪枝且 results 为空时应直接短路
    ok 5 - _probeCandidateRoutes 在 Matrix 剪枝且 results 为空时应直接短路
      ---
      duration_ms: 0.550984
      ...
    # Subtest: _probeCandidateRoutes 在前移短路标记命中时应跳过 fixtures 并继续 search
    ok 6 - _probeCandidateRoutes 在前移短路标记命中时应跳过 fixtures 并继续 search
      ---
      duration_ms: 0.297315
      ...
    # Subtest: _probeCandidateRoutes 在样本已满足阈值时应跳过 search
    ok 7 - _probeCandidateRoutes 在样本已满足阈值时应跳过 search
      ---
      duration_ms: 0.235611
      ...
    # Subtest: _probeCandidateRoutes 在多路全失败时应抛出聚合错误
    ok 8 - _probeCandidateRoutes 在多路全失败时应抛出聚合错误
      ---
      duration_ms: 0.412509
      ...
    # Subtest: _probeResultsCandidateSource 失败降级时应返回 degraded source
    ok 9 - _probeResultsCandidateSource 失败降级时应返回 degraded source
      ---
      duration_ms: 0.404827
      ...
    # Subtest: _probeResultsCandidateSource 遇到 LEAGUE_TIMEOUT 时应直接上抛
    ok 10 - _probeResultsCandidateSource 遇到 LEAGUE_TIMEOUT 时应直接上抛
      ---
      duration_ms: 0.164757
      ...
    # Subtest: _probeResultsCandidateSource 在 J1 results probe 超时后应返回强制 search 空源
    ok 11 - _probeResultsCandidateSource 在 J1 results probe 超时后应返回强制 search 空源
      ---
      duration_ms: 0.264884
      ...
    # Subtest: _probeResultsCandidateSource 在真实联赛预算先到期时不应伪装成 search 短路
    ok 12 - _probeResultsCandidateSource 在真实联赛预算先到期时不应伪装成 search 短路
      ---
      duration_ms: 0.623339
      ...
    # Subtest: _probeFixturesCandidateSource 缺少 fixturesUrl 时应直接返回 null
    ok 13 - _probeFixturesCandidateSource 缺少 fixturesUrl 时应直接返回 null
      ---
      duration_ms: 0.176941
      ...
    # Subtest: _probeFixturesCandidateSource 应生成 fixtures route，并在异常时按策略降级
    ok 14 - _probeFixturesCandidateSource 应生成 fixtures route，并在异常时按策略降级
      ---
      duration_ms: 0.311648
      ...
    # Subtest: _probeSearchCandidateSource 在 search 被禁用时应返回 degraded source
    ok 15 - _probeSearchCandidateSource 在 search 被禁用时应返回 degraded source
      ---
      duration_ms: 0.141944
      ...
    # Subtest: _probeSearchCandidateSource 应覆盖空 pending、blocked、成功与降级分支
    ok 16 - _probeSearchCandidateSource 应覆盖空 pending、blocked、成功与降级分支
      ---
      duration_ms: 2.995384
      ...
    # Subtest: _executeRouteProbeWithNavigator 应使用独占 navigator 并在结束后释放
    ok 17 - _executeRouteProbeWithNavigator 应使用独占 navigator 并在结束后释放
      ---
      duration_ms: 0.195412
      ...
    # Subtest: _executeRouteProbeWithNavigator 在无可用 navigator 时应返回空路由
    ok 18 - _executeRouteProbeWithNavigator 在无可用 navigator 时应返回空路由
      ---
      duration_ms: 0.109383
      ...
    # Subtest: _fetchCandidateRouteArchive 应优先调用 fetchFullSeasonArchive
    ok 19 - _fetchCandidateRouteArchive 应优先调用 fetchFullSeasonArchive
      ---
      duration_ms: 0.132357
      ...
    # Subtest: _fetchCandidateRouteArchive 应覆盖无 navigator、protocolArchive 与无 handler 分支
    ok 20 - _fetchCandidateRouteArchive 应覆盖无 navigator、protocolArchive 与无 handler 分支
      ---
      duration_ms: 0.128621
      ...
    # Subtest: _collectSearchCandidatesForPendingMatches 与 _collectSearchCandidatesFromUrl 应完成 URL 去重与页面抽取
    ok 21 - _collectSearchCandidatesForPendingMatches 与 _collectSearchCandidatesFromUrl 应完成 URL 去重与页面抽取
      ---
      duration_ms: 0.537886
      ...
    # Subtest: _collectSearchCandidatesForPendingMatches 应覆盖无 navigator、空 slug 与无效链接分支
    ok 22 - _collectSearchCandidatesForPendingMatches 应覆盖无 navigator、空 slug 与无效链接分支
      ---
      duration_ms: 0.696216
      ...
    # Subtest: _collectSearchCandidatesForPendingMatches 在 J1 search URL 超时时应审计并继续后续搜索
    ok 23 - _collectSearchCandidatesForPendingMatches 在 J1 search URL 超时时应审计并继续后续搜索
      ---
      duration_ms: 0.636715
      ...
    # Subtest: _collectSearchCandidatesForPendingMatches 在 exact search 全空时应级联触发 fuzzy_prefix
    ok 24 - _collectSearchCandidatesForPendingMatches 在 exact search 全空时应级联触发 fuzzy_prefix
      ---
      duration_ms: 0.880232
      ...
    # Subtest: _collectSearchCandidatesForPendingMatches 在 exact search 已命中时不应触发 fuzzy_prefix
    ok 25 - _collectSearchCandidatesForPendingMatches 在 exact search 已命中时不应触发 fuzzy_prefix
      ---
      duration_ms: 0.260457
      ...
    # Subtest: _collectSearchCandidatesForPendingMatches 在联赛预算耗尽时应短路 search 循环
    ok 26 - _collectSearchCandidatesForPendingMatches 在联赛预算耗尽时应短路 search 循环
      ---
      duration_ms: 0.212554
      ...
    # Subtest: _probeSearchCandidateSource 在容错 search 超时样本存在时应输出审计日志而非整路由失败
    ok 27 - _probeSearchCandidateSource 在容错 search 超时样本存在时应输出审计日志而非整路由失败
      ---
      duration_ms: 0.416276
      ...
    # Subtest: _probeSearchCandidateSource 在所有变体都跑空时应输出 deep audit
    ok 28 - _probeSearchCandidateSource 在所有变体都跑空时应输出 deep audit
      ---
      duration_ms: 0.414574
      ...
    # Subtest: _buildSearchUrlForMatch 应使用标准化别名生成搜索 slug
    ok 29 - _buildSearchUrlForMatch 应使用标准化别名生成搜索 slug
      ---
      duration_ms: 0.117279
      ...
    # Subtest: _buildSearchDescriptorsForMatch 在高噪联赛应补充反向、字典与 fuzzy_prefix 搜索变体
    ok 30 - _buildSearchDescriptorsForMatch 在高噪联赛应补充反向、字典与 fuzzy_prefix 搜索变体
      ---
      duration_ms: 0.34889
      ...
    # Subtest: _selectCandidateSourceWithLocalFallback 在远端为空时应切换到本地字典
    ok 31 - _selectCandidateSourceWithLocalFallback 在远端为空时应切换到本地字典
      ---
      duration_ms: 0.234984
      ...
    # Subtest: _selectCandidateSourceWithLocalFallback 在 probe 抛错时也应走恢复分支
    ok 32 - _selectCandidateSourceWithLocalFallback 在 probe 抛错时也应走恢复分支
      ---
      duration_ms: 0.13408
      ...
    1..32
ok 7 - ReconSourceProber
  ---
  duration_ms: 15.920944
  type: 'suite'
  ...
1..7
# tests 133
# suites 7
# pass 133
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 10800.560248
[TEST-GATE] Recon 核心测试通过，用时 10.13s。

=============================== Coverage summary ===============================
Statements   : 96.52% ( 2948/3054 )
Branches     : 73.87% ( 789/1068 )
Functions    : 99.49% ( 198/199 )
Lines        : 96.52% ( 2948/3054 )
================================================================================
[TEST-GATE] Recon 核心文件行覆盖率通过: 5 个文件均 >= 90%
[Gatekeeper] 门禁通过（mode=pr）。
Branch 'security/gatekeeper-main-branch-lockdown' set up to track remote branch 'security/gatekeeper-main-branch-lockdown' from 'origin'. (PR-mode gate passed)