### PR TITLE
chore: harden production gate diagnostics

### DIFF
--- a/.github/workflows/production-gate.yml
+++ b/.github/workflows/production-gate.yml
@@ -84,13 +84,43 @@ jobs:
             mv .cache/buildx-new .cache/buildx
           fi
 
-      - name: Run authority gatekeeper in container
+      - name: Print resolved dev environment
+        run: |
+          docker compose -f docker-compose.dev.yml config > /tmp/production-gate.compose.yml
+          echo "[Production Gate] Resolved dev container environment:"
+          awk '
+            /^  dev:$/ { in_dev=1 }
+            in_dev { print }
+            in_dev && /^    working_dir:/ { exit }
+          ' /tmp/production-gate.compose.yml | \
+            grep -E 'DB_HOST:|DB_PORT:|DB_NAME:|REDIS_HOST:|REDIS_PORT:|PROXY_HOST:|WSL2_PROXY_HOST:|cpus:'
+
+      - name: CI Environment Diagnostics
+        env:
+          DEV_DB_HOST: db
+          DEV_REDIS_HOST: redis
+          DEV_PROXY_HOST: 127.0.0.1
+        run: |
+          docker compose -f docker-compose.dev.yml up -d dev db redis
+          echo "[Production Gate] Working directory:"
+          pwd
+          echo "[Production Gate] Container status:"
+          docker compose -f docker-compose.dev.yml ps
+          echo "[Production Gate] DEV_* environment variables:"
+          env | grep '^DEV_' || true
+          echo "[Production Gate] Container network alias probe (dev -> db):"
+          docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'ping -c 2 db'
+
+      - name: Run Gatekeeper
         env:
           GATEKEEPER_BUILD: "0"
           GATEKEEPER_CI_MODE: ${{ github.event_name == 'pull_request' && 'pr' || 'push' }}
           DEV_DB_HOST: db
           DEV_REDIS_HOST: redis
           DEV_PROXY_HOST: 127.0.0.1
+          DB_BLUEPRINT_DEBUG: "1"
+          DB_BLUEPRINT_CONNECT_TIMEOUT_MS: "5000"
+          DB_BLUEPRINT_STATEMENT_TIMEOUT_MS: "30000"
         run: bash scripts/devops/gatekeeper.sh --mode="${GATEKEEPER_CI_MODE}"
 
   docker-build:

--- a/scripts/devops/gatekeeper.sh
+++ b/scripts/devops/gatekeeper.sh
@@ -38,6 +38,32 @@ fail() {
   exit 1
 }
 
