### PR TITLE
chore(repo): add model artifact recovery scaffold

### DIFF
--- a/config/model_artifacts.example.json
+++ b/config/model_artifacts.example.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "description": "Example manifest for model artifacts. Do not put secrets or real private URLs in this file.",
+  "artifact_root": "models",
+  "model_zoo_root": "model_zoo",
+  "artifacts": [
+    {
+      "name": "baseline_v1_result_1x2",
+      "path": "models/baseline_v1/baseline_v1_result_1x2.calibrated.joblib",
+      "required_for": "prediction_runtime",
+      "source": "external_artifact_storage_or_training_pipeline",
+      "checksum_sha256": "TODO"
+    },
+    {
+      "name": "titan_v4468_combat",
+      "path": "models/titan_v4468_combat.joblib",
+      "required_for": "prediction_runtime",
+      "source": "external_artifact_storage_or_training_pipeline",
+      "checksum_sha256": "TODO"
+    }
+  ],
+  "notes": [
+    "This is a template only.",
+    "Do not commit real model binaries to Git.",
+    "Do not commit private artifact URLs or credentials.",
+    "Use local ignored directories such as models/ and model_zoo/ for restored artifacts."
+  ]
+}

--- a/docs/MODEL_ARTIFACTS.md
+++ b/docs/MODEL_ARTIFACTS.md
@@ -50,3 +50,29 @@ Recommended next steps:
 2. Add a model download or generation script.
 3. Document required model filenames and checksums.
 4. Ensure CI does not depend on local-only model files.
+
+## Recovery Workflow
+
+This is currently a recovery scaffold only. Production model artifact storage still needs a follow-up integration with object storage, release artifacts, or the training pipeline.
+
+1. Copy `config/model_artifacts.example.json` to `config/model_artifacts.json`.
+2. Fill in the required artifact list and checksums.
+3. Restore artifacts from external storage or regenerate them via the training pipeline.
+4. Place restored files under ignored local directories such as `models/` and `model_zoo/`.
+5. Run:
+
+```bash
+python scripts/model_artifacts/check_model_artifacts.py
+```
+
+For CI or documentation-only validation:
+
+```bash
+python scripts/model_artifacts/check_model_artifacts.py --allow-missing
+```
+
+## Important
+
+Fresh clones do not include production model artifacts.
+Prediction workloads require restored or regenerated model files.
+Unit tests should not depend on production model binaries.

--- a/docs/_reports/REPO_SLIMMING_PHASE2_5_MODEL_ARTIFACT_RECOVERY.md
+++ b/docs/_reports/REPO_SLIMMING_PHASE2_5_MODEL_ARTIFACT_RECOVERY.md
@@ -1,0 +1,32 @@
+# Repo Slimming Phase 2.5 Model Artifact Recovery
+
+## 1. Purpose
+
+This phase adds a minimal recovery/checking scaffold for model artifacts after removing model binaries from Git.
+
+## 2. What Changed
+
+- Added model artifact manifest template
+- Added model artifact checking script
+- Updated model artifact documentation
+
+## 3. What This Does Not Do
+
+This phase does not:
+
+- download production models
+- commit model binaries
+- configure private artifact storage
+- modify prediction runtime logic
+- rewrite Git history
+
+## 4. Current Risk
+
+Fresh clones still require model artifact restoration before prediction workloads can run.
+
+## 5. Next Steps
+
+- Define canonical model artifact storage
+- Add authenticated download mechanism if needed
+- Add checksums for real artifacts
+- Add CI-safe tests that do not require production models

--- a/scripts/model_artifacts/check_model_artifacts.py
+++ b/scripts/model_artifacts/check_model_artifacts.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Check local model artifacts listed in a manifest.
+
+This script does not download, delete, or modify files. It only reports whether
+the configured artifact paths exist in the local checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+DEFAULT_MANIFEST = Path("config/model_artifacts.json")
+EXAMPLE_MANIFEST = Path("config/model_artifacts.example.json")
+
+
+class ManifestError(ValueError):
+    """Raised when the artifact manifest is invalid."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check local model artifact files.")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Path to model artifact manifest. Defaults to config/model_artifacts.json, falling back to the example manifest.",
+    )
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="Exit successfully even when artifact files are missing.",
+    )
+    return parser.parse_args()
+
+
+def resolve_manifest_path(manifest_arg: Path | None) -> Path:
+    if manifest_arg is not None:
+        return manifest_arg
+    if DEFAULT_MANIFEST.exists():
+        return DEFAULT_MANIFEST
+    return EXAMPLE_MANIFEST
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ManifestError(f"Manifest file does not exist: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"Invalid JSON in manifest {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ManifestError("Manifest root must be a JSON object")
+    artifacts = data.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ManifestError("Manifest field 'artifacts' must be a list")
+    return data
+
+
+def validate_artifact(raw: Any, index: int) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        raise ManifestError(f"Artifact entry #{index} must be an object")
+
+    name = raw.get("name")
+    path = raw.get("path")
+    if not isinstance(name, str) or not name.strip():
+        raise ManifestError(f"Artifact entry #{index} is missing a non-empty 'name'")
+    if not isinstance(path, str) or not path.strip():
+        raise ManifestError(f"Artifact entry #{index} is missing a non-empty 'path'")
+
+    return {"name": name, "path": path}
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = resolve_manifest_path(args.manifest)
+
+    try:
+        manifest = load_manifest(manifest_path)
+        artifacts = [
+            validate_artifact(raw, index)
+            for index, raw in enumerate(manifest.get("artifacts", []), start=1)
+        ]
+    except ManifestError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Manifest: {manifest_path}")
+
+    missing = 0
+    for artifact in artifacts:
+        artifact_path = Path(artifact["path"])
+        if artifact_path.exists():
+            print(f"FOUND: {artifact['name']} -> {artifact_path}")
+        else:
+            print(f"MISSING: {artifact['name']} -> {artifact_path}")
+            missing += 1
+
+    total = len(artifacts)
+    print(f"total={total}")
+    print(f"missing={missing}")
+
+    if missing and not args.allow_missing:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds Phase 2.5 of the repository slimming work: a minimal model artifact recovery/checking scaffold.

## Changes

- Add `config/model_artifacts.example.json`
- Add `scripts/model_artifacts/check_model_artifacts.py`
- Update `docs/MODEL_ARTIFACTS.md`
- Add `docs/_reports/REPO_SLIMMING_PHASE2_5_MODEL_ARTIFACT_RECOVERY.md`

## Validation

- `git diff --check` passed
- Artifact checker passes with `--allow-missing`
- Artifact checker fails without `--allow-missing` when model files are missing, as expected
- `docker compose -f docker-compose.dev.yml config` passed
- No business code changed
- No model binaries committed
- No private URLs or credentials added

## Important Notes

This PR does **not** download production models.

It only adds a manifest template and a checker script so that future fresh clones can detect missing model artifacts clearly.

Fresh clones still require either:

1. external model artifact storage, or
2. a model training/generation workflow.

## Follow-up

Recommended next steps:

1. Define canonical external model artifact storage.
2. Add a download or restore script if appropriate.
3. Add real artifact checksums outside Git or in a safe manifest.
4. Plan Phase 3 history cleanup separately with backup and re-clone migration steps.