### PR TITLE
chore(data): add safety-gated data entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 6. 先读后改。没有读过的文件，不直接修改。
 7. 最小修改。除非明确要求，不做顺手重构和无关清理。
 8. 修改后要做与改动范围相匹配的验证。
+9. 数据收割、ETL、Recon、Backfill、Odds、L3/ELO 相关入口默认必须走 `make data-*` 安全门禁。
 
 ### 2.2 默认工作方式
 
@@ -199,6 +200,39 @@ Recon 运行补充约定：
 | 训练模型 | `npm run train` | 宿主机调用后进入容器执行 `scripts/ops/train_model.py` |
 | 生成预测 | `npm run predict` | 宿主机调用后进入容器执行 `scripts/ops/predict_pipeline.py` |
 | ELO 重算 | `<compose> -f docker-compose.dev.yml exec dev npm run elo:recalc` | `scripts/maintenance/recalculate_elo.js` |
+
+### 5.4 数据入口安全门禁
+
+数据收割治理以 `make data-*` 为统一入口。详细规范见：
+
+- `docs/DATA_HARVESTING_GUIDE.md`
+- `docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE4_2.md`
+
+AI / Codex 默认只能执行：
+
+- `make data-help`
+- `make data-check`
+- 用户明确授权的 `make data-local-dry-run`
+
+AI / Codex 不能直接执行：
+
+- `make dev-harvest`
+- `npm start`
+- `node scripts/ops/run_production.js`
+- `node scripts/ops/titan_discovery.js`
+- `npm run titan:total-war`
+- `npm run odds:harvest`
+- `node scripts/ops/recon_scanner.js --season ...`
+- `node scripts/ops/batch_historical_backfill.js`
+- 任何 `--commit` 命令
+- 任何外网收割命令
+- 任何写 DB 命令
+
+`NETWORK_DRY_RUN` 不是安全 dry-run，必须由用户显式授权，并给出 `LIMIT`、`SCOPE`、代理和限速说明。
+
+`DB_WRITE_SMALL` 必须由用户显式授权，命令必须支持并显式使用 `--commit`，同时提供 `LIMIT`、`SCOPE` 和执行前后 DB 统计。
+
+`BULK_HARVEST` 必须有 runbook、备份、监控和停止条件。没有 runbook 时，AI / Codex 不得执行。
 
 ## 6. 核心文件地图
 
@@ -367,6 +401,8 @@ make dev-ps
 ### 10.3 运维与专项文档
 
 - `docs/OPERATIONS_MANUAL.md`
+- `docs/DATA_HARVESTING_GUIDE.md`
+- `docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE4_2.md`
 - `archive_vault_2026/docs_legacy/OPERATIONS_RUNBOOK.md`
 - `docs/OPERATIONS_SOP.md`
 - `docs/ops/backfill_v6_manual.md`

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@
 # ============================================
 
 .PHONY: help up down restart logs test clean build db-reset db-shell lint format security \
-        dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test
+        dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test \
+        data-help data-check data-local-dry-run data-network-dry-run data-db-write-small \
+        data-harvest data-risk-report
 
 # 默认目标
 .DEFAULT_GOAL := help
@@ -219,6 +221,92 @@ dev-harvest: ## 在容器中运行生产收割器
 
 dev-test: ## 在容器中运行测试
 	$(COMPOSE_DEV) exec dev python main.py --test-proxy
