### PR TITLE
feat(l3): upgrade stitching engine to support database-first odds lookup and multi-source mapping

### DIFF
--- a/scripts/ops/l3_stitch_2425.js
+++ b/scripts/ops/l3_stitch_2425.js
@@ -116,6 +116,18 @@ async function getFinalReport(client) {
                 WHERE jsonb_array_length(COALESCE(l.stitch_summary->'conflicts', '[]'::jsonb)) > 0
             ) AS parser_conflict_rows,
             COUNT(*) FILTER (
+                WHERE COALESCE((l.odds_features->>'has_odds_data')::boolean, FALSE)
+            ) AS odds_seeded_rows,
+            COUNT(*) FILTER (
+                WHERE l.odds_features->>'odds_source' = 'odds'
+            ) AS odds_table_seeded_rows,
+            COUNT(*) FILTER (
+                WHERE l.odds_features->>'odds_source' = 'bookmaker_odds_history'
+            ) AS odds_history_seeded_rows,
+            COUNT(*) FILTER (
+                WHERE l.odds_features->>'odds_source' = 'none'
+            ) AS odds_none_rows,
+            COUNT(*) FILTER (
                 WHERE COALESCE((l.elo_features->>'home_elo')::numeric, 0) > 0
             ) AS elo_seeded_rows
         FROM matches m

--- a/scripts/ops/l3_stitch_worker.js
+++ b/scripts/ops/l3_stitch_worker.js
@@ -6,7 +6,10 @@ require('dotenv').config();
 const { Pool } = require('pg');
 const { extractGoldenFeatures } = require('../../src/feature_engine/extractors/GoldenFeatureExtractor');
 const { extractTacticalFeatures } = require('../../src/feature_engine/extractors/TacticalMomentumExtractor');
-const { extractOddsMovementFeatures } = require('../../src/feature_engine/extractors/OddsMovementExtractor');
+const {
+    extractOddsMovementFeatures,
+    extractOddsMovementFeaturesFromOddsData
+} = require('../../src/feature_engine/extractors/OddsMovementExtractor');
 
 const WORKER_INDEX = Number.parseInt(process.env.L3_STITCH_WORKER_INDEX || '0', 10);
 const SHARD_COUNT = Number.parseInt(process.env.L3_STITCH_SHARD_COUNT || '1', 10);
