### PR TITLE
fix(harvest): provision FotMob API bootstrap cookies and lock runtime concurrency

### DIFF
--- a/src/infrastructure/harvesters/base/AbstractHarvester.js
+++ b/src/infrastructure/harvesters/base/AbstractHarvester.js
@@ -49,8 +49,12 @@ let globalSigtermListener = null;
 
 class AbstractHarvester {
     constructor(config = {}) {
+        const requestedMaxWorkers = this._resolveRequestedMaxWorkers(
+            parseInt(process.env.MAX_WORKERS, 10) || config.maxWorkers || 6
+        );
         this.config = {
-            maxWorkers: parseInt(process.env.MAX_WORKERS) || config.maxWorkers || 6,
+            maxWorkers: requestedMaxWorkers,
+            requestedMaxWorkers,
             minDelayMs: parseInt(process.env.MIN_DELAY_MS) || config.minDelayMs || 10000,
             maxDelayMs: parseInt(process.env.MAX_DELAY_MS) || config.maxDelayMs || 20000,
             batchSize: parseInt(process.env.BATCH_SIZE) || config.batchSize || 500,
@@ -198,11 +202,21 @@ class AbstractHarvester {
             preFlightCleanup: () => this._preFlightCleanupNetworkLocks(),
         });
 
-        // Titan 7.0: 弹性并发引擎 - 根据雷达探测到的代理数量动态调整并发数
+        // Titan 7.0: 雷达结果只能下调并发，不能突破启动参数的硬上限
         if (networkInitResult?.discoveredPorts && networkInitResult.discoveredPorts.length > 0) {
             const elasticConcurrency = networkInitResult.discoveredPorts.length;
-            console.log(`⚡ Titan 7.0 弹性并发引擎: 雷达探测到 ${elasticConcurrency} 个代理节点，自动调整并发数`);
-            this.config.maxWorkers = elasticConcurrency;
+            const effectiveMaxWorkers = this._resolveEffectiveMaxWorkers(elasticConcurrency);
+
+            if (elasticConcurrency > this.config.requestedMaxWorkers) {
+                console.log(
+                    `⚡ Titan 7.0 弹性并发引擎: 雷达探测到 ${elasticConcurrency} 个代理节点，` +
+                    `但实际并发受启动参数封顶为 ${effectiveMaxWorkers}`
+                );
+            } else if (elasticConcurrency !== this.config.requestedMaxWorkers) {
+                console.log(`⚡ Titan 7.0 弹性并发引擎: 雷达探测到 ${elasticConcurrency} 个代理节点，实际并发调整为 ${effectiveMaxWorkers}`);
+            }
+
+            this.config.maxWorkers = effectiveMaxWorkers;
         }
         this._ensureContextPoolCapacity(this.config.maxWorkers);
 
@@ -215,6 +229,24 @@ class AbstractHarvester {
         console.log(
             `📋 配置: MAX_WORKERS=${this.config.maxWorkers}, DELAY=${this.config.minDelayMs}-${this.config.maxDelayMs}ms`
         );
+    }
+
+    _resolveRequestedMaxWorkers(value) {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+    }
+
+    _resolveEffectiveMaxWorkers(discoveredPortCount) {
+        const requested = this._resolveRequestedMaxWorkers(
+            this.config?.requestedMaxWorkers || this.config?.maxWorkers || 1
+        );
+        const discovered = Number.parseInt(discoveredPortCount, 10);
+
+        if (!Number.isInteger(discovered) || discovered <= 0) {
+            return requested;
+        }
+
+        return Math.max(1, Math.min(requested, discovered));
     }
 
     async cleanup() {

--- a/src/infrastructure/network/FotMobApiClient.js
+++ b/src/infrastructure/network/FotMobApiClient.js
@@ -17,6 +17,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 20000;
 const DEFAULT_JITTER_MIN_MS = 1500;
 const DEFAULT_JITTER_MAX_MS = 4000;
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36';
+const DEFAULT_BOOTSTRAP_SESSION_TTL_MS = 6 * 60 * 60 * 1000;
 
 function createProxyAgent(proxyServer, targetProtocol, timeoutMs) {
   if (!proxyServer) {
@@ -49,6 +50,123 @@ function buildCookieHeader(cookies = []) {
     .join('; ');
 }
 
+function normalizeCookieDomain(hostname = '') {
+  const normalizedHost = String(hostname || '').trim().replace(/^www\./i, '');
+  if (!normalizedHost) {
+    return '.fotmob.com';
+  }
+  return normalizedHost.startsWith('.')
+    ? normalizedHost
+    : `.${normalizedHost}`;
+}
+
+const COOKIE_ATTRIBUTE_HANDLERS = {
+  domain(cookie, value) {
+    if (value) {
+      cookie.domain = value.startsWith('.') ? value : `.${value}`;
+    }
+  },
+  path(cookie, value) {
+    if (value) {
+      cookie.path = value;
+    }
+  },
+  samesite(cookie, value) {
+    if (value) {
+      cookie.sameSite = value;
+    }
+  },
+  secure(cookie) {
+    cookie.secure = true;
+  },
+  httponly(cookie) {
+    cookie.httpOnly = true;
+  }
+};
+
+function applyCookieAttribute(cookie, attribute) {
+  const [rawKey, ...valueParts] = attribute.split('=');
+  const key = String(rawKey || '').trim().toLowerCase();
+  const value = valueParts.join('=').trim();
+  if (key === 'expires') {
+    const timestamp = Date.parse(value);
+    if (Number.isFinite(timestamp)) {
+      cookie.expires = Math.floor(timestamp / 1000);
+    }
+    return;
+  }
+
+  if (key === 'max-age') {
+    const seconds = Number.parseInt(value, 10);
+    if (Number.isInteger(seconds) && seconds > 0) {
+      cookie.expires = Math.floor((Date.now() + (seconds * 1000)) / 1000);
+    }
+    return;
+  }
+
+  COOKIE_ATTRIBUTE_HANDLERS[key]?.(cookie, value);
+}
+
+function parseSetCookieHeader(rawCookie, defaultDomain) {
+  const parts = String(rawCookie || '')
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const separatorIndex = parts[0].indexOf('=');
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const cookie = {
+    name: parts[0].slice(0, separatorIndex).trim(),
+    value: parts[0].slice(separatorIndex + 1).trim(),
+    domain: defaultDomain,
+    path: '/',
+    httpOnly: false,
+    secure: false
+  };
+
+  if (!cookie.name || !cookie.value) {
+    return null;
+  }
+
+  for (const attribute of parts.slice(1)) {
+    applyCookieAttribute(cookie, attribute);
+  }
+
+  return cookie;
+}
+
+function mergeCookies(...collections) {
+  const merged = new Map();
+
+  for (const collection of collections) {
+    for (const cookie of Array.isArray(collection) ? collection : []) {
+      const name = String(cookie?.name || '').trim();
+      const value = String(cookie?.value || '').trim();
+      if (!name || !value) {
+        continue;
+      }
+
+      const domain = String(cookie?.domain || '').trim();
+      const path = String(cookie?.path || '/').trim() || '/';
+      merged.set(`${name}|${domain}|${path}`, {
+        ...cookie,
+        name,
+        value,
+        path
+      });
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
 class FotMobApiError extends Error {
   constructor(message, context = {}) {
     super(message);
@@ -69,6 +187,7 @@ class FotMobApiClient {
     this.requestTimeoutMs = Number(options.requestTimeoutMs) || DEFAULT_REQUEST_TIMEOUT_MS;
     this.jitterMinMs = Number(options.jitterMinMs) || DEFAULT_JITTER_MIN_MS;
     this.jitterMaxMs = Number(options.jitterMaxMs) || DEFAULT_JITTER_MAX_MS;
+    this.bootstrapSessionTtlMs = Number(options.bootstrapSessionTtlMs) || DEFAULT_BOOTSTRAP_SESSION_TTL_MS;
     this.sessionManager = options.sessionManager || null;
   }
 
@@ -76,7 +195,7 @@ class FotMobApiClient {
     this.sessionManager = sessionManager || null;
   }
 
-  async fetchMatchDetails(match, options = {}) {
+  _resolveRequestContext(match, options = {}) {
     const externalId = String(match?.external_id || '').trim();
     if (!externalId) {
       throw new FotMobApiError('MISSING_MATCH_ID', { code: 'MISSING_MATCH_ID' });
@@ -86,19 +205,23 @@ class FotMobApiClient {
     const referer = String(options.referer || `${this.baseUrl}/match/${externalId}`);
     const port = Number(identity?.proxy?.port || options.port || 0);
     const proxyServer = options.proxyServer || identity?.proxy?.server || identity?.proxy?.url || null;
-    const session = await this._resolveSession(port, proxyServer, options.session);
     const userAgent = String(
       options.userAgent
-      || session?.userAgent
       || identity?.stealth?.userAgent
       || DEFAULT_USER_AGENT
     ).trim();
 
-    await this._applyJitter();
+    return {
+      externalId,
+      identity,
+      referer,
+      port,
+      proxyServer,
+      userAgent
+    };
+  }
 
-    const url = new URL('/api/data/matchDetails', this.baseUrl);
-    url.searchParams.set('matchId', externalId);
-
+  _buildMatchDetailsHeaders(session, userAgent, referer) {
     const headers = {
       accept: 'application/json, text/plain, */*',
       'accept-language': 'zh-Hans,zh;q=0.9,en;q=0.8',
@@ -113,10 +236,64 @@ class FotMobApiClient {
       headers.cookie = cookieHeader;
     }
 
+    return headers;
+  }
+
+  async fetchMatchDetails(match, options = {}) {
+    const requestContext = this._resolveRequestContext(match, options);
+    const {
+      externalId,
+      port,
+      proxyServer,
+      referer,
+      userAgent: defaultUserAgent
+    } = requestContext;
+
+    const session = await this._ensureSession({
+      port,
+      proxyServer,
+      referer,
+      userAgent: defaultUserAgent,
+      explicitSession: options.session
+    });
+    const userAgent = String(
+      options.userAgent
+      || session?.userAgent
+      || requestContext.identity?.stealth?.userAgent
+      || DEFAULT_USER_AGENT
+    ).trim();
+
+    await this._applyJitter();
+
+    const url = new URL('/api/data/matchDetails', this.baseUrl);
+    url.searchParams.set('matchId', externalId);
+
     return this._requestJson(url, {
-      headers,
+      headers: this._buildMatchDetailsHeaders(session, userAgent, referer),
       proxyServer
     });
+  }
+
+  _hasUsableSession(session) {
+    return Array.isArray(session?.cookies) && session.cookies.some((cookie) => {
+      const name = String(cookie?.name || '').trim();
+      const value = String(cookie?.value || '').trim();
+      return name && value;
+    });
+  }
+
+  async _ensureSession(options = {}) {
+    const session = await this._resolveSession(options.port, options.proxyServer, options.explicitSession);
+    if (this._hasUsableSession(session)) {
+      return session;
+    }
+
+    const bootstrapSession = await this._bootstrapSessionFromProbe(options);
+    if (bootstrapSession) {
+      return bootstrapSession;
+    }
+
+    return session;
   }
 
   async _resolveSession(port, proxyServer, explicitSession) {
@@ -138,6 +315,111 @@ class FotMobApiClient {
     }
   }
 
+  _resolveBootstrapTargets(referer) {
+    const baseOrigin = new URL(this.baseUrl);
+    const bootstrapTargets = [new URL('/', baseOrigin)];
+
+    if (!referer) {
+      return bootstrapTargets;
+    }
+
+    try {
+      const refererUrl = new URL(referer, this.baseUrl);
+      if (refererUrl.hostname === baseOrigin.hostname) {
+        bootstrapTargets.push(refererUrl);
+      }
+    } catch {
+      // 忽略非法 referer
+    }
+
+    return bootstrapTargets;
+  }
+
+  async _collectBootstrapCookies(target, proxyServer, userAgent, defaultDomain) {
+    const response = await this._requestRaw(target, {
+      proxyServer,
+      headers: {
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'accept-language': 'zh-Hans,zh;q=0.9,en;q=0.8',
+        'accept-encoding': 'identity',
+        'cache-control': 'no-cache',
+        pragma: 'no-cache',
+        referer: this.baseUrl,
+        'user-agent': userAgent
+      }
+    });
+
+    return (Array.isArray(response?.headers?.['set-cookie']) ? response.headers['set-cookie'] : [])
+      .map((cookie) => parseSetCookieHeader(cookie, defaultDomain))
+      .filter(Boolean);
+  }
+
+  async _persistBootstrapSession(port, session) {
+    if (
+      !this.sessionManager
+      || !Number.isInteger(port)
+      || port <= 0
+      || typeof this.sessionManager.storeSession !== 'function'
+    ) {
+      return session;
+    }
+
+    try {
+      return await this.sessionManager.storeSession(port, session);
+    } catch (error) {
+      if (typeof this.logger?.warn === 'function') {
+        this.logger.warn(`[FotMobApiClient] 预热会话持久化失败: ${error.message}`);
+      }
+      return session;
+    }
+  }
+
+  async _bootstrapSessionFromProbe(options = {}) {
+    const proxyServer = options.proxyServer || null;
+    const userAgent = String(options.userAgent || DEFAULT_USER_AGENT).trim();
+    const defaultDomain = normalizeCookieDomain(new URL(this.baseUrl).hostname);
+    const bootstrapTargets = this._resolveBootstrapTargets(options.referer);
+
+    let collectedCookies = [];
+    for (const target of bootstrapTargets) {
+      try {
+        const freshCookies = await this._collectBootstrapCookies(target, proxyServer, userAgent, defaultDomain);
+
+        if (freshCookies.length > 0) {
+          collectedCookies = mergeCookies(collectedCookies, freshCookies);
+          if (typeof this.logger?.info === 'function') {
+            this.logger.info(`[FotMobApiClient] API 预热成功: ${target.href} -> ${freshCookies.length} 个 Cookie`);
+          }
+        }
+
+        if (collectedCookies.length > 0) {
+          break;
+        }
+      } catch (error) {
+        if (typeof this.logger?.warn === 'function') {
+          this.logger.warn(`[FotMobApiClient] API 预热失败: ${target.href} -> ${error.message}`);
+        }
+      }
+    }
+
+    if (collectedCookies.length === 0) {
+      return null;
+    }
+
+    const session = {
+      port: Number.isInteger(options.port) && options.port > 0 ? options.port : 0,
+      cookies: collectedCookies,
+      origins: [],
+      createdAt: Date.now(),
+      expiresAt: Date.now() + this.bootstrapSessionTtlMs,
+      userAgent,
+      proxyUrl: proxyServer || null,
+      source: 'api_bootstrap_probe'
+    };
+
+    return this._persistBootstrapSession(options.port, session);
+  }
+
   async _applyJitter() {
     const minMs = Math.max(0, this.jitterMinMs);
     const maxMs = Math.max(minMs, this.jitterMaxMs);
@@ -154,7 +436,47 @@ class FotMobApiClient {
     });
   }
 
-  _requestJson(url, options = {}) {
+  async _requestJson(url, options = {}) {
+    const { statusCode, headers, body } = await this._requestRaw(url, options);
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new FotMobApiError(`HTTP_${statusCode}`, {
+        code: 'HTTP_ERROR',
+        statusCode,
+        url: (url instanceof URL ? url.href : String(url)),
+        responseBody: body,
+        headers
+      });
+    }
+
+    try {
+      const parsed = JSON.parse(body);
+      if (!parsed || typeof parsed !== 'object') {
+        throw new FotMobApiError('INVALID_JSON_PAYLOAD', {
+          code: 'INVALID_JSON_PAYLOAD',
+          statusCode,
+          url: (url instanceof URL ? url.href : String(url)),
+          responseBody: body,
+          headers
+        });
+      }
+      return parsed;
+    } catch (error) {
+      if (error instanceof FotMobApiError) {
+        throw error;
+      }
+
+      const isHtmlLike = /^\s*</.test(body);
+      throw new FotMobApiError(isHtmlLike ? 'HTML_CHALLENGE_RESPONSE' : `JSON_PARSE_ERROR:${error.message}`, {
+        code: isHtmlLike ? 'HTML_CHALLENGE_RESPONSE' : 'JSON_PARSE_ERROR',
+        statusCode,
+        url: (url instanceof URL ? url.href : String(url)),
+        responseBody: body,
+        headers
+      });
+    }
+  }
+
+  _requestRaw(url, options = {}) {
     const target = url instanceof URL ? url : new URL(String(url));
     const requestLib = target.protocol === 'https:' ? https : http;
     const agent = createProxyAgent(options.proxyServer, target.protocol, this.requestTimeoutMs);
@@ -176,36 +498,11 @@ class FotMobApiClient {
           rawBody += chunk;
         });
         res.on('end', () => {
-          const statusCode = Number(res.statusCode) || 0;
-          if (statusCode < 200 || statusCode >= 300) {
-            return reject(new FotMobApiError(`HTTP_${statusCode}`, {
-              code: 'HTTP_ERROR',
-              statusCode,
-              url: target.href,
-              responseBody: rawBody
-            }));
-          }
-
-          try {
-            const parsed = JSON.parse(rawBody);
-            if (!parsed || typeof parsed !== 'object') {
-              return reject(new FotMobApiError('INVALID_JSON_PAYLOAD', {
-                code: 'INVALID_JSON_PAYLOAD',
-                statusCode,
-                url: target.href,
-                responseBody: rawBody
-              }));
-            }
-            resolve(parsed);
-          } catch (error) {
-            const isHtmlLike = /^\s*</.test(rawBody);
-            reject(new FotMobApiError(isHtmlLike ? 'HTML_CHALLENGE_RESPONSE' : `JSON_PARSE_ERROR:${error.message}`, {
-              code: isHtmlLike ? 'HTML_CHALLENGE_RESPONSE' : 'JSON_PARSE_ERROR',
-              statusCode,
-              url: target.href,
-              responseBody: rawBody
-            }));
-          }
+          resolve({
+            statusCode: Number(res.statusCode) || 0,
+            headers: res.headers || {},
+            body: rawBody
+          });
         });
       });
 
@@ -236,5 +533,7 @@ class FotMobApiClient {
 module.exports = {
   FotMobApiClient,
   FotMobApiError,
-  buildCookieHeader
+  buildCookieHeader,
+  mergeCookies,
+  parseSetCookieHeader
 };

--- a/src/infrastructure/network/SessionManager.js
+++ b/src/infrastructure/network/SessionManager.js
@@ -362,6 +362,42 @@ class SessionManager {
     }
 
     /**
+     * 写入轻量会话（例如纯 HTTP 预热拿到的基础 Cookie）
+     * @param {number} port - 代理端口
+     * @param {object} session - 会话对象
+     * @returns {Promise<object>} 规范化后的会话
+     */
+    async storeSession(port, session = {}) {
+        if (!this._initialized) {
+            await this.initialize();
+        }
+
+        const normalizedPort = Number.parseInt(port, 10);
+        if (!Number.isInteger(normalizedPort) || normalizedPort <= 0) {
+            throw new Error(`INVALID_SESSION_PORT:${port}`);
+        }
+
+        const now = Date.now();
+        const normalizedSession = {
+            port: normalizedPort,
+            cookies: Array.isArray(session.cookies) ? session.cookies.filter(Boolean) : [],
+            origins: Array.isArray(session.origins) ? session.origins : [],
+            createdAt: Number(session.createdAt) || now,
+            expiresAt: Number(session.expiresAt) || (now + (this.config.sessionTtlHours * 60 * 60 * 1000)),
+            userAgent: session.userAgent || '',
+            viewport: session.viewport || null,
+            proxyUrl: session.proxyUrl || ProxyProvider.buildServer(normalizedPort),
+            source: session.source || 'bootstrap'
+        };
+
+        this._sessionCache.set(normalizedPort, normalizedSession);
+        await this._saveSessionToFile(normalizedPort, normalizedSession);
+        this.logger.info(`端口 ${normalizedPort} 已缓存 ${normalizedSession.cookies.length} 个基础 Cookie`);
+
+        return normalizedSession;
+    }
+
+    /**
      * 获取统计信息
      * @returns {object} 统计信息
      */

--- a/tests/unit/AbstractHarvester.test.js
+++ b/tests/unit/AbstractHarvester.test.js
@@ -155,6 +155,18 @@ describe('AbstractHarvester 完整测试套件', () => {
             assert.strictEqual(harvester.stats.success, 0);
             assert.strictEqual(harvester.stats.failed, 0);
         });
+
+        it('应该将启动参数并发保存为硬上限，并阻止雷达结果越权上调', () => {
+            process.env.MAX_WORKERS = '8';
+            const harvester = createHarvester(AbstractHarvester, {
+                maxWorkers: 8
+            });
+
+            assert.strictEqual(harvester.config.requestedMaxWorkers, 8);
+            assert.strictEqual(harvester._resolveEffectiveMaxWorkers(20), 8);
+            assert.strictEqual(harvester._resolveEffectiveMaxWorkers(6), 6);
+            assert.strictEqual(harvester._resolveEffectiveMaxWorkers(0), 8);
+        });
     });
 
     // ========================================================================

--- a/tests/unit/FotMobApiClient.test.js
+++ b/tests/unit/FotMobApiClient.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    FotMobApiClient,
+    buildCookieHeader,
+    parseSetCookieHeader
+} = require('../../src/infrastructure/network/FotMobApiClient');
+
+describe('FotMobApiClient', () => {
+    it('缺少缓存 Session 时应先探测首页 Cookie，再携带 Cookie 请求 matchDetails API', async () => {
+        const persistedSessions = [];
+        const requests = [];
+        const client = new FotMobApiClient({
+            logger: {
+                info() {},
+                warn() {}
+            },
+            sessionManager: {
+                async getOrRefreshSession() {
+                    return null;
+                },
+                async storeSession(port, session) {
+                    const stored = { ...session, storedPort: port };
+                    persistedSessions.push(stored);
+                    return stored;
+                }
+            }
+        });
+
+        client._applyJitter = async () => {};
+        client._requestRaw = async (url, options = {}) => {
+            requests.push({
+                url: url.href,
+                headers: options.headers || {}
+            });
+
+            if (requests.length === 1) {
+                return {
+                    statusCode: 200,
+                    headers: {
+                        'set-cookie': [
+                            'cf_clearance=token-1; Path=/; HttpOnly; Secure',
+                            '_cfuvid=token-2; Path=/; Secure'
+                        ]
+                    },
+                    body: '<html>ok</html>'
+                };
+            }
+
+            return {
+                statusCode: 200,
+                headers: {},
+                body: JSON.stringify({
+                    general: { matchId: '12345' },
+                    content: { stats: {}, lineup: {} },
+                    header: {}
+                })
+            };
+        };
+
+        const payload = await client.fetchMatchDetails(
+            { external_id: '12345' },
+            {
+                port: 10001,
+                proxyServer: 'socks5://127.0.0.1:10001',
+                referer: 'https://www.fotmob.com/match/12345'
+            }
+        );
+
+        assert.strictEqual(requests.length, 2);
+        assert.match(requests[0].url, /^https:\/\/www\.fotmob\.com\/$/);
+        assert.match(requests[1].url, /api\/data\/matchDetails\?matchId=12345$/);
+        assert.strictEqual(
+            requests[1].headers.cookie,
+            'cf_clearance=token-1; _cfuvid=token-2'
+        );
+        assert.strictEqual(persistedSessions.length, 1);
+        assert.strictEqual(persistedSessions[0].storedPort, 10001);
+        assert.strictEqual(payload.general.matchId, '12345');
+    });
+
+    it('已有有效 Cookie Session 时不应重复执行首页探测', async () => {
+        const requests = [];
+        const client = new FotMobApiClient({
+            sessionManager: {
+                async getOrRefreshSession() {
+                    return {
+                        cookies: [
+                            { name: 'cf_clearance', value: 'cached-token' }
+                        ],
+                        userAgent: 'UA-CACHED'
+                    };
+                }
+            }
+        });
+
+        client._applyJitter = async () => {};
+        client._requestRaw = async (url, options = {}) => {
+            requests.push({ url: url.href, headers: options.headers || {} });
+            return {
+                statusCode: 200,
+                headers: {},
+                body: JSON.stringify({
+                    general: { matchId: '67890' },
+                    content: { stats: {} },
+                    header: {}
+                })
+            };
+        };
+
+        await client.fetchMatchDetails(
+            { external_id: '67890' },
+            {
+                port: 10002,
+                proxyServer: 'socks5://127.0.0.1:10002',
+                referer: 'https://www.fotmob.com/match/67890'
+            }
+        );
+
+        assert.strictEqual(requests.length, 1);
+        assert.strictEqual(requests[0].headers.cookie, 'cf_clearance=cached-token');
+        assert.strictEqual(requests[0].headers['user-agent'], 'UA-CACHED');
+    });
+
+    it('应正确解析 Set-Cookie 并生成 Cookie Header', () => {
+        const cookie = parseSetCookieHeader(
+            'cf_clearance=token-1; Path=/; Domain=fotmob.com; HttpOnly; Secure',
+            '.fotmob.com'
+        );
+
+        assert.deepStrictEqual(cookie, {
+            name: 'cf_clearance',
+            value: 'token-1',
+            domain: '.fotmob.com',
+            path: '/',
+            httpOnly: true,
+            secure: true
+        });
+        assert.strictEqual(
+            buildCookieHeader([cookie, { name: '_cfuvid', value: 'token-2' }]),
+            'cf_clearance=token-1; _cfuvid=token-2'
+        );
+    });
+});

--- a/tests/unit/SessionManager.test.js
+++ b/tests/unit/SessionManager.test.js
@@ -318,6 +318,34 @@ describe('SessionManager', () => {
             });
             assert.strictEqual(await manager.validateSession(7892), true);
         });
+
+        it('storeSession 应规范化并持久化 bootstrap Cookie 会话', async () => {
+            const profilePath = await fs.mkdtemp(path.join(os.tmpdir(), 'session-bootstrap-'));
+            const manager = createMockSessionManager({ profilePath });
+            let savedPayload = null;
+
+            manager._initialized = true;
+            manager._saveSessionToFile = async (port, session) => {
+                savedPayload = { port, session };
+            };
+
+            const stored = await manager.storeSession(7890, {
+                cookies: [
+                    { name: 'cf_clearance', value: 'token', domain: '.fotmob.com' }
+                ],
+                userAgent: 'UA-BOOTSTRAP',
+                source: 'api_bootstrap_probe'
+            });
+
+            assert.strictEqual(stored.port, 7890);
+            assert.strictEqual(stored.cookies.length, 1);
+            assert.strictEqual(stored.userAgent, 'UA-BOOTSTRAP');
+            assert.strictEqual(manager._sessionCache.get(7890).cookies.length, 1);
+            assert.deepStrictEqual(savedPayload.port, 7890);
+            assert.strictEqual(savedPayload.session.source, 'api_bootstrap_probe');
+
+            await fs.rm(profilePath, { recursive: true, force: true });
+        });
     });
 
     describe('文件系统与环境工具', () => {


### PR DESCRIPTION
## Summary
- lock harvester runtime concurrency so radar/proxy discovery can only downscale and never exceed the requested startup cap
- bootstrap FotMob API sessions with lightweight HTTP cookie probes before calling `api/data/matchDetails`
- persist bootstrap cookies through `SessionManager` and cover the new flow with unit tests

## Validation
- `COMPOSE_PROJECT_NAME=footballprediction GATEKEEPER_WORKSPACE_ROOT=/app bash scripts/devops/gatekeeper.sh --mode=commit`
- `docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'cd /app && npm run test:unit'`
- `COMPOSE_PROJECT_NAME=footballprediction GATEKEEPER_WORKSPACE_ROOT=/app git push -u origin feat/fix-fotmob-session-and-concurrency`
