### PR TITLE
feat(training): add match features training gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且仅使用本地 fixture 的 `make data-raw-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 安全占位且不训练、不预测、不写 DB 的 `make data-training-dry-run`
 - 安全占位且不训练、不预测、不写 DB 的 `make data-prediction-dry-run`
+- 用户明确授权且只读 DB 的 `make data-training-feature-dry-run MATCH_ID=<id>`
 
 AI / Codex 不能直接执行：
 
@@ -248,6 +249,9 @@ AI / Codex 不能直接执行：
 - `make data-training-commit CONFIRM_TRAINING=1`
 - `make data-prediction-commit`
 - `make data-prediction-commit CONFIRM_PREDICTION=1`
+- `make data-training-feature-commit`
+- `make data-training-feature-commit CONFIRM_TRAINING_FEATURE=1`
+- `node scripts/ops/match_features_training_local_write_gate.js --commit`
 - `make data-l3-write-commit`
 - `make data-l3-write-commit CONFIRM_L3_WRITE=1`
 - `node scripts/ops/l3_features_local_write_gate.js --commit`
@@ -281,6 +285,20 @@ L3 本地 dry-run 预检背景见：`docs/_reports/L3_RAW_FIXTURE_PREFLIGHT_PHAS
 - 不访问外网
 
 Phase 4.29 中 `make data-training-commit` 和 `make data-prediction-commit` 仍是 blocked / not wired，即使提供 `CONFIRM_TRAINING=1` 或 `CONFIRM_PREDICTION=1` 也不得执行训练、预测或写库。相关背景见：`docs/_reports/L3_FEATURES_SINGLE_INSERT_PHASE4_28.md`、`docs/_reports/L3_FEATURES_LOCAL_WRITE_GATE_PHASE4_26.md` 和 `docs/_reports/L3_FEATURES_WRITE_GATE_PREFLIGHT_PHASE4_24.md`
