### PR TITLE
docs(repo): add post-rewrite clone and env setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -327,3 +327,62 @@ DOM_SURGICAL_HEADLESS=true
 # TraceID 配置 (启用全链路追踪)
 ENABLE_TRACE_ID=true
 TRACE_ID_PREFIX=recon
+
+# ============================================
+# Docker Compose local defaults
+# ============================================
+#
+# These values are safe local-development defaults used by docker-compose.yml
+# and docker-compose.dev.yml. Copy this file to .env before running compose:
+#
+#   cp .env.example .env
+#   docker compose config
+#
+# Do not commit .env.
+
+COMPOSE_PROJECT_NAME=footballprediction
+TZ=Asia/Shanghai
+
+# Service ports
+API_PORT=8000
+DASHBOARD_PORT=3000
+DEBUG_PORT=5678
+REDIS_PORT=6379
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3001
+PGADMIN_PORT=5050
+REDIS_CMD_PORT=8081
+
+# API / admin defaults for local development only
+API_WORKERS=2
+PGADMIN_EMAIL=admin@football.local
+PGADMIN_PASSWORD=admin
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
+
+# Backup / odds service defaults
+BACKUP_RETENTION_DAYS=30
+BACKUP_SCHEDULE=0 2 * * *
+ODDS_SCRAPER_SCHEDULE=0 */4 * * *
+ODDS_SOURCE=oddsportal
+ODDS_BATCH_SIZE=50
+ODDS_DELAY_MIN=2
+ODDS_DELAY_MAX=5
+
+# Optional proxy values. Leave empty unless your machine requires a proxy.
+HTTP_PROXY=
+HTTPS_PROXY=
+
+# Dev container proxy defaults. Override if your local proxy uses a different
+# host or port.
+DEV_HTTP_PROXY=http://host.docker.internal:7897
+DEV_HTTPS_PROXY=http://host.docker.internal:7897
+DEV_HOST_PROXY_PORT=7897
+DEV_PROXY_HOST=host.docker.internal
+DEV_PROXY_PORT=7897
+DEV_PROXY_PORTS=7897
+DEV_NO_PROXY=localhost,127.0.0.1,::1,db,redis,prometheus,grafana,host.docker.internal,mirrors.aliyun.com,registry.npmmirror.com,deb.nodesource.com,npmmirror.com
+
+# Model artifacts are not committed to Git after repo slimming.
+# Keep this path local and restore artifacts through the manifest/checker flow.
+MODEL_ARTIFACT_DIR=./models

--- a/docs/CLONE_GUIDE.md
+++ b/docs/CLONE_GUIDE.md
@@ -44,6 +44,31 @@ Important rules:
 - A fresh clone does not include model artifacts.
 - Missing artifacts should be handled through the model artifact manifest and checker workflow.
 
+## Fresh Clone Setup
+
+After cloning, create a local environment file from the committed template:
+
+```bash
+cp .env.example .env
+docker compose config
+```
+
+`.env` is a local machine configuration file and must not be committed.
+
+`.env.example` is the committed template that keeps safe local defaults for Docker Compose and development setup.
+
+Model artifacts are not distributed through Git. If model files are missing, use the artifact documentation and checker paths:
+
+- Manifest template: `config/model_artifacts.example.json`
+- Artifact guide: `docs/MODEL_ARTIFACTS.md`
+- Checker script: `scripts/model_artifacts/check_model_artifacts.py`
+
+For a fresh clone that does not have local model artifacts yet, use the checker in allow-missing mode when validating artifact wiring:
+
+```bash
+python3 scripts/model_artifacts/check_model_artifacts.py --allow-missing
+```
+
 ## Recommended Local Development Directory
 
 The recommended local development clone on this machine is:

--- a/docs/CLONE_GUIDE.md
+++ b/docs/CLONE_GUIDE.md
@@ -1,0 +1,55 @@
+# Clone Guide
+
+## Recommended Daily Clone
+
+Use a shallow, single-branch, no-tags clone for normal development:
+
+```bash
+git clone \
+  --single-branch \
+  --branch main \
+  --depth 1 \
+  --no-tags \
+  git@github.com:xupeng211/FootballPrediction.git
+```
+
+For this repository, do not add:
+
+```bash
+--filter=blob:none
+```
+
+## Why `--filter=blob:none` Is Not Recommended
+
+Local timing after the history rewrite showed that `--filter=blob:none` is slower for this repository.
+
+Observed results:
+
+- SSH shallow clone without blob filtering was faster than blobless shallow clone.
+- `.git` size was nearly unchanged with blob filtering.
+- Checkout was not the bottleneck.
+- The current `HEAD` tree is approximately 14 MiB.
+- The current tracked file count is approximately 992.
+- Remaining clone latency appears more related to GitHub Git transfer, pack generation, or the local network path than to working tree size.
+
+## After The History Rewrite
+
+The repository history has been rewritten to remove large generated, model, data, and environment artifacts from the main history.
+
+Important rules:
+
+- Old clones should not be used for normal development or push workflows.
+- Collaborators should create a fresh clone.
+- `models/` and `model_zoo/` are no longer tracked by Git.
+- A fresh clone does not include model artifacts.
+- Missing artifacts should be handled through the model artifact manifest and checker workflow.
+
+## Recommended Local Development Directory
+
+The recommended local development clone on this machine is:
+
+```text
+/home/xupeng/FootballPrediction.clean-dev
+```
+
+Keep the older `/home/xupeng/FootballPrediction` directory only as a local reference unless it is intentionally migrated.


### PR DESCRIPTION
## Summary

This PR adds post-history-rewrite clone and local environment setup guidance.

## Changes

- Adds `docs/CLONE_GUIDE.md`
- Adds/updates `.env.example`
- Documents the recommended shallow clone command without `--filter=blob:none`
- Documents local `.env` setup from `.env.example`
- Documents model artifact checker and manifest paths

## Safety

This PR is documentation/config-template only.

It does not:

- Change runtime code
- Run history rewrite
- Run `git filter-repo`
- Force push
- Start or stop Docker services

## Validation

- Confirmed clean-dev clone points at rewritten `main`
- Confirmed `.env` is ignored and not tracked
- Ran `docker compose config` successfully after copying `.env.example` to local `.env`