### PR TITLE
chore(pipeline): add training prediction preflight gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,8 @@ AI / Codex 默认只能执行：
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-raw-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
+- 安全占位且不训练、不预测、不写 DB 的 `make data-training-dry-run`
+- 安全占位且不训练、不预测、不写 DB 的 `make data-prediction-dry-run`
 
 AI / Codex 不能直接执行：
 
@@ -230,10 +232,22 @@ AI / Codex 不能直接执行：
 - `node scripts/ops/batch_historical_backfill.js`
 - `npm run smelt`
 - `npm run l3:stitch`
+- `npm run train`
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run model:train`
+- `npm run model:predict`
 - `scripts/ops/smelt_all.js`
 - `scripts/ops/l3_stitch_pipeline.js`
 - `scripts/ops/l3_stitch_worker.js`
 - `npm run elo:recalc`
+- 任何写 `match_features_training` 的命令
+- 任何写 `predictions` 的命令
+- 任何加载或生成模型 artifact 的训练命令
+- `make data-training-commit`
+- `make data-training-commit CONFIRM_TRAINING=1`
+- `make data-prediction-commit`
+- `make data-prediction-commit CONFIRM_PREDICTION=1`
 - `make data-l3-write-commit`
 - `make data-l3-write-commit CONFIRM_L3_WRITE=1`
 - `node scripts/ops/l3_features_local_write_gate.js --commit`
@@ -253,6 +267,20 @@ AI / Codex 不能直接执行：
 - 不访问外网
 
 L3 本地 dry-run 预检背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHASE4_18.md`
