### PR TITLE
feat(data): add raw match data local ingest gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ AI / Codex 默认只能执行：
 - `make data-check`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
+- 用户明确授权且仅使用本地 fixture 的 `make data-raw-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 
 AI / Codex 不能直接执行：
 
@@ -232,6 +233,8 @@ AI / Codex 不能直接执行：
 - `scripts/ops/l3_stitch_pipeline.js`
 - `scripts/ops/l3_stitch_worker.js`
 - `npm run elo:recalc`
+- `make data-raw-commit`
+- `node scripts/ops/raw_match_data_local_ingest.js --commit`
 - 任何 `--commit` 命令
 - 任何外网收割命令
 - 任何写 DB 命令
@@ -244,6 +247,15 @@ AI / Codex 不能直接执行：
 - 不访问外网
 
 L3 本地 dry-run 预检背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+
+执行 `make data-raw-dry-run` 的前提：
+
+- 用户明确授权
+- fixture 是本地文件
+- 不写 DB
+- 不访问外网
+
+Phase 4.21 中 `make data-raw-commit` 和 `node scripts/ops/raw_match_data_local_ingest.js --commit` 仍是 blocked / not wired。相关背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md` 和 `docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md`
 
 `NETWORK_DRY_RUN` 不是安全 dry-run，必须由用户显式授权，并给出 `LIMIT`、`SCOPE`、代理和限速说明。
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@
 
 .PHONY: help up down restart logs test clean build db-reset db-shell lint format security \
         dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test \
-        data-help data-check data-local-dry-run data-l3-dry-run data-network-dry-run \
-        data-db-write-small data-harvest data-risk-report data-schema-help data-schema-status \
-        data-schema-plan data-schema-migrate
+        data-help data-check data-local-dry-run data-l3-dry-run data-raw-dry-run \
+        data-raw-commit data-network-dry-run data-db-write-small data-harvest \
+        data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
 # 默认目标
 .DEFAULT_GOAL := help
@@ -234,8 +234,10 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-check"
 	@echo "  make data-local-dry-run SAMPLE_HTML=<path> or SAMPLE_CSV=<path>"
 	@echo "  make data-l3-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
+	@echo "  make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-raw-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_RAW_COMMIT=1  # blocked in Phase 4.21"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -275,6 +277,27 @@ data-l3-dry-run: ## Run safe local L3 dry-run from fixture. Requires SAMPLE_RAW 
 	@echo "Running safe local L3 dry-run: SAMPLE_RAW=$(SAMPLE_RAW), MATCH_ID=$(MATCH_ID)"
 	$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_RAW)"
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/l3_local_dry_run.js --fixture "$(SAMPLE_RAW)" --match-id "$(MATCH_ID)"
+
+data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.
+	@if [ -z "$(SAMPLE_RAW)" ] || [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide SAMPLE_RAW=<path> and MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe local raw_match_data ingest dry-run: SAMPLE_RAW=$(SAMPLE_RAW), MATCH_ID=$(MATCH_ID)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_RAW)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/raw_match_data_local_ingest.js --fixture "$(SAMPLE_RAW)" --match-id "$(MATCH_ID)"
+
+data-raw-commit: ## Blocked raw_match_data commit gate. Requires SAMPLE_RAW, MATCH_ID, CONFIRM_RAW_COMMIT=1.
+	@if [ "$(CONFIRM_RAW_COMMIT)" != "1" ]; then \
+		echo "BLOCKED: raw_match_data commit requires CONFIRM_RAW_COMMIT=1 and is not wired in Phase 4.21."; \
+		exit 1; \
+	fi
+	@if [ -z "$(SAMPLE_RAW)" ] || [ -z "$(MATCH_ID)" ]; then \
+		echo "BLOCKED: provide SAMPLE_RAW=<path> and MATCH_ID=<id>; raw_match_data commit is not wired in Phase 4.21."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: raw_match_data commit is not wired in Phase 4.21."
+	@exit 1
 
 data-network-dry-run: ## Blocked unless explicitly authorized. Does not run by default.
 	@if [ "$(CONFIRM_NETWORK)" != "1" ]; then \

