### PR TITLE
feat(l3): add safe local dry-run gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ AI / Codex 默认只能执行：
 - `make data-help`
 - `make data-check`
 - 用户明确授权的 `make data-local-dry-run`
+- 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 
 AI / Codex 不能直接执行：
 
@@ -225,9 +226,24 @@ AI / Codex 不能直接执行：
 - `npm run odds:harvest`
 - `node scripts/ops/recon_scanner.js --season ...`
 - `node scripts/ops/batch_historical_backfill.js`
+- `npm run smelt`
+- `npm run l3:stitch`
+- `scripts/ops/smelt_all.js`
+- `scripts/ops/l3_stitch_pipeline.js`
+- `scripts/ops/l3_stitch_worker.js`
+- `npm run elo:recalc`
 - 任何 `--commit` 命令
 - 任何外网收割命令
 - 任何写 DB 命令
+
+执行 `make data-l3-dry-run` 的前提：
+
+- 用户明确授权
+- fixture 是本地文件
+- 不写 DB
+- 不访问外网
+
+L3 本地 dry-run 预检背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
 
 `NETWORK_DRY_RUN` 不是安全 dry-run，必须由用户显式授权，并给出 `LIMIT`、`SCOPE`、代理和限速说明。
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@
 
 .PHONY: help up down restart logs test clean build db-reset db-shell lint format security \
         dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test \
-        data-help data-check data-local-dry-run data-network-dry-run data-db-write-small \
-        data-harvest data-risk-report data-schema-help data-schema-status data-schema-plan \
-        data-schema-migrate
+        data-help data-check data-local-dry-run data-l3-dry-run data-network-dry-run \
+        data-db-write-small data-harvest data-risk-report data-schema-help data-schema-status \
+        data-schema-plan data-schema-migrate
 
 # 默认目标
 .DEFAULT_GOAL := help
@@ -233,6 +233,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-help"
 	@echo "  make data-check"
 	@echo "  make data-local-dry-run SAMPLE_HTML=<path> or SAMPLE_CSV=<path>"
+	@echo "  make data-l3-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
@@ -265,6 +266,15 @@ data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SA
 		echo "ERROR: provide SAMPLE_HTML=<path> or SAMPLE_CSV=<path>"; \
 		exit 1; \
 	fi
+
+data-l3-dry-run: ## Run safe local L3 dry-run from fixture. Requires SAMPLE_RAW and MATCH_ID.
+	@if [ -z "$(SAMPLE_RAW)" ] || [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide SAMPLE_RAW=<path> and MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe local L3 dry-run: SAMPLE_RAW=$(SAMPLE_RAW), MATCH_ID=$(MATCH_ID)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_RAW)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/l3_local_dry_run.js --fixture "$(SAMPLE_RAW)" --match-id "$(MATCH_ID)"
 
 data-network-dry-run: ## Blocked unless explicitly authorized. Does not run by default.
 	@if [ "$(CONFIRM_NETWORK)" != "1" ]; then \

--- a/docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md
+++ b/docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md
@@ -26,12 +26,12 @@
 - `external_id`: `4837496`
 - 数据源: 本地脱敏样本，不含 secret，不访问外网
 - 结构覆盖:
-  - `raw_data.general`
-  - `raw_data.header`
-  - `raw_data.content.stats`
-  - `raw_data.content.lineup`
-  - `raw_data.content.shotmap`
-  - `raw_data.content.momentum`
+    - `raw_data.general`
+    - `raw_data.header`
+    - `raw_data.content.stats`
+    - `raw_data.content.lineup`
+    - `raw_data.content.shotmap`
+    - `raw_data.content.momentum`
 
 ## 4. Dry-Run 脚本行为
 

