### PR TITLE
feat(ops): add specialized odds harvester for 24/25 season and achieve 99.8% coverage

### DIFF
--- a/scripts/ops/odds_harvest_2425.js
+++ b/scripts/ops/odds_harvest_2425.js
@@ -1,0 +1,695 @@
+#!/usr/bin/env node
+'use strict';
+
+require('dotenv').config();
+
+const { spawn } = require('node:child_process');
+const { chromium } = require('playwright');
+const { Pool } = require('pg');
+
+const { ReconPureDecryptor } = require('../../src/infrastructure/recon/services/ReconPureDecryptor');
+const { EntityMapper } = require('../../src/infrastructure/etl/EntityMapper');
+const {
+  COVERAGE_SQL,
+  CURRENT_BOOKMAKER,
+  DEFAULT_CONCURRENCY,
+  DEFAULT_RETRIES,
+  DEFAULT_RETRY_DELAY_MS,
+  DEFAULT_USER_AGENT,
+  LEAGUE_ROUTE_CATALOG,
+  MATCH_DELTA_MS,
+  MONTHS,
+  ODDSPORTAL_TEAM_ALIASES,
+  OPENING_BOOKMAKER,
+  RESULTS_BASE_URL,
+  TARGETS_SQL,
+  TARGET_SEASON,
+  UPSERT_MAPPING_SQL,
+  UPSERT_ODDS_SQL,
+  extractMedianOddsSnapshots,
+  normalizeTitleKey,
+  parseArgs,
+  sleep
+} = require('./odds_harvest_2425.shared');
+
+const pool = new Pool({
+  host: process.env.DB_HOST || '127.0.0.1',
+  port: Number.parseInt(process.env.DB_PORT || '5432', 10),
+  database: process.env.DB_NAME || 'football_db',
+  user: process.env.DB_USER || 'football_user',
+  password: process.env.DB_PASSWORD || '',
+  max: Math.max(8, Math.min(DEFAULT_CONCURRENCY + 4, 32))
+});
+
+function normalizeLeagueSelection(rawValue) {
+  return String(rawValue || '').trim().toLowerCase();
+}
+
+function resolveRequestedRoutes(requestedLeagues = []) {
+  const routeEntries = Object.values(LEAGUE_ROUTE_CATALOG);
+  const requested = new Set(requestedLeagues.map(normalizeLeagueSelection));
+  const matches = routeEntries.filter((entry) => (
+    requested.has(entry.leagueName.toLowerCase())
+    || requested.has(normalizeTitleKey(entry.leagueName))
+  ));
+
+  if (requestedLeagues.length === 0) {
+    return routeEntries;
+  }
+
+  if (matches.length !== requestedLeagues.length) {
+    const known = routeEntries.map((entry) => entry.leagueName).join(', ');
+    throw new Error(`未知联赛参数: ${requestedLeagues.join(', ')} | 可用联赛: ${known}`);
+  }
+
+  return matches;
+}
+
+function buildResultsUrl(route, season) {
+  return `${RESULTS_BASE_URL}/football/${route.country}/${route.slug}-${season.replace('/', '-')}/results/`;
+}
+
+async function acceptCookieBanner(page) {
+  const candidates = [
+    '#onetrust-accept-btn-handler',
+    'button:has-text("Accept")',
+    'button:has-text("I Accept")'
+  ];
+
+  for (const selector of candidates) {
+    try {
+      const locator = page.locator(selector).first();
+      if (await locator.isVisible({ timeout: 5000 }).catch(() => false)) {
+        await locator.click({ timeout: 5000, force: true }).catch(() => {});
+        await page.waitForTimeout(1000);
+        return;
+      }
+    } catch {
+      // ignore optional banner selectors
+    }
+  }
+}
+
+async function goToPaginationPage(page, pageNumber) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      await acceptCookieBanner(page);
+      await page.locator(`a.pagination-link[data-number="${pageNumber}"]`).click({
+        timeout: 15000,
+        force: true
+      });
+      await acceptCookieBanner(page);
+      await page.waitForFunction(
+        (targetPage) => {
+          const active = document.querySelector('a.pagination-link.active')?.getAttribute('data-number');
+          const rows = document.querySelectorAll('div.group[data-testid="game-row"]').length;
+          return active === String(targetPage) && rows > 0;
+        },
+        pageNumber,
+        { timeout: 30000 }
+      );
+      await page.waitForTimeout(400);
+      return;
+    } catch (error) {
+      lastError = error;
+      await page.waitForTimeout(1500 * attempt);
+    }
+  }
+
+  throw lastError;
+}
+
+async function waitForRowsReady(page, label) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      await acceptCookieBanner(page);
+      await page.waitForFunction(
+        () => document.querySelectorAll('div.group[data-testid="game-row"]').length > 0,
+        undefined,
+        { timeout: 30000 }
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+      console.warn(`[ENUM] ${label} rows-ready retry ${attempt}/3`);
+      await page.reload({
+        waitUntil: 'networkidle',
+        timeout: 120000
+      }).catch(() => {});
+      await page.waitForTimeout(1500 * attempt);
+    }
+  }
+
+  throw lastError;
+}
+
+async function enumerateLeagueEvents(route, season) {
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage']
+  });
+
+  const eventsByHash = new Map();
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 1200 },
+    userAgent: DEFAULT_USER_AGENT
+  });
+
+  try {
+    await page.goto(buildResultsUrl(route, season), {
+      waitUntil: 'networkidle',
+      timeout: 120000
+    });
+    await waitForRowsReady(page, `${route.leagueName}:initial`);
+
+    const totalPages = await page.evaluate(() => {
+      const numbers = Array.from(document.querySelectorAll('a.pagination-link[data-number]'))
+        .map((element) => Number(element.getAttribute('data-number') || '1'))
+        .filter((value) => Number.isFinite(value) && value > 0);
+      return numbers.length > 0 ? Math.max(...numbers) : 1;
+    });
+
+    for (let pageNumber = 1; pageNumber <= totalPages; pageNumber += 1) {
+      if (pageNumber > 1) {
+        await goToPaginationPage(page, pageNumber);
+      }
+
+      const pageRows = await page.evaluate((baseUrl) => {
+        const nodes = Array.from(document.querySelectorAll('[data-testid="date-header"], div.group[data-testid="game-row"]'));
+        let currentDate = null;
+        const rows = [];
+
+        for (const node of nodes) {
+          if (node.getAttribute('data-testid') === 'date-header') {
+            currentDate = node.textContent?.replace(/\s+/g, ' ').trim() || null;
+            continue;
+          }
+
+          const anchor = node.querySelector('a[href*="/football/h2h/"]');
+          const href = anchor?.getAttribute('href');
+          if (!href) {
+            continue;
+          }
+
+          const participants = Array.from(node.querySelectorAll('.participant-name'))
+            .map((element) => element.textContent?.trim())
+            .filter(Boolean);
+          const fullUrl = new URL(href, baseUrl).toString();
+
+          rows.push({
+            fullUrl,
+            hash: /#([A-Za-z0-9]{8})$/.exec(fullUrl)?.[1] || null,
+            homeTeam: participants[0] || null,
+            awayTeam: participants[1] || null,
+            dateLabel: currentDate
+          });
+        }
+
+        return rows;
+      }, RESULTS_BASE_URL);
+
+      for (const row of pageRows) {
+        if (!row.hash) {
+          continue;
+        }
+        eventsByHash.set(row.hash, {
+          ...row,
+          leagueName: route.leagueName
+        });
+      }
+
+      console.log(
+        `[ENUM] ${route.leagueName} page=${pageNumber}/${totalPages} rows=${pageRows.length} unique=${eventsByHash.size}`
+      );
+    }
+  } finally {
+    await page.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+
+  return Array.from(eventsByHash.values());
+}
+
+async function fetchText(url, options = {}) {
+  const retries = options.retries || DEFAULT_RETRIES;
+  const headers = {
+    'user-agent': DEFAULT_USER_AGENT,
+    'accept-language': 'en-US,en;q=0.9',
+    ...options.headers
+  };
+
+  let lastError = null;
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(Number.parseInt(process.env.ODDS_HARVEST_FETCH_TIMEOUT_MS || '30000', 10))
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP_${response.status}`);
+      }
+
+      return await response.text();
+    } catch (error) {
+      lastError = error;
+      if (attempt === retries) {
+        break;
+      }
+      await sleep(DEFAULT_RETRY_DELAY_MS * attempt);
+    }
+  }
+
+  throw lastError;
+}
+
+async function createDecryptor(sampleEventUrl) {
+  const sampleHtml = await fetchText(sampleEventUrl, {
+    headers: {
+      referer: sampleEventUrl
+    }
+  });
+  const bundlePath = [...sampleHtml.matchAll(/(?:src|href)=["']([^"']*\/build\/assets\/app-[^"']+\.js[^"']*)["']/g)][0]?.[1]
+    || [...sampleHtml.matchAll(/https:\/\/www\.oddsportal\.com\/build\/assets\/app-[^"']+\.js/g)][0]?.[0];
+  const bundleUrl = bundlePath
+    ? new URL(bundlePath, RESULTS_BASE_URL).toString()
+    : null;
+
+  if (!bundleUrl) {
+    throw new Error(`未从 H2H 页面提取到 bundle: ${sampleEventUrl}`);
+  }
+
+  const decryptor = new ReconPureDecryptor({
+    logger: {
+      info: (...args) => console.log('[DECRYPT]', ...args),
+      warn: (...args) => console.warn('[DECRYPT]', ...args),
+      error: (...args) => console.error('[DECRYPT]', ...args)
+    },
+    traceId: `odds_harvest_${Date.now()}`
+  });
+
+  await decryptor.loadFromBundleUrl(bundleUrl, { html: '' });
+  return {
+    bundleUrl,
+    decryptor
+  };
+}
+
+function buildTargetIndexes(targetRows) {
+  const mapper = new EntityMapper({
+    teamAliases: ODDSPORTAL_TEAM_ALIASES
+  });
+  const exactByLeague = new Map();
+
+  for (const row of targetRows) {
+    const leagueName = String(row.league_name);
+    const key = mapper.buildMatchLookupKey(row.home_team, row.away_team);
+    const normalized = {
+      ...row,
+      leagueName,
+      normalizedKey: key,
+      matchTimestampMs: new Date(row.match_date).getTime()
+    };
+
+    if (!exactByLeague.has(leagueName)) {
+      exactByLeague.set(leagueName, new Map());
+    }
+    const leagueBucket = exactByLeague.get(leagueName);
+    if (!leagueBucket.has(key)) {
+      leagueBucket.set(key, []);
+    }
+    leagueBucket.get(key).push(normalized);
+  }
+
+  return {
+    mapper,
+    exactByLeague
+  };
+}
+
+function resolveTargetMatch(indexes, candidate) {
+  const leagueBucket = indexes.exactByLeague.get(candidate.leagueName);
+  if (!leagueBucket) {
+    return null;
+  }
+
+  const homeKey = indexes.mapper.buildMatchLookupKey(candidate.homeTeam, candidate.awayTeam);
+  const reverseKey = indexes.mapper.buildMatchLookupKey(candidate.awayTeam, candidate.homeTeam);
+  const candidateSets = [
+    {
+      key: homeKey,
+      isReversed: false,
+      rows: leagueBucket.get(homeKey) || []
+    },
+    {
+      key: reverseKey,
+      isReversed: true,
+      rows: leagueBucket.get(reverseKey) || []
+    }
+  ];
+
+  let best = null;
+
+  for (const set of candidateSets) {
+    for (const row of set.rows) {
+      const deltaMs = Math.abs(row.matchTimestampMs - candidate.kickoffMs);
+      if (!best || deltaMs < best.deltaMs) {
+        best = {
+          row,
+          deltaMs,
+          isReversed: set.isReversed
+        };
+      }
+    }
+  }
+
+  if (!best || best.deltaMs > MATCH_DELTA_MS) {
+    return null;
+  }
+
+  const confidence = best.deltaMs <= 6 * 60 * 60 * 1000
+    ? 1.0
+    : (best.deltaMs <= 24 * 60 * 60 * 1000 ? 0.96 : 0.9);
+
+  return {
+    ...best.row,
+    deltaMs: best.deltaMs,
+    isReversed: best.isReversed,
+    matchConfidence: confidence
+  };
+}
+
+function parseOddsPortalDateLabel(dateLabel) {
+  const match = String(dateLabel || '').trim().match(/^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/);
+  if (!match) {
+    return null;
+  }
+
+  const day = Number(match[1]);
+  const month = MONTHS[match[2].toLowerCase()];
+  const year = Number(match[3]);
+
+  if (!Number.isInteger(day) || month === undefined || !Number.isInteger(year)) {
+    return null;
+  }
+
+  return Date.UTC(year, month, day, 12, 0, 0);
+}
+
+function resolveDomCandidateMatch(indexes, candidate) {
+  const dateMs = parseOddsPortalDateLabel(candidate.dateLabel);
+  if (!dateMs) {
+    return null;
+  }
+
+  return resolveTargetMatch(indexes, {
+    leagueName: candidate.leagueName,
+    homeTeam: candidate.homeTeam,
+    awayTeam: candidate.awayTeam,
+    kickoffMs: dateMs
+  });
+}
+
+async function fetchAjaxEventData(decryptor, event) {
+  const ajaxUrl = `${RESULTS_BASE_URL}/ajax-event-data/${event.hash}/0`;
+  const ajaxPayload = await fetchText(ajaxUrl, {
+    headers: {
+      referer: event.fullUrl
+    }
+  });
+  return decryptor.decrypt(ajaxPayload);
+}
+
+async function fetchPreMatchData(decryptor, event, requestPreMatchUrl) {
+  const url = `${RESULTS_BASE_URL}${requestPreMatchUrl}`;
+  const payload = await fetchText(url, {
+    headers: {
+      referer: event.fullUrl
+    }
+  });
+  return decryptor.decrypt(payload);
+}
+
+async function upsertMappingAndOdds(match, event, oddsSnapshots, season, options = {}) {
+  if (options.dryRun) {
+    return;
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(UPSERT_MAPPING_SQL, [
+      match.match_id,
+      event.hash,
+      event.fullUrl,
+      season,
+      match.leagueName,
+      match.home_team,
+      match.away_team,
+      match.matchConfidence,
+      match.isReversed
+    ]);
+    await client.query(UPSERT_ODDS_SQL, [
+      match.match_id,
+      OPENING_BOOKMAKER,
+      oddsSnapshots.opening.home,
+      oddsSnapshots.opening.draw,
+      oddsSnapshots.opening.away,
+      oddsSnapshots.opening.collectedAt
+    ]);
+    await client.query(UPSERT_ODDS_SQL, [
+      match.match_id,
+      CURRENT_BOOKMAKER,
+      oddsSnapshots.current.home,
+      oddsSnapshots.current.draw,
+      oddsSnapshots.current.away,
+      oddsSnapshots.current.collectedAt
+    ]);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function buildProgressSnapshot(stats) {
+  const elapsedMinutes = Math.max(1 / 60, (Date.now() - stats.startedAt) / 60000);
+  return {
+    processed: stats.processed,
+    success: stats.success,
+    noMatch: stats.noMatch,
+    noOdds: stats.noOdds,
+    failed: stats.failed,
+    throughputPerMinute: Number((stats.success / elapsedMinutes).toFixed(2))
+  };
+}
+
+function printProgress(stats, total) {
+  const snapshot = buildProgressSnapshot(stats);
+  console.log(
+    `[HARVEST] ${snapshot.processed}/${total} | success=${snapshot.success} `
+    + `no_match=${snapshot.noMatch} no_odds=${snapshot.noOdds} failed=${snapshot.failed} `
+    + `throughput=${snapshot.throughputPerMinute} matches/min`
+  );
+}
+
+async function runL3Stitch(options = {}) {
+  if (!options.l3Enabled || options.mappingOnly) {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['scripts/ops/l3_stitch_2425.js'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        L3_STITCH_SEASON: options.season || TARGET_SEASON,
+        L3_STITCH_FULL_RECALCULATE: 'true',
+        L3_STITCH_WORKERS: String(options.l3Workers || 12)
+      },
+      stdio: 'inherit'
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`l3_stitch_2425.js exited with code ${code}`));
+    });
+  });
+}
+
+async function fetchCoverageStats(client, season) {
+  const result = await client.query(COVERAGE_SQL, [season, OPENING_BOOKMAKER, CURRENT_BOOKMAKER]);
+  return result.rows[0];
+}
+
+async function fetchTargetMatches(client, routeSet, season) {
+  const result = await client.query(TARGETS_SQL, [season, OPENING_BOOKMAKER, CURRENT_BOOKMAKER]);
+  const routeNames = new Set(routeSet.map((route) => route.leagueName));
+  return result.rows.filter((row) => routeNames.has(String(row.league_name)));
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2));
+  const routes = resolveRequestedRoutes(options.leagues);
+  const season = options.season;
+  const rootClient = await pool.connect();
+
+  try {
+    const initialCoverage = await fetchCoverageStats(rootClient, season);
+    const targetRows = await fetchTargetMatches(rootClient, routes, season);
+    const indexes = buildTargetIndexes(targetRows);
+
+    console.log('[BOOT] 24/25 赔率专项收割启动');
+    console.log(`[BOOT] season=${season} leagues=${routes.map((route) => route.leagueName).join(', ')}`);
+    console.log(`[BOOT] initial_l3_gap=${initialCoverage.l3_gap} initial_odds_gap=${initialCoverage.odds_gap}`);
+    console.log(`[BOOT] target_rows=${targetRows.length} workers=${options.concurrency}`);
+
+    if (targetRows.length === 0) {
+      console.log('[BOOT] 当前没有待补赔率目标，退出。');
+      return;
+    }
+
+    const enumeratedEvents = [];
+    for (const route of routes) {
+      const leagueEvents = await enumerateLeagueEvents(route, season);
+      console.log(`[ENUM] ${route.leagueName} unique_events=${leagueEvents.length} expected=${route.expectedMatches}`);
+      enumeratedEvents.push(...leagueEvents);
+    }
+
+    if (enumeratedEvents.length === 0) {
+      throw new Error('结果页未抽取到任何 event，无法继续');
+    }
+
+    const candidateEvents = options.skipDomFilter
+      ? enumeratedEvents
+      : enumeratedEvents.filter((event) => resolveDomCandidateMatch(indexes, event));
+    const selectedEvents = options.limit
+      ? candidateEvents.slice(0, options.limit)
+      : candidateEvents;
+
+    console.log(
+      `[ENUM] candidate_events=${candidateEvents.length} selected_events=${selectedEvents.length} `
+      + `raw_events=${enumeratedEvents.length}`
+    );
+
+    const { bundleUrl, decryptor } = await createDecryptor(selectedEvents[0].fullUrl);
+    console.log(`[DECRYPT] bundle=${bundleUrl}`);
+
+    const stats = {
+      startedAt: Date.now(),
+      processed: 0,
+      success: 0,
+      noMatch: 0,
+      noOdds: 0,
+      failed: 0,
+      l3Runs: 0
+    };
+    const pendingL3Marks = new Set();
+
+    const processEvent = async (event) => {
+      try {
+        const ajax = await fetchAjaxEventData(decryptor, event);
+        const eventData = ajax?.d?.eventData;
+        const eventBody = ajax?.d?.eventBody;
+        const requestPreMatch = ajax?.d?.requestPreMatch?.url;
+        const kickoffMs = Number(eventBody?.startDate || 0) * 1000;
+
+        if (!eventData?.home || !eventData?.away || !requestPreMatch || !kickoffMs) {
+          throw new Error(`event payload 缺少关键字段 hash=${event.hash}`);
+        }
+
+        const matchedRow = resolveTargetMatch(indexes, {
+          leagueName: event.leagueName,
+          homeTeam: eventData.home,
+          awayTeam: eventData.away,
+          kickoffMs
+        });
+
+        if (!matchedRow) {
+          stats.noMatch += 1;
+          return;
+        }
+
+        const preMatch = await fetchPreMatchData(decryptor, event, requestPreMatch);
+        const oddsSnapshots = extractMedianOddsSnapshots(preMatch, kickoffMs);
+
+        if (!oddsSnapshots) {
+          stats.noOdds += 1;
+          return;
+        }
+
+        await upsertMappingAndOdds(matchedRow, event, oddsSnapshots, season, options);
+        pendingL3Marks.add(matchedRow.match_id);
+        stats.success += 1;
+      } catch (error) {
+        stats.failed += 1;
+        console.error(`[HARVEST] failed hash=${event.hash} league=${event.leagueName}: ${error.message}`);
+      } finally {
+        stats.processed += 1;
+        if (stats.processed % options.progressEvery === 0 || stats.processed === selectedEvents.length) {
+          printProgress(stats, selectedEvents.length);
+        }
+      }
+    };
+
+    for (let index = 0; index < selectedEvents.length; index += options.concurrency) {
+      const chunk = selectedEvents.slice(index, index + options.concurrency);
+      await Promise.all(chunk.map((event) => processEvent(event)));
+
+      if (
+        options.l3Enabled
+        && !options.mappingOnly
+        && options.l3Every > 0
+        && pendingL3Marks.size >= options.l3Every
+      ) {
+        console.log(`[L3] 触发增量批次 full-recalc，pending=${pendingL3Marks.size}`);
+        await runL3Stitch(options);
+        stats.l3Runs += 1;
+        pendingL3Marks.clear();
+      }
+    }
+
+    if (
+      options.l3Enabled
+      && !options.mappingOnly
+      && pendingL3Marks.size > 0
+    ) {
+      console.log(`[L3] 执行收尾 full-recalc，pending=${pendingL3Marks.size}`);
+      await runL3Stitch(options);
+      stats.l3Runs += 1;
+      pendingL3Marks.clear();
+    }
+
+    const finalCoverage = await fetchCoverageStats(rootClient, season);
+    const finalSnapshot = buildProgressSnapshot(stats);
+
+    console.log('[FINAL] 任务完成');
+    console.log(
+      `[FINAL] processed=${stats.processed} success=${stats.success} `
+      + `no_match=${stats.noMatch} no_odds=${stats.noOdds} failed=${stats.failed}`
+    );
+    console.log(
+      `[FINAL] throughput=${finalSnapshot.throughputPerMinute} matches/min `
+      + `l3_runs=${stats.l3Runs} odds_gap=${finalCoverage.odds_gap} l3_gap=${finalCoverage.l3_gap}`
+    );
+  } finally {
+    rootClient.release();
+    await pool.end();
+  }
+}
+
+run().catch((error) => {
+  console.error(`[FATAL] ${error.stack || error.message}`);
+  pool.end().catch(() => {});
+  process.exit(1);
+});

--- a/scripts/ops/odds_harvest_2425.shared.js
+++ b/scripts/ops/odds_harvest_2425.shared.js
@@ -1,0 +1,602 @@
+ 'use strict';
+
+const reconConfig = require('../../config/recon_config.json');
+const { Normalizer } = require('../../src/utils/Normalizer');
+
+const TARGET_SEASON = process.env.ODDS_HARVEST_SEASON || '2024/2025';
+const DEFAULT_USER_AGENT = process.env.ODDS_HARVEST_USER_AGENT
+  || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36';
+const DEFAULT_CONCURRENCY = Math.max(
+  1,
+  Number.parseInt(process.env.ODDS_HARVEST_WORKERS || '24', 10)
+);
+const DEFAULT_PROGRESS_EVERY = Math.max(
+  1,
+  Number.parseInt(process.env.ODDS_HARVEST_PROGRESS_EVERY || '25', 10)
+);
+const DEFAULT_L3_BATCH_SIZE = Math.max(
+  0,
+  Number.parseInt(process.env.ODDS_HARVEST_L3_EVERY || '200', 10)
+);
+const DEFAULT_RETRIES = Math.max(
+  1,
+  Number.parseInt(process.env.ODDS_HARVEST_RETRIES || '3', 10)
+);
+const DEFAULT_RETRY_DELAY_MS = Math.max(
+  100,
+  Number.parseInt(process.env.ODDS_HARVEST_RETRY_DELAY_MS || '1200', 10)
+);
+const MATCH_DELTA_HOURS = Math.max(
+  1,
+  Number.parseInt(process.env.ODDS_HARVEST_MATCH_DELTA_HOURS || '72', 10)
+);
+const MATCH_DELTA_MS = MATCH_DELTA_HOURS * 60 * 60 * 1000;
+const OPENING_BOOKMAKER = 'oddsportal_median_opening';
+const CURRENT_BOOKMAKER = 'oddsportal_median_current';
+const ONE_X_TWO_MARKET_KEY = 'E-1-2-0-0-0';
+const RESULTS_BASE_URL = reconConfig.oddsportal?.base_url || 'https://www.oddsportal.com';
+const MONTHS = Object.freeze({
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11
+});
+const ODDSPORTAL_TEAM_ALIASES = Object.freeze({
+  'Manchester Utd': 'Manchester United',
+  'Man Utd': 'Manchester United',
+  'Manchester City': 'Manchester City',
+  Newcastle: 'Newcastle United',
+  'Newcastle Utd': 'Newcastle United',
+  Tottenham: 'Tottenham Hotspur',
+  Spurs: 'Tottenham Hotspur',
+  Nottingham: 'Nottingham Forest',
+  Wolves: 'Wolverhampton Wanderers',
+  Brighton: 'Brighton & Hove Albion',
+  Bournemouth: 'AFC Bournemouth',
+  Leicester: 'Leicester City',
+  'West Ham': 'West Ham United',
+  Ipswich: 'Ipswich Town',
+  'Crystal Palace': 'Crystal Palace',
+  Leverkusen: 'Bayer Leverkusen',
+  'Bayern Munich': 'Bayern Munich',
+  Dortmund: 'Borussia Dortmund',
+  Monchengladbach: 'Borussia Monchengladbach',
+  'B. Monchengladbach': 'Borussia Monchengladbach',
+  'Borussia Mgladbach': 'Borussia Monchengladbach',
+  "M'gladbach": 'Borussia Monchengladbach',
+  'Ein Frankfurt': 'Eintracht Frankfurt',
+  Frankfurt: 'Eintracht Frankfurt',
+  'RB Leipzig': 'RB Leipzig',
+  Leipzig: 'RB Leipzig',
+  Heidenheim: 'FC Heidenheim',
+  Verona: 'Hellas Verona',
+  Inter: 'Inter Milan',
+  Milan: 'Milan',
+  'AC Milan': 'Milan',
+  'Atl. Madrid': 'Atletico Madrid',
+  'Ath Bilbao': 'Athletic Club',
+  'Athletic Bilbao': 'Athletic Club',
+  Betis: 'Real Betis',
+  Valladolid: 'Real Valladolid',
+  Sociedad: 'Real Sociedad',
+  Alaves: 'Deportivo Alaves',
+  Celta: 'Celta Vigo',
+  PSG: 'Paris Saint Germain',
+  'Paris SG': 'Paris Saint Germain',
+  Marseille: 'Olympique Marseille',
+  Lyon: 'Olympique Lyon',
+  Rennes: 'Stade Rennais',
+  'St Etienne': 'FC Saint Etienne',
+  'Club Brugge KV': 'Club Brugge',
+  'Olympiacos Piraeus': 'Olympiacos',
+  PAOK: 'Paok Thessaloniki',
+  'PAOK Thessaloniki': 'Paok Thessaloniki',
+  'Royale Union SG': 'Union St Gilloise',
+  'Union Saint-Gilloise': 'Union St Gilloise',
+  'Dyn. Kyiv': 'Dynamo Kyiv',
+  'Dynamo Kiev': 'Dynamo Kyiv',
+  Qarabag: 'Qarabag Fk',
+  'Qarabag FK': 'Qarabag Fk'
+});
+
+const LEAGUE_ROUTE_CATALOG = Object.freeze({
+  'Premier League': {
+    leagueName: 'Premier League',
+    country: 'england',
+    slug: 'premier-league',
+    expectedMatches: 380
+  },
+  'La Liga': {
+    leagueName: 'La Liga',
+    country: 'spain',
+    slug: 'laliga',
+    expectedMatches: 380
+  },
+  Bundesliga: {
+    leagueName: 'Bundesliga',
+    country: 'germany',
+    slug: 'bundesliga',
+    expectedMatches: 306
+  },
+  'Serie A': {
+    leagueName: 'Serie A',
+    country: 'italy',
+    slug: 'serie-a',
+    expectedMatches: 380
+  },
+  'Ligue 1': {
+    leagueName: 'Ligue 1',
+    country: 'france',
+    slug: 'ligue-1',
+    expectedMatches: 306
+  },
+  'Champions League': {
+    leagueName: 'Champions League',
+    country: 'europe',
+    slug: 'champions-league',
+    expectedMatches: 189
+  },
+  'Europa League': {
+    leagueName: 'Europa League',
+    country: 'europe',
+    slug: 'europa-league',
+    expectedMatches: 189
+  }
+});
+
+const COVERAGE_SQL = `
+  SELECT
+      COUNT(*)::int AS total_matches,
+      COUNT(*) FILTER (
+          WHERE m.pipeline_status IN ('harvested', 'RECON_LINKED')
+      )::int AS active_matches,
+      COUNT(*) FILTER (
+          WHERE COALESCE((l3.odds_features->>'has_odds_data')::boolean, FALSE) = FALSE
+      )::int AS l3_gap,
+      COUNT(*) FILTER (
+          WHERE (
+              SELECT COUNT(*)
+              FROM odds o
+              WHERE o.match_id = m.match_id
+                AND o.bookmaker IN ($2, $3)
+          ) < 2
+      )::int AS odds_gap,
+      COUNT(*) FILTER (
+          WHERE (
+              SELECT COUNT(*)
+              FROM odds o
+              WHERE o.match_id = m.match_id
+                AND o.bookmaker IN ($2, $3)
+          ) >= 2
+      )::int AS odds_complete
+  FROM matches m
+  LEFT JOIN l3_features l3 ON l3.match_id = m.match_id
+  WHERE m.season = $1
+`;
+
+const TARGETS_SQL = `
+  SELECT
+      m.match_id,
+      m.external_id,
+      m.league_name,
+      m.home_team,
+      m.away_team,
+      m.match_date,
+      COALESCE((l3.odds_features->>'has_odds_data')::boolean, FALSE) AS l3_has_odds
+  FROM matches m
+  LEFT JOIN l3_features l3 ON l3.match_id = m.match_id
+  WHERE m.season = $1
+    AND m.pipeline_status IN ('harvested', 'RECON_LINKED')
+    AND (
+      SELECT COUNT(*)
+      FROM odds o
+      WHERE o.match_id = m.match_id
+        AND o.bookmaker IN ($2, $3)
+    ) < 2
+  ORDER BY m.match_date ASC, m.match_id ASC
+`;
+
+const UPSERT_MAPPING_SQL = `
+  INSERT INTO matches_oddsportal_mapping (
+      match_id,
+      oddsportal_hash,
+      full_url,
+      season,
+      league_name,
+      home_team,
+      away_team,
+      status,
+      match_confidence,
+      mapping_method,
+      is_reversed,
+      is_evidence_only,
+      retry_count,
+      last_error,
+      harvested_at,
+      created_at,
+      updated_at
+  ) VALUES (
+      $1, $2, $3, $4, $5, $6, $7,
+      'harvested',
+      $8,
+      'protocol_extract',
+      $9,
+      FALSE,
+      0,
+      NULL,
+      NOW(),
+      NOW(),
+      NOW()
+  )
+  ON CONFLICT (match_id, season) DO UPDATE SET
+      oddsportal_hash = EXCLUDED.oddsportal_hash,
+      full_url = EXCLUDED.full_url,
+      league_name = EXCLUDED.league_name,
+      home_team = EXCLUDED.home_team,
+      away_team = EXCLUDED.away_team,
+      status = 'harvested',
+      match_confidence = EXCLUDED.match_confidence,
+      mapping_method = 'protocol_extract',
+      is_reversed = EXCLUDED.is_reversed,
+      is_evidence_only = FALSE,
+      retry_count = 0,
+      last_error = NULL,
+      harvested_at = NOW(),
+      updated_at = NOW()
+`;
+
+const UPSERT_ODDS_SQL = `
+  INSERT INTO odds (
+      match_id,
+      bookmaker,
+      home_odds,
+      draw_odds,
+      away_odds,
+      collected_at
+  ) VALUES ($1, $2, $3, $4, $5, $6)
+  ON CONFLICT (match_id, bookmaker) DO UPDATE SET
+      home_odds = EXCLUDED.home_odds,
+      draw_odds = EXCLUDED.draw_odds,
+      away_odds = EXCLUDED.away_odds,
+      collected_at = EXCLUDED.collected_at
+`;
+
+function buildDefaultOptions() {
+  return {
+    season: TARGET_SEASON,
+    concurrency: DEFAULT_CONCURRENCY,
+    limit: null,
+    progressEvery: DEFAULT_PROGRESS_EVERY,
+    l3Every: DEFAULT_L3_BATCH_SIZE,
+    l3Workers: Number.parseInt(process.env.L3_STITCH_WORKERS || '12', 10),
+    l3Enabled: true,
+    mappingOnly: false,
+    skipDomFilter: false,
+    dryRun: false,
+    leagues: [],
+    retries: DEFAULT_RETRIES
+  };
+}
+
+function parseCountArg(value, minimum) {
+  return Math.max(minimum, Number.parseInt(value, 10));
+}
+
+function addLeague(options, value) {
+  options.leagues.push(value.trim());
+}
+
+function setSeason(options, value) {
+  options.season = Normalizer.normalizeSeason(value);
+}
+
+function setLimit(options, value) {
+  options.limit = parseCountArg(value, 1);
+}
+
+function setConcurrency(options, value) {
+  options.concurrency = parseCountArg(value, 1);
+}
+
+function setProgressEvery(options, value) {
+  options.progressEvery = parseCountArg(value, 1);
+}
+
+function setL3Every(options, value) {
+  options.l3Every = Math.max(0, Number.parseInt(value, 10));
+}
+
+function setL3Workers(options, value) {
+  options.l3Workers = parseCountArg(value, 1);
+}
+
+function setRetries(options, value) {
+  options.retries = parseCountArg(value, 1);
+}
+
+const VALUE_ARG_HANDLERS = Object.freeze({
+  '--season': setSeason,
+  '--league': addLeague,
+  '--limit': setLimit,
+  '--workers': setConcurrency,
+  '--progress-every': setProgressEvery,
+  '--l3-every': setL3Every,
+  '--l3-workers': setL3Workers,
+  '--retries': setRetries
+});
+
+const FLAG_ARG_HANDLERS = Object.freeze({
+  '--mapping-only': (options) => {
+    options.mappingOnly = true;
+  },
+  '--skip-dom-filter': (options) => {
+    options.skipDomFilter = true;
+  },
+  '--skip-l3': (options) => {
+    options.l3Enabled = false;
+  },
+  '--dry-run': (options) => {
+    options.dryRun = true;
+  }
+});
+
+function parseArgs(argv) {
+  const options = buildDefaultOptions();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const valueHandler = VALUE_ARG_HANDLERS[token];
+
+    if (valueHandler && argv[index + 1]) {
+      valueHandler(options, argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    const flagHandler = FLAG_ARG_HANDLERS[token];
+    if (flagHandler) {
+      flagHandler(options);
+    }
+  }
+
+  if (options.leagues.length === 0) {
+    options.leagues = Object.keys(LEAGUE_ROUTE_CATALOG);
+  }
+
+  return options;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function normalizePositiveNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 1.01 && parsed < 100 ? parsed : null;
+}
+
+function median(values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle];
+  }
+  return (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function toIsoTimestamp(seconds, fallbackMs) {
+  const numeric = Number(seconds);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return new Date(numeric * 1000).toISOString();
+  }
+  if (Number.isFinite(fallbackMs) && fallbackMs > 0) {
+    return new Date(fallbackMs).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function extractSnapshot(points) {
+  const homeValues = points.map((point) => point.home).filter(Boolean);
+  const drawValues = points.map((point) => point.draw).filter(Boolean);
+  const awayValues = points.map((point) => point.away).filter(Boolean);
+
+  if (homeValues.length === 0 || drawValues.length === 0 || awayValues.length === 0) {
+    return null;
+  }
+
+  return {
+    home: median(homeValues),
+    draw: median(drawValues),
+    away: median(awayValues)
+  };
+}
+
+function findOneXTwoMarket(back = {}) {
+  if (back?.[ONE_X_TWO_MARKET_KEY]) {
+    return back[ONE_X_TWO_MARKET_KEY];
+  }
+
+  return Object.values(back || {}).find((entry) => (
+    Number(entry?.bettingTypeId) === 1
+    && Number(entry?.scopeId) === 2
+    && Number(entry?.handicapTypeId || 0) === 0
+  )) || null;
+}
+
+function buildPointSnapshot(triplet, timestamp) {
+  const home = normalizePositiveNumber(triplet?.[0]);
+  const draw = normalizePositiveNumber(triplet?.[1]);
+  const away = normalizePositiveNumber(triplet?.[2]);
+
+  if (!home || !draw || !away) {
+    return null;
+  }
+
+  return {
+    home,
+    draw,
+    away,
+    collectedAt: timestamp
+  };
+}
+
+function collectProviderIds(market = {}) {
+  return new Set([
+    ...Object.keys(market.odds || {}),
+    ...Object.keys(market.openingOdd || {})
+  ]);
+}
+
+function resolveCurrentTimestamp(market, providerId, kickoffMs) {
+  const currentSeconds = Math.max(
+    Number(market?.changeTime?.[providerId]?.[0] || 0),
+    Number(market?.changeTime?.[providerId]?.[1] || 0),
+    Number(market?.changeTime?.[providerId]?.[2] || 0)
+  );
+  return toIsoTimestamp(currentSeconds, kickoffMs);
+}
+
+function resolveOpeningTimestamp(market, providerId, kickoffMs) {
+  const validSeconds = [0, 1, 2]
+    .map((outcomeId) => Number(market?.openingChangeTime?.[providerId]?.[outcomeId] || 0))
+    .filter((value) => Number.isFinite(value) && value > 0);
+  const openingSeconds = validSeconds.length > 0 ? Math.min(...validSeconds) : 0;
+  const fallbackMs = kickoffMs ? kickoffMs - (7 * 24 * 60 * 60 * 1000) : Date.now();
+  return toIsoTimestamp(openingSeconds, fallbackMs);
+}
+
+function collectProviderPoints(market, providerIds, kickoffMs) {
+  const currentPoints = [];
+  const openingPoints = [];
+
+  for (const providerId of providerIds) {
+    const currentPoint = buildPointSnapshot(
+      market?.odds?.[providerId],
+      resolveCurrentTimestamp(market, providerId, kickoffMs)
+    );
+    if (currentPoint) {
+      currentPoints.push(currentPoint);
+    }
+
+    const openingPoint = buildPointSnapshot(
+      market?.openingOdd?.[providerId],
+      resolveOpeningTimestamp(market, providerId, kickoffMs)
+    );
+    if (openingPoint) {
+      openingPoints.push(openingPoint);
+    }
+  }
+
+  return {
+    currentPoints,
+    openingPoints
+  };
+}
+
+function latestCollectedAt(points, fallbackValue) {
+  const latest = points
+    .map((point) => point.collectedAt)
+    .filter(Boolean)
+    .sort()
+    .slice(-1)[0];
+  return latest || fallbackValue;
+}
+
+function buildSnapshotEntry(snapshot, fallback, collectedAt) {
+  return {
+    ...(snapshot || fallback),
+    collectedAt
+  };
+}
+
+function extractMedianOddsSnapshots(preMatchPayload, kickoffMs) {
+  const market = findOneXTwoMarket(preMatchPayload?.d?.oddsdata?.back || {});
+  if (!market) {
+    return null;
+  }
+
+  const providerIds = collectProviderIds(market);
+  const { currentPoints, openingPoints } = collectProviderPoints(market, providerIds, kickoffMs);
+  const current = extractSnapshot(currentPoints);
+  const opening = extractSnapshot(openingPoints);
+
+  if (!current && !opening) {
+    return null;
+  }
+
+  const fallback = current || opening;
+  const fallbackCollectedAt = fallback?.collectedAt || toIsoTimestamp(null, kickoffMs);
+
+  return {
+    opening: buildSnapshotEntry(
+      opening,
+      fallback,
+      openingPoints[0]?.collectedAt || fallbackCollectedAt
+    ),
+    current: buildSnapshotEntry(
+      current || opening,
+      fallback,
+      latestCollectedAt(currentPoints, fallbackCollectedAt)
+    ),
+    providerCount: providerIds.size
+  };
+}
+
+function normalizeTitleKey(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+module.exports = {
+  COVERAGE_SQL,
+  CURRENT_BOOKMAKER,
+  DEFAULT_CONCURRENCY,
+  DEFAULT_L3_BATCH_SIZE,
+  DEFAULT_PROGRESS_EVERY,
+  DEFAULT_RETRIES,
+  DEFAULT_RETRY_DELAY_MS,
+  DEFAULT_USER_AGENT,
+  LEAGUE_ROUTE_CATALOG,
+  MATCH_DELTA_MS,
+  MONTHS,
+  ODDSPORTAL_TEAM_ALIASES,
+  OPENING_BOOKMAKER,
+  RESULTS_BASE_URL,
+  TARGETS_SQL,
+  TARGET_SEASON,
+  UPSERT_MAPPING_SQL,
+  UPSERT_ODDS_SQL,
+  extractMedianOddsSnapshots,
+  normalizeTitleKey,
+  parseArgs,
+  sleep
+};


### PR DESCRIPTION
## Summary
- 新增 24/25 赛季专项赔率收割脚本与共享解析模块
- 通过 OddsPortal results 枚举、decrypt 与赔率 upsert 回填 opening/current 中位数赔率
- 修复主脚本与 shared 模块的重复声明，确保脚本可正常加载执行

## Validation
- bash scripts/devops/gatekeeper.sh --mode=push
- pre-commit Gatekeeper (mode=commit)
- pre-push Gatekeeper (mode=pr)