--- a/docs/_reports/RAW_MATCH_DATA_LOCAL_INGEST_GATE_PHASE4_21.md
+++ b/docs/_reports/RAW_MATCH_DATA_LOCAL_INGEST_GATE_PHASE4_21.md
@@ -1,0 +1,252 @@
+# Phase 4.21 - raw_match_data Local Ingest Gate
+
+日期: `2026-05-02`
+
+## 1. 当前 HEAD
+
+- 分支: `feat/raw-match-data-local-ingest-gate`
+- Base HEAD: `3adb15161e2fe079e52fe5503ac6deeb4c15ca28`
+- 基线提交: `3adb151 feat(l3): add safe local dry-run gate`
+
+## 2. 本阶段新增文件
+
+- `scripts/ops/raw_match_data_local_ingest.js`
+- `docs/_reports/RAW_MATCH_DATA_LOCAL_INGEST_GATE_PHASE4_21.md`
+
+修改文件:
+
+- `Makefile`
+- `AGENTS.md`
+
+复用文件:
+
+- `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+
+## 3. raw_match_data 表结构摘要
+
+只读审查结果:
+
+- `id`: `bigint`, `NOT NULL`, default `nextval('raw_match_data_id_seq'::regclass)`
+- `match_id`: `varchar(50)`, `NOT NULL`
+- `external_id`: `varchar(100)`, nullable
+- `raw_data`: `jsonb`, `NOT NULL`
+- `collected_at`: `timestamptz`, nullable, default `CURRENT_TIMESTAMP`
+- `data_version`: `varchar(20)`, nullable, default `'V26.1'`
+- `data_hash`: `varchar(64)`, nullable
+
+约束摘要:
+
+- `raw_match_data_match_id_fkey`: `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+- `raw_match_data_match_id_key`: unique `match_id`
+- `raw_data_not_empty`: `raw_data IS NOT NULL` and not empty JSONB
+- `raw_data_has_match_id`: `raw_data` must contain `matchId`, `general`, or `header`
+- `match_id_format`: supports composite `league_season_external` style or numeric IDs
+- `data_hash` is optional in current schema
+
+## 4. Fixture 审查结果
+
+Fixture:
+
+- `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+
+审查结果:
+
+- `match_id`: `140_20252026_4837496`
+- `external_id`: `4837496`
+- `raw_data.matchId`: `4837496`
+- `raw_data.general`: present
+- `raw_data.header`: present
+- `raw_data.content`: present
+- 符合 `raw_data_has_match_id` 与 `raw_data_not_empty` 约束的 dry-run 预览要求
+- 本阶段未修改 fixture
+
+## 5. Dry-Run 脚本行为
+
+新增脚本:
+
+- `scripts/ops/raw_match_data_local_ingest.js`
+
+dry-run 行为:
+
+- 读取本地 fixture JSON
+- 校验 fixture `match_id` 与 `--match-id` 一致
+- 校验 `raw_data` 存在且为对象
+- 校验 `raw_data.matchId` 存在
+- 校验 `raw_data.general` 或 `raw_data.header` 至少一个存在
+- 只读查询目标 `matches`
+- 只读查询目标 `raw_match_data`
+- 只读查询目标 `bookmaker_odds_history`
+- 使用稳定 JSON 字符串和 `sha256` 生成 `data_hash`
+- 打印 raw ingest preview
+
+禁止行为:
+
+- 不执行 `INSERT`
+- 不执行 `UPDATE`
+- 不执行 `DELETE`
+- 不执行 `CREATE`
+- 不执行 `ALTER`
+- 不执行 `DROP`
+- 不执行 `TRUNCATE`
+- 不执行 `CREATE INDEX`
+- 不调用 L3
+- 不调用 ELO
+- 不访问外网
+
+`--commit` 行为:
+
+- 立即失败
+- 输出 `BLOCKED: raw_match_data commit is not wired in Phase 4.21.`
+- 在建立 DB 连接前结束
+
+## 6. Makefile 入口
+
+新增 dry-run 入口:
+
+```bash
+make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>
+```
+
+新增 blocked commit 入口:
+
+```bash
+make data-raw-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_RAW_COMMIT=1
+```
+
+Phase 4.21 中 `data-raw-commit` 不接真实写库命令。
+
+`data-help` 已加入:
+
+- `make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>`
+- `make data-raw-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_RAW_COMMIT=1  # blocked in Phase 4.21`
+
+## 7. AGENTS.md 更新
+
+新增默认允许项:
+
+- 用户明确授权且仅使用本地 fixture 的 `make data-raw-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
+
+新增禁止项:
+
+- `make data-raw-commit`
+- `node scripts/ops/raw_match_data_local_ingest.js --commit`
+
+继续禁止:
+
+- `npm run smelt`
+- `npm run l3:stitch`
+- `npm run elo:recalc`
+
+引用背景:
+
+- `docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+- `docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md`
+
+## 8. Dry-Run 输出摘要
+
+缺参数验证:
+
+- `make data-raw-dry-run` -> 失败，输出 `ERROR: provide SAMPLE_RAW=<path> and MATCH_ID=<id>`
+
+正常 dry-run:
+
+- `mode`: `dry-run`
+- `match_found`: `true`
+- `raw_match_data_exists`: `false`
+- `raw_match_data_rows`: `0`
+- `odds_history_rows`: `2`
+- `would_insert_raw_match_data`: `false`
+- `target_table`: `raw_match_data`
+- `data_version`: `PHASE4.21_DRY_RUN`
+- `data_hash`: `b13b7c2bf4f9b825e337124f51431d8594ef3a9af03e76dced88ee132addece1`
+
+非执行确认:
+
+- `no_db_writes`
+- `no_insert`
+- `no_update`
+- `no_delete`
+- `no_create_index`
+- `no_l3`
+- `no_elo`
+- `no_external_network`
+
+## 9. Commit Gate Blocked 结果
+
+默认 commit:
+
+- `make data-raw-commit` -> blocked
+- 输出: `BLOCKED: raw_match_data commit requires CONFIRM_RAW_COMMIT=1 and is not wired in Phase 4.21.`
+
+带确认变量:
+
+- `make data-raw-commit SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496 CONFIRM_RAW_COMMIT=1` -> blocked
+- 输出: `BLOCKED: raw_match_data commit is not wired in Phase 4.21.`
+
+结论:
+
+- Phase 4.21 未接真实 raw_match_data 写入路径
+
+## 10. DB 前后统计
+
+执行前:
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          0
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+执行后:
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          0
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+结论:
+
+- dry-run 与 blocked commit 前后 DB 行数无变化
+
+## 11. 明确未执行事项
+
+本阶段未执行:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- raw_match_data commit
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- L3 feature computation write
+- model training
+- prediction write
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- 外网访问
+- 真实 harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume 清理
+- `git push`
+- `git pull`
+- `git fetch --all`
+
+## 12. 下一步建议
+
+- Phase 4.22: push 当前分支、创建 PR、等待 CI
+- 后续: 人工授权 raw_match_data 单条写入 gate
+- 再后续: 基于 raw_match_data 执行 L3 dry-run

