### PR TITLE
fix: integration of football-data.co.uk csv odds pipeline

### DIFF
--- a/scripts/ops/fetch_and_adapt_euro_leagues.js
+++ b/scripts/ops/fetch_and_adapt_euro_leagues.js
@@ -178,6 +178,24 @@ const MARKET_CONFIGS = [
         closeLineValue: '2.5',
     },
 ];
+
+function buildOddsConfig(configs = []) {
+    return configs.reduce((accumulator, config) => {
+        const bookmakerBucket = accumulator[config.bookmakerName] || {};
+        bookmakerBucket[config.marketType] = {
+            open: { ...(config.openColumns || {}) },
+            close: { ...(config.closeColumns || {}) },
+            open_line: config.openLineColumn || '',
+            close_line: config.closeLineColumn || '',
+            open_line_value: config.openLineValue || '',
+            close_line_value: config.closeLineValue || '',
+        };
+        accumulator[config.bookmakerName] = bookmakerBucket;
+        return accumulator;
+    }, {});
+}
+
+const ODDS_CONFIG = buildOddsConfig(MARKET_CONFIGS);
 const TACTICAL_FIELD_ALIASES = {
     homeCorners: ['HC', 'HomeCorners', 'H_Corners'],
     awayCorners: ['AC', 'AwayCorners', 'A_Corners'],
@@ -576,6 +594,8 @@ class CollectingWriter extends Writable {
                 mapper: this.mapper,
                 resolver: this.resolver,
                 leagueMeta: this.sourceMeta,
+                oddsConfig: ODDS_CONFIG,
+                WARNING_LOW_QUALITY_SOURCE,
             });
             this.rows.push(...adapted.rows);
             if (adapted.diagnostics.reusedExisting) {
@@ -665,7 +685,7 @@ async function writeAdaptedCsv(outputPath, rows) {
     const output = fs.createWriteStream(outputPath, { encoding: 'utf8' });
     output.write(`${OUTPUT_HEADERS.join(',')}\n`);
     for (const row of rows) {
-        output.write(formatCsvLine(row));
+        output.write(`${formatCsvLine(row, OUTPUT_HEADERS)}\n`);
     }
     output.end();
     await once(output, 'finish');

--- a/scripts/ops/helpers/euroLeagueAdapters.js
+++ b/scripts/ops/helpers/euroLeagueAdapters.js
@@ -20,8 +20,11 @@ function toCsvCell(value) {
     return str.includes(',') || str.includes('"') || str.includes('\n') ? `"${str.replace(/"/g, '""')}"` : str;
 }
 
-function formatCsvLine(row) {
-    return Object.values(row).map(toCsvCell).join(',');
+function formatCsvLine(row, headers = null) {
+    const values = Array.isArray(headers) && headers.length > 0
+        ? headers.map((header) => row?.[header])
+        : Object.values(row);
+    return values.map(toCsvCell).join(',');
 }
 
 function parseFootballDataDateTime(dateValue, timeValue) {
@@ -58,7 +61,23 @@ function hasCompleteOddsTriplet(oddsValues) {
            oddsValues.away !== null && oddsValues.away !== undefined;
 }
 
+function hasCompleteTwoWayOdds(oddsValues) {
+    return oddsValues.home !== null && oddsValues.home !== undefined &&
+           oddsValues.away !== null && oddsValues.away !== undefined;
+}
+
+function hasCompleteMarketOdds(marketType, oddsValues) {
+    return normalizeText(marketType) === '1x2'
+        ? hasCompleteOddsTriplet(oddsValues)
+        : hasCompleteTwoWayOdds(oddsValues);
+}
+
 function resolveLineValue(row, config, phase) {
+    const lineValue = config[`${phase}_line_value`];
+    if (lineValue !== null && lineValue !== undefined && lineValue !== '') {
+        return String(lineValue);
+    }
+
     const lineCol = config[`${phase}_line`];
     if (!lineCol) return '';
     const val = row[lineCol];
@@ -68,9 +87,9 @@ function resolveLineValue(row, config, phase) {
 
 function mapOutcomeColumns(config, values) {
     return {
-        home: values.home !== undefined ? values.home : null,
+        home: values.home !== undefined ? values.home : (values.over !== undefined ? values.over : null),
         draw: values.draw !== undefined ? values.draw : null,
-        away: values.away !== undefined ? values.away : null,
+        away: values.away !== undefined ? values.away : (values.under !== undefined ? values.under : null),
     };
 }
 
@@ -83,10 +102,10 @@ function buildExpandedOddsRows(row, context, matchCore) {
             if (!hasAnyOddsValue(openValues) && !hasAnyOddsValue(closeValues)) continue;
             const openOutcomes = mapOutcomeColumns(config.open, openValues);
             const closeOutcomes = mapOutcomeColumns(config.close, closeValues);
-            const openLine = resolveLineValue(row, config.open, 'open');
-            const closeLine = resolveLineValue(row, config.close, 'close');
-            const hasOpenTriplet = hasCompleteOddsTriplet(openOutcomes);
-            const hasCloseTriplet = hasCompleteOddsTriplet(closeOutcomes);
+            const openLine = resolveLineValue(row, config, 'open');
+            const closeLine = resolveLineValue(row, config, 'close');
+            const hasOpenTriplet = hasCompleteMarketOdds(marketType, openOutcomes);
+            const hasCloseTriplet = hasCompleteMarketOdds(marketType, closeOutcomes);
             const qualityFlags = [];
             if (!hasOpenTriplet && !hasCloseTriplet) {
                 qualityFlags.push(context.WARNING_LOW_QUALITY_SOURCE);
@@ -119,6 +138,7 @@ module.exports = {
     extractOddsValues,
     hasAnyOddsValue,
     hasCompleteOddsTriplet,
+    hasCompleteMarketOdds,
     resolveLineValue,
     mapOutcomeColumns,
     buildExpandedOddsRows,

--- a/scripts/ops/l3_stitch_worker.js
+++ b/scripts/ops/l3_stitch_worker.js
@@ -308,19 +308,18 @@ function buildOddsDataFromHistoricalRows(rows) {
 
 async function prefetchOddsSources(client, rows) {
     const matchIds = rows.map((row) => row.match_id).filter(Boolean);
-    const externalIds = rows.map((row) => row.external_id).filter(Boolean);
 
     const canonicalRows = matchIds.length > 0
         ? (await client.query(FETCH_CANONICAL_ODDS_SQL, [matchIds])).rows
         : [];
 
-    const historicalRows = externalIds.length > 0
-        ? (await client.query(FETCH_BOOKMAKER_HISTORY_SQL, [externalIds])).rows
+    const historicalRows = matchIds.length > 0
+        ? (await client.query(FETCH_BOOKMAKER_HISTORY_SQL, [matchIds])).rows
         : [];
 
     return {
         canonicalByMatchId: groupRowsByKey(canonicalRows, 'match_id'),
-        historicalByExternalId: groupRowsByKey(historicalRows, 'match_id')
+        historicalByMatchId: groupRowsByKey(historicalRows, 'match_id')
     };
 }
 
@@ -339,9 +338,8 @@ function extractBestAvailableOddsFeatures(row, tacticalFeatures, oddsSources) {
         };
     }
 
-    const historicalKey = row.external_id || row.match_id;
     const historicalData = buildOddsDataFromHistoricalRows(
-        oddsSources.historicalByExternalId.get(historicalKey) || []
+        oddsSources.historicalByMatchId.get(row.match_id) || []
     );
 
     if (historicalData) {

--- a/tests/unit/helpers/euroLeagueAdapters.test.js
+++ b/tests/unit/helpers/euroLeagueAdapters.test.js
@@ -75,6 +75,17 @@ test('formatCsvLine - 应正确格式化 CSV 行', () => {
     assert.strictEqual(result, 'Arsenal,Chelsea,2-1');
 });
 
+test('formatCsvLine - 应按指定表头顺序输出', () => {
+    const row = {
+        away: 'Chelsea',
+        score: '2-1',
+        home: 'Arsenal',
+    };
+
+    const result = formatCsvLine(row, ['home', 'away', 'score']);
+    assert.strictEqual(result, 'Arsenal,Chelsea,2-1');
+});
+
 test('formatCsvLine - 应处理包含特殊字符的行', () => {
     const row = {
         team: 'Man Utd',
@@ -202,6 +213,19 @@ test('resolveLineValue - 应处理缺失盘口', () => {
 
     assert.strictEqual(resolveLineValue(row, config, 'close'), '');
     assert.strictEqual(resolveLineValue(row, {}, 'open'), '');
+});
+
+test('resolveLineValue - 应优先返回固定盘口值', () => {
+    const row = {
+        AHh: '-0.5',
+    };
+
+    const config = {
+        open_line_value: '2.5',
+        open_line: 'AHh',
+    };
+
+    assert.strictEqual(resolveLineValue(row, config, 'open'), '2.5');
 });
 
 test('mapOutcomeColumns - 应正确映射结果列', () => {
@@ -370,4 +394,48 @@ test('buildExpandedOddsRows - 应标记低质量数据源', () => {
     // 所以不会标记为 LOW_QUALITY
     // 修改测试以匹配实际行为
     assert.strictEqual(result[0].quality_flags, '');
+});
+
+test('buildExpandedOddsRows - 应支持大小球列映射到内部标准字段', () => {
+    const row = {
+        'B365>2.5': '1.80',
+        'B365<2.5': '2.00',
+        'B365C>2.5': '1.75',
+        'B365C<2.5': '2.05',
+    };
+
+    const context = {
+        oddsConfig: {
+            Bet365: {
+                'Over/Under': {
+                    open: {
+                        over: 'B365>2.5',
+                        under: 'B365<2.5',
+                    },
+                    close: {
+                        over: 'B365C>2.5',
+                        under: 'B365C<2.5',
+                    },
+                    open_line_value: '2.5',
+                    close_line_value: '2.5',
+                },
+            },
+        },
+        WARNING_LOW_QUALITY_SOURCE: 'LOW_QUALITY',
+    };
+
+    const matchCore = {
+        match_id: '47_20242025_1002',
+    };
+
+    const result = buildExpandedOddsRows(row, context, matchCore);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].market_type, 'Over/Under');
+    assert.strictEqual(result[0].open_line, '2.5');
+    assert.strictEqual(result[0].close_line, '2.5');
+    assert.strictEqual(result[0].open_home, '1.80');
+    assert.strictEqual(result[0].open_draw, '');
+    assert.strictEqual(result[0].open_away, '2.00');
+    assert.strictEqual(result[0].close_home, '1.75');
+    assert.strictEqual(result[0].close_away, '2.05');
 });


### PR DESCRIPTION
## Summary

This PR fixes the end-to-end integration of the football-data.co.uk CSV odds pipeline and closes three concrete gaps that were blocking cloud-safe promotion to `main`:

1. adapter configuration normalization for 1x2 / Asian Handicap / Over/Under markets
2. L3 odds history linkage by internal `match_id` instead of drifting on `external_id`
3. CSV output line termination and header-order stability

## What Changed

### 1. Fix adapter config expansion for football-data.co.uk CSV markets

In `scripts/ops/fetch_and_adapt_euro_leagues.js`, the pipeline now builds a normalized `ODDS_CONFIG` from `MARKET_CONFIGS` before passing it into row expansion logic.

Impact:
- 1x2 markets are expanded with the expected open/close columns
- Asian Handicap markets keep their line metadata
- Over/Under markets now preserve fixed line values like `2.5` correctly

### 2. Fix Over/Under and two-way market mapping

In `scripts/ops/helpers/euroLeagueAdapters.js`:

- `formatCsvLine(row, headers)` now supports explicit header order
- `resolveLineValue()` now prefers fixed `open_line_value` / `close_line_value` before reading a CSV column
- `mapOutcomeColumns()` now maps `over/under` into the internal home/away slots used by downstream storage
- `hasCompleteMarketOdds()` distinguishes 1x2 triplets from two-way markets

Impact:
- Over/Under rows no longer lose their `2.5` line context
- downstream expansion gets stable field alignment
- CSV serialization no longer depends on incidental object key order

### 3. Fix L3 linkage to bookmaker odds history by `match_id`

In `scripts/ops/l3_stitch_worker.js`, the fallback fetch from `bookmaker_odds_history` now keys and groups by `match_id`, not by `external_id`.

Current behavior:
- `prefetchOddsSources()` fetches bookmaker history using the assigned `match_id` list
- fallback lookup also reads `historicalByMatchId.get(row.match_id)`
- L3 now correctly hydrates odds features from `bookmaker_odds_history` when canonical `odds` rows are absent

### 4. Fix CSV newline termination

`writeAdaptedCsv()` now writes:
- rows in `OUTPUT_HEADERS` order
- a terminating newline for every row

## Validation

### Unit test

Executed in container:

```bash
docker compose -f docker-compose.dev.yml exec dev node --test tests/unit/helpers/euroLeagueAdapters.test.js
```

Result:
- 22 tests passed
- 0 failed

### 2024/25 Premier League evidence

#### A. L1 / L2 / L3 alignment is complete

```sql
SELECT COUNT(*) AS matches,
       COUNT(r.match_id) AS raw_rows,
       COUNT(l3.match_id) AS l3_rows
FROM matches m
LEFT JOIN raw_match_data r ON r.match_id = m.match_id
LEFT JOIN l3_features l3 ON l3.match_id = m.match_id
WHERE m.league_name = 'Premier League'
  AND m.season = '2024/2025';
```

Result:

```text
matches | raw_rows | l3_rows
380     | 380      | 380
```

#### B. Bookmaker odds history is present for all 380 matches

```sql
SELECT COUNT(*) AS bookmaker_rows,
       COUNT(DISTINCT boh.match_id) AS bookmaker_matches
FROM bookmaker_odds_history boh
JOIN matches m ON m.match_id = boh.match_id
WHERE m.league_name = 'Premier League'
  AND m.season = '2024/2025';
```

Result:

```text
bookmaker_rows | bookmaker_matches
3945           | 380
```

#### C. Market coverage spans all 380 matches

```sql
SELECT market_type,
       COUNT(*) AS rows,
       COUNT(DISTINCT boh.match_id) AS matches
FROM bookmaker_odds_history boh
JOIN matches m ON m.match_id = boh.match_id
WHERE m.league_name = 'Premier League'
  AND m.season = '2024/2025'
GROUP BY market_type
ORDER BY market_type;
```

Result:

```text
1x2            | 1668 | 380
Asian Handicap | 1140 | 380
Over/Under     | 1137 | 380
```

#### D. L3 is now sourcing from `bookmaker_odds_history` even when canonical `odds` is empty

Canonical odds for 2024/25 Premier League:

```sql
SELECT COUNT(*) AS canonical_rows,
       COUNT(DISTINCT o.match_id) AS canonical_matches
FROM odds o
JOIN matches m ON m.match_id = o.match_id
WHERE m.league_name = 'Premier League'
  AND m.season = '2024/2025';
```

Result:

```text
canonical_rows | canonical_matches
0              | 0
```

Observed L3 row:
- `match_id = 47_20242025_7000001`
- `external_id = csv2425e0_0001`
- `odds_features.odds_source = bookmaker_odds_history`
- `stitch_summary.odds_source = bookmaker_odds_history`
- `_odds_source_rows = 5`

## Files changed

- `scripts/ops/fetch_and_adapt_euro_leagues.js`
- `scripts/ops/helpers/euroLeagueAdapters.js`
- `scripts/ops/l3_stitch_worker.js`
- `tests/unit/helpers/euroLeagueAdapters.test.js`

## Merge Guidance

Please wait for all GitHub Actions checks to pass before merging into `main`.