### PR TITLE
fix(stealth): stabilize worker identity and context pool isolation

### DIFF
--- a/src/infrastructure/browser/BrowserFactory.js
+++ b/src/infrastructure/browser/BrowserFactory.js
@@ -229,6 +229,36 @@ class BrowserFactory {
             || 'en-US,en;q=0.9';
     }
 
+    _buildStableStealthProfile(stealthConfig = {}) {
+        const locale = typeof stealthConfig.locale === 'string' && stealthConfig.locale.trim()
+            ? stealthConfig.locale.trim()
+            : 'en-US';
+        const platform = typeof stealthConfig.platform === 'string' && stealthConfig.platform.trim()
+            ? stealthConfig.platform.trim()
+            : 'Win32';
+        const normalizedLanguages = Array.isArray(stealthConfig.languages) && stealthConfig.languages.length > 0
+            ? stealthConfig.languages.map(value => String(value).trim()).filter(Boolean)
+            : [locale, 'en'].filter((value, index, source) => source.indexOf(value) === index);
+        const hardwareConcurrency = Number.isFinite(Number(stealthConfig.hardwareConcurrency))
+            ? Math.max(1, Math.round(Number(stealthConfig.hardwareConcurrency)))
+            : 8;
+        const deviceMemory = Number.isFinite(Number(stealthConfig.deviceMemory))
+            ? Math.max(1, Math.round(Number(stealthConfig.deviceMemory)))
+            : 8;
+        const webgl = {
+            vendor: stealthConfig.webgl?.vendor || 'Google Inc. (NVIDIA)',
+            renderer: stealthConfig.webgl?.renderer || 'ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0, D3D11)'
+        };
+
+        return {
+            platform,
+            languages: normalizedLanguages.length > 0 ? normalizedLanguages : ['en-US', 'en'],
+            hardwareConcurrency,
+            deviceMemory,
+            webgl
+        };
+    }
+
     // ========================================================================
     // 隐身脚本注入
     // ========================================================================