--- a/docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md
+++ b/docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md
@@ -1,0 +1,193 @@
+# Phase 4.19 - L3 Local Dry-Run Gate
+
+日期: `2026-05-02`
+
+## 1. 当前 HEAD
+
+- 分支: `feat/l3-local-dry-run-gate`
+- Base HEAD: `6ac6ee23b4193a866d5959b506bf7ba1518eb1e2`
+- 基线提交: `6ac6ee2 docs(l3): add raw fixture preflight report`
+
+## 2. 新增文件
+
+- `scripts/ops/l3_local_dry_run.js`
+- `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+- `docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md`
+
+修改文件：
+
+- `Makefile`
+- `AGENTS.md`
+
+## 3. Fixture 摘要
+
+- 本地 fixture 路径: `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+- `match_id`: `140_20252026_4837496`
+- `external_id`: `4837496`
+- 数据源: 本地脱敏样本，不含 secret，不访问外网
+- 结构覆盖:
+  - `raw_data.general`
+  - `raw_data.header`
+  - `raw_data.content.stats`
+  - `raw_data.content.lineup`
+  - `raw_data.content.shotmap`
+  - `raw_data.content.momentum`
+
+## 4. Dry-Run 脚本行为
+
+新增脚本：`scripts/ops/l3_local_dry_run.js`
+
+行为边界：
+
+- 只读取本地 fixture JSON
+- 校验 `--fixture` 与 `--match-id`
+- 只对数据库执行 `SELECT`
+- 只读取 `matches` 与 `bookmaker_odds_history`
+- 生成并打印 L3 preview JSON
+- 不调用 `smelt_all`
+- 不调用 `l3_stitch_pipeline`
+- 不调用 ELO
+- 不执行任何写库或 schema 语句
+- 不访问外网
+
+输出包含：
+
+- `golden_features`
+- `tactical_features`
+- `odds_features`
+- `elo_features`
+- `stitch_summary`
+- `missing_fields`
+- `non_execution_confirmations`
+
+## 5. Makefile 入口
+
+新增安全门禁：
+
+```bash
+make data-l3-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>
+```
+
+入口行为：
+
+- 缺少 `SAMPLE_RAW` 或 `MATCH_ID` 时直接失败
+- 在 `dev` 容器内执行只读脚本
+- 不接旧 L3 入口
+- 不触发 ELO
+- 不执行写库命令
+
+## 6. AGENTS.md 更新
+
+新增允许项：
+
+- 用户明确授权时，可执行 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
+
+新增禁止项：
+
+- `npm run smelt`
+- `npm run l3:stitch`
+- `scripts/ops/smelt_all.js`
+- `scripts/ops/l3_stitch_pipeline.js`
+- `scripts/ops/l3_stitch_worker.js`
+- `npm run elo:recalc`
+
+背景引用：
+
+- `docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+
+## 7. Dry-Run 输出摘要
+
+缺参数验证：
+
+- `make data-l3-dry-run` -> 失败，输出 `ERROR: provide SAMPLE_RAW=<path> and MATCH_ID=<id>`
+
+安全 dry-run 验证：
+
+- `match_found`: `true`
+- `odds_history_rows`: `2`
+- `bookmakers`: `["Bet365", "Pinnacle"]`
+- `markets`: `["1x2", "Asian Handicap"]`
+- `would_write_l3_features`: `false`
+- `would_update_matches`: `false`
+- `would_trigger_elo`: `false`
+- `would_create_index`: `false`
+- `would_create_table`: `false`
+- `missing_fields`: `[]`
+
+非执行确认：
+
+- `no_db_writes`
+- `no_insert`
+- `no_update`
+- `no_delete`
+- `no_create_index`
+- `no_create_table`
+- `no_upsert`
+- `no_l3_write`
+- `no_elo`
+- `no_external_network`
+
+## 8. DB 前后统计
+
+执行前：
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          0
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+执行后：
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          0
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+结论：
+
+- dry-run 前后 DB 行数无变化
+
+## 9. 明确未执行事项
+
+本阶段未执行：
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- L3 feature write
+- model training
+- prediction write
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- 外网访问
+- 真实 harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume 清理
+- `git push`
+- `git pull`
+- `git fetch --all`
+
+## 10. 下一步建议
+
+- push 当前分支
+- 创建 PR
+- 等 CI 绿灯后合并
+- 后续再评估 `raw_match_data` 小范围写入 gate
+- 后续再评估 `l3_features` 小范围写入 gate

--- a/scripts/ops/l3_local_dry_run.js
+++ b/scripts/ops/l3_local_dry_run.js
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+/**
+ * Safe local L3 dry-run gate.
+ *
+ * This script only reads a local fixture and performs SELECT-only DB checks.
+ * It deliberately does not import FeatureSmelter, L3Writer, l3_stitch, or Elo
+ * recomputation code because those paths can write database state.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+
+const { extractGoldenFeatures } = require('../../src/feature_engine/extractors/GoldenFeatureExtractor');
+const { extractTacticalFeatures } = require('../../src/feature_engine/extractors/TacticalMomentumExtractor');
+const {
+    extractOddsMovementFeatures,
+    extractOddsMovementFeaturesFromOddsData
+} = require('../../src/feature_engine/extractors/OddsMovementExtractor');
+
+const FORBIDDEN_SQL = /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|UPSERT|MERGE|GRANT|REVOKE)\b/i;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l3_local_dry_run.js --fixture <path> --match-id <id> [--json]',
+        '',
+        'Safety:',
+        '  SELECT-only DB checks; no L3 writes, no schema writes, no Elo, no network.'
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        fixture: null,
+        matchId: null,
+        json: false,
+        help: false
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--fixture') {
+            args.fixture = argv[index + 1];
+            index += 1;
+        } else if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function readJsonFile(filePath) {
+    const resolved = path.resolve(process.cwd(), filePath);
+    const raw = fs.readFileSync(resolved, 'utf8');
+    return {
+        resolved,
+        data: JSON.parse(raw)
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function normalizeFixtureMatchId(fixture) {
+    return String(fixture.match_id || fixture.raw_data?.matchId || fixture.raw_data?.general?.matchId || '');
+}
+
+function validateFixture(fixture, expectedMatchId) {
+    const missing = [];
+
+    if (!fixture || typeof fixture !== 'object') {
+        throw new Error('Fixture root must be a JSON object');
+    }
+    if (normalizeFixtureMatchId(fixture) !== expectedMatchId) {
+        throw new Error(`Fixture match_id does not match --match-id (${normalizeFixtureMatchId(fixture)} != ${expectedMatchId})`);
+    }
+    if (!fixture.raw_data || typeof fixture.raw_data !== 'object' || Array.isArray(fixture.raw_data)) {
+        missing.push('raw_data');
+    }
+
+    const rawData = fixture.raw_data || {};
+    if (!('matchId' in rawData) && !rawData.general && !rawData.header) {
+        missing.push('raw_data.matchId_or_general_or_header');
+    }
+    if (!rawData.general) {
+        missing.push('raw_data.general');
+    }
+    if (!rawData.header) {
+        missing.push('raw_data.header');
+    }
+    if (!rawData.content) {
+        missing.push('raw_data.content');
+    }
+    if (!rawData.content?.lineup?.homeTeam) {
+        missing.push('raw_data.content.lineup.homeTeam');
+    }
+    if (!rawData.content?.lineup?.awayTeam) {
+        missing.push('raw_data.content.lineup.awayTeam');
+    }
+    if (!Array.isArray(rawData.content?.stats)) {
+        missing.push('raw_data.content.stats[]');
+    }
+    if (!Array.isArray(rawData.content?.shotmap?.shots)) {
+        missing.push('raw_data.content.shotmap.shots[]');
+    }
+
+    return missing;
+}
+
+function toPositiveNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeOddsPayload(payload, collectedAt) {
+    return {
+        home: toPositiveNumber(payload?.home),
+        draw: toPositiveNumber(payload?.draw),
+        away: toPositiveNumber(payload?.away),
+        collectedAt: collectedAt ? new Date(collectedAt).toISOString() : null
+    };
+}
+
+function buildOddsDataFromHistoryRows(rows) {
+    const oneX2Rows = rows.filter(row => String(row.market_type || '').toLowerCase() === '1x2');
+    const opening = oneX2Rows
+        .map(row => normalizeOddsPayload(row.open_odds, row.collected_at))
+        .filter(point => point.home && point.draw && point.away);
+    const closing = oneX2Rows
+        .map(row => normalizeOddsPayload(row.close_odds, row.collected_at))
+        .filter(point => point.home && point.draw && point.away);
+
+    const initial = opening[0] || closing[0] || null;
+    const current = closing[closing.length - 1] || initial;
+    const history = [];
+
+    if (initial) {
+        history.push(initial);
+    }
+    if (
+        current
+        && (
+            !initial
+            || current.home !== initial.home
+            || current.draw !== initial.draw
+            || current.away !== initial.away
+        )
+    ) {
+        history.push(current);
+    }
+
+    return {
+        initial,
+        current,
+        history,
+        hasData: Boolean(initial || current || history.length > 0),
+        odds_source: oneX2Rows.length > 0 ? 'bookmaker_odds_history' : 'none'
+    };
+}
+
+function uniqueSorted(values) {
+    return [...new Set(values.filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function summarizeFixture(rawData) {
+    const shotmapShots = Array.isArray(rawData?.content?.shotmap?.shots)
+        ? rawData.content.shotmap.shots.length
+        : 0;
+    const momentum = rawData?.content?.momentum?.data || rawData?.content?.momentum?.main?.data || [];
+    const lineup = rawData?.content?.lineup || {};
+
+    return {
+        lineup_available: Boolean(lineup.homeTeam && lineup.awayTeam),
+        home_starters: Array.isArray(lineup.homeTeam?.starters) ? lineup.homeTeam.starters.length : 0,
+        away_starters: Array.isArray(lineup.awayTeam?.starters) ? lineup.awayTeam.starters.length : 0,
+        shots_count: shotmapShots,
+        momentum_points: Array.isArray(momentum) ? momentum.length : 0
+    };
+}
+
+function buildStitchSummary(rawData, oddsRows, missingFields) {
+    const fixtureSummary = summarizeFixture(rawData);
+    const conflicts = [];
+
+    if (!rawData?.content) {
+        conflicts.push('missing_content');
+    }
+    if (!fixtureSummary.lineup_available) {
+        conflicts.push('missing_lineup');
+    }
+    if (!rawData?.content?.shotmap || !Array.isArray(rawData.content.shotmap.shots)) {
+        conflicts.push('missing_shotmap');
+    }
+    if (oddsRows.length === 0) {
+        conflicts.push('no_odds_data');
+    }
+
+    return {
+        ...fixtureSummary,
+        odds_history_rows: oddsRows.length,
+        missing_fields: missingFields,
+        conflicts,
+        would_write_l3_features: false,
+        would_update_matches: false,
+        would_trigger_elo: false,
+        would_create_index: false,
+        would_create_table: false
+    };
+}
+
+function selectFeatureHighlights(goldenFeatures, tacticalFeatures, oddsMovementFeatures) {
+    return {
+        golden: {
+            home_market_value_total: goldenFeatures.home_market_value_total,
+            away_market_value_total: goldenFeatures.away_market_value_total,
+            home_rating_avg: goldenFeatures.home_rating_avg,
+            away_rating_avg: goldenFeatures.away_rating_avg,
+            home_starters_count: goldenFeatures.home_starters_count,
+            away_starters_count: goldenFeatures.away_starters_count
+        },
+        tactical: {
+            home_xg: tacticalFeatures.home_xg,
+            away_xg: tacticalFeatures.away_xg,
+            home_possession_pct: tacticalFeatures.home_possession_pct,
+            away_possession_pct: tacticalFeatures.away_possession_pct,
+            home_shots: tacticalFeatures.home_shots,
+            away_shots: tacticalFeatures.away_shots,
+            momentum_samples_count: tacticalFeatures.momentum_samples_count
+        },
+        odds: {
+            has_odds_data: oddsMovementFeatures.has_odds_data,
+            odds_source: oddsMovementFeatures.odds_source,
+            initial_home_odds: oddsMovementFeatures.initial_home_odds,
+            current_home_odds: oddsMovementFeatures.current_home_odds,
+            total_movement: oddsMovementFeatures.total_movement
+        }
+    };
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000
+    };
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (!args.fixture || !args.matchId) {
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const { resolved, data: fixture } = readJsonFile(args.fixture);
+    const missingFields = validateFixture(fixture, args.matchId);
+    const rawData = fixture.raw_data;
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const matchSql = `
+            SELECT match_id, external_id, league_name, season, home_team, away_team,
+                   match_date, status, pipeline_status
+            FROM matches
+            WHERE match_id = $1
+        `;
+        const oddsSql = `
+            SELECT match_id, bookmaker_name, market_type, open_odds, close_odds, collected_at
+            FROM bookmaker_odds_history
+            WHERE match_id = $1
+            ORDER BY bookmaker_name, market_type
+        `;
+
+        const matchResult = await safeSelect(pool, matchSql, [args.matchId]);
+        if (matchResult.rowCount !== 1) {
+            throw new Error(`Target match not found: ${args.matchId}`);
+        }
+
+        const oddsResult = await safeSelect(pool, oddsSql, [args.matchId]);
+        const oddsRows = oddsResult.rows;
+
+        const matchRow = matchResult.rows[0];
+        const goldenExtracted = extractGoldenFeatures(rawData);
+        const tacticalExtracted = extractTacticalFeatures(rawData);
+        const oddsData = buildOddsDataFromHistoryRows(oddsRows);
+        const oddsMovementFeatures = oddsData.hasData
+            ? extractOddsMovementFeaturesFromOddsData(oddsData, tacticalExtracted)
+            : extractOddsMovementFeatures(rawData, tacticalExtracted);
+        const fixtureSummary = summarizeFixture(rawData);
+        const stitchSummary = buildStitchSummary(rawData, oddsRows, missingFields);
+
+        const preview = {
+            mode: 'dry-run',
+            match_id: args.matchId,
+            fixture: {
+                path: args.fixture,
+                resolved_path: resolved,
+                external_id: fixture.external_id || rawData.general?.matchId || null
+            },
+            db: {
+                match_found: true,
+                odds_history_rows: oddsRows.length,
+                match: {
+                    match_id: matchRow.match_id,
+                    external_id: matchRow.external_id,
+                    league_name: matchRow.league_name,
+                    season: matchRow.season,
+                    home_team: matchRow.home_team,
+                    away_team: matchRow.away_team,
+                    match_date: matchRow.match_date ? new Date(matchRow.match_date).toISOString() : null,
+                    status: matchRow.status,
+                    pipeline_status: matchRow.pipeline_status
+                }
+            },
+            golden_features: {
+                league_name: matchRow.league_name,
+                season: matchRow.season,
+                home_team: matchRow.home_team,
+                away_team: matchRow.away_team,
+                match_date: matchRow.match_date ? new Date(matchRow.match_date).toISOString() : null,
+                extracted: goldenExtracted
+            },
+            tactical_features: {
+                shots_count: fixtureSummary.shots_count,
+                momentum_points: fixtureSummary.momentum_points,
+                lineup_available: fixtureSummary.lineup_available,
+                extracted: tacticalExtracted
+            },
+            odds_features: {
+                rows: oddsRows.length,
+                one_x_two_rows: oddsRows.filter(row => String(row.market_type || '').toLowerCase() === '1x2').length,
+                bookmakers: uniqueSorted(oddsRows.map(row => row.bookmaker_name)),
+                markets: uniqueSorted(oddsRows.map(row => row.market_type)),
+                source: oddsData.hasData ? 'bookmaker_odds_history' : 'raw_fixture_or_none',
+                extracted: oddsMovementFeatures
+            },
+            elo_features: {
+                available: false,
+                reason: 'ELO not computed in local dry-run'
+            },
+            feature_highlights: selectFeatureHighlights(goldenExtracted, tacticalExtracted, oddsMovementFeatures),
+            stitch_summary: stitchSummary,
+            missing_fields: missingFields,
+            warnings: oddsRows.length === 0 ? ['target_odds_history_missing'] : [],
+            non_execution_confirmations: [
+                'no_db_writes',
+                'no_insert',
+                'no_update',
+                'no_delete',
+                'no_create_index',
+                'no_create_table',
+                'no_upsert',
+                'no_l3_write',
+                'no_elo',
+                'no_external_network'
+            ]
+        };
+
+        console.log(JSON.stringify(preview, null, 2));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(JSON.stringify({
+        mode: 'dry-run',
+        ok: false,
+        error: error.message,
+        non_execution_confirmations: [
+            'no_db_writes',
+            'no_create_index',
+            'no_elo',
+            'no_external_network'
+        ]
+    }, null, 2));
+    process.exit(1);
+});

--- a/scripts/ops/l3_local_dry_run.js
+++ b/scripts/ops/l3_local_dry_run.js
@@ -17,7 +17,7 @@ const { extractGoldenFeatures } = require('../../src/feature_engine/extractors/G
 const { extractTacticalFeatures } = require('../../src/feature_engine/extractors/TacticalMomentumExtractor');
 const {
     extractOddsMovementFeatures,
-    extractOddsMovementFeaturesFromOddsData
+    extractOddsMovementFeaturesFromOddsData,
 } = require('../../src/feature_engine/extractors/OddsMovementExtractor');
 
 const FORBIDDEN_SQL = /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|UPSERT|MERGE|GRANT|REVOKE)\b/i;
@@ -28,7 +28,7 @@ function usage() {
         '  node scripts/ops/l3_local_dry_run.js --fixture <path> --match-id <id> [--json]',
         '',
         'Safety:',
-        '  SELECT-only DB checks; no L3 writes, no schema writes, no Elo, no network.'
+        '  SELECT-only DB checks; no L3 writes, no schema writes, no Elo, no network.',
     ].join('\n');
 }
 
@@ -37,7 +37,7 @@ function parseArgs(argv) {
         fixture: null,
         matchId: null,
         json: false,
-        help: false
+        help: false,
     };
 
     for (let index = 0; index < argv.length; index += 1) {
@@ -65,7 +65,7 @@ function readJsonFile(filePath) {
     const raw = fs.readFileSync(resolved, 'utf8');
     return {
         resolved,
-        data: JSON.parse(raw)
+        data: JSON.parse(raw),
     };
 }
 
@@ -87,46 +87,56 @@ function normalizeFixtureMatchId(fixture) {
     return String(fixture.match_id || fixture.raw_data?.matchId || fixture.raw_data?.general?.matchId || '');
 }
 
-function validateFixture(fixture, expectedMatchId) {
-    const missing = [];
+function assertFixtureRoot(fixture, expectedMatchId) {
+    const actualMatchId = normalizeFixtureMatchId(fixture);
 
     if (!fixture || typeof fixture !== 'object') {
         throw new Error('Fixture root must be a JSON object');
     }
-    if (normalizeFixtureMatchId(fixture) !== expectedMatchId) {
-        throw new Error(`Fixture match_id does not match --match-id (${normalizeFixtureMatchId(fixture)} != ${expectedMatchId})`);
+    if (actualMatchId !== expectedMatchId) {
+        throw new Error(`Fixture match_id does not match --match-id (${actualMatchId} != ${expectedMatchId})`);
     }
-    if (!fixture.raw_data || typeof fixture.raw_data !== 'object' || Array.isArray(fixture.raw_data)) {
+}
+
+function collectRawDataMissingFields(rawData) {
+    const missing = [];
+
+    if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
         missing.push('raw_data');
     }
 
-    const rawData = fixture.raw_data || {};
-    if (!('matchId' in rawData) && !rawData.general && !rawData.header) {
+    const rawDataObject = rawData || {};
+    if (!('matchId' in rawDataObject) && !rawDataObject.general && !rawDataObject.header) {
         missing.push('raw_data.matchId_or_general_or_header');
     }
-    if (!rawData.general) {
+    if (!rawDataObject.general) {
         missing.push('raw_data.general');
     }
-    if (!rawData.header) {
+    if (!rawDataObject.header) {
         missing.push('raw_data.header');
     }
-    if (!rawData.content) {
+    if (!rawDataObject.content) {
         missing.push('raw_data.content');
     }
-    if (!rawData.content?.lineup?.homeTeam) {
+    if (!rawDataObject.content?.lineup?.homeTeam) {
         missing.push('raw_data.content.lineup.homeTeam');
     }
-    if (!rawData.content?.lineup?.awayTeam) {
+    if (!rawDataObject.content?.lineup?.awayTeam) {
         missing.push('raw_data.content.lineup.awayTeam');
     }
-    if (!Array.isArray(rawData.content?.stats)) {
+    if (!Array.isArray(rawDataObject.content?.stats)) {
         missing.push('raw_data.content.stats[]');
     }
-    if (!Array.isArray(rawData.content?.shotmap?.shots)) {
+    if (!Array.isArray(rawDataObject.content?.shotmap?.shots)) {
         missing.push('raw_data.content.shotmap.shots[]');
     }
 
     return missing;
+}
+
+function validateFixture(fixture, expectedMatchId) {
+    assertFixtureRoot(fixture, expectedMatchId);
+    return collectRawDataMissingFields(fixture.raw_data);
 }
 
 function toPositiveNumber(value) {
@@ -139,7 +149,7 @@ function normalizeOddsPayload(payload, collectedAt) {
         home: toPositiveNumber(payload?.home),
         draw: toPositiveNumber(payload?.draw),
         away: toPositiveNumber(payload?.away),
-        collectedAt: collectedAt ? new Date(collectedAt).toISOString() : null
+        collectedAt: collectedAt ? new Date(collectedAt).toISOString() : null,
     };
 }
 
@@ -160,13 +170,8 @@ function buildOddsDataFromHistoryRows(rows) {
         history.push(initial);
     }
     if (
-        current
-        && (
-            !initial
-            || current.home !== initial.home
-            || current.draw !== initial.draw
-            || current.away !== initial.away
-        )
+        current &&
+        (!initial || current.home !== initial.home || current.draw !== initial.draw || current.away !== initial.away)
     ) {
         history.push(current);
     }
@@ -176,7 +181,7 @@ function buildOddsDataFromHistoryRows(rows) {
         current,
         history,
         hasData: Boolean(initial || current || history.length > 0),
-        odds_source: oneX2Rows.length > 0 ? 'bookmaker_odds_history' : 'none'
+        odds_source: oneX2Rows.length > 0 ? 'bookmaker_odds_history' : 'none',
     };
 }
 
@@ -185,9 +190,7 @@ function uniqueSorted(values) {
 }
 
 function summarizeFixture(rawData) {
-    const shotmapShots = Array.isArray(rawData?.content?.shotmap?.shots)
-        ? rawData.content.shotmap.shots.length
-        : 0;
+    const shotmapShots = Array.isArray(rawData?.content?.shotmap?.shots) ? rawData.content.shotmap.shots.length : 0;
     const momentum = rawData?.content?.momentum?.data || rawData?.content?.momentum?.main?.data || [];
     const lineup = rawData?.content?.lineup || {};
 
@@ -196,7 +199,7 @@ function summarizeFixture(rawData) {
         home_starters: Array.isArray(lineup.homeTeam?.starters) ? lineup.homeTeam.starters.length : 0,
         away_starters: Array.isArray(lineup.awayTeam?.starters) ? lineup.awayTeam.starters.length : 0,
         shots_count: shotmapShots,
-        momentum_points: Array.isArray(momentum) ? momentum.length : 0
+        momentum_points: Array.isArray(momentum) ? momentum.length : 0,
     };
 }
 
@@ -226,7 +229,7 @@ function buildStitchSummary(rawData, oddsRows, missingFields) {
         would_update_matches: false,
         would_trigger_elo: false,
         would_create_index: false,
-        would_create_table: false
+        would_create_table: false,
     };
 }
 
@@ -238,7 +241,7 @@ function selectFeatureHighlights(goldenFeatures, tacticalFeatures, oddsMovementF
             home_rating_avg: goldenFeatures.home_rating_avg,
             away_rating_avg: goldenFeatures.away_rating_avg,
             home_starters_count: goldenFeatures.home_starters_count,
-            away_starters_count: goldenFeatures.away_starters_count
+            away_starters_count: goldenFeatures.away_starters_count,
         },
         tactical: {
             home_xg: tacticalFeatures.home_xg,
@@ -247,15 +250,15 @@ function selectFeatureHighlights(goldenFeatures, tacticalFeatures, oddsMovementF
             away_possession_pct: tacticalFeatures.away_possession_pct,
             home_shots: tacticalFeatures.home_shots,
             away_shots: tacticalFeatures.away_shots,
-            momentum_samples_count: tacticalFeatures.momentum_samples_count
+            momentum_samples_count: tacticalFeatures.momentum_samples_count,
         },
         odds: {
             has_odds_data: oddsMovementFeatures.has_odds_data,
             odds_source: oddsMovementFeatures.odds_source,
             initial_home_odds: oddsMovementFeatures.initial_home_odds,
             current_home_odds: oddsMovementFeatures.current_home_odds,
-            total_movement: oddsMovementFeatures.total_movement
-        }
+            total_movement: oddsMovementFeatures.total_movement,
+        },
     };
 }
 
@@ -268,7 +271,7 @@ function buildDbConfig() {
         password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
         max: 2,
         connectionTimeoutMillis: 5000,
-        idleTimeoutMillis: 5000
+        idleTimeoutMillis: 5000,
     };
 }
 
@@ -327,7 +330,7 @@ async function main() {
             fixture: {
                 path: args.fixture,
                 resolved_path: resolved,
-                external_id: fixture.external_id || rawData.general?.matchId || null
+                external_id: fixture.external_id || rawData.general?.matchId || null,
             },
             db: {
                 match_found: true,
@@ -341,8 +344,8 @@ async function main() {
                     away_team: matchRow.away_team,
                     match_date: matchRow.match_date ? new Date(matchRow.match_date).toISOString() : null,
                     status: matchRow.status,
-                    pipeline_status: matchRow.pipeline_status
-                }
+                    pipeline_status: matchRow.pipeline_status,
+                },
             },
             golden_features: {
                 league_name: matchRow.league_name,
@@ -350,13 +353,13 @@ async function main() {
                 home_team: matchRow.home_team,
                 away_team: matchRow.away_team,
                 match_date: matchRow.match_date ? new Date(matchRow.match_date).toISOString() : null,
-                extracted: goldenExtracted
+                extracted: goldenExtracted,
             },
             tactical_features: {
                 shots_count: fixtureSummary.shots_count,
                 momentum_points: fixtureSummary.momentum_points,
                 lineup_available: fixtureSummary.lineup_available,
-                extracted: tacticalExtracted
+                extracted: tacticalExtracted,
             },
             odds_features: {
                 rows: oddsRows.length,
@@ -364,11 +367,11 @@ async function main() {
                 bookmakers: uniqueSorted(oddsRows.map(row => row.bookmaker_name)),
                 markets: uniqueSorted(oddsRows.map(row => row.market_type)),
                 source: oddsData.hasData ? 'bookmaker_odds_history' : 'raw_fixture_or_none',
-                extracted: oddsMovementFeatures
+                extracted: oddsMovementFeatures,
             },
             elo_features: {
                 available: false,
-                reason: 'ELO not computed in local dry-run'
+                reason: 'ELO not computed in local dry-run',
             },
             feature_highlights: selectFeatureHighlights(goldenExtracted, tacticalExtracted, oddsMovementFeatures),
             stitch_summary: stitchSummary,
@@ -384,8 +387,8 @@ async function main() {
                 'no_upsert',
                 'no_l3_write',
                 'no_elo',
-                'no_external_network'
-            ]
+                'no_external_network',
+            ],
         };
 
         console.log(JSON.stringify(preview, null, 2));
@@ -395,16 +398,17 @@ async function main() {
 }
 
 main().catch(error => {
-    console.error(JSON.stringify({
-        mode: 'dry-run',
-        ok: false,
-        error: error.message,
-        non_execution_confirmations: [
-            'no_db_writes',
-            'no_create_index',
-            'no_elo',
-            'no_external_network'
-        ]
-    }, null, 2));
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: ['no_db_writes', 'no_create_index', 'no_elo', 'no_external_network'],
+            },
+            null,
+            2
+        )
+    );
     process.exit(1);
 });

--- a/tests/fixtures/l3/raw_match_data_phase419_sample.json
+++ b/tests/fixtures/l3/raw_match_data_phase419_sample.json
@@ -1,205 +1,205 @@
 {
-  "match_id": "140_20252026_4837496",
-  "external_id": "4837496",
-  "raw_data": {
-    "matchId": 4837496,
-    "general": {
-      "matchId": 4837496,
-      "leagueId": 140,
-      "leagueName": "Segunda División",
-      "season": "2025/2026",
-      "homeTeam": {
-        "id": 1001401,
-        "name": "Cultural Leonesa"
-      },
-      "awayTeam": {
-        "id": 1001402,
-        "name": "Burgos CF"
-      },
-      "matchTimeUTC": "2026-05-24T17:00:00Z",
-      "matchTimeUTCDate": "2026-05-24T17:00:00Z",
-      "started": false,
-      "finished": false,
-      "coverageLevel": "local_fixture"
-    },
-    "header": {
-      "teams": [
-        {
-          "name": "Cultural Leonesa",
-          "id": 1001401,
-          "score": null
+    "match_id": "140_20252026_4837496",
+    "external_id": "4837496",
+    "raw_data": {
+        "matchId": 4837496,
+        "general": {
+            "matchId": 4837496,
+            "leagueId": 140,
+            "leagueName": "Segunda División",
+            "season": "2025/2026",
+            "homeTeam": {
+                "id": 1001401,
+                "name": "Cultural Leonesa"
+            },
+            "awayTeam": {
+                "id": 1001402,
+                "name": "Burgos CF"
+            },
+            "matchTimeUTC": "2026-05-24T17:00:00Z",
+            "matchTimeUTCDate": "2026-05-24T17:00:00Z",
+            "started": false,
+            "finished": false,
+            "coverageLevel": "local_fixture"
         },
-        {
-          "name": "Burgos CF",
-          "id": 1001402,
-          "score": null
+        "header": {
+            "teams": [
+                {
+                    "name": "Cultural Leonesa",
+                    "id": 1001401,
+                    "score": null
+                },
+                {
+                    "name": "Burgos CF",
+                    "id": 1001402,
+                    "score": null
+                }
+            ],
+            "status": {
+                "started": false,
+                "finished": false,
+                "cancelled": false,
+                "utcTime": "2026-05-24T17:00:00Z",
+                "timezone": "UTC",
+                "scoreStr": "- - -"
+            }
+        },
+        "content": {
+            "stats": [
+                {
+                    "title": "Expected goals (xG)",
+                    "stats": [1.1, 0.9]
+                },
+                {
+                    "title": "Ball possession",
+                    "stats": ["52%", "48%"]
+                },
+                {
+                    "title": "Total shots",
+                    "stats": [11, 9]
+                },
+                {
+                    "title": "Shots on target",
+                    "stats": [4, 3]
+                },
+                {
+                    "title": "Corner kicks",
+                    "stats": [5, 4]
+                },
+                {
+                    "title": "Yellow cards",
+                    "stats": [2, 2]
+                },
+                {
+                    "title": "Red cards",
+                    "stats": [0, 0]
+                },
+                {
+                    "title": "Fouls",
+                    "stats": [13, 12]
+                }
+            ],
+            "lineup": {
+                "homeTeam": {
+                    "id": 1001401,
+                    "name": "Cultural Leonesa",
+                    "formation": "4-2-3-1",
+                    "totalStarterMarketValue": 12.4,
+                    "starters": [
+                        {
+                            "playerId": "cl-1",
+                            "name": "Cultural Keeper",
+                            "position": "GK",
+                            "age": 28,
+                            "marketValue": 1.2,
+                            "performance": {
+                                "rating": 6.8
+                            }
+                        },
+                        {
+                            "playerId": "cl-2",
+                            "name": "Cultural Midfielder",
+                            "position": "MF",
+                            "age": 25,
+                            "marketValue": 2.8,
+                            "performance": {
+                                "rating": 7.1
+                            }
+                        },
+                        {
+                            "playerId": "cl-3",
+                            "name": "Cultural Forward",
+                            "position": "FW",
+                            "age": 27,
+                            "marketValue": 3.4,
+                            "performance": {
+                                "rating": 7.3
+                            }
+                        }
+                    ],
+                    "subs": [
+                        {
+                            "playerId": "cl-sub-1",
+                            "name": "Cultural Substitute",
+                            "position": "MF",
+                            "marketValue": 0.9,
+                            "performance": {
+                                "rating": 6.4
+                            }
+                        }
+                    ],
+                    "unavailable": []
+                },
+                "awayTeam": {
+                    "id": 1001402,
+                    "name": "Burgos CF",
+                    "formation": "4-4-2",
+                    "totalStarterMarketValue": 10.8,
+                    "starters": [
+                        {
+                            "playerId": "bcf-1",
+                            "name": "Burgos Keeper",
+                            "position": "GK",
+                            "age": 29,
+                            "marketValue": 1.0,
+                            "performance": {
+                                "rating": 6.7
+                            }
+                        },
+                        {
+                            "playerId": "bcf-2",
+                            "name": "Burgos Midfielder",
+                            "position": "MF",
+                            "age": 26,
+                            "marketValue": 2.5,
+                            "performance": {
+                                "rating": 6.9
+                            }
+                        },
+                        {
+                            "playerId": "bcf-3",
+                            "name": "Burgos Forward",
+                            "position": "FW",
+                            "age": 24,
+                            "marketValue": 3.1,
+                            "performance": {
+                                "rating": 7.0
+                            }
+                        }
+                    ],
+                    "subs": [
+                        {
+                            "playerId": "bcf-sub-1",
+                            "name": "Burgos Substitute",
+                            "position": "DF",
+                            "marketValue": 0.8,
+                            "performance": {
+                                "rating": 6.3
+                            }
+                        }
+                    ],
+                    "unavailable": []
+                }
+            },
+            "shotmap": {
+                "shots": []
+            },
+            "momentum": {
+                "data": [
+                    { "minute": 10, "value": 8 },
+                    { "minute": 25, "value": -5 },
+                    { "minute": 40, "value": 4 },
+                    { "minute": 55, "value": 7 },
+                    { "minute": 70, "value": -3 },
+                    { "minute": 85, "value": 2 }
+                ]
+            }
+        },
+        "_meta": {
+            "source": "phase419_local_fixture",
+            "dataVersion": "PHASE4.19",
+            "containsSecrets": false,
+            "externalNetworkAccess": false
         }
-      ],
-      "status": {
-        "started": false,
-        "finished": false,
-        "cancelled": false,
-        "utcTime": "2026-05-24T17:00:00Z",
-        "timezone": "UTC",
-        "scoreStr": "- - -"
-      }
-    },
-    "content": {
-      "stats": [
-        {
-          "title": "Expected goals (xG)",
-          "stats": [1.1, 0.9]
-        },
-        {
-          "title": "Ball possession",
-          "stats": ["52%", "48%"]
-        },
-        {
-          "title": "Total shots",
-          "stats": [11, 9]
-        },
-        {
-          "title": "Shots on target",
-          "stats": [4, 3]
-        },
-        {
-          "title": "Corner kicks",
-          "stats": [5, 4]
-        },
-        {
-          "title": "Yellow cards",
-          "stats": [2, 2]
-        },
-        {
-          "title": "Red cards",
-          "stats": [0, 0]
-        },
-        {
-          "title": "Fouls",
-          "stats": [13, 12]
-        }
-      ],
-      "lineup": {
-        "homeTeam": {
-          "id": 1001401,
-          "name": "Cultural Leonesa",
-          "formation": "4-2-3-1",
-          "totalStarterMarketValue": 12.4,
-          "starters": [
-            {
-              "playerId": "cl-1",
-              "name": "Cultural Keeper",
-              "position": "GK",
-              "age": 28,
-              "marketValue": 1.2,
-              "performance": {
-                "rating": 6.8
-              }
-            },
-            {
-              "playerId": "cl-2",
-              "name": "Cultural Midfielder",
-              "position": "MF",
-              "age": 25,
-              "marketValue": 2.8,
-              "performance": {
-                "rating": 7.1
-              }
-            },
-            {
-              "playerId": "cl-3",
-              "name": "Cultural Forward",
-              "position": "FW",
-              "age": 27,
-              "marketValue": 3.4,
-              "performance": {
-                "rating": 7.3
-              }
-            }
-          ],
-          "subs": [
-            {
-              "playerId": "cl-sub-1",
-              "name": "Cultural Substitute",
-              "position": "MF",
-              "marketValue": 0.9,
-              "performance": {
-                "rating": 6.4
-              }
-            }
-          ],
-          "unavailable": []
-        },
-        "awayTeam": {
-          "id": 1001402,
-          "name": "Burgos CF",
-          "formation": "4-4-2",
-          "totalStarterMarketValue": 10.8,
-          "starters": [
-            {
-              "playerId": "bcf-1",
-              "name": "Burgos Keeper",
-              "position": "GK",
-              "age": 29,
-              "marketValue": 1.0,
-              "performance": {
-                "rating": 6.7
-              }
-            },
-            {
-              "playerId": "bcf-2",
-              "name": "Burgos Midfielder",
-              "position": "MF",
-              "age": 26,
-              "marketValue": 2.5,
-              "performance": {
-                "rating": 6.9
-              }
-            },
-            {
-              "playerId": "bcf-3",
-              "name": "Burgos Forward",
-              "position": "FW",
-              "age": 24,
-              "marketValue": 3.1,
-              "performance": {
-                "rating": 7.0
-              }
-            }
-          ],
-          "subs": [
-            {
-              "playerId": "bcf-sub-1",
-              "name": "Burgos Substitute",
-              "position": "DF",
-              "marketValue": 0.8,
-              "performance": {
-                "rating": 6.3
-              }
-            }
-          ],
-          "unavailable": []
-        }
-      },
-      "shotmap": {
-        "shots": []
-      },
-      "momentum": {
-        "data": [
-          { "minute": 10, "value": 8 },
-          { "minute": 25, "value": -5 },
-          { "minute": 40, "value": 4 },
-          { "minute": 55, "value": 7 },
-          { "minute": 70, "value": -3 },
-          { "minute": 85, "value": 2 }
-        ]
-      }
-    },
-    "_meta": {
-      "source": "phase419_local_fixture",
-      "dataVersion": "PHASE4.19",
-      "containsSecrets": false,
-      "externalNetworkAccess": false
     }
-  }
 }

--- a/tests/fixtures/l3/raw_match_data_phase419_sample.json
+++ b/tests/fixtures/l3/raw_match_data_phase419_sample.json
@@ -1,0 +1,205 @@
+{
+  "match_id": "140_20252026_4837496",
+  "external_id": "4837496",
+  "raw_data": {
+    "matchId": 4837496,
+    "general": {
+      "matchId": 4837496,
+      "leagueId": 140,
+      "leagueName": "Segunda División",
+      "season": "2025/2026",
+      "homeTeam": {
+        "id": 1001401,
+        "name": "Cultural Leonesa"
+      },
+      "awayTeam": {
+        "id": 1001402,
+        "name": "Burgos CF"
+      },
+      "matchTimeUTC": "2026-05-24T17:00:00Z",
+      "matchTimeUTCDate": "2026-05-24T17:00:00Z",
+      "started": false,
+      "finished": false,
+      "coverageLevel": "local_fixture"
+    },
+    "header": {
+      "teams": [
+        {
+          "name": "Cultural Leonesa",
+          "id": 1001401,
+          "score": null
+        },
+        {
+          "name": "Burgos CF",
+          "id": 1001402,
+          "score": null
+        }
+      ],
+      "status": {
+        "started": false,
+        "finished": false,
+        "cancelled": false,
+        "utcTime": "2026-05-24T17:00:00Z",
+        "timezone": "UTC",
+        "scoreStr": "- - -"
+      }
+    },
+    "content": {
+      "stats": [
+        {
+          "title": "Expected goals (xG)",
+          "stats": [1.1, 0.9]
+        },
+        {
+          "title": "Ball possession",
+          "stats": ["52%", "48%"]
+        },
+        {
+          "title": "Total shots",
+          "stats": [11, 9]
+        },
+        {
+          "title": "Shots on target",
+          "stats": [4, 3]
+        },
+        {
+          "title": "Corner kicks",
+          "stats": [5, 4]
+        },
+        {
+          "title": "Yellow cards",
+          "stats": [2, 2]
+        },
+        {
+          "title": "Red cards",
+          "stats": [0, 0]
+        },
+        {
+          "title": "Fouls",
+          "stats": [13, 12]
+        }
+      ],
+      "lineup": {
+        "homeTeam": {
+          "id": 1001401,
+          "name": "Cultural Leonesa",
+          "formation": "4-2-3-1",
+          "totalStarterMarketValue": 12.4,
+          "starters": [
+            {
+              "playerId": "cl-1",
+              "name": "Cultural Keeper",
+              "position": "GK",
+              "age": 28,
+              "marketValue": 1.2,
+              "performance": {
+                "rating": 6.8
+              }
+            },
+            {
+              "playerId": "cl-2",
+              "name": "Cultural Midfielder",
+              "position": "MF",
+              "age": 25,
+              "marketValue": 2.8,
+              "performance": {
+                "rating": 7.1
+              }
+            },
+            {
+              "playerId": "cl-3",
+              "name": "Cultural Forward",
+              "position": "FW",
+              "age": 27,
+              "marketValue": 3.4,
+              "performance": {
+                "rating": 7.3
+              }
+            }
+          ],
+          "subs": [
+            {
+              "playerId": "cl-sub-1",
+              "name": "Cultural Substitute",
+              "position": "MF",
+              "marketValue": 0.9,
+              "performance": {
+                "rating": 6.4
+              }
+            }
+          ],
+          "unavailable": []
+        },
+        "awayTeam": {
+          "id": 1001402,
+          "name": "Burgos CF",
+          "formation": "4-4-2",
+          "totalStarterMarketValue": 10.8,
+          "starters": [
+            {
+              "playerId": "bcf-1",
+              "name": "Burgos Keeper",
+              "position": "GK",
+              "age": 29,
+              "marketValue": 1.0,
+              "performance": {
+                "rating": 6.7
+              }
+            },
+            {
+              "playerId": "bcf-2",
+              "name": "Burgos Midfielder",
+              "position": "MF",
+              "age": 26,
+              "marketValue": 2.5,
+              "performance": {
+                "rating": 6.9
+              }
+            },
+            {
+              "playerId": "bcf-3",
+              "name": "Burgos Forward",
+              "position": "FW",
+              "age": 24,
+              "marketValue": 3.1,
+              "performance": {
+                "rating": 7.0
+              }
+            }
+          ],
+          "subs": [
+            {
+              "playerId": "bcf-sub-1",
+              "name": "Burgos Substitute",
+              "position": "DF",
+              "marketValue": 0.8,
+              "performance": {
+                "rating": 6.3
+              }
+            }
+          ],
+          "unavailable": []
+        }
+      },
+      "shotmap": {
+        "shots": []
+      },
+      "momentum": {
+        "data": [
+          { "minute": 10, "value": 8 },
+          { "minute": 25, "value": -5 },
+          { "minute": 40, "value": 4 },
+          { "minute": 55, "value": 7 },
+          { "minute": 70, "value": -3 },
+          { "minute": 85, "value": 2 }
+        ]
+      }
+    },
+    "_meta": {
+      "source": "phase419_local_fixture",
+      "dataVersion": "PHASE4.19",
+      "containsSecrets": false,
+      "externalNetworkAccess": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a safe local L3 dry-run gate that reads a local raw fixture and current DB odds state without writing to the database.

Changes:
- Adds scripts/ops/l3_local_dry_run.js
- Adds tests/fixtures/l3/raw_match_data_phase419_sample.json
- Adds make data-l3-dry-run
- Updates data-help
- Updates AGENTS.md with safe L3 rules
- Adds Phase 4.19 report

Safety properties:
- No DB writes
- No CREATE INDEX / CREATE TABLE
- No UPSERT
- No UPDATE matches
- No ELO trigger
- No external network access
- Does not call smelt_all / l3_stitch / ELO

Validation:
- make data-l3-dry-run without args fails as expected
- make data-l3-dry-run SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496 succeeds
- match_found=true
- odds_history_rows=2
- would_write_l3_features=false
- would_update_matches=false
- would_trigger_elo=false
- DB row counts unchanged after dry-run
- git diff --check

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/l3_local_dry_run.js
- tests/fixtures/l3/raw_match_data_phase419_sample.json
- docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md