+
+执行 `make data-training-dry-run` 或 `make data-prediction-dry-run` 的前提：
+
+- 入口只是安全占位 / runbook preview
+- 不调用 `npm run train` 或 `npm run predict`
+- 不训练模型
+- 不执行预测
+- 不加载或生成模型 artifact
+- 不写 `match_features_training`
+- 不写 `predictions`
+- 不写 DB
+- 不访问外网
+
+Phase 4.29 中 `make data-training-commit` 和 `make data-prediction-commit` 仍是 blocked / not wired，即使提供 `CONFIRM_TRAINING=1` 或 `CONFIRM_PREDICTION=1` 也不得执行训练、预测或写库。相关背景见：`docs/_reports/L3_FEATURES_SINGLE_INSERT_PHASE4_28.md`、`docs/_reports/L3_FEATURES_LOCAL_WRITE_GATE_PHASE4_26.md` 和 `docs/_reports/L3_FEATURES_WRITE_GATE_PREFLIGHT_PHASE4_24.md`
 
 执行 `make data-l3-write-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
         dev-config dev-up dev-down dev-shell dev-logs dev-build dev-ps dev-harvest dev-test \
         data-help data-check data-local-dry-run data-l3-dry-run data-l3-commit \
         data-l3-write-dry-run data-l3-write-commit \
+        data-training-dry-run data-training-commit data-prediction-dry-run data-prediction-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -237,8 +238,12 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l3-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo "  make data-l3-write-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo "  make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
+	@echo "  make data-training-dry-run"
+	@echo "  make data-prediction-dry-run"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
+	@echo "  make data-prediction-commit CONFIRM_PREDICTION=1  # blocked in Phase 4.29"
 	@echo "  make data-l3-write-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_WRITE=1  # blocked in Phase 4.26"
 	@echo "  make data-l3-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_COMMIT=1  # blocked in Phase 4.24"
 	@echo "  make data-raw-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_RAW_COMMIT=1  # blocked in Phase 4.21"
@@ -309,6 +314,34 @@ data-l3-write-commit: ## Blocked l3_features write gate. Requires SAMPLE_RAW, MA
 		exit 1; \
 	fi
 	@echo "BLOCKED: l3_features commit is not wired in Phase 4.26."
+	@exit 1
+
+data-training-dry-run: ## Safe training preflight placeholder. Does not train or write DB.
+	@echo "SAFE PREVIEW ONLY: training dry-run is not wired in Phase 4.29."
+	@echo "No npm run train, model training, model artifact generation, or DB writes are executed."
+	@echo "Current local sample is insufficient for training; requires multi-match finished historical dataset and explicit model artifact policy."
+	@echo "Recommended next step: create a training runbook with dataset scope, artifact paths, backup plan, and validation gates."
+
+data-training-commit: ## Blocked training gate. Requires CONFIRM_TRAINING=1 but remains blocked in Phase 4.29.
+	@if [ "$(CONFIRM_TRAINING)" != "1" ]; then \
+		echo "BLOCKED: training requires CONFIRM_TRAINING=1 and is not wired in Phase 4.29."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: training commit is not wired in Phase 4.29."
+	@exit 1
+
+data-prediction-dry-run: ## Safe prediction preflight placeholder. Does not predict or write DB.
+	@echo "SAFE PREVIEW ONLY: prediction dry-run is not wired in Phase 4.29."
+	@echo "No npm run predict, model inference, prediction write, or DB writes are executed."
+	@echo "Prediction requires l3_features, trusted model artifacts, target window policy, and explicit output/write policy."
+	@echo "Recommended next step: create a prediction runbook with match scope, artifact manifest, and no-write verification gates."
+
+data-prediction-commit: ## Blocked prediction gate. Requires CONFIRM_PREDICTION=1 but remains blocked in Phase 4.29.
+	@if [ "$(CONFIRM_PREDICTION)" != "1" ]; then \
+		echo "BLOCKED: prediction requires CONFIRM_PREDICTION=1 and is not wired in Phase 4.29."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: prediction commit is not wired in Phase 4.29."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/L3_FEATURES_SINGLE_INSERT_PHASE4_28.md
+++ b/docs/_reports/L3_FEATURES_SINGLE_INSERT_PHASE4_28.md
@@ -1,0 +1,151 @@
+# Phase 4.28 - L3 Features Single Insert
+
+## Current HEAD
+
+- Branch: `main`
+- HEAD: `2f179fd4c9a7733342756d7d540cf4d7ba83b380`
+- Target match: `140_20252026_4837496`
+- Fixture: `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+
+## Backup
+
+- Backup file: `data/backups/phase428_pre_l3_features_insert_20260503_171518.dump`
+- Backup size: `69K`
+- Backup command: `pg_dump --format=custom`
+
+## Pre-Insert State
+
+| table                   | rows before |
+| ----------------------- | ----------: |
+| matches                 |           1 |
+| bookmaker_odds_history  |           2 |
+| raw_match_data          |           1 |
+| l3_features             |           0 |
+| match_features_training |           0 |
+| predictions             |           0 |
+
+Target preconditions:
+
+- Target match exists: yes
+- Odds history rows: 2
+- `raw_match_data` exists: yes
+- Target `l3_features` rows: 0
+
+## Insert Result
+
+A single authorized `INSERT INTO l3_features` was executed for:
+
+- `match_id`: `140_20252026_4837496`
+- Source fixture: `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+- Source DB reads: `matches`, `bookmaker_odds_history`, `raw_match_data`
+
+Returned values:
+
+- `match_id`: `140_20252026_4837496`
+- `computed_at`: `2026-05-03 09:15:52.069702+00`
+- `created_at`: `2026-05-03 09:15:52.069702+00`
+- `updated_at`: `2026-05-03 09:15:52.069702+00`
+
+Inserted JSONB groups:
+
+- `golden_features`
+- `tactical_features`
+- `odds_features`
+- `elo_features`
+- `stitch_summary`
+
+Defaulted JSONB groups remain available through table defaults:
+
+- `odds_movement_features`
+- `rolling_features`
+- `efficiency_features`
+- `draw_features`
+- `market_sentiment`
+
+## Post-Insert l3_features Verification
+
+- Target `l3_features` rows: 1
+- `golden_features`: object
+- `tactical_features`: object
+- `odds_features`: object
+- `elo_features`: object
+- `stitch_summary`: object
+
+## Post-Insert Row Counts
+
+| table                   | rows after |
+| ----------------------- | ---------: |
+| matches                 |          1 |
+| bookmaker_odds_history  |          2 |
+| raw_match_data          |          1 |
+| l3_features             |          1 |
+| match_features_training |          0 |
+| predictions             |          0 |
+
+Only `l3_features` changed from 0 to 1.
+
+## Gate Verification
+
+Post-insert `make data-l3-write-dry-run` result:
+
+- `mode`: `dry-run`
+- `match_found`: `true`
+- `raw_match_data_found`: `true`
+- `odds_history_rows`: `2`
+- `l3_features_exists`: `true`
+- `l3_features_rows`: `1`
+- `would_insert_l3_features`: `false`
+- `would_update_matches`: `false`
+- `would_trigger_elo`: `false`
+- Non-execution confirmations include `no_db_writes`, `no_insert`, `no_update`, `no_delete`, `no_smelt`, `no_l3_stitch`, `no_l3_write`, `no_elo`, and `no_external_network`
+
+Post-insert `make data-l3-dry-run` result:
+
+- Read-only dry-run still succeeds
+- `would_write_l3_features`: `false`
+- `would_update_matches`: `false`
+- `would_trigger_elo`: `false`
+
+## Risks And Notes
+
+- This was a manual single-row local dev DB insert, not a production L3 pipeline run.
+- The inserted feature payload is intentionally conservative and traceable to local fixture plus read-only DB preflight data.
+- ELO remains unavailable by design.
+- No `matches` update was performed.
+- No training or prediction table was populated.
+
+## Explicit Non-Execution
+
+The phase did not execute:
+
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `INSERT` into any table except `l3_features`
+- duplicate `l3_features` insert
+- `raw_match_data` commit
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- model training
+- prediction write
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push`
+- `git pull`
+- `git fetch --all`
+- commit
+
+## Next Steps
+
+- Phase 4.29 can submit this report, or design the next `match_features_training` / prediction preflight runbook.
+- Any next write should remain single-match, explicitly authorized, backed up, and isolated from smelt / stitch / ELO unless separately authorized.

