### PR TITLE
feat(l3): add l3 features local write gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ AI / Codex 默认只能执行：
 - `make data-check`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
+- 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-raw-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 
 AI / Codex 不能直接执行：
@@ -233,6 +234,9 @@ AI / Codex 不能直接执行：
 - `scripts/ops/l3_stitch_pipeline.js`
 - `scripts/ops/l3_stitch_worker.js`
 - `npm run elo:recalc`
+- `make data-l3-write-commit`
+- `make data-l3-write-commit CONFIRM_L3_WRITE=1`
+- `node scripts/ops/l3_features_local_write_gate.js --commit`
 - `make data-l3-commit`
 - `make data-l3-commit CONFIRM_L3_COMMIT=1`
 - `make data-raw-commit`
@@ -249,6 +253,15 @@ AI / Codex 不能直接执行：
 - 不访问外网
 
 L3 本地 dry-run 预检背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+
+执行 `make data-l3-write-dry-run` 的前提：
+
+- 用户明确授权
+- fixture 是本地文件
+- 不写 DB
+- 不访问外网
+
+Phase 4.26 中 `make data-l3-write-commit` 和 `node scripts/ops/l3_features_local_write_gate.js --commit` 仍是 blocked / not wired。禁止直接或间接执行 `npm run smelt`、`npm run l3:stitch`、`scripts/ops/smelt_all.js`、`scripts/ops/l3_stitch_pipeline.js`、`scripts/ops/l3_stitch_worker.js`、`npm run elo:recalc` 来替代该门禁。相关背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`、`docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md`、`docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md` 和 `docs/_reports/L3_FEATURES_WRITE_GATE_PREFLIGHT_PHASE4_24.md`
 
 Phase 4.24 中 `make data-l3-commit` 仍是 blocked / not wired。禁止直接或间接执行 `npm run smelt`、`npm run l3:stitch`、`scripts/ops/smelt_all.js`、`scripts/ops/l3_stitch_pipeline.js`、`scripts/ops/l3_stitch_worker.js`、`npm run elo:recalc` 来替代该门禁。相关背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`、`docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md` 和 `docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md`
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 .PHONY: help up down restart logs test clean build db-reset db-shell lint format security \
         dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test \
         data-help data-check data-local-dry-run data-l3-dry-run data-l3-commit \
+        data-l3-write-dry-run data-l3-write-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -234,9 +235,11 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-check"
 	@echo "  make data-local-dry-run SAMPLE_HTML=<path> or SAMPLE_CSV=<path>"
 	@echo "  make data-l3-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
+	@echo "  make data-l3-write-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo "  make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-l3-write-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_WRITE=1  # blocked in Phase 4.26"
 	@echo "  make data-l3-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_COMMIT=1  # blocked in Phase 4.24"
 	@echo "  make data-raw-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_RAW_COMMIT=1  # blocked in Phase 4.21"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
@@ -285,6 +288,27 @@ data-l3-commit: ## Blocked l3_features commit gate. Requires SAMPLE_RAW, MATCH_I
 		exit 1; \
 	fi
 	@echo "BLOCKED: l3_features commit is not wired in Phase 4.24."
