### PR TITLE
docs(dev): standardize docker development entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # ============================================
 
 .PHONY: help up down restart logs test clean build db-reset db-shell lint format security \
-        dev-up dev-down dev-shell dev-logs dev-build dev-harvest dev-test
+        dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test
 
 # 默认目标
 .DEFAULT_GOAL := help
@@ -37,6 +37,8 @@ help: ## 显示帮助信息
 # ============================================
 # Docker 命令
 # ============================================
+COMPOSE_DEV=docker compose -f docker-compose.dev.yml
+
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
 
@@ -189,30 +191,34 @@ deploy: ## 部署到生产环境
 	@echo "$(GREEN)部署完成!$(NC)"
 
 # ============================================
-# 开发容器命令 (V170.000)
+# 标准 Docker 开发入口
 # ============================================
+dev-config: ## 验证开发 Compose 配置
+	$(COMPOSE_DEV) config
+
+dev-build: ## 构建开发镜像
+	$(COMPOSE_DEV) build
+
 dev-up: ## 启动容器化开发环境
-	@echo "$(BLUE)启动开发容器...$(NC)"
-	@./scripts/ops/dev_container.sh
+	$(COMPOSE_DEV) up -d --build --remove-orphans
+
+dev-ps: ## 查看开发容器状态
+	$(COMPOSE_DEV) ps
 
 dev-down: ## 停止开发容器
-	@echo "$(BLUE)停止开发容器...$(NC)"
-	@./scripts/ops/dev_container.sh --stop
+	$(COMPOSE_DEV) down
 
 dev-shell: ## 进入开发容器 Shell
-	@./scripts/ops/dev_container.sh --shell
+	$(COMPOSE_DEV) exec dev bash
 
 dev-logs: ## 查看开发容器日志
-	@./scripts/ops/dev_container.sh --logs
-
-dev-build: ## 强制重建开发镜像
-	@./scripts/ops/dev_container.sh --build
+	$(COMPOSE_DEV) logs -f --tail=200
 
 dev-harvest: ## 在容器中运行生产收割器
-	docker-compose -f docker-compose.dev.yml exec dev npm start
+	$(COMPOSE_DEV) exec dev npm start
 
 dev-test: ## 在容器中运行测试
-	docker-compose -f docker-compose.dev.yml exec dev python main.py --test-proxy
+	$(COMPOSE_DEV) exec dev python main.py --test-proxy
 
 # ============================================
 # 监控命令

--- a/docs/CLONE_GUIDE.md
+++ b/docs/CLONE_GUIDE.md
@@ -57,6 +57,32 @@ docker compose config
 
 `.env.example` is the committed template that keeps safe local defaults for Docker Compose and development setup.
 
+## Docker Development Entrypoint
+
+Use `docker-compose.dev.yml` for the full local development stack. It defines the development container, database, Redis, Prometheus, and Grafana services.
+
+Recommended commands:
+
+```bash
+make dev-config
+make dev-up
+make dev-ps
+make dev-shell
+```
+
+Equivalent direct commands:
+
+```bash
+docker compose -f docker-compose.dev.yml config
+docker compose -f docker-compose.dev.yml up -d --build --remove-orphans
+docker compose -f docker-compose.dev.yml ps
+docker compose -f docker-compose.dev.yml exec dev bash
+```
+
+Do not use bare `docker compose up` for normal development. The default `docker-compose.yml` only covers the basic service subset and is not the complete development stack.
+
+Do not use `docker compose down -v` unless you explicitly intend to clear local Docker data volumes.
+
 Model artifacts are not distributed through Git. If model files are missing, use the artifact documentation and checker paths:
 
 - Manifest template: `config/model_artifacts.example.json`


### PR DESCRIPTION
## Summary

This PR standardizes the Docker development entrypoints after the history rewrite and clean-dev setup.

Changes:
- Updates Makefile dev-* targets to use docker-compose.dev.yml explicitly
- Adds make dev-config, dev-up, dev-ps, dev-shell, dev-logs, dev-build, dev-down
- Documents the recommended Docker development workflow in docs/CLONE_GUIDE.md
- Clarifies that bare docker compose up is not the full development stack
- Clarifies that docker compose down -v should not be used unless intentionally clearing local volumes

Validation:
- make dev-config passes
- make dev-ps shows the full dev stack healthy
- dev container can execute python --version
- No runtime code changes
- No Docker volume cleanup
- No history rewrite

Changed files should only be:
- Makefile
- docs/CLONE_GUIDE.md