+
+# ============================================
+# 数据入口安全门禁
+# ============================================
+data-help: ## Show safe data harvesting entrypoint policy
+	@echo "FootballPrediction data entrypoints are safety-gated."
+	@echo ""
+	@echo "Allowed by default:"
+	@echo "  make data-help"
+	@echo "  make data-check"
+	@echo "  make data-local-dry-run SAMPLE_HTML=<path> or SAMPLE_CSV=<path>"
+	@echo ""
+	@echo "Requires explicit authorization:"
+	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
+	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
+	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
+	@echo ""
+	@echo "Read docs/DATA_HARVESTING_GUIDE.md before running any data task."
+
+data-check: ## Read-only data environment check
+	@echo "Checking data environment in dev container..."
+	$(COMPOSE_DEV) ps
+	$(COMPOSE_DEV) exec -T dev node --version
+	$(COMPOSE_DEV) exec -T dev npm --version
+	$(COMPOSE_DEV) exec -T dev python --version
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/local_dom_ingestor.js --help >/tmp/fp_data_local_dom_help.txt
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/csv_bulk_loader.js --help >/tmp/fp_data_csv_loader_help.txt
+	@echo "OK: read-only data environment check completed."
+
+data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.
+	@if [ -n "$(SAMPLE_HTML)" ]; then \
+		echo "Running local HTML preview only: $(SAMPLE_HTML)"; \
+		$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_HTML)"; \
+		$(COMPOSE_DEV) exec -T dev node scripts/ops/local_dom_ingestor.js --file "$(SAMPLE_HTML)"; \
+	elif [ -n "$(SAMPLE_CSV)" ]; then \
+		echo "Running local CSV preview only: $(SAMPLE_CSV)"; \
+		$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_CSV)"; \
+		$(COMPOSE_DEV) exec -T dev node scripts/ops/csv_bulk_loader.js --file "$(SAMPLE_CSV)" --batch-size 50 --error-log /tmp/csv_bulk_loader_errors.jsonl; \
+	else \
+		echo "ERROR: provide SAMPLE_HTML=<path> or SAMPLE_CSV=<path>"; \
+		exit 1; \
+	fi
+
+data-network-dry-run: ## Blocked unless explicitly authorized. Does not run by default.
+	@if [ "$(CONFIRM_NETWORK)" != "1" ]; then \
+		echo "BLOCKED: NETWORK_DRY_RUN requires CONFIRM_NETWORK=1 plus LIMIT and SCOPE."; \
+		echo "Read docs/DATA_HARVESTING_GUIDE.md."; \
+		exit 1; \
+	fi
+	@if [ -z "$(LIMIT)" ] || [ -z "$(SCOPE)" ]; then \
+		echo "BLOCKED: provide LIMIT=<n> and SCOPE=<league/season/date/match scope>."; \
+		exit 1; \
+	fi
+	@echo "NETWORK_DRY_RUN authorized for SCOPE=$(SCOPE), LIMIT=$(LIMIT)."
+	@echo "No default network command is wired in Phase 4.3. Create a runbook before execution."
+	@exit 1
+
+data-db-write-small: ## Blocked unless explicitly authorized. Requires --commit-capable runbook.
+	@if [ "$(CONFIRM_DB_WRITE)" != "1" ]; then \
+		echo "BLOCKED: DB_WRITE_SMALL requires CONFIRM_DB_WRITE=1."; \
+		exit 1; \
+	fi
+	@if [ -z "$(LIMIT)" ] || [ -z "$(SCOPE)" ]; then \
+		echo "BLOCKED: provide LIMIT=<n> and SCOPE=<league/season/date/match scope>."; \
+		exit 1; \
+	fi
+	@echo "DB_WRITE_SMALL authorized for SCOPE=$(SCOPE), LIMIT=$(LIMIT)."
+	@echo "No default DB write command is wired in Phase 4.3. Confirm backup, pre/post DB stats, and --commit before execution."
+	@exit 1
+
+data-harvest: ## Blocked bulk harvesting gate. Requires runbook and explicit authorization.
+	@if [ "$(CONFIRM_BULK_HARVEST)" != "1" ]; then \
+		echo "BLOCKED: BULK_HARVEST requires CONFIRM_BULK_HARVEST=1."; \
+		exit 1; \
+	fi
+	@if [ -z "$(RUNBOOK)" ]; then \
+		echo "BLOCKED: provide RUNBOOK=<path>."; \
+		exit 1; \
+	fi
+	@echo "BULK_HARVEST authorization detected with RUNBOOK=$(RUNBOOK)."
+	@echo "No bulk command is wired in Phase 4.3. Review runbook, backup, monitoring, and stop conditions first."
+	@exit 1
+
+data-risk-report: ## Print location of data entrypoint governance docs
+	@echo "Data harvesting guide: docs/DATA_HARVESTING_GUIDE.md"
+	@echo "Governance report: docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE4_2.md"
 
 # ============================================
 # 监控命令


### PR DESCRIPTION
## Summary

Adds safety-gated data entrypoints to prevent accidental harvesting, scraping, ingestion, or DB writes.

Changes:
- Adds Makefile data-* safety gates:
  - data-help
  - data-check
  - data-local-dry-run
  - data-network-dry-run
  - data-db-write-small
  - data-harvest
  - data-risk-report
- Blocks network dry-run, DB writes, and bulk harvest by default unless explicit confirmation variables are provided
- Updates AGENTS.md so AI/Codex must use make data-* gates and must not directly run high-risk data commands
- References docs/DATA_HARVESTING_GUIDE.md and the Phase 4.2 governance report

Validation:
- make data-help
- make data-check
- make data-network-dry-run defaults to blocked
- make data-db-write-small defaults to blocked
- make data-harvest defaults to blocked
- git diff --check

No runtime harvesting was executed.
No external data sources were accessed.
No database writes were performed.

Changed files:
- Makefile
- AGENTS.md
