### PR TITLE
test(coverage): raise expansion gate above threshold

### DIFF
--- a/scripts/ops/batch_historical_backfill.js
+++ b/scripts/ops/batch_historical_backfill.js
@@ -250,6 +250,7 @@ function runDiscovery(target, season, options) {
         return;
     }
 
+    const commandRunner = options.commandRunner || runCommand;
     const args = [
         'scripts/ops/titan_discovery.js',
         `--league=${target.id}`,
@@ -263,7 +264,7 @@ function runDiscovery(target, season, options) {
         args.push('--dry-run');
     }
 
-    runCommand(`L1 低频播种 ${target.name} ${season}`, 'node', args, {
+    commandRunner(`L1 低频播种 ${target.name} ${season}`, 'node', args, {
         env: { FOTMOB_COMPLIANCE_MODE: 'true' },
     });
 }
@@ -275,8 +276,9 @@ function runCsvFlow(target, season, options) {
 
     const outputPath = buildAdaptedCsvPath(options.outputDir, target, season);
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    const commandRunner = options.commandRunner || runCommand;
 
-    runCommand(`下载并适配 CSV ${target.code} ${season}`, 'node', [
+    commandRunner(`下载并适配 CSV ${target.code} ${season}`, 'node', [
         'scripts/ops/fetch_and_adapt_euro_leagues.js',
         '--league-code',
         target.code,
@@ -299,7 +301,7 @@ function runCsvFlow(target, season, options) {
         loaderArgs.push('--commit');
     }
 
-    runCommand(`导入 matches / bookmaker_odds_history ${target.name} ${season}`, 'node', loaderArgs);
+    commandRunner(`导入 matches / bookmaker_odds_history ${target.name} ${season}`, 'node', loaderArgs);
     return outputPath;
 }
 
@@ -308,7 +310,8 @@ function runComplianceHarvest(target, season, options) {
         return;
     }
 
-    runCommand(
+    const commandRunner = options.commandRunner || runCommand;
+    commandRunner(
         `FOTMOB 合规低频 L2 ${target.name} ${season}`,
         'node',
         [
@@ -335,15 +338,16 @@ function runComplianceHarvest(target, season, options) {
 }
 
 function runPostProcessing(options) {
+    const commandRunner = options.commandRunner || runCommand;
     if (!options.skipElo) {
-        runCommand('ELO 全量重算', 'node', [
+        commandRunner('ELO 全量重算', 'node', [
             'scripts/maintenance/recalculate_elo.js',
             ...(options.dryRun ? ['--dry-run'] : []),
         ]);
     }
 
     if (!options.skipL3) {
-        runCommand('L3 特征熔炼', 'node', ['scripts/ops/smelt_all.js', ...(options.dryRun ? ['--dry-run'] : [])]);
+        commandRunner('L3 特征熔炼', 'node', ['scripts/ops/smelt_all.js', ...(options.dryRun ? ['--dry-run'] : [])]);
     }
 }
 
@@ -408,6 +412,7 @@ async function main(argv = process.argv.slice(2)) {
     return report;
 }
 
+/* node:coverage ignore next 6 */
 if (require.main === module) {
     main().catch(error => {
         console.error(`[EXPANSION] 失败: ${error.message}`);
@@ -419,8 +424,16 @@ module.exports = {
     DEFAULT_SEASONS,
     EXPANSION_TARGETS,
     SEASON_CODE_BY_SEASON,
+    buildAdaptedCsvPath,
     buildPlan,
+    main,
     normalizeSeasonInput,
     parseArgs,
     resolveTargets,
+    runCommand,
+    runComplianceHarvest,
+    runCsvFlow,
+    runDiscovery,
+    runPostProcessing,
+    writeReport,
 };

--- a/tests/unit/BatchHistoricalBackfill.test.js
+++ b/tests/unit/BatchHistoricalBackfill.test.js
@@ -2,14 +2,25 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
     DEFAULT_SEASONS,
     EXPANSION_TARGETS,
+    buildAdaptedCsvPath,
     buildPlan,
+    main,
     normalizeSeasonInput,
     parseArgs,
     resolveTargets,
+    runCommand,
+    runComplianceHarvest,
+    runCsvFlow,
+    runDiscovery,
+    runPostProcessing,
+    writeReport,
 } = require('../../scripts/ops/batch_historical_backfill');
 
 test('batch_historical_backfill 默认覆盖三季和 12 个扩军目标', () => {
@@ -52,4 +63,172 @@ test('batch_historical_backfill 扩军目标应包含真实 FotMob 二级联赛 
         EXPANSION_TARGETS.some(target => target.id === 77 && target.code === 'D2'),
         false
     );
+});
+
+test('batch_historical_backfill CLI 应覆盖防御性参数分支', () => {
+    const absoluteOutput = path.join(os.tmpdir(), 'expansion.csv');
+    const options = parseArgs([
+        '',
+        '--dry-run',
+        '--fotmob-compliance',
+        '--skip-discovery',
+        '--skip-csv',
+        '--skip-elo',
+        '--skip-l3',
+        '--output-dir',
+        absoluteOutput,
+        '--harvest-limit',
+        '7',
+        '--leagues',
+        'D2,146,D2',
+        '--seasons',
+        '2022/2023,20222023',
+    ]);
+    const plan = buildPlan(options);
+
+    assert.equal(options.commit, false);
+    assert.equal(options.dryRun, true);
+    assert.equal(options.fotmobCompliance, true);
+    assert.equal(options.skipDiscovery, true);
+    assert.equal(options.skipCsv, true);
+    assert.equal(options.skipElo, true);
+    assert.equal(options.skipL3, true);
+    assert.equal(options.outputDir, absoluteOutput);
+    assert.equal(options.harvestLimit, 7);
+    assert.deepEqual(plan.seasons, ['2022/2023']);
+    assert.deepEqual(
+        plan.targets.map(target => target.code),
+        ['D2']
+    );
+
+    assert.throws(() => parseArgs(['--leagues']), /参数 --leagues 缺少值/);
+    assert.throws(() => parseArgs(['--harvest-limit', '0']), /参数 --harvest-limit 必须是正整数/);
+    assert.throws(() => parseArgs(['--unknown']), /未知参数/);
+    assert.throws(() => resolveTargets(['NOPE']), /未支持的扩军联赛/);
+});
+
+test('batch_historical_backfill 编排辅助函数应支持安全短路与失败降级', async () => {
+    const target = resolveTargets(['D2'])[0];
+    const outputPath = buildAdaptedCsvPath('/tmp/expansion-output', target, '2022/2023');
+
+    assert.equal(outputPath, '/tmp/expansion-output/D2_2223_adapted.csv');
+    assert.equal(runCsvFlow(target, '2022/2023', { skipCsv: true }), null);
+    assert.doesNotThrow(() => runDiscovery(target, '2022/2023', { skipDiscovery: true, fotmobCompliance: true }));
+    assert.doesNotThrow(() => runDiscovery(target, '2022/2023', { skipDiscovery: false, fotmobCompliance: false }));
+    assert.doesNotThrow(() => runComplianceHarvest(target, '2022/2023', { fotmobCompliance: false, dryRun: false }));
+    assert.doesNotThrow(() => runComplianceHarvest(target, '2022/2023', { fotmobCompliance: true, dryRun: true }));
+    assert.doesNotThrow(() => runPostProcessing({ skipElo: true, skipL3: true }));
+
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+        assert.equal(await main(['--help']), null);
+    } finally {
+        console.log = originalLog;
+    }
+
+    const originalMkdirSync = fs.mkdirSync;
+    const originalWarn = console.warn;
+    fs.mkdirSync = () => {
+        throw new Error('locked');
+    };
+    console.warn = () => {};
+    try {
+        assert.equal(writeReport({ ok: true }), null);
+    } finally {
+        fs.mkdirSync = originalMkdirSync;
+        console.warn = originalWarn;
+    }
+
+    assert.doesNotThrow(() => runCommand('成功命令', process.execPath, ['-e', 'process.exit(0)']));
+    assert.throws(() => runCommand('失败命令', process.execPath, ['-e', 'process.exit(3)']), /失败命令 失败: exit=3/);
+});
+
+test('batch_historical_backfill 主流程 dry-run 应在全跳过模式下生成收口报告', async () => {
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+        const report = await main([
+            '--dry-run',
+            '--skip-discovery',
+            '--skip-csv',
+            '--skip-elo',
+            '--skip-l3',
+            '--leagues',
+            'D2',
+            '--season',
+            '2022/2023',
+        ]);
+
+        assert.equal(report.mode, 'dry-run');
+        assert.equal(report.expectedMatches, 306);
+        assert.deepEqual(report.seasons, ['2022/2023']);
+        assert.deepEqual(
+            report.targets.map(target => target.code),
+            ['D2']
+        );
+        assert.deepEqual(report.csvFiles, []);
+        assert.match(report.startedAt, /^\d{4}-\d{2}-\d{2}T/);
+        assert.match(report.finishedAt, /^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+        console.log = originalLog;
+    }
+});
+
+test('batch_historical_backfill 应按顺序编排真实入口但允许测试替换命令执行器', () => {
+    const calls = [];
+    const commandRunner = (label, command, args, options = {}) => {
+        calls.push({ label, command, args, env: options.env || {} });
+    };
+    const target = resolveTargets(['D2'])[0];
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'historical-backfill-'));
+
+    runDiscovery(target, '2022/2023', {
+        dryRun: true,
+        fotmobCompliance: true,
+        skipDiscovery: false,
+        commandRunner,
+    });
+    const csvPath = runCsvFlow(target, '2022/2023', {
+        commit: true,
+        skipCsv: false,
+        outputDir,
+        commandRunner,
+    });
+    runComplianceHarvest(target, '2022/2023', {
+        dryRun: false,
+        fotmobCompliance: true,
+        harvestLimit: 3,
+        commandRunner,
+    });
+    runPostProcessing({ dryRun: true, skipElo: false, skipL3: false, commandRunner });
+
+    assert.equal(csvPath, path.join(outputDir, 'D2_2223_adapted.csv'));
+    assert.deepEqual(
+        calls.map(call => call.label),
+        [
+            'L1 低频播种 2. Bundesliga 2022/2023',
+            '下载并适配 CSV D2 2022/2023',
+            '导入 matches / bookmaker_odds_history 2. Bundesliga 2022/2023',
+            'FOTMOB 合规低频 L2 2. Bundesliga 2022/2023',
+            'ELO 全量重算',
+            'L3 特征熔炼',
+        ]
+    );
+    assert.equal(calls[0].command, 'node');
+    assert.ok(calls[0].args.includes('--dry-run'));
+    assert.equal(calls[0].env.FOTMOB_COMPLIANCE_MODE, 'true');
+    assert.deepEqual(calls[1].args.slice(0, 5), [
+        'scripts/ops/fetch_and_adapt_euro_leagues.js',
+        '--league-code',
+        'D2',
+        '--season-code',
+        '2223',
+    ]);
+    assert.ok(calls[2].args.includes('--commit'));
+    assert.ok(calls[3].args.includes('--limit'));
+    assert.ok(calls[3].args.includes('3'));
+    assert.equal(calls[3].env.MAX_WORKERS, '1');
+    assert.ok(calls[4].args.includes('--dry-run'));
+    assert.ok(calls[5].args.includes('--dry-run'));
 });

--- a/tests/unit/EuroLeagueAdapters.test.js
+++ b/tests/unit/EuroLeagueAdapters.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    calculateAlignmentScore,
+    calculateStringSimilarity,
+    extractOddsValues,
+    formatCsvLine,
+    hasAnyOddsValue,
+    hasCompleteMarketOdds,
+    hasCompleteOddsTriplet,
+    mapOutcomeColumns,
+    normalizeText,
+    parseFootballDataDateTime,
+    resolveCsvField,
+    resolveLeagueTimezone,
+    resolveLineValue,
+    selectBestAlignmentCandidate,
+    toCsvCell,
+    buildExpandedOddsRows,
+} = require('../../scripts/ops/helpers/euroLeagueAdapters');
+
+test('euroLeagueAdapters 应规范化 CSV 字段、时间和文本相似度', () => {
+    assert.equal(resolveLeagueTimezone('Bundesliga'), 'Europe/Berlin');
+    assert.equal(resolveLeagueTimezone('Championship'), 'Europe/London');
+    assert.equal(resolveLeagueTimezone('Unknown League'), 'UTC');
+    assert.equal(resolveCsvField({ HomeTeam: '', home: 'Darmstadt' }, ['HomeTeam', 'home']), 'Darmstadt');
+    assert.equal(resolveCsvField({ HomeTeam: '' }, ['HomeTeam', 'home']), null);
+    assert.equal(toCsvCell('Borussia, Dortmund'), '"Borussia, Dortmund"');
+    assert.equal(toCsvCell('He said "yes"'), '"He said ""yes"""');
+    assert.equal(formatCsvLine({ home: 'A', away: 'B' }, ['away', 'home']), 'B,A');
+    assert.equal(parseFootballDataDateTime('', '15:00'), null);
+    assert.equal(parseFootballDataDateTime('01/08/22', '20:30', { timeZone: 'UTC' }), '2022-08-01T20:30:00.000Z');
+    assert.equal(parseFootballDataDateTime('01/08/2022', '', { timeZone: 'UTC' }), '2022-08-01T15:00:00.000Z');
+    assert.equal(normalizeText('Borussia Dortmund'), 'Borussia Dortmund');
+    assert.equal(calculateStringSimilarity('', 'Dortmund'), 0);
+    assert.equal(calculateStringSimilarity('Borussia Dortmund', 'Borussia Dortmund'), 1);
+    assert.ok(calculateStringSimilarity('FC Koln', 'Koln') > 0.8);
+});
+
+test('euroLeagueAdapters 应给候选比赛生成可解释的对齐结果', () => {
+    const target = {
+        homeTeam: 'Hamburger SV',
+        awayTeam: 'St Pauli',
+        matchDate: '2022-08-01T18:30:00.000Z',
+    };
+    const candidates = [
+        {
+            match_id: 'later',
+            home_team: 'Hamburger SV',
+            away_team: 'St Pauli',
+            match_date: '2022-08-01T19:00:00.000Z',
+        },
+        {
+            match_id: 'best',
+            home_team: 'Hamburger SV',
+            away_team: 'St Pauli',
+            match_date: '2022-08-01T18:30:00.000Z',
+        },
+    ];
+
+    const score = calculateAlignmentScore({
+        requestedHomeTeam: target.homeTeam,
+        requestedAwayTeam: target.awayTeam,
+        requestedMatchDate: target.matchDate,
+        candidateHomeTeam: candidates[0].home_team,
+        candidateAwayTeam: candidates[0].away_team,
+        candidateMatchDate: candidates[0].match_date,
+    });
+    assert.equal(score.homeSimilarity, 1);
+    assert.equal(score.awaySimilarity, 1);
+    assert.ok(score.timeScore < 1);
+
+    const matched = selectBestAlignmentCandidate([candidates[1]], target);
+    assert.equal(matched.status, 'matched');
+    assert.equal(matched.candidate.match_id, 'best');
+    assert.equal(matched.alignmentMeta.name_similarity, 1);
+
+    assert.equal(selectBestAlignmentCandidate([], target).status, 'not_found');
+    assert.equal(
+        selectBestAlignmentCandidate(
+            [
+                {
+                    match_id: 'reversed',
+                    home_team: 'St Pauli',
+                    away_team: 'Hamburger SV',
+                    match_date: target.matchDate,
+                },
+            ],
+            target
+        ).status,
+        'orientation_conflict'
+    );
+    assert.equal(
+        selectBestAlignmentCandidate(
+            [
+                {
+                    match_id: 'weak',
+                    home_team: 'Unrelated Home',
+                    away_team: 'Unrelated Away',
+                    match_date: target.matchDate,
+                },
+            ],
+            target,
+            { minConfidenceScore: 0.95, minOrientationMargin: -1 }
+        ).status,
+        'low_confidence'
+    );
+    assert.equal(selectBestAlignmentCandidate(candidates, target, { minScoreGap: 0.99 }).status, 'ambiguous');
+});
+
+test('euroLeagueAdapters 应展开多市场赔率行并标记低质量来源', () => {
+    const row = {
+        openHome: '1.80',
+        openDraw: '3.50',
+        openAway: '4.20',
+        closeHome: '1.75',
+        closeDraw: '3.60',
+        closeAway: '4.40',
+        over: '1.91',
+        line: '2.5',
+    };
+    const oddsConfig = {
+        Pinnacle: {
+            '1x2': {
+                open: { home: 'openHome', draw: 'openDraw', away: 'openAway' },
+                close: { home: 'closeHome', draw: 'closeDraw', away: 'closeAway' },
+                open_line_value: '',
+                close_line: 'line',
+            },
+            goals: {
+                open: { over: 'missingOver', under: 'missingUnder' },
+                close: { over: 'over', under: 'missingUnder' },
+                open_line: 'missingLine',
+                close_line_value: '2.5',
+            },
+        },
+    };
+
+    const values = extractOddsValues(row, oddsConfig.Pinnacle['1x2'].open);
+    assert.deepEqual(values, { home: '1.80', draw: '3.50', away: '4.20' });
+    assert.equal(hasAnyOddsValue(values), true);
+    assert.equal(hasAnyOddsValue({ home: '', away: null }), false);
+    assert.equal(hasCompleteOddsTriplet(values), true);
+    assert.equal(hasCompleteMarketOdds('1x2', values), true);
+    assert.equal(hasCompleteMarketOdds('goals', { home: '1.91', away: '1.91' }), true);
+    assert.equal(resolveLineValue(row, oddsConfig.Pinnacle['1x2'], 'close'), '2.5');
+    assert.equal(resolveLineValue(row, oddsConfig.Pinnacle.goals, 'open'), '');
+    assert.deepEqual(mapOutcomeColumns({}, { over: '1.91', under: '1.95' }), {
+        home: '1.91',
+        draw: null,
+        away: '1.95',
+    });
+
+    const expanded = buildExpandedOddsRows(
+        row,
+        {
+            oddsConfig,
+            WARNING_LOW_QUALITY_SOURCE: 'LOW_QUALITY_SOURCE',
+        },
+        {
+            match_id: 'D2_20222023_1',
+            season: '2022/2023',
+        }
+    );
+
+    assert.equal(expanded.length, 2);
+    assert.equal(expanded[0].bookmaker_name, 'Pinnacle');
+    assert.equal(expanded[0].market_type, '1x2');
+    assert.equal(expanded[0].close_away, '4.40');
+    assert.equal(expanded[0].quality_flags, '');
+    assert.equal(expanded[1].market_type, 'goals');
+    assert.equal(expanded[1].close_line, '2.5');
+    assert.equal(expanded[1].quality_flags, 'LOW_QUALITY_SOURCE');
+});

--- a/tests/unit/OddsPortalDom.test.js
+++ b/tests/unit/OddsPortalDom.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { extractOddsFromDOM } = require('../../src/infrastructure/shared/helpers/oddsPortalDom');
+
+async function withFakeDom(documentStub, callback) {
+    const originalDocument = global.document;
+    const originalWindow = global.window;
+    global.document = documentStub;
+    global.window = {
+        location: {
+            href: 'https://www.oddsportal.com/football/germany/2-bundesliga/sample/',
+        },
+    };
+
+    try {
+        return await callback();
+    } finally {
+        global.document = originalDocument;
+        global.window = originalWindow;
+    }
+}
+
+function buildPage() {
+    return {
+        evaluate(fn) {
+            return fn();
+        },
+    };
+}
+
+test('oddsPortalDom 应优先从脚本 JSON 提取 1x2，并识别主力庄家行', async () => {
+    const documentStub = {
+        title: 'OddsPortal sample',
+        body: {
+            innerText: 'Pinnacle 1.91 3.40 4.20 Bet365 1.95 3.30 4.10',
+        },
+        querySelectorAll(selector) {
+            if (selector === 'script') {
+                return [
+                    {
+                        textContent: 'window.__DATA__={"odds":{"1x2":[1.91,3.4,4.2]}};',
+                    },
+                ];
+            }
+            if (selector === 'tr, .row, .bookmaker-row, [class*="bookmaker"]') {
+                return [{ innerText: 'Pinnacle 1.91 3.40 4.20' }, { innerText: 'Bet365 1.95 3.30 4.10' }];
+            }
+            return [];
+        },
+    };
+
+    const result = await withFakeDom(documentStub, () => extractOddsFromDOM(buildPage()));
+
+    assert.deepEqual(result['1x2'], ['1.91', '3.40', '4.20']);
+    assert.deepEqual(result.pinnacleOdds, ['1.91', '3.40', '4.20']);
+    assert.deepEqual(result.bet365Odds, ['1.95', '3.30', '4.10']);
+    assert.equal(result._source, 'script_json');
+    assert.equal(result._diagnostic.title, 'OddsPortal sample');
+});
+
+test('oddsPortalDom 应在无脚本赔率时回退到标准 DOM 选择器并设置主赔率', async () => {
+    const documentStub = {
+        title: 'DOM odds sample',
+        body: {
+            innerText: 'fallback text 9.99 8.88 7.77',
+        },
+        querySelectorAll(selector) {
+            if (selector === 'script' || selector === 'tr, .row, .bookmaker-row, [class*="bookmaker"]') {
+                return [];
+            }
+            if (selector === '[data-testid*="odd"]') {
+                return [{ textContent: '2.05' }, { textContent: '3.15' }, { textContent: '3.80' }];
+            }
+            return [];
+        },
+    };
+
+    const result = await withFakeDom(documentStub, () => extractOddsFromDOM(buildPage()));
+
+    assert.deepEqual(result['1x2'], ['2.05', '3.15', '3.80']);
+    assert.deepEqual(result.pinnacleOdds, ['2.05', '3.15', '3.80']);
+    assert.equal(result.bet365Odds, null);
+    assert.equal(result._source, 'dom_[data-testid*="odd"]');
+});
+
+test('oddsPortalDom 应在脚本扫描异常或脚本无效时继续走文本回退', async () => {
+    const selectorCalls = [];
+    const documentStub = {
+        title: 'Fallback odds sample',
+        body: {
+            innerText: 'Pinnacle suspended 1.88 3.25 4.50',
+        },
+        querySelectorAll(selector) {
+            selectorCalls.push(selector);
+            if (selector === 'script') {
+                throw new Error('blocked script access');
+            }
+            if (selector === 'tr, .row, .bookmaker-row, [class*="bookmaker"]') {
+                return [{ innerText: 'Pinnacle suspended' }];
+            }
+            if (selector === '.odds') {
+                return [{ textContent: 'N/A' }, { textContent: '0.99' }, { textContent: '101.00' }];
+            }
+            return [];
+        },
+    };
+
+    const result = await withFakeDom(documentStub, () => extractOddsFromDOM(buildPage()));
+
+    assert.ok(selectorCalls.includes('script'));
+    assert.deepEqual(result['1x2'], ['1.88', '3.25', '4.50']);
+    assert.deepEqual(result.pinnacleOdds, ['1.88', '3.25', '4.50']);
+    assert.equal(result.bet365Odds, null);
+    assert.equal(result._source, 'text_extract');
+});


### PR DESCRIPTION
## Summary
- add batch historical backfill tests for CLI guards, skip paths, command-runner injection, reports, and orchestration order
- add pure DOM odds extraction fallback tests
- add euro league adapter tests for alignment, CSV formatting, dates, and odds row expansion

## Validation
- docker compose -f docker-compose.dev.yml exec -T dev npm run lint
- docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check scripts/ops/batch_historical_backfill.js tests/unit/BatchHistoricalBackfill.test.js tests/unit/OddsPortalDom.test.js tests/unit/EuroLeagueAdapters.test.js
- docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage => lines=87.64 branches=80.11 functions=80.10
- git pre-commit and pre-push Gatekeeper passed with DEV_DB_HOST=db DEV_REDIS_HOST=redis