### PR TITLE
chore(db): add schema migration safety gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 7. 最小修改。除非明确要求，不做顺手重构和无关清理。
 8. 修改后要做与改动范围相匹配的验证。
 9. 数据收割、ETL、Recon、Backfill、Odds、L3/ELO 相关入口默认必须走 `make data-*` 安全门禁。
+10. DB schema migration 默认必须走 `make data-schema-*` 安全门禁，禁止直接执行 migration apply。
 
 ### 2.2 默认工作方式
 
@@ -234,6 +235,31 @@ AI / Codex 不能直接执行：
 
 `BULK_HARVEST` 必须有 runbook、备份、监控和停止条件。没有 runbook 时，AI / Codex 不得执行。
 
+### 5.5 DB Schema Migration 安全门禁
+
+DB schema migration 治理以 `make data-schema-*` 为统一入口。执行规范见：
+
+- `docs/_reports/DB_SCHEMA_MIGRATION_RUNBOOK_PHASE4_8.md`
+
+AI / Codex 默认只能执行：
+
+- `make data-schema-help`
+- `make data-schema-status`
+- `make data-schema-plan`
+
+AI / Codex 不能执行：
+
+- `make data-schema-migrate`
+- any migration apply / migrate up / schema sync
+- `ensureBlueprintOnCurrentDatabase`
+- cold-start blueprint check
+- `alembic upgrade`
+- 任何 `CREATE` / `ALTER` / `INSERT` / `UPDATE` / `DELETE` / `DROP` / `TRUNCATE`
+
+Schema migration 必须有人类明确授权。执行前必须有 runbook、DB 备份、应用文件清单、post-apply verification plan 和回滚方案。
+
+Phase 4.9 中 `make data-schema-migrate` 即使提供确认变量也只到安全门禁，不接真实 migration 执行。
+
 ## 6. 核心文件地图
 
 ### 6.1 业务入口
@@ -403,6 +429,7 @@ make dev-ps
 - `docs/OPERATIONS_MANUAL.md`
 - `docs/DATA_HARVESTING_GUIDE.md`
 - `docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE4_2.md`
+- `docs/_reports/DB_SCHEMA_MIGRATION_RUNBOOK_PHASE4_8.md`
 - `archive_vault_2026/docs_legacy/OPERATIONS_RUNBOOK.md`
 - `docs/OPERATIONS_SOP.md`
 - `docs/ops/backfill_v6_manual.md`

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 .PHONY: help up down restart logs test clean build db-reset db-shell lint format security \
         dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test \
         data-help data-check data-local-dry-run data-network-dry-run data-db-write-small \
-        data-harvest data-risk-report
+        data-harvest data-risk-report data-schema-help data-schema-status data-schema-plan \
+        data-schema-migrate
 
 # 默认目标
 .DEFAULT_GOAL := help
@@ -239,6 +240,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
 	@echo ""
 	@echo "Read docs/DATA_HARVESTING_GUIDE.md before running any data task."
+	@echo "For DB schema migration safety gates, run: make data-schema-help"
 
 data-check: ## Read-only data environment check
 	@echo "Checking data environment in dev container..."
@@ -307,6 +309,64 @@ data-harvest: ## Blocked bulk harvesting gate. Requires runbook and explicit aut
 data-risk-report: ## Print location of data entrypoint governance docs
 	@echo "Data harvesting guide: docs/DATA_HARVESTING_GUIDE.md"
 	@echo "Governance report: docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE4_2.md"