+	@exit 1
+
+data-l3-write-dry-run: ## Run safe local l3_features write preview. Requires SAMPLE_RAW and MATCH_ID.
+	@if [ -z "$(SAMPLE_RAW)" ] || [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide SAMPLE_RAW=<path> and MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe local l3_features write dry-run: SAMPLE_RAW=$(SAMPLE_RAW), MATCH_ID=$(MATCH_ID)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_RAW)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/l3_features_local_write_gate.js --fixture "$(SAMPLE_RAW)" --match-id "$(MATCH_ID)"
+
+data-l3-write-commit: ## Blocked l3_features write gate. Requires SAMPLE_RAW, MATCH_ID, CONFIRM_L3_WRITE=1.
+	@if [ "$(CONFIRM_L3_WRITE)" != "1" ]; then \
+		echo "BLOCKED: l3_features write requires CONFIRM_L3_WRITE=1 and is not wired in Phase 4.26."; \
+		exit 1; \
+	fi
+	@if [ -z "$(SAMPLE_RAW)" ] || [ -z "$(MATCH_ID)" ]; then \
+		echo "BLOCKED: provide SAMPLE_RAW=<path> and MATCH_ID=<id>; l3_features commit is not wired in Phase 4.26."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: l3_features commit is not wired in Phase 4.26."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/L3_FEATURES_LOCAL_WRITE_GATE_PHASE4_26.md
+++ b/docs/_reports/L3_FEATURES_LOCAL_WRITE_GATE_PHASE4_26.md
@@ -1,0 +1,148 @@
+# Phase 4.26 - L3 Features Local Write Gate
+
+## Current HEAD
+
+- Base HEAD: `1a0ef9c4a4e474f27dccecf8ab90a195f24a794a`
+- Working branch: `feat/l3-features-local-write-gate`
+- Target match: `140_20252026_4837496`
+- Fixture: `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+
+## Current DB State
+
+Read-only row counts before and after validation:
+
+| table                   | before | after |
+| ----------------------- | -----: | ----: |
+| matches                 |      1 |     1 |
+| bookmaker_odds_history  |      2 |     2 |
+| raw_match_data          |      1 |     1 |
+| l3_features             |      0 |     0 |
+| match_features_training |      0 |     0 |
+| predictions             |      0 |     0 |
+
+## l3_features Table Summary
+
+- Primary key: `match_id`
+- Foreign key: `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+- Optional scalar field: `external_id`
+- JSONB fields with default `{}`: `golden_features`, `tactical_features`, `odds_movement_features`, `odds_features`, `elo_features`, `rolling_features`, `efficiency_features`, `draw_features`, `market_sentiment`, `stitch_summary`
+- Timestamp fields with default `now()`: `computed_at`, `created_at`, `updated_at`
+- Future minimal single-row insert can provide `match_id`, optional `external_id`, and selected JSONB feature payloads while relying on JSONB and timestamp defaults.
+
+## Preconditions
+
+- Target match exists in `matches`
+- `bookmaker_odds_history` has 2 rows for the target match
+- `raw_match_data` has 1 row for the target match
+- `l3_features` has 0 rows for the target match
+
+## Added Script
+
+Added `scripts/ops/l3_features_local_write_gate.js`.
+
+Behavior:
+
+- Default mode is dry-run.
+- Reads only a local fixture.
+- Validates fixture match id against `--match-id`.
+- Performs SELECT-only DB checks for `matches`, `bookmaker_odds_history`, `raw_match_data`, and `l3_features`.
+- Builds a future `l3_features` preview record with `golden_features`, `tactical_features`, `odds_movement_features`, `odds_features`, `elo_features`, `stitch_summary`, and empty default-compatible JSONB groups.
+- Does not call `npm run smelt`, `npm run l3:stitch`, `l3_stitch_pipeline`, `l3_stitch_worker`, or ELO code.
+- Does not write DB state.
+
+Commit behavior:
+
+- `--commit` returns `BLOCKED: l3_features commit is not wired in Phase 4.26.`
+- `CONFIRM_L3_WRITE=1` does not enable writes in this phase.
+
+## Makefile Entrypoints
+
+Added:
+
+```bash
+make data-l3-write-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>
+make data-l3-write-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_WRITE=1
+```
+
+`data-l3-write-commit` remains blocked / not wired in Phase 4.26.
+
+## AGENTS.md Update
+
+Updated AI / Codex data safety rules:
+
+- Allow `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>` only with explicit user authorization, local fixture input, no DB writes, and no external network access.
+- Forbid `make data-l3-write-commit`, `make data-l3-write-commit CONFIRM_L3_WRITE=1`, and `node scripts/ops/l3_features_local_write_gate.js --commit` unless a future phase separately authorizes a new workflow.
+- Continue forbidding `npm run smelt`, `npm run l3:stitch`, `scripts/ops/smelt_all.js`, `scripts/ops/l3_stitch_pipeline.js`, `scripts/ops/l3_stitch_worker.js`, and `npm run elo:recalc`.
+
+Related reports:
+
+- `docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+- `docs/_reports/L3_LOCAL_DRY_RUN_GATE_PHASE4_19.md`
+- `docs/_reports/RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_23.md`
+- `docs/_reports/L3_FEATURES_WRITE_GATE_PREFLIGHT_PHASE4_24.md`
+
+## Dry-Run Validation
+
+`make data-l3-write-dry-run` without arguments failed as expected.
+
+Normal dry-run:
+
+```bash
+make data-l3-write-dry-run \
+  SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json \
+  MATCH_ID=140_20252026_4837496
+```
+
+Result summary:
+
+- `mode`: `dry-run`
+- `match_found`: `true`
+- `raw_match_data_found`: `true`
+- `odds_history_rows`: `2`
+- `l3_features_exists`: `false`
+- `would_insert_l3_features`: `false`
+- `would_update_matches`: `false`
+- `would_trigger_elo`: `false`
+- Non-execution confirmations include `no_db_writes`, `no_insert`, `no_update`, `no_delete`, `no_create_index`, `no_smelt`, `no_l3_stitch`, `no_l3_write`, `no_elo`, and `no_external_network`
+
+## Commit Gate Validation
+
+Both commands remained blocked:
+
+```bash
+make data-l3-write-commit
+make data-l3-write-commit \
+  SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json \
+  MATCH_ID=140_20252026_4837496 \
+  CONFIRM_L3_WRITE=1
+```
+
+No DB writes were performed.
+
+## Explicit Non-Execution
+
+The phase did not execute:
+
+- `INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE`
+- `l3_features` write
+- `raw_match_data` commit
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- L3 feature computation write
+- model training
+- prediction write
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+
+## Next Steps
+
+- A future real `l3_features` write must be separately authorized.
+- Before any real write, create a DB backup and restrict execution to one explicit `match_id`.
+- Continue forbidding `npm run smelt`, `npm run l3:stitch`, and ELO execution unless a future phase explicitly authorizes them.

--- a/scripts/ops/l3_features_local_write_gate.js
+++ b/scripts/ops/l3_features_local_write_gate.js
@@ -1,0 +1,481 @@
+#!/usr/bin/env node
+/**
+ * Safe local l3_features write preview gate.
+ *
+ * Phase 4.26 deliberately keeps commit mode blocked. The script only reads a
+ * local fixture and performs SELECT-only DB checks to produce a future
+ * l3_features insert preview.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+
+const { extractGoldenFeatures } = require('../../src/feature_engine/extractors/GoldenFeatureExtractor');
+const { extractTacticalFeatures } = require('../../src/feature_engine/extractors/TacticalMomentumExtractor');
+const {
+    extractOddsMovementFeatures,
+    extractOddsMovementFeaturesFromOddsData,
+} = require('../../src/feature_engine/extractors/OddsMovementExtractor');
+
+const FORBIDDEN_SQL = /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|UPSERT|MERGE|GRANT|REVOKE)\b/i;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l3_features_local_write_gate.js --fixture <path> --match-id <id> [--commit]',
+        '',
+        'Safety:',
+        '  Dry-run only in Phase 4.26; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        fixture: null,
+        matchId: null,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--fixture') {
+            args.fixture = argv[index + 1];
+            index += 1;
+        } else if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function readJsonFile(filePath) {
+    const resolved = path.resolve(process.cwd(), filePath);
+    const raw = fs.readFileSync(resolved, 'utf8');
+    return {
+        resolved,
+        data: JSON.parse(raw),
+    };
+}
+
+function normalizeFixtureMatchId(fixture) {
+    return String(fixture.match_id || fixture.raw_data?.matchId || fixture.raw_data?.general?.matchId || '');
+}
+
+function assertFixtureRoot(fixture, expectedMatchId) {
+    if (!fixture || typeof fixture !== 'object' || Array.isArray(fixture)) {
+        throw new Error('Fixture root must be a JSON object');
+    }
+
+    const actualMatchId = normalizeFixtureMatchId(fixture);
+    if (actualMatchId !== expectedMatchId) {
+        throw new Error(`Fixture match_id does not match --match-id (${actualMatchId} != ${expectedMatchId})`);
+    }
+}
+
+function collectRawDataMissingFields(rawData) {
+    const missing = [];
+
+    if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
+        missing.push('raw_data');
+    }
+
+    const rawDataObject = rawData || {};
+    if (!('matchId' in rawDataObject) && !rawDataObject.general && !rawDataObject.header) {
+        missing.push('raw_data.matchId_or_general_or_header');
+    }
+    if (!rawDataObject.general) {
+        missing.push('raw_data.general');
+    }
+    if (!rawDataObject.header) {
+        missing.push('raw_data.header');
+    }
+    if (!rawDataObject.content) {
+        missing.push('raw_data.content');
+    }
+    if (!rawDataObject.content?.lineup?.homeTeam) {
+        missing.push('raw_data.content.lineup.homeTeam');
+    }
+    if (!rawDataObject.content?.lineup?.awayTeam) {
+        missing.push('raw_data.content.lineup.awayTeam');
+    }
+    if (!Array.isArray(rawDataObject.content?.stats)) {
+        missing.push('raw_data.content.stats[]');
+    }
+    if (!Array.isArray(rawDataObject.content?.shotmap?.shots)) {
+        missing.push('raw_data.content.shotmap.shots[]');
+    }
+
+    return missing;
+}
+
+function validateFixture(fixture, expectedMatchId) {
+    assertFixtureRoot(fixture, expectedMatchId);
+    return collectRawDataMissingFields(fixture.raw_data);
+}
+
+function toPositiveNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeOddsPayload(payload, collectedAt) {
+    return {
+        home: toPositiveNumber(payload?.home),
+        draw: toPositiveNumber(payload?.draw),
+        away: toPositiveNumber(payload?.away),
+        collectedAt: collectedAt ? new Date(collectedAt).toISOString() : null,
+    };
+}
+
+function buildOddsDataFromHistoryRows(rows) {
+    const oneX2Rows = rows.filter(row => String(row.market_type || '').toLowerCase() === '1x2');
+    const opening = oneX2Rows
+        .map(row => normalizeOddsPayload(row.open_odds, row.collected_at))
+        .filter(point => point.home && point.draw && point.away);
+    const closing = oneX2Rows
+        .map(row => normalizeOddsPayload(row.close_odds, row.collected_at))
+        .filter(point => point.home && point.draw && point.away);
+
+    const initial = opening[0] || closing[0] || null;
+    const current = closing[closing.length - 1] || initial;
+    const history = [];
+
+    if (initial) {
+        history.push(initial);
+    }
+    if (
+        current &&
+        (!initial || current.home !== initial.home || current.draw !== initial.draw || current.away !== initial.away)
+    ) {
+        history.push(current);
+    }
+
+    return {
+        initial,
+        current,
+        history,
+        hasData: Boolean(initial || current || history.length > 0),
+        odds_source: oneX2Rows.length > 0 ? 'bookmaker_odds_history' : 'none',
+    };
+}
+
+function uniqueSorted(values) {
+    return [...new Set(values.filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function summarizeFixture(rawData) {
+    const shotmapShots = Array.isArray(rawData?.content?.shotmap?.shots) ? rawData.content.shotmap.shots.length : 0;
+    const momentum = rawData?.content?.momentum?.data || rawData?.content?.momentum?.main?.data || [];
+    const lineup = rawData?.content?.lineup || {};
+
+    return {
+        lineup_available: Boolean(lineup.homeTeam && lineup.awayTeam),
+        home_starters: Array.isArray(lineup.homeTeam?.starters) ? lineup.homeTeam.starters.length : 0,
+        away_starters: Array.isArray(lineup.awayTeam?.starters) ? lineup.awayTeam.starters.length : 0,
+        shots_count: shotmapShots,
+        momentum_points: Array.isArray(momentum) ? momentum.length : 0,
+    };
+}
+
+function buildStitchSummary({ rawData, oddsRows, missingFields, rawRows, l3Rows }) {
+    const fixtureSummary = summarizeFixture(rawData);
+    const conflicts = [];
+
+    if (!rawData?.content) {
+        conflicts.push('missing_content');
+    }
+    if (!fixtureSummary.lineup_available) {
+        conflicts.push('missing_lineup');
+    }
+    if (!rawData?.content?.shotmap || !Array.isArray(rawData.content.shotmap.shots)) {
+        conflicts.push('missing_shotmap');
+    }
+    if (oddsRows.length === 0) {
+        conflicts.push('no_odds_data');
+    }
+    if (rawRows.length === 0) {
+        conflicts.push('no_raw_match_data');
+    }
+    if (l3Rows.length > 0) {
+        conflicts.push('l3_features_already_exists');
+    }
+
+    return {
+        ...fixtureSummary,
+        odds_history_rows: oddsRows.length,
+        raw_match_data_rows: rawRows.length,
+        l3_features_rows: l3Rows.length,
+        missing_fields: missingFields,
+        conflicts,
+        source: 'local_fixture_and_read_only_db',
+        would_insert_l3_features: false,
+        would_update_matches: false,
+        would_trigger_elo: false,
+        would_create_index: false,
+        would_create_table: false,
+    };
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function buildBlockedCommitPayload() {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        error: 'BLOCKED: l3_features commit is not wired in Phase 4.26.',
+        non_execution_confirmations: [
+            'no_db_writes',
+            'no_insert',
+            'no_update',
+            'no_delete',
+            'no_create_index',
+            'no_smelt',
+            'no_l3_stitch',
+            'no_elo',
+            'no_external_network',
+        ],
+    };
+}
+
+function buildPreview({ args, fixturePath, fixture, matchRow, oddsRows, rawRows, l3Rows, missingFields }) {
+    const rawData = fixture.raw_data;
+    const goldenExtracted = extractGoldenFeatures(rawData);
+    const tacticalExtracted = extractTacticalFeatures(rawData);
+    const oddsData = buildOddsDataFromHistoryRows(oddsRows);
+    const oddsMovementFeatures = oddsData.hasData
+        ? extractOddsMovementFeaturesFromOddsData(oddsData, tacticalExtracted)
+        : extractOddsMovementFeatures(rawData, tacticalExtracted);
+    const fixtureSummary = summarizeFixture(rawData);
+    const oddsFeatureSummary = {
+        rows: oddsRows.length,
+        one_x_two_rows: oddsRows.filter(row => String(row.market_type || '').toLowerCase() === '1x2').length,
+        bookmakers: uniqueSorted(oddsRows.map(row => row.bookmaker_name)),
+        markets: uniqueSorted(oddsRows.map(row => row.market_type)),
+        source: oddsData.hasData ? 'bookmaker_odds_history' : 'raw_fixture_or_none',
+        extracted: oddsMovementFeatures,
+    };
+    const eloFeatures = {
+        available: false,
+        reason: 'ELO not computed in local write gate dry-run',
+    };
+    const stitchSummary = buildStitchSummary({
+        rawData,
+        oddsRows,
+        missingFields,
+        rawRows,
+        l3Rows,
+    });
+
+    return {
+        mode: 'dry-run',
+        match_id: args.matchId,
+        fixture: {
+            path: args.fixture,
+            resolved_path: fixturePath,
+            external_id: fixture.external_id || rawData.general?.matchId || rawData.matchId || null,
+        },
+        db: {
+            match_found: true,
+            raw_match_data_found: rawRows.length > 0,
+            raw_match_data_rows: rawRows.length,
+            odds_history_rows: oddsRows.length,
+            l3_features_exists: l3Rows.length > 0,
+            l3_features_rows: l3Rows.length,
+            match: {
+                match_id: matchRow.match_id,
+                external_id: matchRow.external_id,
+                league_name: matchRow.league_name,
+                season: matchRow.season,
+                home_team: matchRow.home_team,
+                away_team: matchRow.away_team,
+                match_date: matchRow.match_date ? new Date(matchRow.match_date).toISOString() : null,
+                status: matchRow.status,
+                pipeline_status: matchRow.pipeline_status,
+            },
+        },
+        preview_record: {
+            target_table: 'l3_features',
+            would_insert_l3_features: false,
+            match_id: args.matchId,
+            external_id: matchRow.external_id || fixture.external_id || null,
+            golden_features: {
+                league_name: matchRow.league_name,
+                season: matchRow.season,
+                home_team: matchRow.home_team,
+                away_team: matchRow.away_team,
+                match_date: matchRow.match_date ? new Date(matchRow.match_date).toISOString() : null,
+                extracted: goldenExtracted,
+            },
+            tactical_features: {
+                shots_count: fixtureSummary.shots_count,
+                momentum_points: fixtureSummary.momentum_points,
+                lineup_available: fixtureSummary.lineup_available,
+                extracted: tacticalExtracted,
+            },
+            odds_movement_features: oddsMovementFeatures,
+            odds_features: oddsFeatureSummary,
+            elo_features: eloFeatures,
+            rolling_features: {},
+            efficiency_features: {},
+            draw_features: {},
+            market_sentiment: {},
+            stitch_summary: stitchSummary,
+            computed_at: 'database_default_now_when_future_commit_is_authorized',
+        },
+        stitch_summary: stitchSummary,
+        missing_fields: missingFields,
+        warnings: oddsRows.length === 0 ? ['target_odds_history_missing'] : [],
+        non_execution_confirmations: [
+            'no_db_writes',
+            'no_insert',
+            'no_update',
+            'no_delete',
+            'no_create_index',
+            'no_create_table',
+            'no_upsert',
+            'no_smelt',
+            'no_l3_stitch',
+            'no_l3_write',
+            'no_elo',
+            'no_external_network',
+        ],
+    };
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error(JSON.stringify(buildBlockedCommitPayload(), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.fixture || !args.matchId) {
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const { resolved, data: fixture } = readJsonFile(args.fixture);
+    const missingFields = validateFixture(fixture, args.matchId);
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const matchSql = `
+            SELECT match_id, external_id, league_name, season, home_team, away_team,
+                   match_date, status, pipeline_status
+            FROM matches
+            WHERE match_id = $1
+        `;
+        const oddsSql = `
+            SELECT match_id, bookmaker_name, market_type, open_odds, close_odds, collected_at
+            FROM bookmaker_odds_history
+            WHERE match_id = $1
+            ORDER BY bookmaker_name, market_type
+        `;
+        const rawSql = `
+            SELECT id, match_id, external_id, data_version, data_hash, collected_at
+            FROM raw_match_data
+            WHERE match_id = $1
+            ORDER BY collected_at DESC
+        `;
+        const l3Sql = `
+            SELECT match_id, external_id, computed_at, created_at, updated_at
+            FROM l3_features
+            WHERE match_id = $1
+        `;
+
+        const matchResult = await safeSelect(pool, matchSql, [args.matchId]);
+        if (matchResult.rowCount !== 1) {
+            throw new Error(`Target match not found: ${args.matchId}`);
+        }
+
+        const oddsResult = await safeSelect(pool, oddsSql, [args.matchId]);
+        const rawResult = await safeSelect(pool, rawSql, [args.matchId]);
+        if (rawResult.rowCount < 1) {
+            throw new Error(`Target raw_match_data not found: ${args.matchId}`);
+        }
+
+        const l3Result = await safeSelect(pool, l3Sql, [args.matchId]);
+        const preview = buildPreview({
+            args,
+            fixturePath: resolved,
+            fixture,
+            matchRow: matchResult.rows[0],
+            oddsRows: oddsResult.rows,
+            rawRows: rawResult.rows,
+            l3Rows: l3Result.rows,
+            missingFields,
+        });
+
+        console.log(JSON.stringify(preview, null, 2));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: [
+                    'no_db_writes',
+                    'no_insert',
+                    'no_update',
+                    'no_delete',
+                    'no_create_index',
+                    'no_smelt',
+                    'no_l3_stitch',
+                    'no_elo',
+                    'no_external_network',
+                ],
+            },
+            null,
+            2
+        )
+    );
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a safe local l3_features write gate.

Changes:
- Adds scripts/ops/l3_features_local_write_gate.js
- Adds make data-l3-write-dry-run
- Adds blocked make data-l3-write-commit
- Updates data-help
- Updates AGENTS.md with l3_features write safety rules
- Adds Phase 4.26 report

Safety:
- Dry-run only by default
- data-l3-write-commit remains blocked / not wired in this phase
- No l3_features writes
- No INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE
- No smelt / l3:stitch / ELO execution
- No external network access

Validation:
- make data-l3-write-dry-run without args fails as expected
- make data-l3-write-dry-run SAMPLE_RAW=tests/fixtures/l3/raw_match_data_phase419_sample.json MATCH_ID=140_20252026_4837496 succeeds
- make data-l3-write-commit remains blocked with and without CONFIRM_L3_WRITE=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/l3_features_local_write_gate.js
- docs/_reports/L3_FEATURES_LOCAL_WRITE_GATE_PHASE4_26.md