--- a/scripts/ops/raw_match_data_local_ingest.js
+++ b/scripts/ops/raw_match_data_local_ingest.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Safe local raw_match_data ingest preview gate.
+ *
+ * Phase 4.21 deliberately keeps commit mode blocked. The script only reads a
+ * local fixture and performs SELECT-only DB checks to produce an ingest preview.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+
+const DATA_VERSION = 'PHASE4.21_DRY_RUN';
+const FORBIDDEN_SQL = /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|UPSERT|MERGE|GRANT|REVOKE)\b/i;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/raw_match_data_local_ingest.js --fixture <path> --match-id <id> [--commit]',
+        '',
+        'Safety:',
+        '  Dry-run only in Phase 4.21; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        fixture: null,
+        matchId: null,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--fixture') {
+            args.fixture = argv[index + 1];
+            index += 1;
+        } else if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function readJsonFile(filePath) {
+    const resolved = path.resolve(process.cwd(), filePath);
+    const raw = fs.readFileSync(resolved, 'utf8');
+    return {
+        resolved,
+        data: JSON.parse(raw),
+    };
+}
+
+function normalizeFixtureMatchId(fixture) {
+    return String(fixture.match_id || fixture.raw_data?.matchId || fixture.raw_data?.general?.matchId || '');
+}
+
+function assertFixture(fixture, expectedMatchId) {
+    if (!fixture || typeof fixture !== 'object' || Array.isArray(fixture)) {
+        throw new Error('Fixture root must be a JSON object');
+    }
+
+    const actualMatchId = normalizeFixtureMatchId(fixture);
+    if (actualMatchId !== expectedMatchId) {
+        throw new Error(`Fixture match_id does not match --match-id (${actualMatchId} != ${expectedMatchId})`);
+    }
+
+    const rawData = fixture.raw_data;
+    if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
+        throw new Error('Fixture raw_data must be a JSON object');
+    }
+    if (!Object.prototype.hasOwnProperty.call(rawData, 'matchId')) {
+        throw new Error('Fixture raw_data.matchId is required');
+    }
+    if (!rawData.general && !rawData.header) {
+        throw new Error('Fixture raw_data.general or raw_data.header is required');
+    }
+}
+
+function stableStringify(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableStringify).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        const keys = Object.keys(value).sort();
+        const entries = keys.map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+        return `{${entries.join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function calculateDataHash(rawData) {
+    return crypto.createHash('sha256').update(stableStringify(rawData)).digest('hex');
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function buildBlockedCommitPayload() {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        error: 'BLOCKED: raw_match_data commit is not wired in Phase 4.21.',
+        non_execution_confirmations: [
+            'no_db_writes',
+            'no_insert',
+            'no_update',
+            'no_delete',
+            'no_create_index',
+            'no_l3',
+            'no_elo',
+            'no_external_network',
+        ],
+    };
+}
+
+function buildPreview({ args, fixturePath, fixture, matchFound, rawRows, oddsRows }) {
+    const rawData = fixture.raw_data;
+    const dataHash = calculateDataHash(rawData);
+
+    return {
+        mode: 'dry-run',
+        match_id: args.matchId,
+        fixture: {
+            path: args.fixture,
+            resolved_path: fixturePath,
+            external_id: fixture.external_id || String(rawData.matchId),
+            raw_data_keys: Object.keys(rawData).sort(),
+            data_hash: dataHash,
+        },
+        db: {
+            match_found: matchFound,
+            raw_match_data_exists: rawRows.length > 0,
+            raw_match_data_rows: rawRows.length,
+            odds_history_rows: oddsRows.length,
+        },
+        preview: {
+            would_insert_raw_match_data: false,
+            target_table: 'raw_match_data',
+            data_version: DATA_VERSION,
+            insert_blocked_in_phase: 'Phase 4.21',
+        },
+        non_execution_confirmations: [
+            'no_db_writes',
+            'no_insert',
+            'no_update',
+            'no_delete',
+            'no_create_index',
+            'no_l3',
+            'no_elo',
+            'no_external_network',
+        ],
+    };
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error(JSON.stringify(buildBlockedCommitPayload(), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.fixture || !args.matchId) {
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const { resolved, data: fixture } = readJsonFile(args.fixture);
+    assertFixture(fixture, args.matchId);
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const matchSql = `
+            SELECT match_id
+            FROM matches
+            WHERE match_id = $1
+        `;
+        const rawSql = `
+            SELECT match_id, external_id, data_version, data_hash, collected_at
+            FROM raw_match_data
+            WHERE match_id = $1
+            ORDER BY collected_at DESC
+        `;
+        const oddsSql = `
+            SELECT match_id, bookmaker_name, market_type
+            FROM bookmaker_odds_history
+            WHERE match_id = $1
+            ORDER BY bookmaker_name, market_type
+        `;
+
+        const matchResult = await safeSelect(pool, matchSql, [args.matchId]);
+        if (matchResult.rowCount !== 1) {
+            throw new Error(`Target match not found: ${args.matchId}`);
+        }
+
+        const rawResult = await safeSelect(pool, rawSql, [args.matchId]);
+        const oddsResult = await safeSelect(pool, oddsSql, [args.matchId]);
+        const preview = buildPreview({
+            args,
+            fixturePath: resolved,
+            fixture,
+            matchFound: true,
+            rawRows: rawResult.rows,
+            oddsRows: oddsResult.rows,
+        });
+
+        console.log(JSON.stringify(preview, null, 2));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: [
+                    'no_db_writes',
+                    'no_insert',
+                    'no_update',
+                    'no_delete',
+                    'no_create_index',
+                    'no_l3',
+                    'no_elo',
+                    'no_external_network',
+                ],
+            },
+            null,
+            2
+        )
+    );
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a safe local raw_match_data ingest gate.

Changes:
- Adds scripts/ops/raw_match_data_local_ingest.js
- Adds make data-raw-dry-run
- Adds blocked make data-raw-commit
- Updates data-help
- Updates AGENTS.md with raw_match_data safety rules
- Adds Phase 4.21 report

Safety properties:
- Dry-run only by default
- data-raw-commit remains blocked / not wired in this phase
- No DB writes
- No INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE
- No L3/ELO/train/predict execution
- No external network access

Validation:
- make data-raw-dry-run without args fails as expected
- make data-raw-dry-run SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496 succeeds
- make data-raw-commit remains blocked with and without CONFIRM_RAW_COMMIT=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/raw_match_data_local_ingest.js
- docs/_reports/RAW_MATCH_DATA_LOCAL_INGEST_GATE_PHASE4_21.md