+
+执行 `make data-training-feature-dry-run MATCH_ID=<id>` 的前提：
+
+- 用户明确授权
+- 只读查询本地 DB
+- 不训练模型
+- 不执行预测
+- 不加载或生成模型 artifact
+- 不写 `match_features_training`
+- 不写 `predictions`
+- 不写 DB
+- 不访问外网
+
+Phase 4.30 中 `make data-training-feature-commit`、`make data-training-feature-commit CONFIRM_TRAINING_FEATURE=1` 和 `node scripts/ops/match_features_training_local_write_gate.js --commit` 仍是 blocked / not wired。禁止直接或间接执行 `npm run train`、`npm run predict`、`npm run model:train`、`npm run model:predict` 或任何写 `match_features_training` / `predictions` 的命令来替代该门禁。相关背景见：`docs/_reports/TRAINING_PREDICTION_PREFLIGHT_PHASE4_29.md` 和 `docs/_reports/L3_FEATURES_SINGLE_INSERT_PHASE4_28.md`
 
 执行 `make data-l3-write-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
         data-help data-check data-local-dry-run data-l3-dry-run data-l3-commit \
         data-l3-write-dry-run data-l3-write-commit \
         data-training-dry-run data-training-commit data-prediction-dry-run data-prediction-commit \
+        data-training-feature-dry-run data-training-feature-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -240,8 +241,10 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>"
 	@echo "  make data-training-dry-run"
 	@echo "  make data-prediction-dry-run"
+	@echo "  make data-training-feature-dry-run MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
 	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
 	@echo "  make data-prediction-commit CONFIRM_PREDICTION=1  # blocked in Phase 4.29"
 	@echo "  make data-l3-write-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_L3_WRITE=1  # blocked in Phase 4.26"
@@ -342,6 +345,26 @@ data-prediction-commit: ## Blocked prediction gate. Requires CONFIRM_PREDICTION=
 		exit 1; \
 	fi
 	@echo "BLOCKED: prediction commit is not wired in Phase 4.29."
+	@exit 1
+
+data-training-feature-dry-run: ## Run safe local match_features_training write preview. Requires MATCH_ID.
+	@if [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe local match_features_training write dry-run: MATCH_ID=$(MATCH_ID)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/match_features_training_local_write_gate.js --match-id "$(MATCH_ID)"
+
+data-training-feature-commit: ## Blocked match_features_training write gate. Requires MATCH_ID, CONFIRM_TRAINING_FEATURE=1.
+	@if [ "$(CONFIRM_TRAINING_FEATURE)" != "1" ]; then \
+		echo "BLOCKED: match_features_training write requires CONFIRM_TRAINING_FEATURE=1 and is not wired in Phase 4.30."; \
+		exit 1; \
+	fi
+	@if [ -z "$(MATCH_ID)" ]; then \
+		echo "BLOCKED: provide MATCH_ID=<id>; match_features_training commit is not wired in Phase 4.30."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: match_features_training commit is not wired in Phase 4.30."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/MATCH_FEATURES_TRAINING_GATE_PHASE4_30.md
+++ b/docs/_reports/MATCH_FEATURES_TRAINING_GATE_PHASE4_30.md
@@ -1,0 +1,230 @@
+# Phase 4.30 - match_features_training Local Write Gate
+
+## Current HEAD
+
+- Base HEAD: `82f2d4da7a5eb4998c904c5f1068922143cc08b5`
+- Working branch: `feat/training-feature-local-write-gate`
+- Target match: `140_20252026_4837496`
+- Fixture context: `tests/fixtures/l3/raw_match_data_phase419_sample.json`
+
+## Current DB State
+
+| table                   | rows before gate | rows after gate |
+| ----------------------- | ---------------: | --------------: |
+| matches                 |                1 |               1 |
+| bookmaker_odds_history  |                2 |               2 |
+| raw_match_data          |                1 |               1 |
+| l3_features             |                1 |               1 |
+| match_features_training |                0 |               0 |
+| predictions             |                0 |               0 |
+
+Target chain state:
+
+- Target match exists: yes
+- Target `l3_features` exists: yes
+- Target `match_features_training` rows: 0
+- Target `predictions` rows: 0
+- Target `l3_features` JSONB types: `golden_features`, `tactical_features`, `odds_features`, `elo_features`, and `stitch_summary` are all objects
+
+## Phase 4.29 Gate Verification
+
+Existing mainline training / prediction gates were revalidated before adding the Phase 4.30 gate:
+
+- `make data-training-dry-run`: safe preview only; no training and no DB writes
+- `make data-training-commit`: blocked
+- `make data-training-commit CONFIRM_TRAINING=1`: still blocked
+- `make data-prediction-dry-run`: safe preview only; no prediction and no DB writes
+- `make data-prediction-commit`: blocked
+- `make data-prediction-commit CONFIRM_PREDICTION=1`: still blocked
+
+No `npm run train`, `npm run predict`, model artifact generation, prediction write, or DB write was executed.
+
+## match_features_training Structure Summary
+
+Required fields:
+
+- `match_id`
+- `season`
+- `match_date`
+- `home_team`
+- `away_team`
+
+Defaults:
+
+- `feature_version`: `'V25.1'`
+- `feature_count`: `0`
+- `created_at`: `CURRENT_TIMESTAMP`
+- `updated_at`: `CURRENT_TIMESTAMP`
+
+Feature fields:
+
+- Nullable numeric fields cover rolling xG, shots on target, possession, team rating, table position, points, Elo gap, fatigue, rest days, incentives, low scoring tendency, and Elo cluster features.
+- `adaptive_features` is nullable JSONB and is the natural future target for a compact preview derived from `l3_features`.
+
+Constraints:
+
+- Primary key: `match_id`
+- Foreign key: `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+
+Minimum future insert fields:
+
+- `match_id`
+- `season`
+- `match_date`
+- `home_team`
+- `away_team`
+- Optional derived values from `l3_features`, most likely stored under `adaptive_features`
+
+## Training / Prediction Risk Audit
+
+Observed high-risk entries remain blocked:
+
+- `npm run train`, `npm run train:fast`, and `npm run train:deep` invoke `scripts/ops/train_model.py`.
+- `npm run predict`, `npm run predict:dry`, and `npm run predict:json` invoke `scripts/ops/predict_pipeline.py`.
+- Existing `predict:dry` is not treated as a Phase 4.30-safe no-op because it still enters model loading / inference flow.
+- `npm run l3:stitch`, `npm run smelt`, and ELO recalculation entries remain outside this phase.
+
+Current data is sufficient to generate a training feature preview: yes.
+
+Current data is sufficient for real model training: no. There is only one scheduled local sample, no finished historical outcome set, and no model artifact policy.
+
+Current data is sufficient for prediction execution: no. Prediction requires an authorized model artifact policy, target window, inference runbook, and explicit write policy.
+
+## Added Gate Behavior
+
+Added script:
+
+```bash
+node scripts/ops/match_features_training_local_write_gate.js --match-id <id>
+```
+
+Default behavior:
+
+- Runs dry-run mode.
+- Performs SELECT-only checks against `matches`, `l3_features`, `match_features_training`, and `predictions`.
+- Builds a `match_features_training` preview from the existing `l3_features` row.
+- Marks the record as not trainable because a single scheduled match is insufficient for training.
+- Confirms no DB writes, training, prediction, model artifact writes, or external network access.
+
+Commit behavior:
+
+- `--commit` exits non-zero immediately.
+- Error: `BLOCKED: match_features_training commit is not wired in Phase 4.30.`
+- No DB writes are wired behind commit mode.
+
+## Makefile Entrypoints
+
+Added safe dry-run:
+
+```bash
+make data-training-feature-dry-run MATCH_ID=<id>
+```
+
+Added blocked commit gate:
+
+```bash
+make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1
+```
+
+The commit gate remains blocked / not wired in Phase 4.30, even with `CONFIRM_TRAINING_FEATURE=1`.
+
+## AGENTS.md Update
+
+`AGENTS.md` now permits only the dry-run gate when explicitly authorized:
+
+- `make data-training-feature-dry-run MATCH_ID=<id>`
+
+It explicitly forbids:
+
+- `make data-training-feature-commit`
+- `make data-training-feature-commit CONFIRM_TRAINING_FEATURE=1`
+- `node scripts/ops/match_features_training_local_write_gate.js --commit`
+- `npm run train`
+- `npm run predict`
+- `npm run model:train`
+- `npm run model:predict`
+- Any write to `match_features_training` or `predictions`
+
+Related reports:
+
+- `docs/_reports/TRAINING_PREDICTION_PREFLIGHT_PHASE4_29.md`
+- `docs/_reports/L3_FEATURES_SINGLE_INSERT_PHASE4_28.md`
+
+## Dry-run Output Summary
+
+Validation command:
+
+```bash
+make data-training-feature-dry-run MATCH_ID=140_20252026_4837496
+```
+
+Observed semantics:
+
+- `mode`: `dry-run`
+- `match_found`: true
+- `l3_features_found`: true
+- `match_features_training_exists`: false
+- `predictions_exists`: false
+- `would_insert_match_features_training`: false
+- `would_train_model`: false
+- `would_write_predictions`: false
+- `feature_source`: `l3_features`
+- `trainable`: false
+- `reason`: `Single scheduled match is insufficient for real model training.`
+
+Non-execution confirmations:
+
+- `no_db_writes`
+- `no_insert`
+- `no_update`
+- `no_delete`
+- `no_training`
+- `no_prediction`
+- `no_model_artifact_write`
+- `no_external_network`
+
+## Commit Gate Verification
+
+Validation commands:
+
+```bash
+make data-training-feature-commit
+make data-training-feature-commit MATCH_ID=140_20252026_4837496 CONFIRM_TRAINING_FEATURE=1
+```
+
+Observed results:
+
+- Default commit gate: blocked
+- Commit gate with `CONFIRM_TRAINING_FEATURE=1`: still blocked
+- No DB writes, training, prediction, or model artifact writes were executed.
+
+## Next Steps
+
+- Future `match_features_training` writes require a separate user authorization phase.
+- A backup must be taken before any authorized write.
+- Writes should remain restricted to one explicitly scoped `match_id` until a broader runbook exists.
+- Real training remains blocked until there is a multi-match finished historical dataset, outcome strategy, feature schema mapping, artifact policy, and validation plan.
+- Prediction remains blocked until there is a trusted model artifact manifest, target window policy, no-write preview semantics, and explicit output/write authorization.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE`
+- `match_features_training` write
+- `predictions` write
+- model training
+- prediction execution
+- `npm run train`
+- `npm run predict`
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup

--- a/scripts/ops/match_features_training_local_write_gate.js
+++ b/scripts/ops/match_features_training_local_write_gate.js
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Safe local match_features_training write preview gate.
+ *
+ * Phase 4.30 deliberately keeps commit mode blocked. The script performs
+ * SELECT-only DB checks and builds a future match_features_training preview
+ * from the existing l3_features row without training, prediction, or writes.
+ */
+
+'use strict';
+
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL = /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/match_features_training_local_write_gate.js --match-id <id> [--json]',
+        '  node scripts/ops/match_features_training_local_write_gate.js --match-id <id> --commit',
+        '',
+        'Safety:',
+        '  Dry-run only in Phase 4.30; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        matchId: null,
+        json: false,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function buildBlockedCommitPayload() {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        error: 'BLOCKED: match_features_training commit is not wired in Phase 4.30.',
+        non_execution_confirmations: [
+            'no_db_writes',
+            'no_insert',
+            'no_update',
+            'no_delete',
+            'no_training',
+            'no_prediction',
+            'no_model_artifact_write',
+            'no_external_network',
+        ],
+    };
+}
+
+function asObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function summarizeJsonFeature(value) {
+    const objectValue = asObject(value);
+    return {
+        type: Array.isArray(value) ? 'array' : typeof value,
+        key_count: Object.keys(objectValue).length,
+        keys: Object.keys(objectValue).sort().slice(0, 20),
+        source: objectValue.source || objectValue.odds_source || null,
+    };
+}
+
+function buildFeaturePreview({ matchId, matchRow, l3Row, trainingRows, predictionRows }) {
+    const goldenFeatures = asObject(l3Row?.golden_features);
+    const tacticalFeatures = asObject(l3Row?.tactical_features);
+    const oddsFeatures = asObject(l3Row?.odds_features);
+    const eloFeatures = asObject(l3Row?.elo_features);
+    const stitchSummary = asObject(l3Row?.stitch_summary);
+
+    return {
+        mode: 'dry-run',
+        match_id: matchId,
+        db: {
+            match_found: Boolean(matchRow),
+            l3_features_found: Boolean(l3Row),
+            match_features_training_exists: trainingRows.length > 0,
+            match_features_training_rows: trainingRows.length,
+            predictions_exists: predictionRows.length > 0,
+            prediction_rows: predictionRows.length,
+        },
+        preview_record: {
+            target_table: 'match_features_training',
+            would_insert_match_features_training: false,
+            match_id: matchId,
+            feature_source: 'l3_features',
+            candidate_required_fields: {
+                season: matchRow?.season || null,
+                match_date: matchRow?.match_date ? new Date(matchRow.match_date).toISOString() : null,
+                home_team: matchRow?.home_team || null,
+                away_team: matchRow?.away_team || null,
+                feature_version: 'database_default_V25.1_when_future_commit_is_authorized',
+            },
+            feature_summary: {
+                golden_features: summarizeJsonFeature(goldenFeatures),
+                tactical_features: summarizeJsonFeature(tacticalFeatures),
+                odds_features: summarizeJsonFeature(oddsFeatures),
+                elo_features: summarizeJsonFeature(eloFeatures),
+                stitch_summary: summarizeJsonFeature(stitchSummary),
+            },
+            adaptive_features_preview: {
+                source: 'phase4.30_l3_features_preview',
+                l3_computed_at: l3Row?.computed_at ? new Date(l3Row.computed_at).toISOString() : null,
+                l3_created_at: l3Row?.created_at ? new Date(l3Row.created_at).toISOString() : null,
+                golden_feature_keys: Object.keys(goldenFeatures).sort(),
+                tactical_feature_keys: Object.keys(tacticalFeatures).sort(),
+                odds_feature_keys: Object.keys(oddsFeatures).sort(),
+                elo_available: eloFeatures.available === true,
+                stitch_source: stitchSummary.source || null,
+            },
+            trainable: false,
+            reason: 'Single scheduled match is insufficient for real model training.',
+        },
+        training_summary: {
+            would_train_model: false,
+            minimum_dataset_required: 'multi-match finished historical dataset with outcomes',
+            model_artifact_policy_required: true,
+        },
+        prediction_summary: {
+            would_write_predictions: false,
+            reason: 'Prediction execution is blocked in Phase 4.30.',
+        },
+        non_execution_confirmations: [
+            'no_db_writes',
+            'no_insert',
+            'no_update',
+            'no_delete',
+            'no_training',
+            'no_prediction',
+            'no_model_artifact_write',
+            'no_external_network',
+        ],
+    };
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error(JSON.stringify(buildBlockedCommitPayload(), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.matchId) {
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const matchSql = `
+            SELECT match_id, external_id, league_name, season, home_team, away_team,
+                   match_date, status, pipeline_status
+            FROM matches
+            WHERE match_id = $1
+        `;
+        const l3Sql = `
+            SELECT match_id, computed_at, created_at, updated_at,
+                   golden_features, tactical_features, odds_features, elo_features, stitch_summary
+            FROM l3_features
+            WHERE match_id = $1
+        `;
+        const trainingSql = `
+            SELECT match_id
+            FROM match_features_training
+            WHERE match_id = $1
+        `;
+        const predictionSql = `
+            SELECT match_id
+            FROM predictions
+            WHERE match_id = $1
+        `;
+
+        const matchResult = await safeSelect(pool, matchSql, [args.matchId]);
+        const l3Result = await safeSelect(pool, l3Sql, [args.matchId]);
+        const trainingResult = await safeSelect(pool, trainingSql, [args.matchId]);
+        const predictionResult = await safeSelect(pool, predictionSql, [args.matchId]);
+
+        const preview = buildFeaturePreview({
+            matchId: args.matchId,
+            matchRow: matchResult.rows[0] || null,
+            l3Row: l3Result.rows[0] || null,
+            trainingRows: trainingResult.rows,
+            predictionRows: predictionResult.rows,
+        });
+
+        console.log(JSON.stringify(preview, null, 2));
+
+        if (!preview.db.match_found || !preview.db.l3_features_found) {
+            process.exitCode = 1;
+        }
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: [
+                    'no_db_writes',
+                    'no_insert',
+                    'no_update',
+                    'no_delete',
+                    'no_training',
+                    'no_prediction',
+                    'no_model_artifact_write',
+                    'no_external_network',
+                ],
+            },
+            null,
+            2
+        )
+    );
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a safe local match_features_training gate.

Changes:
- Adds scripts/ops/match_features_training_local_write_gate.js
- Adds make data-training-feature-dry-run
- Adds blocked make data-training-feature-commit
- Updates data-help
- Updates AGENTS.md with match_features_training safety rules
- Adds Phase 4.30 report

Safety:
- Dry-run only by default
- data-training-feature-commit remains blocked / not wired in this phase
- No match_features_training writes
- No predictions writes
- No model training
- No prediction execution
- No INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE
- No external network access

Validation:
- make data-training-feature-dry-run without args fails as expected
- make data-training-feature-dry-run MATCH_ID=140_20252026_4837496 succeeds
- make data-training-feature-commit remains blocked with and without CONFIRM_TRAINING_FEATURE=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/match_features_training_local_write_gate.js
- docs/_reports/MATCH_FEATURES_TRAINING_GATE_PHASE4_30.md