### PR TITLE
fix(discovery): block cross-season contamination and finish total-war smelt stage

### DIFF
--- a/config/season_windows.json
+++ b/config/season_windows.json
@@ -3,6 +3,32 @@
   "version": "V6.1-FULL-LEAGUES",
   "last_updated": "2026-03-27",
   "description": "定义五大联赛各赛季的有效时间窗口，用于过滤API返回的越界数据",
+  "derived_windows": {
+    "strategies": {
+      "dual_year": {
+        "start_month_day": "06-01",
+        "end_month_day": "07-31",
+        "description": "跨年赛季宽容窗口，覆盖资格赛与季前/季后边界"
+      },
+      "calendar_year": {
+        "start_month_day": "01-01",
+        "end_month_day": "12-31",
+        "description": "自然年赛事窗口，用于单年联赛与杯赛/洲际大赛"
+      }
+    },
+    "league_strategy_overrides": {
+      "44": "calendar_year",
+      "50": "calendar_year",
+      "77": "calendar_year",
+      "112": "calendar_year",
+      "130": "calendar_year",
+      "223": "calendar_year",
+      "268": "calendar_year",
+      "289": "calendar_year",
+      "290": "calendar_year",
+      "9080": "calendar_year"
+    }
+  },
   "seasons": {
     "2023/2024": {
       "start": "2023-08-11",

--- a/scripts/ops/total_war_pipeline.js
+++ b/scripts/ops/total_war_pipeline.js
@@ -2,7 +2,7 @@
 /* eslint-disable complexity, max-lines */
 /**
  * @file total_war_pipeline.js
- * @description TOTAL WAR 自动编排器，串行调度 Discovery / Harvest / Recon
+ * @description TOTAL WAR 自动编排器，串行调度 Discovery / Harvest / Recon / Smelt
  */
 
 'use strict';
@@ -71,7 +71,7 @@ TOTAL WAR PIPELINE - 24 小时自动编排器
   --recon-limit=N            Recon 单批上限，默认读取配置
   --recon-threshold=N        触发 Recon 的新增 raw 阈值，默认 50
   --threshold=0.X            Recon 匹配置信度阈值，透传给 recon_scanner
-  --task-stage=STAGE         指定阶段: auto|discovery|harvest|recon，默认 auto
+  --task-stage=STAGE         指定阶段: auto|discovery|harvest|recon|smelt，默认 auto
   --skip-leagues=LIST        Recon 跳过联赛（逗号分隔，可重复）
   --include-all-leagues      Recon 忽略默认 skip_list，显式纳入全部联赛
   --retry-failed-only        仅执行 pending/harvested/mismatch 收尾，不再触发 Discovery
@@ -118,7 +118,7 @@ function mergeLeagueLists(...lists) {
 
 function normalizeTaskStage(value) {
   const normalized = String(value || 'auto').trim().toLowerCase();
-  const allowedStages = new Set(['auto', 'discovery', 'harvest', 'recon']);
+  const allowedStages = new Set(['auto', 'discovery', 'harvest', 'recon', 'smelt']);
   if (allowedStages.has(normalized)) {
     return normalized;
   }
@@ -607,11 +607,13 @@ class TotalWarPipeline {
       lastDiscoveryAt: null,
       lastHarvestAt: null,
       lastReconAt: null,
+      lastSmeltAt: null,
       lastReconRawCount: 0,
       tasks: {
         discovery: this._defaultTaskState(),
         harvest: this._defaultTaskState(),
-        recon: this._defaultTaskState()
+        recon: this._defaultTaskState(),
+        smelt: this._defaultTaskState()
       }
     };
   }
@@ -649,7 +651,8 @@ class TotalWarPipeline {
         tasks: {
           discovery: { ...this._defaultTaskState(), ...(persisted.tasks || {}).discovery },
           harvest: { ...this._defaultTaskState(), ...(persisted.tasks || {}).harvest },
-          recon: { ...this._defaultTaskState(), ...(persisted.tasks || {}).recon }
+          recon: { ...this._defaultTaskState(), ...(persisted.tasks || {}).recon },
+          smelt: { ...this._defaultTaskState(), ...(persisted.tasks || {}).smelt }
         }
       };
     }
@@ -734,6 +737,11 @@ class TotalWarPipeline {
         name: 'recon',
         enabled: this._isTaskStageAllowed('recon')
           && this._isReconDue(metrics)
+      },
+      {
+        name: 'smelt',
+        enabled: this._isTaskStageAllowed('smelt')
+          && this._isSmeltDue(metrics)
       }
     ];
 
@@ -784,6 +792,21 @@ class TotalWarPipeline {
       return true;
     }
     return rawDelta >= this.options.reconThreshold;
+  }
+
+  _isSmeltDue(metrics) {
+    const rawWithoutL3Count = Number(metrics.rawWithoutL3Count || 0);
+    if (rawWithoutL3Count <= 0) {
+      return false;
+    }
+
+    if ((this.options.taskStage || 'auto') === 'smelt') {
+      return true;
+    }
+
+    return Number(metrics.pendingCount || 0) === 0
+      && Number(metrics.harvestedCount || 0) === 0
+      && Number(metrics.mismatchCount || 0) === 0;
   }
 
   _isTaskCoolingDown(taskName) {
@@ -894,6 +917,14 @@ class TotalWarPipeline {
 
   buildTaskEnv(taskName, options = {}) {
     const env = { ...process.env };
+    if (taskName === 'smelt') {
+      env.ACTIVE_SEASON = this.options.dbSeason;
+      env.ACTIVE_SEASON_TAG = this.options.dbSeason.replace('/', '');
+      env.L3_STITCH_SEASON = this.options.dbSeason;
+      env.L3_STITCH_SEASON_TAG = this.options.dbSeason.replace('/', '');
+      return env;
+    }
+
     if (taskName !== 'recon') {
       return env;
     }
@@ -1077,6 +1108,17 @@ class TotalWarPipeline {
       };
     }
 
+    if (taskName === 'smelt') {
+      return {
+        task: taskName,
+        command,
+        args: [
+          path.join(ROOT_DIR, 'scripts/ops/l3_stitch_pipeline.js')
+        ],
+        env: this.buildTaskEnv(taskName, options)
+      };
+    }
+
     throw new Error(`未知任务: ${taskName}`);
   }
 
@@ -1173,6 +1215,8 @@ class TotalWarPipeline {
     } else if (taskName === 'recon') {
       this.state.lastReconAt = taskState.lastSuccessAt;
       this.state.lastReconRawCount = metrics.rawCount;
+    } else if (taskName === 'smelt') {
+      this.state.lastSmeltAt = taskState.lastSuccessAt;
     }
   }
 