--- a/docs/_reports/TRAINING_PREDICTION_PREFLIGHT_PHASE4_29.md
+++ b/docs/_reports/TRAINING_PREDICTION_PREFLIGHT_PHASE4_29.md
@@ -1,0 +1,223 @@
+# Phase 4.29 - Training / Prediction Preflight Gates
+
+## Current HEAD
+
+- Base HEAD: `2f179fd4c9a7733342756d7d540cf4d7ba83b380`
+- Working branch: `feat/training-prediction-preflight-gates`
+- Target match: `140_20252026_4837496`
+
+## Phase 4.28 Status
+
+Phase 4.28 completed a single authorized local `l3_features` insert:
+
+- `matches`: 1
+- `bookmaker_odds_history`: 2
+- `raw_match_data`: 1
+- `l3_features`: 1
+- `match_features_training`: 0
+- `predictions`: 0
+
+The Phase 4.28 report is included in this change:
+
+- `docs/_reports/L3_FEATURES_SINGLE_INSERT_PHASE4_28.md`
+
+## Current DB Row Counts
+
+| table                   | rows before gates | rows after gates |
+| ----------------------- | ----------------: | ---------------: |
+| matches                 |                 1 |                1 |
+| bookmaker_odds_history  |                 2 |                2 |
+| raw_match_data          |                 1 |                1 |
+| l3_features             |                 1 |                1 |
+| match_features_training |                 0 |                0 |
+| predictions             |                 0 |                0 |
+
+## Target Chain State
+
+- Target match exists: yes
+- Target `l3_features` exists: yes
+- `golden_features`: object
+- `tactical_features`: object
+- `odds_features`: object
+- `elo_features`: object
+- `stitch_summary`: object
+- Target `match_features_training` rows: 0
+- Target `predictions` rows: 0
+
+## match_features_training Structure Summary
+
+Required fields:
+
+- `match_id`
+- `season`
+- `match_date`
+- `home_team`
+- `away_team`
+
+Defaults:
+
+- `feature_version`: `V25.1`
+- `feature_count`: `0`
+- `created_at`: `CURRENT_TIMESTAMP`
+- `updated_at`: `CURRENT_TIMESTAMP`
+
+Feature fields:
+
+- Numeric rolling / table / points / Elo / fatigue / incentive fields are nullable.
+- `adaptive_features` is nullable JSONB.
+
+Constraints:
+
+- Primary key: `match_id`
+- Foreign key: `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+
+Training suitability:
+
+- Current local data is not sufficient for training.
+- There is only one scheduled target match and zero `match_features_training` rows.
+- The inspected training script requires finished matches with scores and enough historical examples. Its default minimum sample count is 100.
+
+## predictions Structure Summary
+
+Required fields:
+
+- `id`
+- `match_id`
+- `model_version`
+- `predicted_result`
+
+Defaults:
+
+- `id`: sequence-backed
+- `prediction_date`: `CURRENT_TIMESTAMP`
+
+Prediction fields:
+
+- `confidence_home`, `confidence_draw`, `confidence_away`, `final_confidence`, and `edge` are nullable numeric fields.
+- `recommended_bet` and `is_correct` are nullable.
+
+Constraints:
+
+- Primary key: `id`
+- Unique key: `(match_id, model_version)`
+- Foreign key: `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+
+Prediction suitability:
+
+- Current data is not sufficient for a trusted prediction execution.
+- The target match is scheduled and has `l3_features`, but `elo_features` is intentionally unavailable.
+- A trusted model artifact policy, prediction target window, and explicit write policy are still missing.
+
+## Training / Prediction Entry Risk Audit
+
+Observed package scripts:
+
+- `npm run train` runs `scripts/ops/train_model.py`
+- `npm run train:fast` runs the same training pipeline with smaller hyperparameters
+- `npm run train:deep` runs the same training pipeline with larger hyperparameters
+- `npm run predict` runs `scripts/ops/predict_pipeline.py`
+- `npm run predict:dry` runs `scripts/ops/predict_pipeline.py --dry-run`
+- `npm run predict:json` runs `scripts/ops/predict_pipeline.py --format json`
+
+Training risk:
+
+- `scripts/ops/train_model.py` reads finished historical matches joined to `l3_features`.
+- It trains an XGBoost model.
+- It saves model and scaler artifacts through `joblib.dump`.
+- It is not a safe dry-run gate.
+- It depends on a sufficiently large finished historical dataset and model artifact policy.
+
+Prediction risk:
+
+- `scripts/ops/predict_pipeline.py` loads the TITAN model through `get_titan_model`.
+- It reads pending matches joined to `l3_features`.
+- Its `--dry-run` flag still enters the model loading and inference path.
+- It is not a Phase 4.29-safe no-op preview.
+- Additional inference modules include code paths capable of inserting into `predictions`; those paths must remain blocked unless separately authorized.
+
+## Added Makefile Gates
+
+Added safe preview placeholders:
+
+```bash
+make data-training-dry-run
+make data-prediction-dry-run
+```
+
+These do not call training or prediction scripts and do not write DB state.
+
+Added blocked commit gates:
+
+```bash
+make data-training-commit CONFIRM_TRAINING=1
+make data-prediction-commit CONFIRM_PREDICTION=1
+```
+
+These remain blocked / not wired in Phase 4.29, even with confirmation variables.
+
+## AGENTS.md Update Summary
+
+The AI / Codex safety rules now explicitly forbid:
+
+- `npm run train`
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run model:train`
+- `npm run model:predict`
+- Any command that writes `match_features_training`
+- Any command that writes `predictions`
+- Any training command that loads or generates model artifacts
+- `make data-training-commit`
+- `make data-training-commit CONFIRM_TRAINING=1`
+- `make data-prediction-commit`
+- `make data-prediction-commit CONFIRM_PREDICTION=1`
+
+Allowed by default only when they remain no-op safety previews:
+
+- `make data-training-dry-run`
+- `make data-prediction-dry-run`
+
+## Gate Verification
+
+Executed safe gate verification:
+
+- `make data-training-dry-run`: safe preview only, no training
+- `make data-training-commit`: blocked
+- `make data-training-commit CONFIRM_TRAINING=1`: still blocked
+- `make data-prediction-dry-run`: safe preview only, no prediction
+- `make data-prediction-commit`: blocked
+- `make data-prediction-commit CONFIRM_PREDICTION=1`: still blocked
+
+No training, prediction, model artifact generation, or DB writes were executed.
+
+## Next Steps
+
+- A future training phase should define a runbook with dataset scope, minimum sample criteria, feature schema, model artifact paths, validation metrics, and rollback / cleanup policy.
+- A future prediction phase should define a runbook with match scope, model artifact manifest, target window, output policy, no-write dry-run semantics, and explicit DB write authorization if needed.
+- Keep `npm run train`, `npm run predict`, smelt, stitch, and ELO blocked until a future phase explicitly authorizes them.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE`
+- `match_features_training` write
+- `predictions` write
+- model training
+- prediction execution
+- `npm run train`
+- `npm run predict`
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git fetch --all`
+- `git pull`
+- file deletion


### PR DESCRIPTION
## Summary

Adds the Phase 4.28 l3_features single insert report and Phase 4.29 training/prediction preflight gates.

Changes:
- Adds Phase 4.28 l3_features single insert report
- Adds Phase 4.29 training/prediction preflight report
- Adds blocked training and prediction gates in Makefile
- Updates AGENTS.md with training/prediction safety rules

Safety:
- No training executed
- No prediction executed
- No match_features_training writes
- No predictions writes
- No smelt / l3:stitch / ELO execution
- No external data access

Validation:
- training dry-run remains safe preview only
- training commit remains blocked
- prediction dry-run remains safe preview only
- prediction commit remains blocked
- DB row counts unchanged
- git diff --check
- prettier check