@@ -238,8 +268,10 @@ class BrowserFactory {
      * V4.46.1: 修复 platform 与 UA 不一致导致的指纹泄露
      * @param {import('playwright').Page} page - Playwright 页面对象
      */
-    async injectStealthScripts(page) {
-        await page.addInitScript(() => {
+    async injectStealthScripts(page, identity = null) {
+        const stableFingerprint = this._buildStableStealthProfile(identity?.stealth || {});
+
+        await page.addInitScript((fingerprint) => {
             // ═══════════════════════════════════════════════════════════════
             // 核心指纹覆盖 - 必须与 UA 完全一致
             // ═══════════════════════════════════════════════════════════════
@@ -252,25 +284,25 @@ class BrowserFactory {
 
             // 【关键修复】覆盖 platform - 必须与 UA 中的 Windows 匹配
             Object.defineProperty(navigator, 'platform', {
-                get: () => 'Win32',
+                get: () => fingerprint.platform,
                 configurable: true
             });
 
             // 【关键修复】模拟语言 - 包含 q 值权重
             Object.defineProperty(navigator, 'languages', {
-                get: () => ['en-US', 'en'],
+                get: () => fingerprint.languages,
                 configurable: true
             });
 
-            // 模拟硬件并发 (随机化)
+            // 绑定稳定硬件并发，避免同一身份在每次页面加载时漂移
             Object.defineProperty(navigator, 'hardwareConcurrency', {
-                get: () => 8 + (Math.floor(Math.random() * 17)),
+                get: () => fingerprint.hardwareConcurrency,
                 configurable: true
             });
 
-            // 模拟设备内存
+            // 绑定稳定设备内存
             Object.defineProperty(navigator, 'deviceMemory', {
-                get: () => [4, 8, 8, 16, 16, 32][Math.floor(Math.random() * 6)],
+                get: () => fingerprint.deviceMemory,
                 configurable: true
             });
 
@@ -306,15 +338,9 @@ class BrowserFactory {
             });
 
             // ═══════════════════════════════════════════════════════════════
-            // WebGL 指纹伪装 - 随机化
+            // WebGL 指纹伪装 - 复用稳定渲染器，避免每次页面初始化漂移
             // ═══════════════════════════════════════════════════════════════
-            const WEBGL_RENDERERS = [
-                { vendor: 'Google Inc. (NVIDIA)', renderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0, D3D11)' },
-                { vendor: 'Google Inc. (NVIDIA)', renderer: 'ANGLE (NVIDIA, NVIDIA GeForce GTX 1660 Direct3D11 vs_5_0 ps_5_0, D3D11)' },
-                { vendor: 'Google Inc. (AMD)', renderer: 'ANGLE (AMD, AMD Radeon RX 580 Direct3D11 vs_5_0 ps_5_0, D3D11)' },
-                { vendor: 'Google Inc. (Intel)', renderer: 'ANGLE (Intel, Intel UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)' }
-            ];
-            const selectedRenderer = WEBGL_RENDERERS[Math.floor(Math.random() * WEBGL_RENDERERS.length)];
+            const selectedRenderer = fingerprint.webgl;
 
             const getParameterProxyHandler = {
                 apply: function(target, thisArg, args) {
@@ -336,25 +362,6 @@ class BrowserFactory {
                 const originalGetParameter2 = WebGL2RenderingContext.prototype.getParameter;
                 WebGL2RenderingContext.prototype.getParameter = new Proxy(originalGetParameter2, getParameterProxyHandler);
             }
-
-            // ═══════════════════════════════════════════════════════════════
-            // Canvas 指纹噪音
-            // ═══════════════════════════════════════════════════════════════
-            const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
-            HTMLCanvasElement.prototype.toDataURL = function(type) {
-                if (this.width > 0 && this.height > 0) {
-                    const ctx = this.getContext('2d');
-                    if (ctx) {
-                        // 添加微弱噪音
-                        const imageData = ctx.getImageData(0, 0, this.width, this.height);
-                        for (let i = 0; i < imageData.data.length; i += 4) {
-                            imageData.data[i] ^= (Math.random() * 2) | 0;
-                        }
-                        ctx.putImageData(imageData, 0, 0);
-                    }
-                }
-                return originalToDataURL.apply(this, arguments);
-            };
 
             // ═══════════════════════════════════════════════════════════════
             // 隐藏自动化标志
@@ -401,9 +408,6 @@ class BrowserFactory {
                 if (this === navigator.permissions?.query) {
                     return 'function query() { [native code] }';
                 }
-                if (this === HTMLCanvasElement.prototype.toDataURL) {
-                    return 'function toDataURL() { [native code] }';
-                }
                 return oldToString.call(this);
             };
 
@@ -421,8 +425,7 @@ class BrowserFactory {
                 }
             });
 
-            console.log('[Stealth] V4.46.1 深度隐身脚本已注入');
-        });
+        }, stableFingerprint);
     }
 
     // ========================================================================

--- a/src/infrastructure/browser/ContextPoolManager.js
+++ b/src/infrastructure/browser/ContextPoolManager.js
@@ -123,7 +123,7 @@ class ContextPoolManager {
         if (deps.networkManager) {
             cookieLoaded = await deps.networkManager.loadSessionToContext(context, identity.proxy.port);
         }
-        if (!cookieLoaded) {
+        if (!cookieLoaded && deps.allowSharedBrowserStateCookies === true) {
             cookieLoaded = await deps.browserFactory.loadBrowserStateCookies(context);
         }
 
@@ -334,6 +334,14 @@ class ContextPoolManager {
             totalReuses: 0,
             totalEvictions: 0
         };
+    }
+
+    setMaxSize(maxSize) {
+        const normalized = Number.parseInt(maxSize, 10);
+        if (Number.isFinite(normalized) && normalized > 0) {
+            this.config.maxSize = normalized;
+        }
+        return this.config.maxSize;
     }
 }
 

--- a/src/infrastructure/harvesters/ProductionHarvester.js
+++ b/src/infrastructure/harvesters/ProductionHarvester.js
@@ -248,6 +248,8 @@ class ProductionHarvester extends AbstractHarvester {
         const captureResults = payload.captureResults === true || this.config.captureBulkResults === true;
         const pendingMatchFilters = this._normalizePendingFilters(payload);
 
+        this._ensureContextPoolCapacity(concurrency);
+
         const state = {
             startedAt: Date.now(),
             total: 0,

--- a/src/infrastructure/harvesters/base/AbstractHarvester.js
+++ b/src/infrastructure/harvesters/base/AbstractHarvester.js
@@ -64,6 +64,8 @@ class AbstractHarvester {
             verboseLogging: process.env.VERBOSE_LOGGING === 'true' || config.verboseLogging || false,
             shutdownTimeoutMs: parseInt(process.env.SHUTDOWN_TIMEOUT_MS) || config.shutdownTimeoutMs || 30000,
             harvestTimeoutMs: parseInt(process.env.HARVEST_TIMEOUT_MS) || config.harvestTimeoutMs || 120000,
+            contextPoolBuffer: parseInt(process.env.CONTEXT_POOL_BUFFER, 10) || config.contextPoolBuffer || 5,
+            contextPoolMaxSize: parseInt(process.env.CONTEXT_POOL_MAX_SIZE, 10) || config.contextPoolMaxSize || 0,
             navigationWaitUntil: process.env.HARVEST_NAVIGATION_WAIT_UNTIL || config.navigationWaitUntil || 'domcontentloaded',
             navigationTimeoutMs: parseInt(process.env.HARVEST_NAVIGATION_TIMEOUT_MS, 10)
                 || config.navigationTimeoutMs
@@ -101,7 +103,7 @@ class AbstractHarvester {
 
         this.contextPool = new HarvesterContextPool({
             maxUsage: 10,
-            maxSize: 20,
+            maxSize: this._resolveContextPoolMaxSize(this.config.maxWorkers),
         });
         this._bindContextPoolCompatibility();
         this._bindTelemetryCompatibility();
@@ -200,6 +202,7 @@ class AbstractHarvester {
             console.log(`⚡ Titan 7.0 弹性并发引擎: 雷达探测到 ${elasticConcurrency} 个代理节点，自动调整并发数`);
             this.config.maxWorkers = elasticConcurrency;
         }
+        this._ensureContextPoolCapacity(this.config.maxWorkers);
 
         // 初始化 WorkerPool
         this.workerPool = getWorkerPool({
@@ -414,7 +417,7 @@ class AbstractHarvester {
 
         try {
             page = await context.newPage();
-            await this.browserFactory.injectStealthScripts(page);
+            await this.browserFactory.injectStealthScripts(page, identity);
 
             if (isNewContext) {
                 await this.browserFactory.warmupHomepage(page, { scrollMore: false, randomScrolls: false });
@@ -526,6 +529,7 @@ class AbstractHarvester {
         const result = await this.contextPool.getOrCreate(workerId, identity, {
             browserFactory: this.browserFactory,
             networkManager: this.networkManager,
+            allowSharedBrowserStateCookies: false,
         });
 
         return {
@@ -555,8 +559,8 @@ class AbstractHarvester {
         return this.contextPool.closeWorkerContext(workerId, reason);
     }
 
-    async _injectStealthScripts(page) {
-        await this.browserFactory.injectStealthScripts(page);
+    async _injectStealthScripts(page, identity = null) {
+        await this.browserFactory.injectStealthScripts(page, identity);
     }
 
     async _simulateHumanBehavior(page) {
@@ -610,6 +614,30 @@ class AbstractHarvester {
 
     _delay(ms) {
         return new Promise(resolve => { setTimeout(resolve, ms); });
+    }
+
+    _resolveContextPoolMaxSize(targetWorkers) {
+        const requestedWorkers = Number.parseInt(targetWorkers, 10);
+        const fallbackWorkers = Number.parseInt(this.config.maxWorkers, 10);
+        const workerCount = Number.isFinite(requestedWorkers) && requestedWorkers > 0
+            ? requestedWorkers
+            : (Number.isFinite(fallbackWorkers) && fallbackWorkers > 0 ? fallbackWorkers : 1);
+        const buffer = Number.isFinite(Number.parseInt(this.config.contextPoolBuffer, 10))
+            ? Math.max(0, Number.parseInt(this.config.contextPoolBuffer, 10))
+            : 5;
+        const explicitMaxSize = Number.isFinite(Number.parseInt(this.config.contextPoolMaxSize, 10))
+            ? Math.max(0, Number.parseInt(this.config.contextPoolMaxSize, 10))
+            : 0;
+
+        return Math.max(workerCount + buffer, explicitMaxSize, 1);
+    }
+
+    _ensureContextPoolCapacity(targetWorkers) {
+        const nextMaxSize = this._resolveContextPoolMaxSize(targetWorkers);
+        if (nextMaxSize > this.contextPool.config.maxSize) {
+            this.contextPool.setMaxSize(nextMaxSize);
+        }
+        return this.contextPool.config.maxSize;
     }
 
     _teardownGracefulShutdown() {

--- a/src/infrastructure/network/NetworkManager.js
+++ b/src/infrastructure/network/NetworkManager.js
@@ -245,7 +245,11 @@ class NetworkManager {
         }
 
         // 生成隐身指纹
-        const stealth = this.stealthGenerator();
+        const stealth = this.stealthGenerator({
+            workerId,
+            port: proxyAssignment.port,
+            useFixed: true
+        });
 
         // 创建 Worker 身份
         const identity = new WorkerIdentity(workerId, proxyAssignment, stealth);
@@ -460,7 +464,11 @@ class NetworkManager {
         });
         const proxyAssignment = this._buildProxyAssignment(workerId, lease, 'RETRY');
 
-        const stealth = this.stealthGenerator();
+        const stealth = this.stealthGenerator({
+            workerId,
+            port: proxyAssignment.port,
+            useFixed: true
+        });
         const identity = new WorkerIdentity(workerId, proxyAssignment, stealth);
         identity.proxyLeaseId = lease.id;
         this.workerIdentities.set(workerId, identity);

--- a/src/infrastructure/network/ProxyProvider.js
+++ b/src/infrastructure/network/ProxyProvider.js
@@ -29,6 +29,8 @@ const DEFAULT_GATEWAY_PREFLIGHT_TIMEOUT_MS = 1500;
 const DEFAULT_TRANSIENT_CONTEXT_COOLDOWN_MS = 3000;
 const DEFAULT_UPSTREAM_BLOCK_BASE_COOLDOWN_MS = 5000;
 const DEFAULT_UPSTREAM_BLOCK_MAX_COOLDOWN_MS = 15000;
+const DEFAULT_SEVERE_TRANSPORT_MIN_COOLDOWN_MS = 300000;
+const DEFAULT_SEVERE_TRANSPORT_MAX_COOLDOWN_MS = 900000;
 
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
@@ -78,15 +80,36 @@ function isTimeoutLike(reason = '') {
     || message.includes('etimedout');
 }
 
+function isSevereTransportFailure(reason = '') {
+  const message = String(reason || '').toLowerCase();
+  return message.includes('err_connection_closed')
+    || message.includes('client network socket disconnected before secure tls connection was established')
+    || message.includes('tls handshake')
+    || message.includes('tlsv1')
+    || message.includes('ssl')
+    || message.includes('econnreset')
+    || message.includes('econnrefused')
+    || message.includes('socket hang up')
+    || message.includes('err_proxy_connection_failed')
+    || message.includes('proxy connection failed');
+}
+
 function normalizeFailureClass(failureClass, statusCode, reason = '') {
   const normalized = String(failureClass || '').trim().toLowerCase();
-  if (normalized) {
+  const message = String(reason || '').toLowerCase();
+
+  if (normalized && normalized !== 'proxy_transport') {
     return normalized;
   }
 
-  const message = String(reason || '').toLowerCase();
   if (statusCode === 429) {
     return 'rate_limit';
+  }
+  if (isSevereTransportFailure(message)) {
+    return 'severe_transport_failure';
+  }
+  if (normalized) {
+    return normalized;
   }
   if (message.includes('err_empty_response') || message.includes('empty_response')) {
     return 'upstream_block';
@@ -103,6 +126,9 @@ function normalizeFailureClass(failureClass, statusCode, reason = '') {
 }
 
 function resolveHealthPenalty(statusCode, reason = '', failureClass = 'hard_proxy_failure') {
+  if (failureClass === 'severe_transport_failure') {
+    return 45;
+  }
   if (failureClass === 'browser_context_transient') {
     return 2;
   }
@@ -215,6 +241,14 @@ class ProxyProvider extends EventEmitter {
       upstreamBlockMaxCooldownMs: positiveNumber(
         options.upstreamBlockMaxCooldownMs,
         DEFAULT_UPSTREAM_BLOCK_MAX_COOLDOWN_MS
+      ),
+      severeTransportMinCooldownMs: positiveNumber(
+        options.severeTransportMinCooldownMs,
+        DEFAULT_SEVERE_TRANSPORT_MIN_COOLDOWN_MS
+      ),
+      severeTransportMaxCooldownMs: positiveNumber(
+        options.severeTransportMaxCooldownMs,
+        DEFAULT_SEVERE_TRANSPORT_MAX_COOLDOWN_MS
       ),
       heartbeatFailureCooldownMs: positiveNumber(
         options.heartbeatFailureCooldownMs,
@@ -832,6 +866,37 @@ class ProxyProvider extends EventEmitter {
       return true;
     }
 
+    if (failureClass === 'severe_transport_failure') {
+      const cooldownMs = this._resolveSevereFailureCooldownMs(node);
+      node.isolatedUntil = Math.max(node.isolatedUntil, now + cooldownMs);
+      node.cooldownUntil = Math.max(node.cooldownUntil, now + cooldownMs);
+      this._emitAlert('proxy_severe_backoff', node, {
+        statusCode,
+        reason,
+        failureClass,
+        isolatedUntil: node.isolatedUntil,
+        cooldownUntil: node.cooldownUntil,
+        cooldownMs,
+        consecutiveFailures: node.consecutiveFailures
+      });
+      this._emitAlert('proxy_cooled_down', node, {
+        statusCode,
+        reason,
+        cooldownUntil: node.cooldownUntil,
+        cooldownMs,
+        consecutiveFailures: node.consecutiveFailures
+      });
+      if (node.healthScore < this.config.minHealthScore) {
+        this._emitAlert('proxy_health_score_blocked', node, {
+          statusCode,
+          reason,
+          healthScore: node.healthScore,
+          minHealthScore: this.config.minHealthScore
+        });
+      }
+      return true;
+    }
+
     if (failureClass === 'browser_context_transient' || failureClass === 'upstream_block') {
       const cooldownMs = this._resolveSoftFailureCooldownMs(failureClass, node);
       if (cooldownMs > 0) {
@@ -887,7 +952,11 @@ class ProxyProvider extends EventEmitter {
   }
 
   _shouldCooldownNode(statusCode, node, failureClass = 'hard_proxy_failure') {
-    if (failureClass === 'browser_context_transient' || failureClass === 'upstream_block') {
+    if (
+      failureClass === 'browser_context_transient'
+      || failureClass === 'upstream_block'
+      || failureClass === 'severe_transport_failure'
+    ) {
       return false;
     }
     if (statusCode === 403) {
@@ -903,6 +972,9 @@ class ProxyProvider extends EventEmitter {
   }
 
   _resolveFailureCooldownMs(statusCode, failureClass = 'hard_proxy_failure') {
+    if (failureClass === 'severe_transport_failure') {
+      return this._resolveSevereFailureCooldownMs({ consecutiveFailures: 1 });
+    }
     if (failureClass === 'browser_context_transient' || failureClass === 'upstream_block') {
       return this._resolveSoftFailureCooldownMs(failureClass, { consecutiveFailures: 1 });
     }
@@ -934,6 +1006,15 @@ class ProxyProvider extends EventEmitter {
     }
 
     return 0;
+  }
+
+  _resolveSevereFailureCooldownMs(node) {
+    const consecutiveFailures = Math.max(1, Number(node?.consecutiveFailures) || 1);
+    const multiplier = Math.min(3, consecutiveFailures);
+    return Math.min(
+      this.config.severeTransportMaxCooldownMs,
+      this.config.severeTransportMinCooldownMs * multiplier
+    );
   }
 
   getStats() {

--- a/src/infrastructure/network/SessionManager.js
+++ b/src/infrastructure/network/SessionManager.js
@@ -16,8 +16,8 @@
 const { chromium } = require('playwright');
 const fs = require('fs').promises;
 const path = require('path');
-const FactoryConfig = require('../../../config/factory_config');
 const { ProxyProvider } = require('./ProxyProvider');
+const { generateStealthHeaders } = require('./StealthFingerprint');
 
 // V4.46.5 HARDENING: 本地确定性 ID 生成器（零模拟铁律）
 function generateLockId(port) {
@@ -465,7 +465,7 @@ class SessionManager {
         this.logger.info(`端口 ${port} 启动可见浏览器...`);
 
         // 获取隐身指纹
-        const stealth = this._generateStealthHeaders();
+        const stealth = this._generateStealthHeaders(port);
 
         // 启动可见浏览器
         const browser = await chromium.launch({
@@ -490,7 +490,7 @@ class SessionManager {
         });
 
         // 注入隐身脚本
-        await this._injectStealthScripts(context);
+        await this._injectStealthScripts(context, stealth);
 
         const page = await context.newPage();
 
@@ -606,8 +606,21 @@ class SessionManager {
      * @private
      * @param {import('playwright').BrowserContext} context - Playwright 上下文
      */
-    async _injectStealthScripts(context) {
-        await context.addInitScript(() => {
+    async _injectStealthScripts(context, stealth = {}) {
+        const fingerprint = {
+            hardwareConcurrency: Number.isFinite(Number(stealth.hardwareConcurrency))
+                ? Math.max(1, Math.round(Number(stealth.hardwareConcurrency)))
+                : 8,
+            deviceMemory: Number.isFinite(Number(stealth.deviceMemory))
+                ? Math.max(1, Math.round(Number(stealth.deviceMemory)))
+                : 8,
+            webgl: {
+                vendor: stealth.webgl?.vendor || 'Google Inc. (NVIDIA)',
+                renderer: stealth.webgl?.renderer || 'ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0)'
+            }
+        };
+
+        await context.addInitScript((stableFingerprint) => {
             /* eslint-disable no-undef */
             // 禁用 webdriver 标志
             Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
@@ -615,8 +628,8 @@ class SessionManager {
             // WebGL 伪装
             const getParameter = WebGLRenderingContext.prototype.getParameter;
             WebGLRenderingContext.prototype.getParameter = function(p) {
-                if (p === 37445) return 'Google Inc. (NVIDIA)';
-                if (p === 37446) return 'ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0)';
+                if (p === 37445) return stableFingerprint.webgl.vendor;
+                if (p === 37446) return stableFingerprint.webgl.renderer;
                 return getParameter.apply(this, arguments);
             };
 
@@ -624,23 +637,23 @@ class SessionManager {
             if (typeof WebGL2RenderingContext !== 'undefined') {
                 const getParameter2 = WebGL2RenderingContext.prototype.getParameter;
                 WebGL2RenderingContext.prototype.getParameter = function(p) {
-                    if (p === 37445) return 'Google Inc. (NVIDIA)';
-                    if (p === 37446) return 'ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0)';
+                    if (p === 37445) return stableFingerprint.webgl.vendor;
+                    if (p === 37446) return stableFingerprint.webgl.renderer;
                     return getParameter2.apply(this, arguments);
                 };
             }
 
             // 硬件伪装
             Object.defineProperty(navigator, 'hardwareConcurrency', {
-                get: () => 8,
+                get: () => stableFingerprint.hardwareConcurrency,
                 configurable: true
             });
             Object.defineProperty(navigator, 'deviceMemory', {
-                get: () => 8,
+                get: () => stableFingerprint.deviceMemory,
                 configurable: true
             });
             /* eslint-enable no-undef */
-        });
+        }, fingerprint);
     }
 
     /**
@@ -648,26 +661,11 @@ class SessionManager {
      * @private
      * @returns {object} 隐身配置
      */
-    _generateStealthHeaders() {
-        // V180: 使用与 ProductionHarvester 完全一致的深度隐身配置
-        const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0 Safari/537.36';
-        const viewport = { width: 1920, height: 1080 };
-
-        return {
-            userAgent,
-            viewport,
-            extraHTTPHeaders: {
-                'sec-ch-ua': '"Chromium";v="131", "Google Chrome";v="131", "Not-A.Brand";v="99"',
-                'sec-ch-ua-mobile': '?0',
-                'sec-ch-ua-platform': '"Windows"',
-                'sec-fetch-dest': 'document',
-                'sec-fetch-mode': 'navigate',
-                'sec-fetch-site': 'none',
-                'sec-fetch-user': '?1',
-                'accept-language': 'en-US,en;q=0.9',
-                'accept-encoding': 'gzip, deflate, br'
-            }
-        };
+    _generateStealthHeaders(port = 1) {
+        return generateStealthHeaders({
+            port,
+            useFixed: true
+        });
     }
 
     /**

--- a/src/infrastructure/network/StealthFingerprint.js
+++ b/src/infrastructure/network/StealthFingerprint.js
@@ -97,6 +97,37 @@ function getRandomViewport() {
     return GHOST_VIEWPORTS[Math.floor(Math.random() * GHOST_VIEWPORTS.length)];
 }
 
+function normalizeSeed(value, fallback = 1) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveHeaderOptions(useFixedOrOptions = true, maybeSeed = 1) {
+    if (typeof useFixedOrOptions === 'object' && useFixedOrOptions !== null) {
+        return {
+            useFixed: useFixedOrOptions.useFixed !== false,
+            seed: normalizeSeed(
+                useFixedOrOptions.seed
+                    || useFixedOrOptions.port
+                    || useFixedOrOptions.workerId,
+                1
+            )
+        };
+    }
+
+    if (typeof useFixedOrOptions === 'number') {
+        return {
+            useFixed: true,
+            seed: normalizeSeed(useFixedOrOptions, 1)
+        };
+    }
+
+    return {
+        useFixed: useFixedOrOptions !== false,
+        seed: normalizeSeed(maybeSeed, 1)
+    };
+}
+
 /**
  * V185: 生成随机化的深度隐身配置
  * @param {number} workerId - Worker ID，用于确定性随机
@@ -136,16 +167,25 @@ function generateStealthConfig(workerId = 1) {
  * @param {boolean} useFixed - 是否使用固定指纹 (默认 true)
  * @returns {object} 包含 userAgent, viewport, extraHTTPHeaders 的对象
  */
-function generateStealthHeaders(useFixed = true) {
+function generateStealthHeaders(useFixedOrOptions = true, maybeSeed = 1) {
+    const { useFixed, seed } = resolveHeaderOptions(useFixedOrOptions, maybeSeed);
+
     if (useFixed) {
         const ua = FIXED_FINGERPRINT.userAgent;
         const viewport = FIXED_FINGERPRINT.viewport;
+        const stableFingerprint = generateStealthConfig(seed);
 
         return {
             userAgent: ua,
             viewport,
             locale: FIXED_FINGERPRINT.locale,
             timezoneId: FIXED_FINGERPRINT.timezoneId,
+            platform: FIXED_FINGERPRINT.platform,
+            deviceScaleFactor: FIXED_FINGERPRINT.deviceScaleFactor,
+            hardwareConcurrency: stableFingerprint.hardwareConcurrency,
+            deviceMemory: stableFingerprint.deviceMemory,
+            webgl: stableFingerprint.webgl,
+            fonts: stableFingerprint.fonts,
             extraHTTPHeaders: {
                 'sec-ch-ua': '"Chromium";v="131", "Google Chrome";v="131", "Not-A.Brand";v="99"',
                 'sec-ch-ua-mobile': '?0',

--- a/tests/unit/HarvesterContextPool.test.js
+++ b/tests/unit/HarvesterContextPool.test.js
@@ -99,4 +99,30 @@ describe('HarvesterContextPool 单元测试', () => {
         assert.deepStrictEqual(closedContexts.sort((a, b) => a - b), [1, 2], '所有 Context 都应被关闭');
         assert.strictEqual(pool.getSize(), 0, '故障清理后池应为空');
     });
+
+    it('默认应禁止回退到共享 browser_state Cookie', async () => {
+        const pool = new HarvesterContextPool({ maxSize: 5, maxUsage: 10, logger: silentLogger });
+        let sharedCookieLoads = 0;
+
+        const deps = {
+            browserFactory: {
+                createContext: async () => ({
+                    close: async () => {},
+                    clearCookies: async () => {}
+                }),
+                loadBrowserStateCookies: async () => {
+                    sharedCookieLoads++;
+                    return true;
+                }
+            },
+            networkManager: {
+                loadSessionToContext: async () => false
+            }
+        };
+
+        const result = await pool.getOrCreate(1, { proxy: { port: 7890 } }, deps);
+
+        assert.strictEqual(sharedCookieLoads, 0, '默认不应加载共享 Cookie');
+        assert.strictEqual(result.entry.cookieLoaded, false, '无端口会话时应保持纯净 Context');
+    });
 });

--- a/tests/unit/NetworkManager.test.js
+++ b/tests/unit/NetworkManager.test.js
@@ -356,11 +356,15 @@ describe('src/infrastructure/network/NetworkManager', () => {
 
   test('assignWorkerIdentity 应覆盖复用、Shield 回退、Session 警告与降级代理池分支', async () => {
     Date.now = () => 1700000001000;
+    const stealthInputs = [];
     const loaded = loadNetworkManagerModule({
-      stealthGenerator: () => ({
+      stealthGenerator: (seed) => {
+        stealthInputs.push(seed);
+        return {
         userAgent: 'UA-CUSTOM',
         viewport: { width: 1440, height: 900 },
-      }),
+        };
+      },
     });
     try {
       const proxyProvider = createProxyProvider({
@@ -372,6 +376,7 @@ describe('src/infrastructure/network/NetworkManager', () => {
       const identity = await manager.assignWorkerIdentity(2);
       assert.strictEqual(identity.proxy.port, 7891);
       assert.strictEqual(identity.stealth.userAgent, 'UA-CUSTOM');
+      assert.deepStrictEqual(stealthInputs[0], { workerId: 2, port: 7891, useFixed: true });
       assert.strictEqual(manager.getWorkerIdentity(2), identity);
       assert.ok(loaded.state.consoleLogs.some(message => message.includes('Worker 2 新身份绑定')));
 

--- a/tests/unit/ProductionHarvester.test.js
+++ b/tests/unit/ProductionHarvester.test.js
@@ -33,6 +33,17 @@ describe('ProductionHarvester', () => {
             assert.strictEqual(harvester.config.dryRun, true);
         });
 
+        it('应让 Context 池容量始终高于并发数', () => {
+            harvester = new ProductionHarvester({
+                maxWorkers: 25,
+                dryRun: true
+            });
+
+            assert.ok(harvester.contextPool.config.maxSize >= 30, 'Context 池应至少等于并发数加缓冲');
+            assert.strictEqual(harvester._ensureContextPoolCapacity(40), 45);
+            assert.ok(harvester.contextPool.config.maxSize >= 45);
+        });
+
         it('应使用环境变量默认值', () => {
             harvester = new ProductionHarvester();
 

--- a/tests/unit/ProxyProvider.test.js
+++ b/tests/unit/ProxyProvider.test.js
@@ -131,6 +131,48 @@ describe('src/infrastructure/network/ProxyProvider', () => {
     assert.strictEqual(node.cooling, false);
   });
 
+  test('ERR_CONNECTION_CLOSED 应升级为 5-15 分钟重故障隔离', async () => {
+    let now = 40_000;
+    const alerts = [];
+    const provider = new ProxyProvider({
+      now: () => now,
+      healthCheckIntervalMs: 0,
+      minHealthScore: 60,
+      severeTransportMinCooldownMs: 300_000,
+      severeTransportMaxCooldownMs: 900_000
+    });
+
+    provider.on('alert', payload => {
+      alerts.push(payload);
+    });
+
+    const lease = await provider.acquire({
+      consumer: 'harvest',
+      sessionKey: 'severe-transport',
+      sticky: false
+    });
+
+    await provider.reportFailure(lease.id, {
+      failureClass: 'proxy_transport',
+      reason: 'page.goto: net::ERR_CONNECTION_CLOSED; Client network socket disconnected before secure TLS connection was established'
+    });
+
+    let node = provider.getNodeStates().find(item => item.port === lease.proxy.port);
+    assert.strictEqual(node.isolated, true);
+    assert.strictEqual(node.cooling, true);
+    assert.ok(node.healthScore < 60);
+    assert.ok(alerts.some(item => item.type === 'proxy_severe_backoff' && item.port === lease.proxy.port));
+
+    now += 299_999;
+    node = provider.getNodeStates().find(item => item.port === lease.proxy.port);
+    assert.strictEqual(node.cooling, true);
+
+    now += 2;
+    node = provider.getNodeStates().find(item => item.port === lease.proxy.port);
+    assert.strictEqual(node.cooling, false);
+    assert.strictEqual(node.isolated, false);
+  });
+
   test('503 在 observationThreshold=1 时应首次命中立即进入 20 分钟冷却', async () => {
     let now = 30_000;
     const alerts = [];

--- a/tests/unit/SessionManager.test.js
+++ b/tests/unit/SessionManager.test.js
@@ -484,8 +484,8 @@ describe('SessionManager', () => {
 
             const initScripts = [];
             await manager._injectStealthScripts({
-                async addInitScript(script) {
-                    initScripts.push(script);
+                async addInitScript(script, arg) {
+                    initScripts.push(() => script(arg));
                 }
             });
 

--- a/tests/unit/StealthFingerprint.test.js
+++ b/tests/unit/StealthFingerprint.test.js
@@ -58,7 +58,16 @@ describe('src/infrastructure/network/StealthFingerprint', () => {
     assert.deepStrictEqual(fixed.viewport, fingerprint.FIXED_FINGERPRINT.viewport);
     assert.strictEqual(fixed.locale, 'en-US');
     assert.strictEqual(fixed.timezoneId, 'Europe/London');
+    assert.strictEqual(typeof fixed.hardwareConcurrency, 'number');
+    assert.strictEqual(typeof fixed.deviceMemory, 'number');
+    assert.ok(fixed.webgl.renderer.includes('ANGLE'));
     assert.strictEqual(fixed.extraHTTPHeaders['sec-ch-ua-platform'], '"Windows"');
+
+    const seeded = fingerprint.generateStealthHeaders({ port: 7895, useFixed: true });
+    const seededConfig = fingerprint.generateStealthConfig(7895);
+    assert.strictEqual(seeded.hardwareConcurrency, seededConfig.hardwareConcurrency);
+    assert.strictEqual(seeded.deviceMemory, seededConfig.deviceMemory);
+    assert.deepStrictEqual(seeded.webgl, seededConfig.webgl);
 
     Math.random = mockRandomSequence([0, 0]);
     const chrome = fingerprint.generateStealthHeaders(false);


### PR DESCRIPTION
## Summary
- bind harvester context pool capacity to effective concurrency with a safety buffer
- stabilize worker fingerprints by reusing per-port identity traits and disabling page-level random drift
- isolate proxy cookie state per worker/port and harden severe transport backoff to 5-15 minutes

## Verification
- docker compose run ... node --test tests/unit/BrowserFactory.test.js tests/unit/SessionManager.test.js tests/unit/ProductionHarvester.test.js tests/unit/HarvesterContextPool.test.js tests/unit/ProxyProvider.test.js tests/unit/StealthFingerprint.test.js tests/unit/NetworkManager.test.js tests/unit/AbstractHarvester.test.js
- docker compose run ... npm run lint
- docker compose run ... npm run test:unit
- gatekeeper.sh --mode=commit
- pre-push gatekeeper (mode=pr)