@@ -52,6 +55,37 @@ const UPSERT_SQL = `
         stitch_summary = EXCLUDED.stitch_summary,
         computed_at = EXCLUDED.computed_at,
         updated_at = NOW()
+`;
+
+const FETCH_CANONICAL_ODDS_SQL = `
+    SELECT
+        id,
+        match_id,
+        bookmaker,
+        home_odds,
+        draw_odds,
+        away_odds,
+        collected_at
+    FROM odds
+    WHERE match_id = ANY($1::varchar[])
+      AND home_odds IS NOT NULL
+      AND draw_odds IS NOT NULL
+      AND away_odds IS NOT NULL
+    ORDER BY match_id ASC, collected_at ASC NULLS LAST, id ASC
+`;
+
+const FETCH_BOOKMAKER_HISTORY_SQL = `
+    SELECT
+        id,
+        match_id,
+        bookmaker_name,
+        open_odds,
+        close_odds,
+        collected_at
+    FROM bookmaker_odds_history
+    WHERE match_id = ANY($1::varchar[])
+      AND lower(market_type) = '1x2'
+    ORDER BY match_id ASC, collected_at ASC NULLS LAST, id ASC
 `;
 
 function sendMessage(message) {
@@ -102,7 +136,227 @@ function buildConflictSummary(rawData, tacticalFeatures, goldenFeatures, oddsFea
         shotmap_shots: shotmapShots,
         rating_samples: ratingSamples,
         has_odds_data: !!oddsFeatures?.has_odds_data,
+        odds_source: oddsFeatures?._odds_source || 'none',
         conflicts
+    };
+}
+
+function groupRowsByKey(rows, keyField) {
+    const grouped = new Map();
+
+    for (const row of rows) {
+        const key = row?.[keyField];
+        if (!key) {
+            continue;
+        }
+
+        if (!grouped.has(key)) {
+            grouped.set(key, []);
+        }
+        grouped.get(key).push(row);
+    }
+
+    return grouped;
+}
+
+function toPositiveNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function median(values) {
+    if (values.length === 0) {
+        return null;
+    }
+
+    const sorted = [...values].sort((left, right) => left - right);
+    const middle = Math.floor(sorted.length / 2);
+
+    if (sorted.length % 2 === 1) {
+        return sorted[middle];
+    }
+
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function aggregateOddsTriplet(points, collectedAt = null) {
+    const homeValues = points.map((point) => point.home).filter(Boolean);
+    const drawValues = points.map((point) => point.draw).filter(Boolean);
+    const awayValues = points.map((point) => point.away).filter(Boolean);
+
+    if (homeValues.length === 0 || drawValues.length === 0 || awayValues.length === 0) {
+        return null;
+    }
+
+    return {
+        home: median(homeValues),
+        draw: median(drawValues),
+        away: median(awayValues),
+        collectedAt
+    };
+}
+
+function normalizeCanonicalOddsRow(row) {
+    return {
+        home: toPositiveNumber(row.home_odds),
+        draw: toPositiveNumber(row.draw_odds),
+        away: toPositiveNumber(row.away_odds),
+        collectedAt: row.collected_at ? new Date(row.collected_at).toISOString() : null
+    };
+}
+
+function normalizeHistoryOddsPayload(payload, collectedAt) {
+    return {
+        home: toPositiveNumber(payload?.home),
+        draw: toPositiveNumber(payload?.draw),
+        away: toPositiveNumber(payload?.away),
+        collectedAt: collectedAt ? new Date(collectedAt).toISOString() : null
+    };
+}
+
+function buildOddsDataFromCanonicalRows(rows) {
+    if (!rows || rows.length === 0) {
+        return null;
+    }
+
+    const groupedByTimestamp = new Map();
+
+    for (const row of rows) {
+        const normalized = normalizeCanonicalOddsRow(row);
+        if (!normalized.home || !normalized.draw || !normalized.away) {
+            continue;
+        }
+
+        const timestampKey = normalized.collectedAt || `snapshot-${row.id}`;
+        if (!groupedByTimestamp.has(timestampKey)) {
+            groupedByTimestamp.set(timestampKey, []);
+        }
+        groupedByTimestamp.get(timestampKey).push(normalized);
+    }
+
+    const history = Array.from(groupedByTimestamp.entries())
+        .map(([timestampKey, points]) => aggregateOddsTriplet(points, timestampKey.startsWith('snapshot-') ? null : timestampKey))
+        .filter(Boolean);
+
+    if (history.length === 0) {
+        return null;
+    }
+
+    return {
+        initial: history[0],
+        current: history[history.length - 1],
+        history,
+        hasData: true,
+        odds_source: 'odds',
+        _odds_source: 'odds',
+        _odds_source_rows: rows.length,
+        _odds_source_points: history.length
+    };
+}
+
+function buildOddsDataFromHistoricalRows(rows) {
+    if (!rows || rows.length === 0) {
+        return null;
+    }
+
+    const openingPoints = rows
+        .map((row) => normalizeHistoryOddsPayload(row.open_odds, row.collected_at))
+        .filter((point) => point.home && point.draw && point.away);
+
+    const closingPoints = rows
+        .map((row) => normalizeHistoryOddsPayload(row.close_odds, row.collected_at))
+        .filter((point) => point.home && point.draw && point.away);
+
+    const initial = aggregateOddsTriplet(openingPoints, openingPoints[0]?.collectedAt || null);
+    const current = aggregateOddsTriplet(closingPoints, closingPoints[closingPoints.length - 1]?.collectedAt || null);
+
+    if (!initial && !current) {
+        return null;
+    }
+
+    const history = [];
+    if (initial) {
+        history.push(initial);
+    }
+    if (
+        current
+        && (
+            !initial
+            || initial.home !== current.home
+            || initial.draw !== current.draw
+            || initial.away !== current.away
+        )
+    ) {
+        history.push(current);
+    }
+
+    return {
+        initial: initial || current,
+        current: current || initial,
+        history,
+        hasData: true,
+        odds_source: 'bookmaker_odds_history',
+        _odds_source: 'bookmaker_odds_history',
+        _odds_source_rows: rows.length,
+        _odds_source_points: history.length
+    };
+}
+
+async function prefetchOddsSources(client, rows) {
+    const matchIds = rows.map((row) => row.match_id).filter(Boolean);
+    const externalIds = rows.map((row) => row.external_id).filter(Boolean);
+
+    const canonicalRows = matchIds.length > 0
+        ? (await client.query(FETCH_CANONICAL_ODDS_SQL, [matchIds])).rows
+        : [];
+
+    const historicalRows = externalIds.length > 0
+        ? (await client.query(FETCH_BOOKMAKER_HISTORY_SQL, [externalIds])).rows
+        : [];
+
+    return {
+        canonicalByMatchId: groupRowsByKey(canonicalRows, 'match_id'),
+        historicalByExternalId: groupRowsByKey(historicalRows, 'match_id')
+    };
+}
+
+function extractBestAvailableOddsFeatures(row, tacticalFeatures, oddsSources) {
+    const canonicalData = buildOddsDataFromCanonicalRows(
+        oddsSources.canonicalByMatchId.get(row.match_id) || []
+    );
+
+    if (canonicalData) {
+        return {
+            ...extractOddsMovementFeaturesFromOddsData(canonicalData, tacticalFeatures),
+            odds_source: canonicalData.odds_source,
+            _odds_source: canonicalData._odds_source,
+            _odds_source_rows: canonicalData._odds_source_rows,
+            _odds_source_points: canonicalData._odds_source_points
+        };
+    }
+
+    const historicalKey = row.external_id || row.match_id;
+    const historicalData = buildOddsDataFromHistoricalRows(
+        oddsSources.historicalByExternalId.get(historicalKey) || []
+    );
+
+    if (historicalData) {
+        return {
+            ...extractOddsMovementFeaturesFromOddsData(historicalData, tacticalFeatures),
+            odds_source: historicalData.odds_source,
+            _odds_source: historicalData._odds_source,
+            _odds_source_rows: historicalData._odds_source_rows,
+            _odds_source_points: historicalData._odds_source_points
+        };
+    }
+
+    const rawFeatures = extractOddsMovementFeatures(row.raw_data, tacticalFeatures);
+    return {
+        ...rawFeatures,
+        odds_source: rawFeatures.has_odds_data ? 'raw_data' : 'none',
+        _odds_source: rawFeatures.has_odds_data ? 'raw_data' : 'none',
+        _odds_source_rows: 0,
+        _odds_source_points: Number(rawFeatures.odds_history_count || 0)
     };
 }
 
@@ -148,13 +402,14 @@ async function run() {
 
     try {
         const rows = await fetchMatches(client);
+        const oddsSources = await prefetchOddsSources(client, rows);
         sendMessage({ type: 'worker_start', workerIndex: WORKER_INDEX, assigned: rows.length });
 
         for (const row of rows) {
             try {
                 const goldenFeatures = extractGoldenFeatures(row.raw_data);
                 const tacticalFeatures = extractTacticalFeatures(row.raw_data);
-                const oddsFeatures = extractOddsMovementFeatures(row.raw_data);
+                const oddsFeatures = extractBestAvailableOddsFeatures(row, tacticalFeatures, oddsSources);
                 const summary = buildConflictSummary(row.raw_data, tacticalFeatures, goldenFeatures, oddsFeatures);
 
                 if (summary.conflicts.length > 0) {

--- a/src/feature_engine/extractors/OddsMovementExtractor.js
+++ b/src/feature_engine/extractors/OddsMovementExtractor.js
@@ -52,21 +52,39 @@ function extractOddsMovementFeatures(rawData, tacticalFeatures = {}, config = DE
         return createEmptyOddsFeatures();
     }
 
+    return extractOddsMovementFeaturesFromOddsData(
+        extractOddsData(rawData),
+        tacticalFeatures,
+        config
+    );
+}
+
+/**
+ * 从标准化赔率快照中提取赔率变动特征
+ * @param {object} oddsData
+ * @param {object} tacticalFeatures
+ * @param {object} config
+ * @returns {object}
+ */
+function extractOddsMovementFeaturesFromOddsData(oddsData, tacticalFeatures = {}, config = DEFAULT_CONFIG) {
+    const normalizedOddsData = normalizeOddsData(oddsData);
+
+    if (!normalizedOddsData.hasData) {
+        return createEmptyOddsFeatures();
+    }
+
     const features = {};
 
-    // 提取赔率数据
-    const oddsData = extractOddsData(rawData);
-
     // 1. 基础赔率特征
-    const basicFeatures = extractBasicOddsFeatures(oddsData);
+    const basicFeatures = extractBasicOddsFeatures(normalizedOddsData);
     Object.assign(features, basicFeatures);
 
     // 2. 隐含概率（Market Consensus）
-    const consensusFeatures = calculateMarketConsensus(oddsData);
+    const consensusFeatures = calculateMarketConsensus(normalizedOddsData);
     Object.assign(features, consensusFeatures);
 
     // 3. Steam 信号检测
-    const steamFeatures = detectSteamSignals(oddsData, config);
+    const steamFeatures = detectSteamSignals(normalizedOddsData, config);
     Object.assign(features, steamFeatures);
 
     // 4. 异常检测（与 xG 模型对比）
@@ -74,6 +92,7 @@ function extractOddsMovementFeatures(rawData, tacticalFeatures = {}, config = DE
     Object.assign(features, anomalyFeatures);
 
     // 元数据
+    features.odds_source = oddsData.odds_source || 'raw_data';
     features._version = 'V176.0.0';
     features._extractedAt = new Date().toISOString();
 
@@ -137,6 +156,61 @@ function extractOddsData(rawData) {
     oddsData.hasData = !!(oddsData.initial.home || oddsData.current.home);
 
     return oddsData;
+}
+
+function normalizePositiveNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeOddsTriplet(candidate = {}) {
+    return {
+        home: normalizePositiveNumber(candidate?.home),
+        draw: normalizePositiveNumber(candidate?.draw),
+        away: normalizePositiveNumber(candidate?.away)
+    };
+}
+
+function normalizeOddsHistoryEntry(entry) {
+    const normalized = normalizeOddsTriplet(entry);
+
+    if (!normalized.home && !normalized.draw && !normalized.away) {
+        return null;
+    }
+
+    if (Number.isFinite(Number(entry?.minutesToKickoff))) {
+        normalized.minutesToKickoff = Number(entry.minutesToKickoff);
+    }
+
+    if (entry?.collectedAt) {
+        normalized.collectedAt = entry.collectedAt;
+    }
+
+    return normalized;
+}
+
+function normalizeOddsData(oddsData = {}) {
+    const initial = normalizeOddsTriplet(oddsData.initial);
+    const current = normalizeOddsTriplet(oddsData.current);
+    const history = Array.isArray(oddsData.history)
+        ? oddsData.history.map(normalizeOddsHistoryEntry).filter(Boolean)
+        : [];
+
+    const hasTriplet = (triplet) => !!(triplet.home || triplet.draw || triplet.away);
+    const hasData = Boolean(
+        oddsData.hasData
+        || hasTriplet(initial)
+        || hasTriplet(current)
+        || history.length > 0
+    );
+
+    return {
+        initial,
+        current,
+        history,
+        hasData,
+        odds_source: oddsData.odds_source || null
+    };
 }
 
 /**
@@ -370,6 +444,7 @@ function createEmptyOddsFeatures() {
         steam_detected: false,
         steam_strength: 0,
         odds_anomaly_flag: false,
+        odds_source: 'none',
         _error: 'No odds data available',
         _version: 'V176.0.0',
         _extractedAt: new Date().toISOString()
@@ -378,6 +453,7 @@ function createEmptyOddsFeatures() {
 
 module.exports = {
     extractOddsMovementFeatures,
+    extractOddsMovementFeaturesFromOddsData,
     extractOddsData,
     calculateMarketConsensus,
     detectSteamSignals,

--- a/tests/unit/Smelter_Audit.test.js
+++ b/tests/unit/Smelter_Audit.test.js
@@ -198,7 +198,10 @@ describe('🔥 FeatureSmelter 生产级压力审计', () => {
     describe('Extractor 组件测试', () => {
         const { extractGoldenFeatures } = require('../../src/feature_engine/extractors/GoldenFeatureExtractor.js');
         const { extractTacticalFeatures } = require('../../src/feature_engine/extractors/TacticalMomentumExtractor.js');
-        const { extractOddsMovementFeatures } = require('../../src/feature_engine/extractors/OddsMovementExtractor.js');
+        const {
+            extractOddsMovementFeatures,
+            extractOddsMovementFeaturesFromOddsData
+        } = require('../../src/feature_engine/extractors/OddsMovementExtractor.js');
 
         describe('GoldenFeatureExtractor', () => {
             it('应该正确提取标准数据', () => {
@@ -271,6 +274,24 @@ describe('🔥 FeatureSmelter 生产级压力审计', () => {
                 const features = extractOddsMovementFeatures(data);
                 
                 assert.strictEqual(features.has_odds_data, false, '应标记无赔率数据');
+            });
+
+            it('应该支持数据库赔率快照输入', () => {
+                const features = extractOddsMovementFeaturesFromOddsData({
+                    initial: { home: 1.95, draw: 3.4, away: 4.2 },
+                    current: { home: 1.82, draw: 3.55, away: 4.6 },
+                    history: [
+                        { home: 1.95, draw: 3.4, away: 4.2 },
+                        { home: 1.82, draw: 3.55, away: 4.6 }
+                    ],
+                    hasData: true
+                });
+
+                assert.strictEqual(features.has_odds_data, true, '数据库赔率应被识别为有效');
+                assert.strictEqual(features.odds_source, 'raw_data', '标准化快照应走统一赔率来源标记');
+                assert.strictEqual(features.initial_home_odds, 1.95, '应保留开盘赔率');
+                assert.strictEqual(features.current_home_odds, 1.82, '应保留收盘赔率');
+                assert.strictEqual(features.favorite, 'home', '应能计算市场热门方');
             });
         });
     });


### PR DESCRIPTION
## Summary
- Upgrade L3 stitching to prefer database odds rows before raw FotMob fallback.
- Support canonical odds rows by match_id and bookmaker_odds_history rows by external_id.
- Add odds_source reporting so missing source rows are explicit.

## Verification
- node --test tests/unit/Smelter_Audit.test.js: 45/45 pass
- bash scripts/devops/gatekeeper.sh --mode=commit: pass
- git push hook PR gate: pass, including incremental JS and recon-core coverage
- L3 24/25 restitch: 2130 processed, 2130 success, 0 failed, odds_none_rows=2130