@@ -1214,9 +1258,13 @@ class TotalWarPipeline {
     `;
 
     const rawQuery = `
-      SELECT COUNT(*) AS raw_count
+      SELECT
+        COUNT(*) AS raw_count,
+        COUNT(l.match_id) AS l3_count,
+        COUNT(*) FILTER (WHERE l.match_id IS NULL) AS raw_without_l3_count
       FROM raw_match_data r
       JOIN matches m USING (match_id)
+      LEFT JOIN l3_features l USING (match_id)
       WHERE m.season = $1
     `;
 
@@ -1236,6 +1284,8 @@ class TotalWarPipeline {
       failedCount: parseInt(counts.failed_count || 0, 10),
       linkedCount: parseInt(counts.linked_count || 0, 10),
       rawCount,
+      l3Count: parseInt(rawRow.l3_count || 0, 10),
+      rawWithoutL3Count: parseInt(rawRow.raw_without_l3_count || 0, 10),
       rawDeltaSinceRecon: Math.max(0, rawCount - (this.state.lastReconRawCount || 0))
     };
   }

--- a/src/infrastructure/services/DiscoveryService.js
+++ b/src/infrastructure/services/DiscoveryService.js
@@ -299,10 +299,11 @@ class DiscoveryService {
         lookaheadDays: this.config.lookaheadDays,
         fullSync
       });
+      const guardedFixtures = this._applySeasonWindowGuard(fixtures, target, season);
       const expectedMatches = this.configManager.getExpectedMatches(leagueId, season);
       const criticalWarnings = [];
 
-      if (!fixtures || fixtures.length === 0) {
+      if (!guardedFixtures || guardedFixtures.length === 0) {
         this.uiHelper.printNoFixtures(`W${workerId}`, name);
         if (expectedMatches && expectedMatches > 0) {
           const warning = {
@@ -319,22 +320,22 @@ class DiscoveryService {
         return { total: 0, inserted: 0, updated: 0, failed: 0, criticalWarnings };
       }
 
-      this.uiHelper.printParsedFixtures(`W${workerId}`, name, fixtures.length);
-      if (expectedMatches && fixtures.length < expectedMatches) {
+      this.uiHelper.printParsedFixtures(`W${workerId}`, name, guardedFixtures.length);
+      if (expectedMatches && guardedFixtures.length < expectedMatches) {
         const warning = {
           leagueId,
           name,
           season,
-          actual: fixtures.length,
+          actual: guardedFixtures.length,
           expected: expectedMatches,
-          missing: expectedMatches - fixtures.length
+          missing: expectedMatches - guardedFixtures.length
         };
         criticalWarnings.push(warning);
-        this.uiHelper.printCriticalWarn(`W${workerId}`, name, season, fixtures.length, expectedMatches);
+        this.uiHelper.printCriticalWarn(`W${workerId}`, name, season, guardedFixtures.length, expectedMatches);
       }
 
       // V6.7.5-EXTRACTED: 使用 Repository 入库
-      const result = await this.fixtureRepository.persist(fixtures);
+      const result = await this.fixtureRepository.persist(guardedFixtures);
       result.criticalWarnings = criticalWarnings;
 
       this.uiHelper.printProgress(`W${workerId}`, name, result);
@@ -457,6 +458,50 @@ class DiscoveryService {
     }
 
     throw new Error(`无法获取联赛 ${internalLeagueId} 赛季 ${normalizedSeason} 的数据`);
+  }
+
+  _applySeasonWindowGuard(fixtures, target, season) {
+    if (!Array.isArray(fixtures) || fixtures.length === 0) {
+      return [];
+    }
+
+    const leagueId = Number(target?.id);
+    const seasonWindow = typeof this.configManager?.getSeasonDateWindow === 'function'
+      ? this.configManager.getSeasonDateWindow(leagueId, season)
+      : null;
+
+    if (!seasonWindow?.start || !seasonWindow?.end) {
+      return fixtures;
+    }
+
+    const start = new Date(`${seasonWindow.start}T00:00:00.000Z`);
+    const end = new Date(`${seasonWindow.end}T23:59:59.999Z`);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      this.logger.warn(
+        `[HOUND-GUARD] ⚠️  赛季窗口配置非法，跳过过滤: league=${leagueId} season=${season} `
+        + `start=${seasonWindow.start} end=${seasonWindow.end}`
+      );
+      return fixtures;
+    }
+
+    const filteredFixtures = fixtures.filter((fixture) => {
+      const matchDate = new Date(fixture?.match_date);
+      if (Number.isNaN(matchDate.getTime())) {
+        return true;
+      }
+      return matchDate >= start && matchDate <= end;
+    });
+
+    const droppedCount = fixtures.length - filteredFixtures.length;
+    if (droppedCount > 0) {
+      this.logger.warn(
+        `[HOUND-GUARD] 🛡️  拦截越界赛程: league=${leagueId} season=${season} `
+        + `window=${seasonWindow.start}..${seasonWindow.end} source=${seasonWindow.source || 'unknown'} `
+        + `dropped=${droppedCount}/${fixtures.length}`
+      );
+    }
+
+    return filteredFixtures;
   }
 
   /**

--- a/src/infrastructure/services/L1ConfigManager.js
+++ b/src/infrastructure/services/L1ConfigManager.js
@@ -103,6 +103,18 @@ class L1ConfigManager {
     return this._resolveExpectedMatches(this.runtimeConfig.season_windows || {}, Number(leagueId), season);
   }
 
+  getSeasonDateWindow(leagueId, season) {
+    if (!season) {
+      return null;
+    }
+    return this._resolveSeasonDateWindow(
+      this.runtimeConfig.season_windows || {},
+      this.runtimeConfig.season_window_derivation || {},
+      Number(leagueId),
+      season
+    );
+  }
+
   buildLeagueApiUrl(leagueId, season) {
     const providerLeagueId = this.getProviderLeagueId(leagueId);
     return `https://www.fotmob.com/api/data/leagues?id=${Number(providerLeagueId)}&season=${encodeURIComponent(season)}`;
@@ -129,7 +141,8 @@ class L1ConfigManager {
       active_seasons: activeSeasons,
       default_season: defaultSeason,
       single_year_league_ids: singleYearLeagueIds,
-      season_windows: seasonWindows.seasons || {}
+      season_windows: seasonWindows.seasons || {},
+      season_window_derivation: seasonWindows.derived_windows || {}
     };
   }
 
