### PR TITLE
docs(repo): add history rewrite go no-go checklist

### DIFF
--- a/docs/REPO_HISTORY_REWRITE_GO_NO_GO.md
+++ b/docs/REPO_HISTORY_REWRITE_GO_NO_GO.md
@@ -1,0 +1,155 @@
+# Repository History Rewrite Go / No-Go Checklist
+
+## 1. Purpose
+
+This document is the final approval checklist before any real Git history rewrite.
+
+It is an approval artifact only. It does not authorize automated execution, and it must not be treated as a script.
+
+## 2. Current Status
+
+- Phase 1 completed: `.gitignore` guardrails and data/model storage policy are merged.
+- Phase 2 completed: `models/` and `model_zoo/` were removed from the current Git index.
+- Phase 2.5 completed: model artifact recovery/checking scaffold is merged.
+- Phase 3 planning completed: history cleanup plan and audit are merged.
+- Phase 3.1 dry run recorded: first automatic candidate run stopped at the safety gate.
+- Phase 3.2 dry run recorded: narrower mirror dry run completed.
+- Phase 3.3 manual dry run recorded: manual-path mirror dry run completed.
+- Real history rewrite not yet executed.
+
+Current repository state before any real rewrite:
+
+- Working tree size: `217M`
+- `.git` size: `200M`
+- Git pack size: `197.71 MiB`
+
+GitHub readiness snapshot:
+
+- Open PR count: `0`
+- PR gate: clear at the time of this checklist
+- Remote branch review: required
+- Unmerged remote branch detected: `origin/chore/ci-hardening`
+
+## 3. Proposed Cleanup Paths
+
+The final candidate paths are exactly:
+
+```text
+backups/git_before_filter_repo_20251004_220053/repo_backup.bundle
+data/grafana/plugins/redis-datasource/
+data/processed/v51_features_all.csv
+data/archive/football_prediction_direct.pkl
+models/
+model_zoo/
+venv/
+.venv/
+```
+
+Do not expand this list without a new dry run and explicit approval.
+
+## 4. Explicitly Excluded Paths
+
+The following paths are explicitly excluded from the proposed real rewrite:
+
+```text
+src/
+docs/
+scripts/
+tests/
+config/
+.github/
+patches/
+archive/
+data/raw/
+```
+
+These paths may still contain large objects, but they require separate review and are out of scope for the proposed low-risk cleanup.
+
+## 5. Expected Benefit
+
+Phase 3.3 manual mirror dry run result:
+
+- Before mirror size: `230M`
+- After mirror size: `162M`
+- Estimated reduction: `68M`
+- Estimated reduction percentage: approximately `29.6%`
+- Before Git pack size: `228.66 MiB`
+- After Git pack size: `159.10 MiB`
+- Estimated Git pack reduction: `69.56 MiB`
+- Estimated Git pack reduction percentage: approximately `30.4%`
+
+Functional validation from the cleaned dry-run mirror:
+
+- Fresh clone: passed
+- `docker compose config`: passed
+- model artifact checker with `--allow-missing`: passed
+
+## 6. Required Go Criteria
+
+- [ ] Final cleanup path list approved
+- [ ] Backup mirror exists
+- [ ] Backup tar.gz exists
+- [ ] Backup restore / clone verified
+- [ ] No open PRs
+- [ ] No important unmerged branches
+- [ ] Maintenance window selected
+- [ ] Collaborator notice sent
+- [ ] Re-clone / migration instructions prepared
+- [ ] Model artifact recovery docs merged
+- [ ] CI passing before rewrite
+- [ ] Dry-run cleaned mirror fresh clone validated
+- [ ] Rollback plan reviewed
+- [ ] Force push / mirror push strategy approved
+
+## 7. No-Go Conditions
+
+Do not proceed if:
+
+- Any open PR remains
+- Any collaborator has unmerged work
+- Backup is missing or unverified
+- Maintenance window is not approved
+- Final path list is not approved
+- CI is failing
+- Re-clone plan is not ready
+- Owner has not explicitly said `GO`
+
+Current status: `NO-GO until remote branch review and explicit owner approval are complete`.
+
+## 8. Execution Strategy Draft
+
+Important: Example only. Do not execute from this document automatically.
+
+High-level execution steps:
+
+1. Freeze merges.
+2. Create final mirror backup.
+3. Verify backup clone and archive.
+4. Create execution mirror.
+5. Run the approved history rewrite command on the execution mirror only.
+6. Validate the cleaned mirror size and object list.
+7. Fresh clone from the cleaned mirror and run validation checks.
+8. Push rewritten history only after explicit `GO`.
+9. Require all users to re-clone or follow the approved migration plan.
+10. Keep the backup until the team confirms the rewritten repository is stable.
+
+## 9. Rollback Strategy
+
+Rollback depends on the final mirror backup.
+
+- Use the mirror backup if pushed history is bad.
+- Re-push backup mirror only under emergency approval.
+- Prevent old clones from pushing stale history.
+- Announce rollback status to all collaborators.
+- Require fresh clone after rollback if the remote history changed again.
+
+## 10. Approval
+
+Final decision:
+
+- [ ] GO
+- [ ] NO-GO
+
+Approver:
+Date:
+Notes:

