### PR TITLE
chore(l3): add l3 features write gate preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,8 @@ AI / Codex 不能直接执行：
 - `scripts/ops/l3_stitch_pipeline.js`
 - `scripts/ops/l3_stitch_worker.js`
 - `npm run elo:recalc`
+- `make data-l3-commit`
+- `make data-l3-commit CONFIRM_L3_COMMIT=1`
 - `make data-raw-commit`
 - `node scripts/ops/raw_match_data_local_ingest.js --commit`
 - 任何 `--commit` 命令
@@ -247,6 +249,8 @@ AI / Codex 不能直接执行：
 - 不访问外网
 
 L3 本地 dry-run 预检背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+
+Phase 4.24 中 `make data-l3-commit` 仍是 blocked / not wired。禁止直接或间接执行 `npm run smelt`、`npm run l3:stitch`、`scripts/ops/smelt_all.js`、`scripts/ops/l3_stitch_pipeline.js`、`scripts/ops/l3_stitch_worker.js`、`npm run elo:recalc` 来替代该门禁。相关背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`、`docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md` 和 `docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md`
 
 执行 `make data-raw-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@
 
 .PHONY: help up down restart logs test clean build db-reset db-shell lint format security \
         dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test \
-        data-help data-check data-local-dry-run data-l3-dry-run data-raw-dry-run \
-        data-raw-commit data-network-dry-run data-db-write-small data-harvest \
+        data-help data-check data-local-dry-run data-l3-dry-run data-l3-commit \
+        data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
 # 默认目标
@@ -237,6 +237,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-l3-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_COMMIT=1  # blocked in Phase 4.24"
 	@echo "  make data-raw-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_RAW_COMMIT=1  # blocked in Phase 4.21"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
@@ -277,6 +278,14 @@ data-l3-dry-run: ## Run safe local L3 dry-run from fixture. Requires SAMPLE_RAW 
 	@echo "Running safe local L3 dry-run: SAMPLE_RAW=$(SAMPLE_RAW), MATCH_ID=$(MATCH_ID)"
 	$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_RAW)"
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/l3_local_dry_run.js --fixture "$(SAMPLE_RAW)" --match-id "$(MATCH_ID)"
+
+data-l3-commit: ## Blocked l3_features commit gate. Requires SAMPLE_RAW, MATCH_ID, CONFIRM_L3_COMMIT=1.
+	@if [ "$(CONFIRM_L3_COMMIT)" != "1" ]; then \
+		echo "BLOCKED: l3_features commit requires CONFIRM_L3_COMMIT=1 and is not wired in Phase 4.24."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: l3_features commit is not wired in Phase 4.24."
+	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.
 	@if [ -z "$(SAMPLE_RAW)" ] || [ -z "$(MATCH_ID)" ]; then \