@@ -159,11 +172,82 @@ class L1ConfigManager {
 
   _resolveExpectedMatches(seasonConfig, leagueId, season) {
     const candidates = [
-      this._findSeasonWindowByLeague(seasonConfig[season], leagueId),
-      this._findSeasonWindowBySuffix(seasonConfig, leagueId, season),
+      this._resolveSeasonWindowEntry(seasonConfig, leagueId, season),
       ...Object.values(seasonConfig).filter((window) => this._isSeasonWindowMatch(window, leagueId, season))
     ];
     return candidates.find((window) => Number.isFinite(Number(window?.expected_matches)))?.expected_matches || null;
+  }
+
+  _resolveSeasonDateWindow(seasonConfig, derivationConfig, leagueId, season) {
+    const explicitWindow = this._resolveSeasonWindowEntry(seasonConfig, leagueId, season);
+    if (explicitWindow?.start && explicitWindow?.end) {
+      return {
+        start: explicitWindow.start,
+        end: explicitWindow.end,
+        source: 'explicit'
+      };
+    }
+
+    const derivedWindow = this._buildDerivedSeasonWindow(derivationConfig, leagueId, season);
+    if (derivedWindow) {
+      return derivedWindow;
+    }
+
+    return null;
+  }
+
+  _resolveSeasonWindowEntry(seasonConfig, leagueId, season) {
+    return [
+      this._findSeasonWindowByLeague(seasonConfig[season], leagueId),
+      this._findSeasonWindowBySuffix(seasonConfig, leagueId, season)
+    ].find(Boolean) || null;
+  }
+
+  _buildDerivedSeasonWindow(derivationConfig, leagueId, season) {
+    const seasonYears = this._extractSeasonYears(season);
+    if (!seasonYears) {
+      return null;
+    }
+
+    const strategies = derivationConfig?.strategies || {};
+    const overrides = derivationConfig?.league_strategy_overrides || {};
+    const strategyKey = String(overrides[String(leagueId)] || 'dual_year').trim();
+    const strategy = strategies[strategyKey];
+
+    if (!strategy?.start_month_day || !strategy?.end_month_day) {
+      return null;
+    }
+
+    const startYear = seasonYears.startYear;
+    const endYear = strategyKey === 'calendar_year'
+      ? seasonYears.startYear
+      : seasonYears.endYear > seasonYears.startYear
+        ? seasonYears.endYear
+        : seasonYears.startYear + 1;
+
+    return {
+      start: `${startYear}-${strategy.start_month_day}`,
+      end: `${endYear}-${strategy.end_month_day}`,
+      source: `derived:${strategyKey}`
+    };
+  }
+
+  _extractSeasonYears(season) {
+    const matches = String(season || '').match(/\d{4}/g);
+    if (!Array.isArray(matches) || matches.length === 0) {
+      return null;
+    }
+
+    const startYear = Number.parseInt(matches[0], 10);
+    const endYear = matches.length > 1
+      ? Number.parseInt(matches[1], 10)
+      : startYear;
+
+    if (!Number.isInteger(startYear) || !Number.isInteger(endYear)) {
+      return null;
+    }
+
+    return { startYear, endYear };
   }
 
   _findSeasonWindowByLeague(window, leagueId) {

--- a/src/infrastructure/services/SeasonStrategy.js
+++ b/src/infrastructure/services/SeasonStrategy.js
@@ -13,20 +13,6 @@ function normalizeSeasonFingerprint(season) {
   return String(season || '').replace(/[^0-9]/g, '');
 }
 
-function extractPrimarySeasonYear(season) {
-  const directMatch = String(season || '').match(/(\d{4})/);
-  if (directMatch) {
-    return parseInt(directMatch[1], 10);
-  }
-
-  const fingerprint = normalizeSeasonFingerprint(season);
-  if (fingerprint.length >= 4) {
-    return parseInt(fingerprint.slice(0, 4), 10);
-  }
-
-  return Number.NaN;
-}
-
 /**
  * 赛季策略接口
  * @interface ISeasonStrategy
@@ -262,32 +248,12 @@ class SeasonDiscovery {
         this.logger.info(`[SeasonDiscovery] ✅ 包含匹配: ${targetYear} -> ${partialMatch}`);
         return partialMatch;
       }
-      
-      // 策略 3: 最接近匹配
-      const targetYearNum = extractPrimarySeasonYear(targetYear);
-      let closestMatch = null;
-      let minDiff = Infinity;
-      
-      for (const seasonId of availableSeasons) {
-        const year = extractPrimarySeasonYear(seasonId);
-        if (Number.isFinite(year) && Number.isFinite(targetYearNum)) {
-          const diff = Math.abs(year - targetYearNum);
-          if (diff < minDiff) {
-            minDiff = diff;
-            closestMatch = seasonId;
-          }
-        }
-      }
-      
-      if (closestMatch && minDiff <= 1) {
-        this.logger.info(`[SeasonDiscovery] ✅ 最接近匹配: ${targetYear} -> ${closestMatch}`);
-        return closestMatch;
-      }
-      
-      // 回退: 使用第一个可用赛季
-      const fallbackSeason = availableSeasons[0];
-      this.logger.warn(`[SeasonDiscovery] ⚠️  回退到第一个可用赛季: ${fallbackSeason}`);
-      return fallbackSeason;
+
+      // 安全策略: 禁止“最接近赛季”与“首个赛季”回退，避免把 25/26 或 2026 混入 24/25。
+      this.logger.warn(
+        `[SeasonDiscovery] ⚠️  未找到可信赛季映射，保持原始 season=${targetYear}，available=${availableSeasons.join(',')}`
+      );
+      return targetYear;
       
     } catch (error) {
       this.logger.warn(`[SeasonDiscovery] ⚠️  探测失败: ${error.message}`);

--- a/tests/unit/DiscoveryService.test.js
+++ b/tests/unit/DiscoveryService.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const { DiscoveryService } = require('../../src/infrastructure/services/DiscoveryService');
 const { DiscoveryParser } = require('../../src/infrastructure/services/DiscoveryParser');
+const { SeasonDiscovery } = require('../../src/infrastructure/services/SeasonStrategy');
 
 describe('DiscoveryService - V6.7 L1 发现引擎', () => {
   let service;
@@ -414,6 +415,18 @@ describe('DiscoveryService - V6.7 L1 发现引擎', () => {
   });
 
   describe('工业级硬化链路', () => {
+    it('SeasonDiscovery 在无可信候选时应保留原始目标赛季，禁止跨赛季回退', async () => {
+      const discovery = new SeasonDiscovery({
+        logger: { info() {}, warn() {}, error() {} },
+        apiRequest: async () => ({
+          allAvailableSeasons: ['2026', '2025/2026']
+        })
+      });
+
+      const resolvedSeason = await discovery.discover(77, '2024');
+      assert.strictEqual(resolvedSeason, '2024');
+    });
+
     it('内部联赛存在 providerId 映射时，应使用 providerId 请求并保留内部 ID 入库', async () => {
       const requests = [];
       const persisted = [];
@@ -944,6 +957,47 @@ describe('DiscoveryService - V6.7 L1 发现引擎', () => {
         );
         assert.ok(warns.some((message) => message.includes('API 请求失败: api down')));
         assert.ok(errors.some((message) => message.includes('灵魂抽取失败: soul down')));
+      } finally {
+        await testService.close();
+      }
+    });
+
+    it('_applySeasonWindowGuard 应剔除越界赛程并保留窗口内数据', async () => {
+      const testService = new DiscoveryService({
+        silent: true,
+        delayMs: 0,
+        dbPool: { end: async () => {}, connect: async () => ({ release: () => {} }) },
+        configManager: {
+          getRuntimeConfig: () => ({
+            active_leagues: [],
+            active_seasons: ['2024/2025'],
+            default_season: '2024/2025',
+            single_year_league_ids: []
+          }),
+          getSeasonDateWindow: () => ({
+            start: '2024-06-01',
+            end: '2025-07-31',
+            source: 'derived:dual_year'
+          }),
+          getSingleYearLeagueIds: () => []
+        },
+        browserProvider: { isInitialized: () => false, close: async () => {} },
+        networkInterceptor: { getCapturedApis: () => new Map(), reset: () => {} }
+      });
+
+      try {
+        const filtered = testService._applySeasonWindowGuard([
+          {
+            match_id: '87_20242025_in',
+            match_date: '2025-05-20T18:00:00.000Z'
+          },
+          {
+            match_id: '87_20242025_out',
+            match_date: '2026-05-20T18:00:00.000Z'
+          }
+        ], { id: 87 }, '2024/2025');
+
+        assert.deepStrictEqual(filtered.map((fixture) => fixture.match_id), ['87_20242025_in']);
       } finally {
         await testService.close();
       }

--- a/tests/unit/SeasonStrategy.test.js
+++ b/tests/unit/SeasonStrategy.test.js
@@ -60,10 +60,10 @@ describe('SeasonStrategy', () => {
     assert.doesNotThrow(() => defaultDiscovery.logger.info('noop-info'));
     assert.doesNotThrow(() => defaultDiscovery.logger.warn('noop-warn'));
     assert.doesNotThrow(() => defaultDiscovery.logger.error('noop-error'));
-    assert.strictEqual(await defaultDiscovery.discover(52, '2026'), '2028/2029');
+    assert.strictEqual(await defaultDiscovery.discover(52, '2026'), '2026');
   });
 
-  it('赛季探测应覆盖精确、包含、最接近、回退与异常分支', async () => {
+  it('赛季探测应覆盖精确、包含、安全保底与异常分支', async () => {
     const warnings = [];
     const discovery = new SeasonDiscovery({
       logger: {
@@ -93,10 +93,11 @@ describe('SeasonStrategy', () => {
     assert.strictEqual(await discovery.discover(47, '2025'), '2025');
     assert.strictEqual(await discovery.discover(47, '20242025'), '2024/2025');
     assert.strictEqual(await discovery.discover(48, '2026'), '2025/2026');
-    assert.strictEqual(await discovery.discover(49, '2026'), '2027/2028');
+    assert.strictEqual(await discovery.discover(49, '2026'), '2026');
     assert.strictEqual(await discovery.discover(50, '2026'), '2026');
     assert.strictEqual(await discovery.discover(51, '2026'), '2026');
     assert.ok(warnings.some((message) => message.includes('未获取到 allAvailableSeasons')));
+    assert.ok(warnings.some((message) => message.includes('未找到可信赛季映射')));
     assert.ok(warnings.some((message) => message.includes('探测失败')));
   });
 });

--- a/tests/unit/TotalWarPipeline.Config.test.js
+++ b/tests/unit/TotalWarPipeline.Config.test.js
@@ -358,6 +358,7 @@ test('TotalWarPipeline parseArgs 应在参数非法时抛错或回退默认值',
     assert.equal(options.loopMs, 60_000);
     assert.equal(options.reconLimit, getDefaultReconLimit());
     assert.equal(options.failureLimit, 3);
+    assert.equal(parseArgs(['--season', '2025/2026', '--task-stage', 'smelt']).taskStage, 'smelt');
     assert.throws(() => parseArgs(['--season', '2025/2026', '--task-stage', 'invalid']), /不支持的 --task-stage/);
     assert.throws(() => parseArgs(['--season']), /参数 --season 缺少取值/);
   } finally {

--- a/tests/unit/TotalWarPipeline.Supervisor.test.js
+++ b/tests/unit/TotalWarPipeline.Supervisor.test.js
@@ -532,7 +532,7 @@ test('TotalWarPipeline.collectMetrics 应解析数据库计数与 raw 增量', a
     async query(sql) {
       if (sql.includes('raw_match_data')) {
         return {
-          rows: [{ raw_count: '25' }]
+          rows: [{ raw_count: '25', l3_count: '20', raw_without_l3_count: '5' }]
         };
       }
 
@@ -557,6 +557,8 @@ test('TotalWarPipeline.collectMetrics 应解析数据库计数与 raw 增量', a
     failedCount: 4,
     linkedCount: 5,
     rawCount: 25,
+    l3Count: 20,
+    rawWithoutL3Count: 5,
     rawDeltaSinceRecon: 15
   });
 });
@@ -910,6 +912,8 @@ test('TotalWarPipeline.runChild 与 collectMetrics 应覆盖默认兜底分支',
     failedCount: 0,
     linkedCount: 0,
     rawCount: 0,
+    l3Count: 0,
+    rawWithoutL3Count: 0,
     rawDeltaSinceRecon: 0
   });
 });

--- a/tests/unit/TotalWarPipeline.test.js
+++ b/tests/unit/TotalWarPipeline.test.js
@@ -66,10 +66,12 @@ test('parseArgs 应兼容 --season 2025/2026', () => {
   assert.equal(result.dryRun, true);
 });
 
-test('parseArgs 应支持 --task-stage recon', () => {
+test('parseArgs 应支持 --task-stage recon 与 smelt', () => {
   const result = parseArgs(['--season', '2025/2026', '--task-stage', 'recon', '--once']);
+  const smeltResult = parseArgs(['--season', '2025/2026', '--task-stage', 'smelt', '--once']);
 
   assert.equal(result.taskStage, 'recon');
+  assert.equal(smeltResult.taskStage, 'smelt');
 });
 
 test('parseArgs 应支持 Recon 阈值与 mismatch-only 透传参数', () => {
@@ -317,6 +319,25 @@ test('task-stage=harvest 时应禁止 recon 抢占调度', () => {
   assert.equal(task, 'harvest');
 });
 
+test('当 Recon 收尾完成且仍有缺失 L3 时，编排器应进入 smelt', () => {
+  const pipeline = new TotalWarPipeline(parseArgs(['--season', '2025/2026', '--once']));
+  pipeline.state.lastDiscoveryAt = new Date().toISOString();
+
+  const task = pipeline.decideNextTask({
+    pendingCount: 0,
+    harvestedCount: 0,
+    mismatchCount: 0,
+    failedCount: 0,
+    linkedCount: 3712,
+    rawCount: 4005,
+    l3Count: 3900,
+    rawWithoutL3Count: 105,
+    rawDeltaSinceRecon: 0
+  });
+
+  assert.equal(task, 'smelt');
+});
+
 test('Discovery 子任务应显式透传安全并发，避免依赖脚本默认值', () => {
   const pipeline = new TotalWarPipeline(parseArgs([
     '--season',
@@ -335,6 +356,17 @@ test('Discovery 子任务应显式透传安全并发，避免依赖脚本默认�
     '--concurrency',
     '5'
   ]);
+});
+
+test('Smelt 子任务应调用 l3_stitch_pipeline 并注入赛季上下文', () => {
+  const pipeline = new TotalWarPipeline(parseArgs(['--season', '2025/2026', '--once']));
+  const task = pipeline.buildTaskCommand('smelt');
+
+  assert.equal(task.args[0].endsWith(path.join('scripts', 'ops', 'l3_stitch_pipeline.js')), true);
+  assert.equal(task.env.ACTIVE_SEASON, '2025/2026');
+  assert.equal(task.env.ACTIVE_SEASON_TAG, '20252026');
+  assert.equal(task.env.L3_STITCH_SEASON, '2025/2026');
+  assert.equal(task.env.L3_STITCH_SEASON_TAG, '20252026');
 });
 
 test('Logger 在日志文件超过阈值时必须执行轮转并保留最新内容', () => {


### PR DESCRIPTION
## Summary\n- block unsafe season fallback in Discovery and add league-aware season window guards\n- add final smelt/l3 stitch stage to total-war pipeline with season-scoped metrics\n- locally delete 995 cross-season polluted matches from the dev database and verify remaining dirty matches = 0\n\n## Validation\n- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/DiscoveryService.test.js\n- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/TotalWarPipeline.test.js tests/unit/TotalWarPipeline.Config.test.js tests/unit/TotalWarPipeline.Supervisor.test.js\n- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/SeasonStrategy.test.js\n- docker compose -f docker-compose.dev.yml exec -T dev npm run lint\n- bash scripts/devops/gatekeeper.sh --mode=commit\n- pre-push gatekeeper (pr mode)