+	@echo "DB schema migration runbook: docs/_reports/DB_SCHEMA_MIGRATION_RUNBOOK_PHASE4_8.md"
+
+data-schema-help: ## Show DB schema migration safety gate policy
+	@echo "FootballPrediction DB schema migration is safety-gated."
+	@echo ""
+	@echo "Allowed by default:"
+	@echo "  make data-schema-help"
+	@echo "  make data-schema-status"
+	@echo "  make data-schema-plan"
+	@echo ""
+	@echo "Blocked by default:"
+	@echo "  make data-schema-migrate"
+	@echo ""
+	@echo "Future migration execution requires all of:"
+	@echo "  CONFIRM_SCHEMA_MIGRATION=1"
+	@echo "  BACKUP_CONFIRMED=1"
+	@echo "  RUNBOOK=docs/_reports/DB_SCHEMA_MIGRATION_RUNBOOK_PHASE4_8.md"
+	@echo ""
+	@echo "Phase 4.9 does not wire migration execution. Read the runbook first."
+
+data-schema-status: ## Read-only DB schema status check
+	@echo "Checking DB schema status with read-only SQL..."
+	$(COMPOSE_DEV) exec -T db sh -lc 'psql -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" -c "\dt"'
+	$(COMPOSE_DEV) exec -T db sh -lc 'psql -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" -c "SELECT table_name FROM information_schema.tables WHERE table_schema = '\''public'\'' AND table_name IN ('\''bookmaker_odds_history'\'', '\''matches_oddsportal_mapping'\'', '\''l3_features'\'', '\''alembic_version'\'', '\''schema_migrations'\'', '\''knex_migrations'\'') ORDER BY table_name;"'
+	$(COMPOSE_DEV) exec -T db sh -lc 'psql -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" -c "SELECT '\''matches'\'' AS table_name, COUNT(*) AS rows FROM matches UNION ALL SELECT '\''raw_match_data'\'', COUNT(*) FROM raw_match_data UNION ALL SELECT '\''odds'\'', COUNT(*) FROM odds UNION ALL SELECT '\''match_features_training'\'', COUNT(*) FROM match_features_training UNION ALL SELECT '\''predictions'\'', COUNT(*) FROM predictions UNION ALL SELECT '\''league_config'\'', COUNT(*) FROM league_config UNION ALL SELECT '\''feature_registry'\'', COUNT(*) FROM feature_registry UNION ALL SELECT '\''data_collection_log'\'', COUNT(*) FROM data_collection_log;"'
+	$(COMPOSE_DEV) exec -T db sh -lc 'psql -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" -c "SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = '\''public'\'' AND table_name IN ('\''matches'\'', '\''raw_match_data'\'', '\''odds'\'') ORDER BY table_name, ordinal_position;"'
+	@echo "OK: read-only DB schema status check completed."
+
+data-schema-plan: ## Print planned DB schema migration order without executing SQL
+	@echo "Recommended DB schema migration order from docs/_reports/DB_SCHEMA_MIGRATION_RUNBOOK_PHASE4_8.md:"
+	@echo "  database/migrations/V6.5__hardened_matches_schema.sql"
+	@echo "  database/migrations/V6.6__hardened_l2_raw_storage.sql"
+	@echo "  database/migrations/V12.2__add_matches_pipeline_status.sql"
+	@echo "  database/migrations/V12.3__expand_matches_pipeline_status_for_recon.sql"
+	@echo "  database/migrations/V12.4__create_matches_oddsportal_mapping.sql"
+	@echo "  database/migrations/V12.5__create_bookmaker_odds_history.sql"
+	@echo "  database/migrations/V12.6__allow_numeric_fotmob_ids_in_raw_match_data.sql"
+	@echo "  database/migrations/V12.7__add_tactical_stats_to_matches.sql"
+	@echo "  database/migrations/V12.8__add_alignment_meta_to_bookmaker_odds_history.sql"
+	@echo "  database/migrations/V26.4__create_l3_features_table.sql"
+	@echo "No SQL was executed."
+
+data-schema-migrate: ## Blocked DB schema migration gate. Execution is not wired in Phase 4.9.
+	@if [ "$(CONFIRM_SCHEMA_MIGRATION)" != "1" ]; then \
+		echo "BLOCKED: schema migration requires CONFIRM_SCHEMA_MIGRATION=1."; \
+		exit 1; \
+	fi
+	@if [ "$(BACKUP_CONFIRMED)" != "1" ]; then \
+		echo "BLOCKED: schema migration requires BACKUP_CONFIRMED=1."; \
+		exit 1; \
+	fi
+	@if [ "$(RUNBOOK)" != "docs/_reports/DB_SCHEMA_MIGRATION_RUNBOOK_PHASE4_8.md" ]; then \
+		echo "BLOCKED: provide RUNBOOK=docs/_reports/DB_SCHEMA_MIGRATION_RUNBOOK_PHASE4_8.md."; \
+		exit 1; \
+	fi
+	@echo "Phase 4.9 safety gate reached. Migration execution is not wired in this phase."
+	@echo "No CREATE/ALTER/INSERT/UPDATE/DELETE was executed."
+	@exit 1
 
 # ============================================
 # 监控命令


### PR DESCRIPTION
## Summary

Adds safety-gated schema migration entrypoints.

Changes:
- Adds Makefile data-schema-* targets:
  - data-schema-help
  - data-schema-status
  - data-schema-plan
  - data-schema-migrate
- Allows safe read-only schema status and migration plan checks
- Blocks migration execution by default
- Keeps data-schema-migrate not wired for execution in this phase
- Updates AGENTS.md so AI/Codex cannot directly execute migration apply, blueprint checks, Alembic upgrade, or write SQL

Validation:
- make data-schema-help
- make data-schema-status
- make data-schema-plan
- make data-schema-migrate defaults to blocked
- make data-schema-migrate with confirmation variables still does not execute migration
- git diff --check

No migrations were executed.
No database writes were performed.
No external data access was performed.

Changed files:
- Makefile
- AGENTS.md