--- a/docs/_reports/REPO_SLIMMING_PHASE3_4_GO_NO_GO.md
+++ b/docs/_reports/REPO_SLIMMING_PHASE3_4_GO_NO_GO.md
@@ -1,0 +1,167 @@
+# Repo Slimming Phase 3.4 Go / No-Go Report
+
+## 1. Scope
+
+This phase prepares the final approval checklist for real history rewrite.
+
+It does not execute history rewrite.
+
+This phase only adds documentation for final review, collaborator notification, and execution-day planning.
+
+## 2. Current Repository Size
+
+- Working tree: `217M`
+- `.git`: `200M`
+- Git pack: `197.71 MiB`
+- Packed objects: `201857`
+- Pack count: `1`
+
+The main repository still contains the old historical objects because no real history rewrite has been executed.
+
+## 3. Phase 3.3 Dry Run Summary
+
+Manual cleanup paths:
+
+```text
+backups/git_before_filter_repo_20251004_220053/repo_backup.bundle
+data/grafana/plugins/redis-datasource/
+data/processed/v51_features_all.csv
+data/archive/football_prediction_direct.pkl
+models/
+model_zoo/
+venv/
+.venv/
+```
+
+Dry-run result:
+
+- Before mirror size: `230M`
+- After mirror size: `162M`
+- Reduction estimate: `68M`, approximately `29.6%`
+- Before Git pack size: `228.66 MiB`
+- After Git pack size: `159.10 MiB`
+- Git pack reduction estimate: `69.56 MiB`, approximately `30.4%`
+- Fresh clone verification: passed
+- `docker compose config`: passed
+- Artifact checker: passed with `--allow-missing`
+
+Phase 3.3 risk level: low-to-medium for the manual whitelist itself.
+
+## 4. GitHub Readiness
+
+- Open PR count: `0`
+- Open PR list: none
+- PR gate: clear
+
+Remote branches observed after pruning:
+
+```text
+origin/HEAD -> origin/main
+origin/chore/ci-hardening
+origin/docs/tep-001-csv-bulk-loader
+origin/feat/fix-csv-odds-pipeline
+origin/feature/csv-bulk-loader
+origin/feature/euro-leagues-expansion
+origin/feature/final-orphan-purge
+origin/feature/fotmob-reset-realignment
+origin/feature/semi-auto-etl-factory
+origin/hotfix/ci-gate-hardening
+origin/main
+```
+
+Unmerged remote branch check:
+
+```text
+origin/chore/ci-hardening
+```
+
+Remote branch notes:
+
+- No open PRs were found.
+- `origin/chore/ci-hardening` is not merged into `origin/main`.
+- The remaining remote branches still require owner review before real history rewrite.
+- The current status must remain `NO-GO` until branch ownership and migration handling are confirmed.
+
+## 5. Proposed Final Cleanup Paths
+
+The proposed final cleanup paths are exactly:
+
+```text
+backups/git_before_filter_repo_20251004_220053/repo_backup.bundle
+data/grafana/plugins/redis-datasource/
+data/processed/v51_features_all.csv
+data/archive/football_prediction_direct.pkl
+models/
+model_zoo/
+venv/
+.venv/
+```
+
+Do not expand this list without a new dry run and explicit approval.
+
+## 6. Explicitly Excluded Paths
+
+The proposed real rewrite excludes:
+
+```text
+src/
+docs/
+scripts/
+tests/
+config/
+.github/
+patches/
+archive/
+data/raw/
+```
+
+These paths are not approved for cleanup in the proposed low-risk rewrite.
+
+## 7. Go / No-Go Status
+
+Current status: `NO-GO`
+
+Reasons:
+
+- Human approval has not been granted.
+- Backup usability has not been independently verified.
+- Maintenance window has not been selected.
+- Collaborator notice has not been sent.
+- Re-clone / migration instructions have not been approved.
+- Force push / mirror push strategy has not been approved.
+- At least one remote branch is not merged into `origin/main`: `origin/chore/ci-hardening`.
+
+If the branch review is resolved and all required approvals are completed, this can move to `READY FOR MANUAL GO REVIEW`. It must not become `GO` automatically.
+
+## 8. Required Human Approval
+
+Before any real rewrite, the owner must explicitly approve:
+
+- final path list approval
+- backup verification
+- maintenance window
+- collaborator notice
+- re-clone plan
+- force push / mirror push strategy
+- handling plan for open PRs and non-main branches
+- rollback plan
+
+The owner must explicitly say `GO` before execution.
+
+## 9. Explicitly Not Executed
+
+This phase did not execute:
+
+- `git filter-repo`
+- BFG
+- force push
+- mirror push
+- history rewrite
+- local data deletion
+- Docker cleanup
+
+## 10. Next Recommended Action
+
+Create a PR for this approval document.
+
+After the PR is merged, review the Go / No-Go checklist with the repository owner. Do not execute the real history rewrite until the owner explicitly approves the final path list, branch handling plan, backup, maintenance window, collaborator notice, migration plan, and push strategy.