+run_with_failure_reason() {
+  local reason="$1"
+  shift
+
+  local stderr_file=''
+  local status=0
+  stderr_file="$(mktemp -t gatekeeper-stderr.XXXXXX)"
+
+  set +e
+  "$@" 2> >(tee "$stderr_file" >&2)
+  status=$?
+  set -e
+
+  if (( status != 0 )); then
+    printf '[Gatekeeper] GATEKEEPER_FAILURE_REASON=%s\n' "$reason" >&2
+    if [[ -s "$stderr_file" ]]; then
+      printf '[Gatekeeper] STDERR_CAPTURE_BEGIN reason=%s\n' "$reason" >&2
+      cat "$stderr_file" >&2
+      printf '[Gatekeeper] STDERR_CAPTURE_END reason=%s\n' "$reason" >&2
+    fi
+  fi
+
+  rm -f "$stderr_file"
+  return "$status"
+}
+
 resolve_auto_mode() {
   local branch=''
 
@@ -263,6 +289,9 @@ if [[ "${GATEKEEPER_IN_CONTAINER:-0}" != "1" ]]; then
   "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" exec -T "$DEV_SERVICE" \
     env GATEKEEPER_IN_CONTAINER=1 GATEKEEPER_MODE="$MODE" GATEKEEPER_WORKSPACE_ROOT="$WORKSPACE_ROOT" \
     GATEKEEPER_HOST_PREFLIGHT_DONE=1 GITHUB_ACTIONS="${GITHUB_ACTIONS:-}" CI="${CI:-}" \
+    DB_BLUEPRINT_DEBUG="${DB_BLUEPRINT_DEBUG:-}" \
+    DB_BLUEPRINT_CONNECT_TIMEOUT_MS="${DB_BLUEPRINT_CONNECT_TIMEOUT_MS:-}" \
+    DB_BLUEPRINT_STATEMENT_TIMEOUT_MS="${DB_BLUEPRINT_STATEMENT_TIMEOUT_MS:-}" \
     bash "$CONTAINER_GATEKEEPER_PATH"
   exit $?
 fi
@@ -980,8 +1009,9 @@ run_static_quality_checks() {
 
 run_cold_start_integrity_guard() {
   log '执行 [GATE-COLD-START] 冷启动蓝图校验。'
+  log "冷启动参数: DB_HOST=${DB_HOST:-unset} DB_PORT=${DB_PORT:-unset} DB_NAME=${DB_NAME:-unset} admin_db=${DB_ADMIN_NAME:-postgres} connect_timeout_ms=${DB_BLUEPRINT_CONNECT_TIMEOUT_MS:-5000} statement_timeout_ms=${DB_BLUEPRINT_STATEMENT_TIMEOUT_MS:-30000} debug=${DB_BLUEPRINT_DEBUG:-0}"
 
-  node <<'NODE'
+  run_with_failure_reason 'dbBlueprint cold start integrity guard failed' node - <<'NODE'
 const { runColdStartBlueprintCheck } = require('./scripts/ops/helpers/dbBlueprint');
 
 (async () => {
@@ -990,7 +1020,9 @@ const { runColdStartBlueprintCheck } = require('./scripts/ops/helpers/dbBlueprin
     `[GATE-COLD-START] PASS - 空库回放成功 - 临时库 ${result.databaseName}，蓝图 ${result.appliedFiles.length} 个文件`
   );
 })().catch((error) => {
+  console.error('GATEKEEPER_FAILURE_REASON=dbBlueprint cold start integrity guard failed');
   console.error(`[GATE-COLD-START] FAIL - ${error.message}`);
+  console.error(error?.stack || error);
   process.exit(1);
 });
 NODE
@@ -1136,7 +1168,7 @@ run_js_coverage_guard() {
   log "执行 Node 覆盖率门禁（阈值 ${COVERAGE_THRESHOLD}%）。"
   rm -rf "${COVERAGE_DIR}/node"
   mkdir -p "${COVERAGE_DIR}/node"
-  npm run test:coverage
+  run_with_failure_reason 'npm run test:coverage failed' npm run test:coverage
 }
 
 run_python_coverage_guard() {
@@ -1180,7 +1212,7 @@ run_coverage_guards() {
 
 run_recon_core_coverage_guard() {
   log '执行 Recon 核心独立覆盖率门禁（行覆盖率 >= 90%）。'
-  npm run test:coverage:recon-core
+  run_with_failure_reason 'npm run test:coverage:recon-core failed' npm run test:coverage:recon-core
 }
 
 run_remote_merge_enforcement() {

--- a/scripts/ops/helpers/dbBlueprint.js
+++ b/scripts/ops/helpers/dbBlueprint.js
@@ -9,11 +9,37 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const INIT_DB_PATH = path.join(REPO_ROOT, 'deploy/docker/init_db.sql');
 const MIGRATIONS_DIR = path.join(REPO_ROOT, 'database/migrations');
 const CORE_TABLES = ['matches', 'raw_match_data', 'matches_oddsportal_mapping'];
+const DEFAULT_CONNECT_TIMEOUT_MS = Number.parseInt(
+  process.env.DB_BLUEPRINT_CONNECT_TIMEOUT_MS || '5000',
+  10
+);
+const DEFAULT_STATEMENT_TIMEOUT_MS = Number.parseInt(
+  process.env.DB_BLUEPRINT_STATEMENT_TIMEOUT_MS || '30000',
+  10
+);
 const REQUIRED_COLUMNS = {
   matches: ['match_id', 'season', 'pipeline_status'],
   raw_match_data: ['match_id', 'raw_data', 'data_version'],
   matches_oddsportal_mapping: ['match_id', 'season', 'oddsportal_hash', 'is_evidence_only']
 };
+
+function resolveBlueprintLogger(options = {}) {
+  if (typeof options.logger === 'function') {
+    return options.logger;
+  }
+
+  if (process.env.DB_BLUEPRINT_DEBUG === '1') {
+    return (message) => console.log(`[DB-BLUEPRINT] ${message}`);
+  }
+
+  return null;
+}
+
+function emitBlueprintLog(logger, message) {
+  if (typeof logger === 'function') {
+    logger(message);
+  }
+}
 
 function quoteIdentifier(identifier) {
   return `"${String(identifier || '').replace(/"/g, '""')}"`;
@@ -76,8 +102,38 @@ function buildDbConnectionConfig(overrides = {}) {
     database: process.env.DB_NAME || 'football_db',
     user: process.env.DB_USER || 'football_user',
     password: process.env.DB_PASSWORD || 'football_pass',
+    connectionTimeoutMillis: DEFAULT_CONNECT_TIMEOUT_MS,
     ...overrides
   };
+}
+
+function formatDbConnectionTrace(connectionConfig = {}) {
+  return [
+    `host=${connectionConfig.host || '127.0.0.1'}`,
+    `port=${connectionConfig.port || 5432}`,
+    `user=${connectionConfig.user || 'football_user'}`,
+    `database=${connectionConfig.database || 'football_db'}`,
+    `connection_timeout_ms=${connectionConfig.connectionTimeoutMillis ?? 'unset'}`
+  ].join(' ');
+}
+
+async function checkDbConnection(pool, connectionConfig = {}, options = {}) {
+  const label = options.label || 'db_blueprint';
+  const startedAt = Date.now();
+  console.log(`[DB-BLUEPRINT] checkDbConnection.start label=${label} ${formatDbConnectionTrace(connectionConfig)}`);
+
+  try {
+    const client = await pool.connect();
+    console.log(`[DB-BLUEPRINT] checkDbConnection.ok label=${label} ms=${Date.now() - startedAt}`);
+    return client;
+  } catch (err) {
+    const elapsedMs = Date.now() - startedAt;
+    console.error(
+      `[DB-BLUEPRINT] checkDbConnection.fail label=${label} ms=${elapsedMs} ${formatDbConnectionTrace(connectionConfig)}`
+    );
+    console.error(err?.stack || err);
+    throw err;
+  }
 }
 
 function createBlueprintCheckDatabaseName(prefix = 'gatekeeper_cold_start') {
@@ -88,18 +144,24 @@ function createBlueprintCheckDatabaseName(prefix = 'gatekeeper_cold_start') {
     .slice(0, 60);
 }
 
-async function executeSqlFile(client, filePath) {
+async function executeSqlFile(client, filePath, options = {}) {
   const sql = readExecutableSql(filePath);
   if (!sql) {
+    emitBlueprintLog(options.logger, `skip_empty_sql file=${path.relative(REPO_ROOT, filePath)}`);
     return;
   }
+
+  const relativePath = path.relative(REPO_ROOT, filePath);
+  const startedAt = Date.now();
+  emitBlueprintLog(options.logger, `apply_sql.start file=${relativePath}`);
   await client.query(sql);
+  emitBlueprintLog(options.logger, `apply_sql.done file=${relativePath} ms=${Date.now() - startedAt}`);
 }
 
-async function applyBlueprint(client, filePaths = resolveBlueprintSqlFiles()) {
+async function applyBlueprint(client, filePaths = resolveBlueprintSqlFiles(), options = {}) {
   const applied = [];
   for (const filePath of filePaths) {
-    await executeSqlFile(client, filePath);
+    await executeSqlFile(client, filePath, options);
     applied.push(path.relative(REPO_ROOT, filePath));
   }
   return applied;
@@ -162,9 +224,10 @@ async function assertCoreSchema(client) {
   return inspection;
 }
 
-async function runBlueprintWriteProbe(client) {
+async function runBlueprintWriteProbe(client, options = {}) {
   const probeExternalId = `${Date.now()}`;
   const probeMatchId = `999_20252026_${probeExternalId}`;
+  emitBlueprintLog(options.logger, `write_probe.start match_id=${probeMatchId}`);
   await client.query('BEGIN');
   try {
     await client.query(`
@@ -254,55 +317,95 @@ async function runBlueprintWriteProbe(client) {
     `, [probeMatchId]);
 
     await client.query('ROLLBACK');
+    emitBlueprintLog(options.logger, `write_probe.done match_id=${probeMatchId}`);
   } catch (error) {
     await client.query('ROLLBACK');
+    emitBlueprintLog(options.logger, `write_probe.fail match_id=${probeMatchId} error=${error.message}`);
     throw error;
   }
 }
 
 async function withTemporaryDatabase(options = {}, callback) {
+  const logger = resolveBlueprintLogger(options);
   const adminConfig = buildDbConnectionConfig({
     database: options.adminDatabase || process.env.DB_ADMIN_NAME || 'postgres'
   });
   const adminPool = new Pool(adminConfig);
   const databaseName = options.databaseName || createBlueprintCheckDatabaseName(options.prefix);
+  let adminClient = null;
   try {
-    await adminPool.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`);
+    adminClient = await checkDbConnection(adminPool, adminConfig, { label: 'admin_database' });
+    emitBlueprintLog(
+      logger,
+      `create_database.start database=${databaseName} host=${adminConfig.host} port=${adminConfig.port} timeout_ms=${adminConfig.connectionTimeoutMillis}`
+    );
+    await adminClient.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`);
+    emitBlueprintLog(logger, `create_database.done database=${databaseName}`);
     const scopedConfig = buildDbConnectionConfig({ database: databaseName });
     const scopedPool = new Pool(scopedConfig);
     try {
+      emitBlueprintLog(
+        logger,
+        `connect_scoped.ready database=${databaseName} host=${scopedConfig.host} port=${scopedConfig.port} timeout_ms=${scopedConfig.connectionTimeoutMillis}`
+      );
       return await callback({
         databaseName,
         pool: scopedPool,
-        connectionConfig: scopedConfig
+        connectionConfig: scopedConfig,
+        logger
       });
     } finally {
       await scopedPool.end();
+      emitBlueprintLog(logger, `connect_scoped.closed database=${databaseName}`);
     }
   } finally {
     try {
-      await adminPool.query(`
-        SELECT pg_terminate_backend(pid)
-        FROM pg_stat_activity
-        WHERE datname = $1
-          AND pid <> pg_backend_pid()
-      `, [databaseName]);
-      await adminPool.query(`DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)}`);
+      if (adminClient) {
+        emitBlueprintLog(logger, `drop_database.start database=${databaseName}`);
+        await adminClient.query(`
+          SELECT pg_terminate_backend(pid)
+          FROM pg_stat_activity
+          WHERE datname = $1
+            AND pid <> pg_backend_pid()
+        `, [databaseName]);
+        await adminClient.query(`DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)}`);
+        emitBlueprintLog(logger, `drop_database.done database=${databaseName}`);
+      }
     } finally {
+      if (adminClient) {
+        adminClient.release();
+      }
       await adminPool.end();
+      emitBlueprintLog(logger, `admin_pool.closed database=${databaseName}`);
     }
   }
 }
 
 async function runColdStartBlueprintCheck(options = {}) {
-  return withTemporaryDatabase({ prefix: options.prefix || 'gatekeeper_cold_start' }, async ({ pool, databaseName }) => {
-    const client = await pool.connect();
+  return withTemporaryDatabase({ prefix: options.prefix || 'gatekeeper_cold_start', ...options }, async ({
+    pool,
+    databaseName,
+    connectionConfig,
+    logger
+  }) => {
+    const client = await checkDbConnection(pool, connectionConfig, { label: 'cold_start_scoped_database' });
     try {
-      const appliedFiles = await applyBlueprint(client, options.filePaths);
-      const inspection = await assertCoreSchema(client);
-      if (options.runWriteProbe !== false) {
-        await runBlueprintWriteProbe(client);
+      if (Number.isFinite(DEFAULT_STATEMENT_TIMEOUT_MS) && DEFAULT_STATEMENT_TIMEOUT_MS > 0) {
+        await client.query(`SET statement_timeout TO ${DEFAULT_STATEMENT_TIMEOUT_MS}`);
+        emitBlueprintLog(logger, `statement_timeout.set database=${databaseName} timeout_ms=${DEFAULT_STATEMENT_TIMEOUT_MS}`);
       }
+
+      emitBlueprintLog(logger, `cold_start.begin database=${databaseName}`);
+      const appliedFiles = await applyBlueprint(client, options.filePaths, { logger });
+      const inspection = await assertCoreSchema(client);
+      emitBlueprintLog(
+        logger,
+        `schema_assert.done database=${databaseName} missing_tables=${inspection.missingTables.length} missing_columns=${inspection.missingColumns.length}`
+      );
+      if (options.runWriteProbe !== false) {
+        await runBlueprintWriteProbe(client, { logger });
+      }
+      emitBlueprintLog(logger, `cold_start.done database=${databaseName} applied_files=${appliedFiles.length}`);
       return {
         databaseName,
         appliedFiles,
@@ -310,16 +413,19 @@ async function runColdStartBlueprintCheck(options = {}) {
       };
     } finally {
       client.release();
+      emitBlueprintLog(logger, `client.released database=${databaseName}`);
     }
   });
 }
 
 async function ensureBlueprintOnCurrentDatabase(options = {}) {
-  const pool = new Pool(buildDbConnectionConfig({
+  const connectionConfig = buildDbConnectionConfig({
     database: options.database || process.env.DB_NAME || 'football_db'
-  }));
-  const client = await pool.connect();
+  });
+  const pool = new Pool(connectionConfig);
+  let client = null;
   try {
+    client = await checkDbConnection(pool, connectionConfig, { label: 'current_database_blueprint' });
     const before = await inspectCoreSchema(client);
     const requiresBlueprint = before.missingTables.length > 0 || before.missingColumns.length > 0;
     const appliedFiles = [];
@@ -351,7 +457,9 @@ async function ensureBlueprintOnCurrentDatabase(options = {}) {
       after
     };
   } finally {
-    client.release();
+    if (client) {
+      client.release();
+    }
     await pool.end();
   }
 }
@@ -366,6 +474,7 @@ module.exports = {
   resolveBlueprintSqlFiles,
   resolveMigrationSqlFiles,
   readExecutableSql,
+  checkDbConnection,
   applyBlueprint,
   inspectCoreSchema,
   assertCoreSchema,


### PR DESCRIPTION
## Summary
- 在 `scripts/ops/helpers/dbBlueprint.js` 增加数据库连接黑匣子追踪，显式记录 host/port/user、连接超时、失败耗时与堆栈
- 在 `.github/workflows/production-gate.yml` 插入 `CI Environment Diagnostics` 预检步骤，输出 `pwd`、`docker compose ps`、`DEV_*` 环境变量与容器内 `ping -c 2 db` 结果
- 在 `scripts/devops/gatekeeper.sh` 增加 `GATEKEEPER_FAILURE_REASON` 与 stderr 捕获，避免 `dbBlueprint` 与 `npm run test:*` 路径静默失败

## Verification
- `docker compose -f docker-compose.dev.yml config`
- `docker compose -f docker-compose.dev.yml exec -T dev bash -n /app/scripts/devops/gatekeeper.sh`
- `docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'ping -c 2 db'`
- `docker compose -f docker-compose.dev.yml exec -T dev env DB_HOST=db DB_PORT=5432 DB_NAME=football_db DB_USER=football_user DB_PASSWORD=football_pass DB_BLUEPRINT_DEBUG=1 DB_BLUEPRINT_CONNECT_TIMEOUT_MS=5000 DB_BLUEPRINT_STATEMENT_TIMEOUT_MS=30000 node - <<'NODE' ... NODE`
- 本地 `git commit` 触发的 commit 门禁通过
- 本地 `git push` 触发的 PR 门禁通过

## Diagnostics
- 下次红灯先看 GitHub Actions 的 `CI Environment Diagnostics` Step
- 若预检通过但仍失败，再看 `Run Gatekeeper` Step 中的 `GATEKEEPER_FAILURE_REASON` 与 `[DB-BLUEPRINT] checkDbConnection.fail`