--- a/docs/_reports/L3_FEATURES_WRITE_GATE_PREFLIGHT_PHASE4_24.md
+++ b/docs/_reports/L3_FEATURES_WRITE_GATE_PREFLIGHT_PHASE4_24.md
@@ -1,0 +1,236 @@
+# Phase 4.24 - L3 Features Write Gate Preflight
+
+日期: `2026-05-03`
+
+## 1. 当前 HEAD
+
+- 分支: `feat/l3-features-write-gate-preflight`
+- Base HEAD: `a559e9492640c042c51371eab9594e19f09acace`
+- 基线提交: `a559e94 feat(data): add raw match data local ingest gate`
+
+## 2. Phase 4.23 raw_match_data 写入状态摘要
+
+Phase 4.23 完成一次人工授权的单条 `raw_match_data` 写入:
+
+- `match_id`: `140_20252026_4837496`
+- `external_id`: `4837496`
+- `data_version`: `PHASE4.23`
+- `data_hash`: `b13b7c2bf4f9b825e337124f51431d8594ef3a9af03e76dced88ee132addece1`
+- returned `id`: `1`
+
+Phase 4.23 报告:
+
+- `docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md`
+
+## 3. 当前 DB 行数
+
+只读统计:
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          1
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+结论:
+
+- `raw_match_data` 已有目标单条 fixture raw
+- `l3_features` 仍为 0
+- 未执行 L3 写入
+
+## 4. l3_features 表结构摘要
+
+只读审查结果:
+
+- `match_id`: `varchar(50)`, `NOT NULL`, primary key
+- `external_id`: `varchar(50)`, nullable
+- `golden_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `tactical_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `odds_movement_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `odds_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `elo_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `rolling_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `efficiency_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `draw_features`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `market_sentiment`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `stitch_summary`: `jsonb`, `NOT NULL`, default `'{}'::jsonb`
+- `computed_at`: `timestamptz`, `NOT NULL`, default `now()`
+- `created_at`: `timestamptz`, `NOT NULL`, default `now()`
+- `updated_at`: `timestamptz`, `NOT NULL`, default `now()`
+
+约束:
+
+- `l3_features_pkey`: primary key on `match_id`
+- `l3_features_match_id_fkey`: `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+
+## 5. l3_features 写入前置条件
+
+未来人工授权单条写入至少需要:
+
+- 明确 `match_id = 140_20252026_4837496`
+- 确认 `matches` 目标行存在
+- 确认 `raw_match_data` 目标行存在
+- 确认 `l3_features` 目标行不存在
+- 确认写入只触达 `l3_features`
+- 明确 JSONB payload 来源和字段边界
+- 明确是否允许 `elo_features` 为空占位
+- 明确是否允许仅使用 dry-run preview 产物
+- 执行前备份 DB
+- 执行后验证主要表行数
+
+本阶段不执行以上写入。
+
+## 6. data-l3-dry-run 验证摘要
+
+命令:
+
+```bash
+make data-l3-dry-run SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496
+```
+
+结果摘要:
+
+- `mode`: `dry-run`
+- `match_found`: `true`
+- `odds_history_rows`: `2`
+- `would_write_l3_features`: `false`
+- `would_update_matches`: `false`
+- `would_trigger_elo`: `false`
+- `would_create_index`: `false`
+- `would_create_table`: `false`
+- `no_db_writes`: present
+- `no_l3_write`: present
+- `no_elo`: present
+- `no_external_network`: present
+
+## 7. 新增 data-l3-commit blocked gate
+
+新增 Makefile 目标:
+
+```bash
+make data-l3-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_COMMIT=1
+```
+
+Phase 4.24 行为:
+
+- 默认 blocked
+- 即使提供 `CONFIRM_L3_COMMIT=1` 仍 blocked / not wired
+- 不调用 `npm run smelt`
+- 不调用 `npm run l3:stitch`
+- 不调用 `scripts/ops/l3_stitch_pipeline.js`
+- 不调用 `scripts/ops/smelt_all.js`
+- 不写 DB
+- 不触发 ELO
+
+## 8. AGENTS.md 更新摘要
+
+新增禁止项:
+
+- `make data-l3-commit`
+- `make data-l3-commit CONFIRM_L3_COMMIT=1`
+
+继续禁止:
+
+- `npm run smelt`
+- `npm run l3:stitch`
+- `scripts/ops/smelt_all.js`
+- `scripts/ops/l3_stitch_pipeline.js`
+- `scripts/ops/l3_stitch_worker.js`
+- `npm run elo:recalc`
+
+引用背景:
+
+- `docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+- `docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md`
+- `docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md`
+
+## 9. Blocked Commit 验证结果
+
+默认命令:
+
+```bash
+make data-l3-commit
+```
+
+结果:
+
+- blocked
+- 输出: `BLOCKED: l3_features commit requires CONFIRM_L3_COMMIT=1 and is not wired in Phase 4.24.`
+
+带确认变量:
+
+```bash
+make data-l3-commit SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496 CONFIRM_L3_COMMIT=1
+```
+
+结果:
+
+- blocked
+- 输出: `BLOCKED: l3_features commit is not wired in Phase 4.24.`
+
+## 10. DB 前后统计
+
+执行 blocked gate 前:
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          1
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+执行 blocked gate 后:
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          1
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+结论:
+
+- DB 行数无变化
+
+## 11. 明确未执行事项
+
+本阶段未执行:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- l3_features write
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- L3 feature computation write
+- model training
+- prediction write
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- 外网访问
+- 真实 harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume 清理
+- `git fetch --all`
+- `git pull`
+- 删除文件
+
+## 12. 下一步建议
+
+- 后续可设计人工授权单条 `l3_features` 写入
+- 仍禁止 `npm run smelt` / `npm run l3:stitch` / ELO
+- 写入 runbook 应包含备份、单条范围、JSONB payload、post-write 验证和停止条件

--- a/docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md
+++ b/docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md
@@ -1,0 +1,207 @@
+# Phase 4.23 - raw_match_data Single Insert
+
+日期: `2026-05-03`
+
+## 1. 当前 HEAD
+
+- 分支: `main`
+- HEAD: `a559e9492640c042c51371eab9594e19f09acace`
+- 提交: `a559e94 feat(data): add raw match data local ingest gate`
+
+## 2. 备份
+
+- 备份文件: `data/backups/phase423_pre_raw_match_data_insert_20260503_153326.dump`
+- 文件大小: `68K`
+- 备份命令: `pg_dump --format=custom`
+- 备份结果: 成功，文件非空
+
+## 3. 写入前行数
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          0
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+目标 match:
+
+- `match_id`: `140_20252026_4837496`
+- `external_id`: `4837496`
+- `league_name`: `Segunda División`
+- `season`: `2025/2026`
+- `home_team`: `Cultural Leonesa`
+- `away_team`: `Burgos CF`
+- `match_date`: `2026-05-24 17:00:00+00`
+- `status`: `scheduled`
+- `pipeline_status`: `pending`
+
+写入前目标 raw rows:
+
+- `target_raw_rows`: `0`
+
+## 4. Fixture
+
+- Fixture path: `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+- `match_id`: `140_20252026_4837496`
+- `external_id`: `4837496`
+- `raw_data` top-level keys:
+    - `_meta`
+    - `content`
+    - `general`
+    - `header`
+    - `matchId`
+
+## 5. Data Hash
+
+- `data_hash`: `b13b7c2bf4f9b825e337124f51431d8594ef3a9af03e76dced88ee132addece1`
+- 算法: 稳定 JSON 字符串 + `sha256`
+- 与 `data-raw-dry-run` 输出一致
+
+## 6. INSERT 结果
+
+人工授权范围:
+
+- 只允许写入 `raw_match_data`
+- 只允许写入 `match_id = 140_20252026_4837496`
+- 不允许写入任何其他业务表
+
+结果:
+
+- `INSERT 0 1`
+- `COMMIT`
+- returned `id`: `1`
+- returned `match_id`: `140_20252026_4837496`
+- returned `external_id`: `4837496`
+- returned `data_version`: `PHASE4.23`
+- returned `data_hash`: `b13b7c2bf4f9b825e337124f51431d8594ef3a9af03e76dced88ee132addece1`
+- returned `collected_at`: `2026-05-03 07:33:43.721507+00`
+
+## 7. 写入后 raw_match_data 验证
+
+目标行数:
+
+- `target_raw_rows`: `1`
+
+关键字段:
+
+```text
+has_match_id  true
+has_general   true
+has_header    true
+has_content   true
+```
+
+写入后 top-level keys:
+
+- `_meta`
+- `content`
+- `general`
+- `header`
+- `matchId`
+
+## 8. 写入后总体行数
+
+```text
+matches                 1
+bookmaker_odds_history  2
+raw_match_data          1
+l3_features             0
+match_features_training 0
+predictions             0
+```
+
+结论:
+
+- 只有 `raw_match_data` 从 `0` 变为 `1`
+- 其他主要表行数未变
+
+## 9. data-raw-dry-run 写入后识别结果
+
+写入后重新运行:
+
+```bash
+make data-raw-dry-run SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496
+```
+
+结果摘要:
+
+- `mode`: `dry-run`
+- `match_found`: `true`
+- `raw_match_data_exists`: `true`
+- `raw_match_data_rows`: `1`
+- `odds_history_rows`: `2`
+- `would_insert_raw_match_data`: `false`
+- `no_db_writes`: present
+
+## 10. data-l3-dry-run 仍然只读结果
+
+写入后运行:
+
+```bash
+make data-l3-dry-run SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496
+```
+
+结果摘要:
+
+- `match_found`: `true`
+- `odds_history_rows`: `2`
+- `would_write_l3_features`: `false`
+- `would_update_matches`: `false`
+- `would_trigger_elo`: `false`
+- `no_db_writes`: present
+- `no_l3_write`: present
+- `no_elo`: present
+- `no_external_network`: present
+
+未执行:
+
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+
+## 11. 风险与下一步建议
+
+风险:
+
+- 当前仅写入 1 条本地脱敏 fixture raw 数据。
+- 尚未执行真实 L3 写入。
+- 尚未验证基于已入库 raw_match_data 的 L3 小范围写入。
+
+下一步建议:
+
+- Phase 4.24: 提交 Phase 4.23 报告
+- 或设计 `l3_features` 小范围写入 runbook
+
+## 12. 明确未执行事项
+
+本阶段未执行:
+
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `INSERT` 到除 `raw_match_data` 外的任何表
+- raw_match_data 重复写入
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- L3 feature computation write
+- model training
+- prediction write
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- 外网访问
+- 真实 harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume 清理
+- `git push`
+- `git pull`
+- `git fetch --all`
+- commit


### PR DESCRIPTION
## Summary

Adds the Phase 4.23 raw_match_data single insert report and Phase 4.24 L3 features write gate preflight.

Changes:
- Adds Phase 4.23 raw_match_data insert report
- Adds Phase 4.24 L3 features write gate preflight report
- Adds blocked make data-l3-commit gate
- Updates AGENTS.md with L3 commit safety rules
- Updates data-help

Safety:
- No l3_features writes
- data-l3-commit remains blocked / not wired
- No smelt / l3:stitch / ELO execution
- No DB writes in this phase
- No external data access

Validation:
- make data-raw-dry-run confirms raw_match_data_exists=true
- make data-l3-dry-run succeeds and remains read-only
- make data-l3-commit remains blocked with and without CONFIRM_L3_COMMIT=1
- DB row counts unchanged
- git diff --check
- prettier check