--- a/docs/templates/HISTORY_REWRITE_COLLABORATOR_NOTICE.md
+++ b/docs/templates/HISTORY_REWRITE_COLLABORATOR_NOTICE.md
@@ -1,0 +1,48 @@
+# Git History Rewrite Notice
+
+## Summary
+
+We plan to rewrite the Git history of `xupeng211/FootballPrediction` to remove large generated/data/model artifacts from repository history.
+
+## Why
+
+The repository history contains large generated artifacts that slow down clone/fetch operations.
+
+## Impact
+
+After the rewrite:
+
+- Old clones should not be used for normal push/pull.
+- Developers should fresh clone the repository.
+- Pushing from old clones can reintroduce removed objects.
+
+## Required Action
+
+Before the maintenance window:
+
+1. Commit or stash your work.
+2. Push any important branches.
+3. Stop merging during the maintenance window.
+
+After the rewrite:
+
+1. Move your old clone aside.
+2. Fresh clone the repository.
+3. Re-apply local work carefully if needed.
+
+## Suggested Commands
+
+```bash
+mv FootballPrediction FootballPrediction.pre-history-rewrite-backup
+git clone git@github.com:xupeng211/FootballPrediction.git
+```
+
+## Do Not
+
+Do not run `git pull` in an old clone and then push.
+
+## Contact
+
+Owner:
+Maintenance window:
+Status:


### PR DESCRIPTION
## Summary

This PR adds the Phase 3.4 Go / No-Go checklist for a potential future repository history rewrite.

## Changes

- Add `docs/REPO_HISTORY_REWRITE_GO_NO_GO.md`
- Add `docs/_reports/REPO_SLIMMING_PHASE3_4_GO_NO_GO.md`
- Add `docs/templates/HISTORY_REWRITE_COLLABORATOR_NOTICE.md`

## Current Decision

Current status is **NO-GO**.

This PR does **not** execute real history cleanup.

## Safety Confirmation

This PR is documentation-only.

It did not execute:

- `git filter-repo`
- BFG
- force push
- mirror push
- history rewrite
- local data deletion
- Docker cleanup

## Important Notes

A real history rewrite must not happen until the owner explicitly approves GO and confirms:

- final cleanup path list
- backup usability
- maintenance window
- collaborator notice
- open PR / remote branch handling
- re-clone / migration plan
- force push / mirror push strategy

The current report notes that remote non-main branches still exist, including `origin/chore/ci-hardening`, which must be handled before any real history rewrite.
