### PR TITLE
fix(harvest): bootstrap FotMob sessions via browser transport

### DIFF
--- a/src/infrastructure/network/FotMobApiClient.js
+++ b/src/infrastructure/network/FotMobApiClient.js
@@ -11,6 +11,7 @@ const { URL } = require('node:url');
 const { HttpProxyAgent } = require('http-proxy-agent');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { SocksProxyAgent } = require('socks-proxy-agent');
+const { BrowserProvider } = require('../services/BrowserProvider');
 
 const DEFAULT_BASE_URL = 'https://www.fotmob.com';
 const DEFAULT_REQUEST_TIMEOUT_MS = 20000;
@@ -18,6 +19,21 @@ const DEFAULT_JITTER_MIN_MS = 1500;
 const DEFAULT_JITTER_MAX_MS = 4000;
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36';
 const DEFAULT_BOOTSTRAP_SESSION_TTL_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_BROWSER_BOOTSTRAP_TIMEOUT_MS = 30000;
+const DEFAULT_BROWSER_BOOTSTRAP_POLL_INTERVAL_MS = 1000;
+const CRITICAL_BOOTSTRAP_COOKIE_NAMES = new Set(['cf_clearance', '__cf_bm', '_cfuvid']);
+
+function resolveCookieExpiry(rawExpires) {
+  const expires = Number(rawExpires);
+  if (!Number.isFinite(expires) || expires <= 0) {
+    return { expires: null, expired: false };
+  }
+
+  return {
+    expires,
+    expired: expires < (Date.now() / 1000)
+  };
+}
 
 function createProxyAgent(proxyServer, targetProtocol, timeoutMs) {
   if (!proxyServer) {
@@ -188,7 +204,12 @@ class FotMobApiClient {
     this.jitterMinMs = Number(options.jitterMinMs) || DEFAULT_JITTER_MIN_MS;
     this.jitterMaxMs = Number(options.jitterMaxMs) || DEFAULT_JITTER_MAX_MS;
     this.bootstrapSessionTtlMs = Number(options.bootstrapSessionTtlMs) || DEFAULT_BOOTSTRAP_SESSION_TTL_MS;
+    this.browserBootstrapTimeoutMs = Number(options.browserBootstrapTimeoutMs) || DEFAULT_BROWSER_BOOTSTRAP_TIMEOUT_MS;
+    this.browserBootstrapPollIntervalMs = Number(options.browserBootstrapPollIntervalMs) || DEFAULT_BROWSER_BOOTSTRAP_POLL_INTERVAL_MS;
     this.sessionManager = options.sessionManager || null;
+    this.browserBootstrapFactory = typeof options.browserBootstrapFactory === 'function'
+      ? options.browserBootstrapFactory
+      : (bootstrapOptions) => this._createDefaultBrowserBootstrapProvider(bootstrapOptions);
   }
 
   setSessionManager(sessionManager) {
@@ -254,7 +275,8 @@ class FotMobApiClient {
       proxyServer,
       referer,
       userAgent: defaultUserAgent,
-      explicitSession: options.session
+      explicitSession: options.session,
+      identity: requestContext.identity
     });
     const userAgent = String(
       options.userAgent
@@ -335,23 +357,161 @@ class FotMobApiClient {
     return bootstrapTargets;
   }
 
-  async _collectBootstrapCookies(target, proxyServer, userAgent, defaultDomain) {
-    const response = await this._requestRaw(target, {
-      proxyServer,
-      headers: {
-        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'accept-language': 'zh-Hans,zh;q=0.9,en;q=0.8',
-        'accept-encoding': 'identity',
-        'cache-control': 'no-cache',
-        pragma: 'no-cache',
-        referer: this.baseUrl,
-        'user-agent': userAgent
-      }
-    });
+  _normalizeBrowserCookie(rawCookie = {}, defaultDomain) {
+    const name = String(rawCookie?.name || '').trim();
+    const value = String(rawCookie?.value || '').trim();
+    const domain = String(rawCookie?.domain || defaultDomain || '').trim() || defaultDomain;
 
-    return (Array.isArray(response?.headers?.['set-cookie']) ? response.headers['set-cookie'] : [])
-      .map((cookie) => parseSetCookieHeader(cookie, defaultDomain))
+    if (!name || !value || !domain) {
+      return null;
+    }
+
+    const normalized = {
+      name,
+      value,
+      domain,
+      path: String(rawCookie?.path || '/').trim() || '/',
+      httpOnly: Boolean(rawCookie?.httpOnly),
+      secure: Boolean(rawCookie?.secure)
+    };
+
+    const expiry = resolveCookieExpiry(rawCookie?.expires);
+    if (expiry.expired) {
+      return null;
+    }
+    if (expiry.expires) {
+      normalized.expires = expiry.expires;
+    }
+
+    const sameSite = String(rawCookie?.sameSite || '').trim();
+    if (sameSite) {
+      normalized.sameSite = sameSite;
+    }
+
+    return normalized;
+  }
+
+  _normalizeBrowserCookies(cookies = [], defaultDomain) {
+    return (Array.isArray(cookies) ? cookies : [])
+      .map((cookie) => this._normalizeBrowserCookie(cookie, defaultDomain))
       .filter(Boolean);
+  }
+
+  _hasCriticalBootstrapCookie(cookies = []) {
+    return (Array.isArray(cookies) ? cookies : []).some((cookie) => {
+      const name = String(cookie?.name || '').trim().toLowerCase();
+      return CRITICAL_BOOTSTRAP_COOKIE_NAMES.has(name);
+    });
+  }
+
+  _resolveBootstrapViewport(identity) {
+    const width = Number(identity?.stealth?.viewport?.width);
+    const height = Number(identity?.stealth?.viewport?.height);
+    if (width > 0 && height > 0) {
+      return { width, height };
+    }
+    return undefined;
+  }
+
+  _createBrowserLogger() {
+    return {
+      info: (...args) => this.logger?.info?.(...args),
+      warn: (...args) => this.logger?.warn?.(...args),
+      error: (...args) => this.logger?.error?.(...args)
+    };
+  }
+
+  _createDefaultBrowserBootstrapProvider(options = {}) {
+    const fixedProxy = options.proxyServer
+      ? {
+        server: String(options.proxyServer),
+        port: Number(options.port) || 0
+      }
+      : null;
+
+    return new BrowserProvider({
+      logger: this._createBrowserLogger(),
+      headless: true,
+      userAgent: options.userAgent || DEFAULT_USER_AGENT,
+      viewport: options.viewport || undefined,
+      defaultTimeoutMs: this.browserBootstrapTimeoutMs,
+      fixedProxy
+    });
+  }
+
+  async _collectBrowserBootstrapCookies(browserProvider, target, defaultDomain) {
+    const page = browserProvider?.getPage?.();
+    const context = page?.context?.();
+    if (!context || typeof context.cookies !== 'function') {
+      return [];
+    }
+
+    const targetUrls = [this.baseUrl];
+    if (target?.href) {
+      targetUrls.push(target.href);
+    }
+
+    const deadline = Date.now() + this.browserBootstrapTimeoutMs;
+    let cookies = [];
+
+    while (Date.now() <= deadline) {
+      let rawCookies = [];
+      try {
+        rawCookies = await context.cookies(targetUrls);
+      } catch (error) {
+        if (typeof this.logger?.warn === 'function') {
+          this.logger.warn(`[FotMobApiClient] 浏览器读取 Cookie 失败: ${error.message}`);
+        }
+        break;
+      }
+
+      cookies = mergeCookies(cookies, this._normalizeBrowserCookies(rawCookies, defaultDomain));
+      if (this._hasCriticalBootstrapCookie(cookies)) {
+        return cookies;
+      }
+
+      await browserProvider.sleep(this.browserBootstrapPollIntervalMs);
+    }
+
+    return cookies;
+  }
+
+  async _runBrowserBootstrapTarget(browserProvider, target, index, defaultDomain) {
+    if (index === 0) {
+      await browserProvider.warmup(target.href, {
+        waitUntil: 'domcontentloaded',
+        timeout: this.browserBootstrapTimeoutMs
+      });
+    } else {
+      await browserProvider.goto(target.href, {
+        waitUntil: 'domcontentloaded',
+        timeout: this.browserBootstrapTimeoutMs
+      });
+    }
+
+    const freshCookies = await this._collectBrowserBootstrapCookies(browserProvider, target, defaultDomain);
+    if (freshCookies.length > 0 && typeof this.logger?.info === 'function') {
+      const cookieSummary = this._hasCriticalBootstrapCookie(freshCookies) ? '命中关键 Cookie' : '获取到基础 Cookie';
+      this.logger.info(
+        `[FotMobApiClient] 浏览器破冰成功: ${target.href} -> ${freshCookies.length} 个 Cookie (${cookieSummary})`
+      );
+    }
+
+    return freshCookies;
+  }
+
+  async _closeBrowserBootstrapProvider(browserProvider) {
+    if (!browserProvider || typeof browserProvider.close !== 'function') {
+      return;
+    }
+
+    try {
+      await browserProvider.close();
+    } catch (error) {
+      if (typeof this.logger?.warn === 'function') {
+        this.logger.warn(`[FotMobApiClient] 浏览器破冰关闭失败: ${error.message}`);
+      }
+    }
   }
 
   async _persistBootstrapSession(port, session) {
@@ -379,27 +539,34 @@ class FotMobApiClient {
     const userAgent = String(options.userAgent || DEFAULT_USER_AGENT).trim();
     const defaultDomain = normalizeCookieDomain(new URL(this.baseUrl).hostname);
     const bootstrapTargets = this._resolveBootstrapTargets(options.referer);
+    const browserProvider = this.browserBootstrapFactory({
+      identity: options.identity || null,
+      port: options.port,
+      proxyServer,
+      userAgent,
+      viewport: this._resolveBootstrapViewport(options.identity)
+    });
 
     let collectedCookies = [];
-    for (const target of bootstrapTargets) {
-      try {
-        const freshCookies = await this._collectBootstrapCookies(target, proxyServer, userAgent, defaultDomain);
+    try {
+      for (const [index, target] of bootstrapTargets.entries()) {
+        try {
+          const freshCookies = await this._runBrowserBootstrapTarget(browserProvider, target, index, defaultDomain);
+          if (freshCookies.length > 0) {
+            collectedCookies = mergeCookies(collectedCookies, freshCookies);
+          }
 
-        if (freshCookies.length > 0) {
-          collectedCookies = mergeCookies(collectedCookies, freshCookies);
-          if (typeof this.logger?.info === 'function') {
-            this.logger.info(`[FotMobApiClient] API 预热成功: ${target.href} -> ${freshCookies.length} 个 Cookie`);
+          if (this._hasCriticalBootstrapCookie(collectedCookies)) {
+            break;
+          }
+        } catch (error) {
+          if (typeof this.logger?.warn === 'function') {
+            this.logger.warn(`[FotMobApiClient] 浏览器破冰失败: ${target.href} -> ${error.message}`);
           }
         }
-
-        if (collectedCookies.length > 0) {
-          break;
-        }
-      } catch (error) {
-        if (typeof this.logger?.warn === 'function') {
-          this.logger.warn(`[FotMobApiClient] API 预热失败: ${target.href} -> ${error.message}`);
-        }
       }
+    } finally {
+      await this._closeBrowserBootstrapProvider(browserProvider);
     }
 
     if (collectedCookies.length === 0) {
@@ -413,8 +580,9 @@ class FotMobApiClient {
       createdAt: Date.now(),
       expiresAt: Date.now() + this.bootstrapSessionTtlMs,
       userAgent,
+      viewport: this._resolveBootstrapViewport(options.identity) || null,
       proxyUrl: proxyServer || null,
-      source: 'api_bootstrap_probe'
+      source: 'browser_bootstrap_probe'
     };
 
     return this._persistBootstrapSession(options.port, session);

--- a/src/infrastructure/services/BrowserProvider.js
+++ b/src/infrastructure/services/BrowserProvider.js
@@ -10,6 +10,56 @@
 'use strict';
 
 const { chromium } = require('playwright');
+const { URL } = require('node:url');
+
+function parseProxyServer(server) {
+  try {
+    const parsed = new URL(server);
+    return {
+      host: parsed.hostname,
+      port: Number(parsed.port) || 0,
+    };
+  } catch {
+    return {
+      host: '',
+      port: 0,
+    };
+  }
+}
+
+function normalizeFixedProxy(proxy) {
+  if (typeof proxy === 'string') {
+    const server = proxy.trim();
+    if (!server) {
+      return null;
+    }
+    return { server, ...parseProxyServer(server) };
+  }
+
+  if (!proxy) {
+    return null;
+  }
+
+  const server = String(proxy.server || proxy.url || '').trim();
+  if (!server) {
+    return null;
+  }
+
+  const parsedProxy = parseProxyServer(server);
+  const normalized = {
+    ...proxy,
+    server,
+    host: String(proxy.host || '').trim(),
+    port: Number(proxy.port) || 0,
+  };
+
+  if (!normalized.host || normalized.port <= 0) {
+    normalized.host = normalized.host || parsedProxy.host;
+    normalized.port = normalized.port || parsedProxy.port;
+  }
+
+  return normalized;
+}
 
 function classifyBrowserFailure(reason = '') {
   const message = String(reason || '').toLowerCase();
@@ -79,7 +129,8 @@ class BrowserProvider {
     this.config = {
       headless: options.headless !== false,
       viewport: options.viewport || { width: 1920, height: 1080 },
-      userAgent: options.userAgent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+      userAgent: options.userAgent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      fixedProxy: normalizeFixedProxy(options.fixedProxy || options.proxyServer || null)
     };
     
     this.browser = null;
@@ -148,10 +199,10 @@ class BrowserProvider {
     this.logger.info('[BrowserProvider] 🕵️  启动影子浏览器 (闪击模式)...');
     
     try {
-      const proxyLease = await this.ensureProxyLease('browser-launch');
+      const launchProxy = await this._resolveLaunchProxy('browser-launch');
       this.browser = await chromium.launch({
         headless: this.config.headless,
-        ...(proxyLease ? { proxy: { server: proxyLease.proxy.server } } : {}),
+        ...(launchProxy ? { proxy: { server: launchProxy.server } } : {}),
         args: [
           '--disable-dev-shm-usage',
           '--disable-gpu',
@@ -173,7 +224,7 @@ class BrowserProvider {
       this.page = await this._createFreshPage('initialize-launch');
       
       this.logger.info(
-        `[BrowserProvider] ✅ 浏览器实例创建成功${proxyLease ? ` | Port ${proxyLease.proxy.port}` : ''}`
+        `[BrowserProvider] ✅ 浏览器实例创建成功${launchProxy?.port ? ` | Port ${launchProxy.port}` : ''}`
       );
       return this.page;
       
@@ -686,6 +737,15 @@ class BrowserProvider {
     });
 
     return this.proxyLease;
+  }
+
+  async _resolveLaunchProxy(reason = 'browser') {
+    if (this.config.fixedProxy?.server) {
+      return this.config.fixedProxy;
+    }
+
+    const proxyLease = await this.ensureProxyLease(reason);
+    return proxyLease ? proxyLease.proxy : null;
   }
 
   getCurrentProxyLease() {

--- a/tests/unit/BrowserProvider.test.js
+++ b/tests/unit/BrowserProvider.test.js
@@ -257,6 +257,40 @@ describe('src/infrastructure/services/BrowserProvider', () => {
     assert.deepStrictEqual(releaseCalls, ['LEASE-1']);
   });
 
+  test('固定代理模式应直接使用 fixedProxy 启动浏览器', async () => {
+    let launchProxy = null;
+
+    const fakeBrowser = {
+      async newPage() {
+        return {
+          removeAllListeners() {},
+        };
+      },
+      async close() {},
+    };
+
+    const { BrowserProvider } = loadBrowserProvider({
+      async launch(options) {
+        launchProxy = options.proxy;
+        return fakeBrowser;
+      },
+    });
+
+    const provider = new BrowserProvider({
+      fixedProxy: {
+        server: 'socks5://127.0.0.1:10001',
+        port: 10001,
+      },
+    });
+
+    await provider.initialize();
+    await provider.close();
+
+    assert.deepStrictEqual(launchProxy, {
+      server: 'socks5://127.0.0.1:10001',
+    });
+  });
+
   test('初始化失败与页面预热失败时应记录错误/告警', async () => {
     const infoLogs = [];
     const warnLogs = [];

--- a/tests/unit/FotMobApiClient.test.js
+++ b/tests/unit/FotMobApiClient.test.js
@@ -10,9 +10,11 @@ const {
 } = require('../../src/infrastructure/network/FotMobApiClient');
 
 describe('FotMobApiClient', () => {
-    it('缺少缓存 Session 时应先探测首页 Cookie，再携带 Cookie 请求 matchDetails API', async () => {
+    it('缺少缓存 Session 时应先通过浏览器破冰获取 Cookie，再携带 Cookie 请求 matchDetails API', async () => {
         const persistedSessions = [];
         const requests = [];
+        const browserBootstrapCalls = [];
+        let browserClosed = false;
         const client = new FotMobApiClient({
             logger: {
                 info() {},
@@ -27,6 +29,50 @@ describe('FotMobApiClient', () => {
                     persistedSessions.push(stored);
                     return stored;
                 }
+            },
+            browserBootstrapFactory(options = {}) {
+                browserBootstrapCalls.push(options);
+                return {
+                    async warmup(url, warmupOptions) {
+                        browserBootstrapCalls.push({ type: 'warmup', url, warmupOptions });
+                    },
+                    async goto(url, gotoOptions) {
+                        browserBootstrapCalls.push({ type: 'goto', url, gotoOptions });
+                    },
+                    async sleep(ms) {
+                        browserBootstrapCalls.push({ type: 'sleep', ms });
+                    },
+                    getPage() {
+                        return {
+                            context() {
+                                return {
+                                    async cookies() {
+                                        return [
+                                            {
+                                                name: 'cf_clearance',
+                                                value: 'token-1',
+                                                domain: '.fotmob.com',
+                                                path: '/',
+                                                httpOnly: true,
+                                                secure: true
+                                            },
+                                            {
+                                                name: '_cfuvid',
+                                                value: 'token-2',
+                                                domain: '.fotmob.com',
+                                                path: '/',
+                                                secure: true
+                                            }
+                                        ];
+                                    }
+                                };
+                            }
+                        };
+                    },
+                    async close() {
+                        browserClosed = true;
+                    }
+                };
             }
         });
 
@@ -36,19 +82,6 @@ describe('FotMobApiClient', () => {
                 url: url.href,
                 headers: options.headers || {}
             });
-
-            if (requests.length === 1) {
-                return {
-                    statusCode: 200,
-                    headers: {
-                        'set-cookie': [
-                            'cf_clearance=token-1; Path=/; HttpOnly; Secure',
-                            '_cfuvid=token-2; Path=/; Secure'
-                        ]
-                    },
-                    body: '<html>ok</html>'
-                };
-            }
 
             return {
                 statusCode: 200,
@@ -70,15 +103,18 @@ describe('FotMobApiClient', () => {
             }
         );
 
-        assert.strictEqual(requests.length, 2);
-        assert.match(requests[0].url, /^https:\/\/www\.fotmob\.com\/$/);
-        assert.match(requests[1].url, /api\/data\/matchDetails\?matchId=12345$/);
+        assert.strictEqual(requests.length, 1);
+        assert.match(requests[0].url, /api\/data\/matchDetails\?matchId=12345$/);
+        assert.strictEqual(browserBootstrapCalls[0].proxyServer, 'socks5://127.0.0.1:10001');
+        assert.strictEqual(browserBootstrapCalls.some(call => call.type === 'warmup'), true);
+        assert.strictEqual(browserClosed, true);
         assert.strictEqual(
-            requests[1].headers.cookie,
+            requests[0].headers.cookie,
             'cf_clearance=token-1; _cfuvid=token-2'
         );
         assert.strictEqual(persistedSessions.length, 1);
         assert.strictEqual(persistedSessions[0].storedPort, 10001);
+        assert.strictEqual(persistedSessions[0].source, 'browser_bootstrap_probe');
         assert.strictEqual(payload.general.matchId, '12345');
     });
 


### PR DESCRIPTION
## Summary\n- replace Node-only FotMob bootstrap probing with BrowserProvider-based cookie bootstrap bound to the worker proxy\n- persist browser-acquired FotMob cookies into SessionManager, then resume API-first matchDetails requests\n- add fixed-proxy BrowserProvider support and coverage for the new bootstrap path\n\n## Verification\n- docker compose -f docker-compose.dev.yml exec -T dev npm run lint\n- docker compose -f docker-compose.dev.yml exec -T dev npm run test:unit\n- docker compose -f docker-compose.dev.yml exec -T dev bash -lc "node --test tests/unit/FotMobApiClient.test.js tests/unit/BrowserProvider.test.js"\n- bash scripts/devops/gatekeeper.sh --mode=commit