### PR TITLE
feat(training): add dataset status audit gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,8 @@ AI / Codex 默认只能执行：
 - 安全占位且不训练、不预测、不写 DB 的 `make data-prediction-dry-run`
 - 用户明确授权且只读 DB 的 `make data-training-feature-dry-run MATCH_ID=<id>`
 - 用户明确授权且只读 DB 的 `make data-prediction-write-dry-run MATCH_ID=<id>`
+- 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-dataset-status`
+- 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-training-dataset-dry-run`
 
 AI / Codex 不能直接执行：
 
@@ -256,6 +258,8 @@ AI / Codex 不能直接执行：
 - `make data-prediction-write-commit`
 - `make data-prediction-write-commit CONFIRM_PREDICTION_WRITE=1`
 - `node scripts/ops/prediction_local_write_gate.js --commit`
+- `make data-training-dataset-export`
+- `make data-training-dataset-export CONFIRM_DATASET_EXPORT=1`
 - `make data-l3-write-commit`
 - `make data-l3-write-commit CONFIRM_L3_WRITE=1`
 - `node scripts/ops/l3_features_local_write_gate.js --commit`
@@ -316,6 +320,18 @@ Phase 4.30 中 `make data-training-feature-commit`、`make data-training-feature
 - 不访问外网
 
 Phase 4.32 中 `make data-prediction-write-commit`、`make data-prediction-write-commit CONFIRM_PREDICTION_WRITE=1` 和 `node scripts/ops/prediction_local_write_gate.js --commit` 仍是 blocked / not wired。禁止直接或间接执行 `npm run predict`、`npm run predict:dry`、`npm run model:predict`、`npm run train`、`npm run model:train`、任何加载未经授权模型 artifact 的命令或任何写 `predictions` 的命令来替代该门禁。相关背景见：`docs/_reports/MATCH_FEATURES_TRAINING_SINGLE_INSERT_PHASE4_31.md` 和 `docs/_reports/TRAINING_PREDICTION_PREFLIGHT_PHASE4_29.md`
+
+执行 `make data-dataset-status` 或 `make data-training-dataset-dry-run` 的前提：
+
+- 入口只做 SELECT-only DB 审计
+- 不训练模型
+- 不执行预测
+- 不加载或生成模型 artifact
+- 不导出数据集或大文件
+- 不写 DB
+- 不访问外网
+
+Phase 4.36 中 `make data-training-dataset-export` 和 `make data-training-dataset-export CONFIRM_DATASET_EXPORT=1` 仍是 blocked / not wired。真实训练前必须先通过 dataset readiness report；单条 local sample 不能作为真实训练集；scheduled match 不能作为训练 label；`P4_LOCAL_BASELINE` manual / baseline prediction 不是模型输出；`predictions` 表不能反哺训练。相关背景见：`docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md` 和 `docs/_reports/PREDICTION_SINGLE_INSERT_PHASE4_34B.md`
 
 执行 `make data-l3-write-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
         data-training-dry-run data-training-commit data-prediction-dry-run data-prediction-commit \
         data-training-feature-dry-run data-training-feature-commit \
         data-prediction-write-dry-run data-prediction-write-commit \
+        data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -244,8 +245,11 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-prediction-dry-run"
 	@echo "  make data-training-feature-dry-run MATCH_ID=<id>"
 	@echo "  make data-prediction-write-dry-run MATCH_ID=<id>"
+	@echo "  make data-dataset-status"
+	@echo "  make data-training-dataset-dry-run"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
 	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
@@ -388,6 +392,20 @@ data-prediction-write-commit: ## Blocked predictions write gate. Requires MATCH_
 		exit 1; \
 	fi
 	@echo "BLOCKED: prediction commit is not wired in Phase 4.32."
+	@exit 1
+
+data-dataset-status: ## Run SELECT-only dataset status audit. Does not train, export, predict, or write DB.
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/dataset_status_audit.js
+
+data-training-dataset-dry-run: ## Run SELECT-only training dataset readiness audit. Does not train, export, or write DB.
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/dataset_status_audit.js
+
+data-training-dataset-export: ## Blocked dataset export gate. Remains not wired in Phase 4.36.
+	@if [ "$(CONFIRM_DATASET_EXPORT)" != "1" ]; then \
+		echo "BLOCKED: dataset export requires CONFIRM_DATASET_EXPORT=1 and is not wired in Phase 4.36."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: dataset export is not wired in Phase 4.36."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md
+++ b/docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md
@@ -1,0 +1,244 @@
+# Phase 4.36 - Dataset Status / Sample Audit Gate
+
+## Current HEAD
+
+- Base HEAD: `9ddc3ebb4babc27a21463f5ab4583537d13d3bb5`
+- Working branch: `feat/dataset-status-audit-gate`
+
+## Current Pipeline Closure
+
+Current local dev DB remains at the minimal local closure established in Phase 4.34B:
+
+- `matches`: 1
+- `bookmaker_odds_history`: 2
+- `raw_match_data`: 1
+- `l3_features`: 1
+- `match_features_training`: 1
+- `predictions`: 1
+
+The single `predictions` row is still the authorized local manual / baseline record:
+
+- `match_id`: `140_20252026_4837496`
+- `model_version`: `P4_LOCAL_BASELINE`
+- `predicted_result`: `draw`
+
+It is not a trained model output, did not run `npm run predict`, and did not load any model artifact.
+
+## Dataset Status Script
+
+Added:
+
+- `scripts/ops/dataset_status_audit.js`
+
+Behavior:
+
+- SELECT-only DB audit.
+- No DB writes.
+- No dataset export.
+- No model training.
+- No prediction execution.
+- No model artifact loading.
+- No external network access.
+
+Supported arguments:
+
+- default text output
+- `--json`
+- `--match-id <id>`
+
+The script reports:
+
+1. Core table row counts.
+2. `matches` status / label distribution.
+3. Label readiness counts.
+4. Feature readiness counts.
+5. Leakage risk flags.
+6. Training readiness verdict.
+7. Explicit non-execution confirmations.
+
+## Makefile Entrypoints
+
+Added:
+
+- `make data-dataset-status`
+- `make data-training-dataset-dry-run`
+
+Both entrypoints call:
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T dev node scripts/ops/dataset_status_audit.js
+```
+
+Added blocked gate:
+
+- `make data-training-dataset-export`
+
+Blocked behavior:
+
+- default: blocked
+- `CONFIRM_DATASET_EXPORT=1`: still blocked / not wired in Phase 4.36
+
+## AGENTS.md Update
+
+Updated `AGENTS.md` to document that AI / Codex may run:
+
+- `make data-dataset-status`
+- `make data-training-dataset-dry-run`
+
+Only under these constraints:
+
+- SELECT-only DB access
+- no training
+- no prediction
+- no dataset export
+- no model artifact loading
+- no external network
+
+Also documented:
+
+- real training requires a dataset readiness report first
+- single local sample cannot be used as a real training set
+- scheduled matches cannot be used as labels
+- manual / baseline predictions are not model outputs
+- `predictions` must not feed back into training
+
+References added:
+
+- `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
+- `docs/_reports/PREDICTION_SINGLE_INSERT_PHASE4_34B.md`
+
+## Dataset Audit Result
+
+Observed DB row counts:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    1 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Observed `matches` status distribution:
+
+| status    | is_finished | actual_result_is_null | score_complete | rows |
+| --------- | ----------: | --------------------: | -------------: | ---: |
+| scheduled |       false |                  true |          false |    1 |
+
+Label readiness:
+
+- `finished_matches = 0`
+- `matches_with_actual_result = 0`
+- `matches_with_scores = 0`
+- `trainable_label_rows = 0`
+- `scheduled_or_unlabeled_rows = 1`
+
+Feature readiness:
+
+- `matches_with_raw_match_data = 1`
+- `matches_with_l3_features = 1`
+- `matches_with_training_features = 1`
+- `matches_with_odds_history = 1`
+- `full_feature_chain_rows = 1`
+
+Leakage risk flags:
+
+- `scheduled_matches_with_training_features = 1`
+- `baseline_prediction_rows = 1`
+- `prediction_rows_not_training_labels = 1`
+- `raw_match_data_missing_collected_at = 0`
+- `odds_history_missing_collected_at = 0`
+- `l3_features_missing_computed_at = 0`
+- `training_features_missing_audit_timestamps = 0`
+
+Caveat:
+
+- Feature timing still must be proven against kickoff cutoff before any future real training phase.
+
+## Training Readiness Verdict
+
+Verdict:
+
+- `trainable = false`
+
+Reason:
+
+- current dev DB contains one scheduled local sample
+- there is no finished labeled match set
+- there are zero trainable label rows
+- the current closure proves wiring only, not dataset readiness
+
+Recommended next step:
+
+- build a finished-match sample audit before training
+
+## Validation
+
+Executed:
+
+```bash
+make data-dataset-status
+make data-training-dataset-dry-run
+make data-training-dataset-export || true
+make data-training-dataset-export CONFIRM_DATASET_EXPORT=1 || true
+```
+
+Results:
+
+- `data-dataset-status`: success
+- `data-training-dataset-dry-run`: success
+- `data-training-dataset-export`: blocked
+- `data-training-dataset-export CONFIRM_DATASET_EXPORT=1`: blocked
+
+DB before and after checks remained unchanged:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    1 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+## Next Step Suggestion
+
+Recommended next phase:
+
+```text
+Phase 4.37: read-only finished-match sample source audit
+```
+
+Alternative:
+
+```text
+Phase 4.37: design a safe historical sample acquisition runbook
+```
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE`
+- `COPY / \copy`
+- DB writes
+- model training
+- real prediction execution
+- model artifact loading
+- `npm run train`
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run predict:json`
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- dataset export
+- Docker volume cleanup

--- a/scripts/ops/dataset_status_audit.js
+++ b/scripts/ops/dataset_status_audit.js
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.36 dataset status / sample audit gate.
+ *
+ * This script is deliberately SELECT-only. It reports training dataset
+ * readiness without exporting files, training models, running prediction
+ * pipelines, loading model artifacts, or calling external networks.
+ */
+
+'use strict';
+
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+
+const FINISHED_STATUSES = ['finished', 'completed', 'complete', 'ft', 'full_time'];
+const MINIMUM_DISCUSSION_LABEL_ROWS = 200;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/dataset_status_audit.js [--json] [--match-id <id>]',
+        '',
+        'Safety:',
+        '  SELECT-only dataset status audit. No training, prediction, DB writes, artifact loading, network calls, or file export.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        json: false,
+        matchId: null,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--json') {
+            args.json = true;
+        } else if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    if (args.matchId === '') {
+        throw new Error('--match-id requires a non-empty value');
+    }
+
+    return args;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function toInt(value) {
+    if (value === null || value === undefined) return 0;
+    return Number.parseInt(value, 10);
+}
+
+function normalizeCounts(row) {
+    return Object.fromEntries(Object.entries(row).map(([key, value]) => [key, toInt(value)]));
+}
+
+function normalizeStatusRow(row) {
+    return {
+        status: row.status,
+        is_finished: row.is_finished,
+        actual_result_is_null: row.actual_result_is_null,
+        score_complete: row.score_complete,
+        rows: toInt(row.rows),
+    };
+}
+
+function normalizeMatchFocus(row) {
+    if (!row) return null;
+    return {
+        match_id: row.match_id,
+        league_name: row.league_name,
+        season: row.season,
+        home_team: row.home_team,
+        away_team: row.away_team,
+        match_date: row.match_date ? new Date(row.match_date).toISOString() : null,
+        status: row.status,
+        is_finished: row.is_finished,
+        actual_result: row.actual_result,
+        scores_complete: row.scores_complete,
+        has_raw_match_data: row.has_raw_match_data,
+        has_l3_features: row.has_l3_features,
+        has_training_features: row.has_training_features,
+        has_odds_history: row.has_odds_history,
+        has_prediction: row.has_prediction,
+        trainable_label: row.trainable_label,
+    };
+}
+
+function buildTrainingReadiness({ db, labelReadiness, featureReadiness }) {
+    const trainableLabelRows = labelReadiness.trainable_label_rows;
+    const fullFeatureChainRows = featureReadiness.full_feature_chain_rows;
+    const enoughLabels = trainableLabelRows >= MINIMUM_DISCUSSION_LABEL_ROWS;
+    const enoughFeatureChains = fullFeatureChainRows >= MINIMUM_DISCUSSION_LABEL_ROWS;
+    const trainable = enoughLabels && enoughFeatureChains;
+
+    let reason =
+        `Current DB has ${trainableLabelRows} trainable labeled rows and ${fullFeatureChainRows} full feature-chain rows; ` +
+        `minimum pre-training discussion threshold is ${MINIMUM_DISCUSSION_LABEL_ROWS}.`;
+
+    if (db.matches === 1 && trainableLabelRows === 0) {
+        reason = 'Current dev DB has one scheduled local sample and no finished labeled match set.';
+    }
+
+    return {
+        trainable,
+        reason,
+        minimum_discussion_label_rows: MINIMUM_DISCUSSION_LABEL_ROWS,
+        recommended_next_step: 'Build a finished-match sample audit before training.',
+    };
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_create',
+        'no_alter',
+        'no_drop',
+        'no_truncate',
+        'no_copy',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+        'no_file_export',
+    ];
+}
+
+function formatKeyValueRows(rows) {
+    return rows.map(([key, value]) => `  ${key}: ${value}`).join('\n');
+}
+
+function formatStatusDistribution(rows) {
+    if (rows.length === 0) return '  none';
+    return rows
+        .map(
+            row =>
+                `  status=${row.status} is_finished=${row.is_finished} actual_result_is_null=${row.actual_result_is_null} score_complete=${row.score_complete} rows=${row.rows}`
+        )
+        .join('\n');
+}
+
+function formatText(payload) {
+    const lines = [
+        'mode=dataset-status',
+        'safety=SELECT-only; no DB writes; no training; no prediction; no model artifact load; no external network; no file export',
+        '',
+        'DB row counts:',
+        formatKeyValueRows(Object.entries(payload.db)),
+        '',
+        'Match status distribution:',
+        formatStatusDistribution(payload.match_status_distribution),
+        '',
+        'Label readiness:',
+        formatKeyValueRows(Object.entries(payload.label_readiness)),
+        '',
+        'Feature readiness:',
+        formatKeyValueRows(Object.entries(payload.feature_readiness)),
+        '',
+        'Leakage risk flags:',
+        formatKeyValueRows(Object.entries(payload.leakage_risk_flags)),
+        '',
+        'Training readiness:',
+        formatKeyValueRows(Object.entries(payload.training_readiness)),
+    ];
+
+    if (payload.match_focus) {
+        lines.push('', 'Match focus:', formatKeyValueRows(Object.entries(payload.match_focus)));
+    }
+
+    lines.push(
+        '',
+        'Non-execution confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n')
+    );
+    return lines.join('\n');
+}
+
+async function fetchDbCounts(pool) {
+    const sql = `
+        SELECT
+            (SELECT COUNT(*) FROM matches) AS matches,
+            (SELECT COUNT(*) FROM bookmaker_odds_history) AS bookmaker_odds_history,
+            (SELECT COUNT(*) FROM raw_match_data) AS raw_match_data,
+            (SELECT COUNT(*) FROM l3_features) AS l3_features,
+            (SELECT COUNT(*) FROM match_features_training) AS match_features_training,
+            (SELECT COUNT(*) FROM predictions) AS predictions
+    `;
+    const result = await safeSelect(pool, sql);
+    return normalizeCounts(result.rows[0]);
+}
+
+async function fetchStatusDistribution(pool) {
+    const sql = `
+        SELECT
+            COALESCE(status, 'unknown') AS status,
+            is_finished,
+            actual_result IS NULL AS actual_result_is_null,
+            home_score IS NOT NULL AND away_score IS NOT NULL AS score_complete,
+            COUNT(*) AS rows
+        FROM matches
+        GROUP BY COALESCE(status, 'unknown'), is_finished, actual_result IS NULL, home_score IS NOT NULL AND away_score IS NOT NULL
+        ORDER BY rows DESC, status ASC
+    `;
+    const result = await safeSelect(pool, sql);
+    return result.rows.map(normalizeStatusRow);
+}
+
+async function fetchLabelReadiness(pool) {
+    const sql = `
+        SELECT
+            COUNT(*) FILTER (
+                WHERE is_finished IS TRUE OR LOWER(COALESCE(status, '')) = ANY($1)
+            ) AS finished_matches,
+            COUNT(*) FILTER (
+                WHERE actual_result IS NOT NULL AND TRIM(actual_result) <> ''
+            ) AS matches_with_actual_result,
+            COUNT(*) FILTER (
+                WHERE home_score IS NOT NULL AND away_score IS NOT NULL
+            ) AS matches_with_scores,
+            COUNT(*) FILTER (
+                WHERE
+                    (is_finished IS TRUE OR LOWER(COALESCE(status, '')) = ANY($1))
+                    AND (
+                        (actual_result IS NOT NULL AND TRIM(actual_result) <> '')
+                        OR (home_score IS NOT NULL AND away_score IS NOT NULL)
+                    )
+            ) AS trainable_label_rows,
+            COUNT(*) FILTER (
+                WHERE NOT (
+                    (is_finished IS TRUE OR LOWER(COALESCE(status, '')) = ANY($1))
+                    AND (
+                        (actual_result IS NOT NULL AND TRIM(actual_result) <> '')
+                        OR (home_score IS NOT NULL AND away_score IS NOT NULL)
+                    )
+                )
+            ) AS scheduled_or_unlabeled_rows
+        FROM matches
+    `;
+    const result = await safeSelect(pool, sql, [FINISHED_STATUSES]);
+    return normalizeCounts(result.rows[0]);
+}
+
+async function fetchFeatureReadiness(pool) {
+    const sql = `
+        SELECT
+            (SELECT COUNT(DISTINCT match_id) FROM raw_match_data) AS matches_with_raw_match_data,
+            (SELECT COUNT(DISTINCT match_id) FROM l3_features) AS matches_with_l3_features,
+            (SELECT COUNT(DISTINCT match_id) FROM match_features_training) AS matches_with_training_features,
+            (SELECT COUNT(DISTINCT match_id) FROM bookmaker_odds_history) AS matches_with_odds_history,
+            (
+                SELECT COUNT(DISTINCT m.match_id)
+                FROM matches m
+                WHERE EXISTS (SELECT 1 FROM raw_match_data r WHERE r.match_id = m.match_id)
+                  AND EXISTS (SELECT 1 FROM l3_features l3 WHERE l3.match_id = m.match_id)
+                  AND EXISTS (SELECT 1 FROM match_features_training mt WHERE mt.match_id = m.match_id)
+                  AND EXISTS (SELECT 1 FROM bookmaker_odds_history bo WHERE bo.match_id = m.match_id)
+            ) AS full_feature_chain_rows
+    `;
+    const result = await safeSelect(pool, sql);
+    return normalizeCounts(result.rows[0]);
+}
+
+async function fetchLeakageRiskFlags(pool) {
+    const sql = `
+        SELECT
+            (
+                SELECT COUNT(DISTINCT m.match_id)
+                FROM matches m
+                JOIN match_features_training mt ON mt.match_id = m.match_id
+                WHERE NOT (m.is_finished IS TRUE OR LOWER(COALESCE(m.status, '')) = ANY($1))
+            ) AS scheduled_matches_with_training_features,
+            (
+                SELECT COUNT(*)
+                FROM predictions
+                WHERE model_version = 'P4_LOCAL_BASELINE'
+            ) AS baseline_prediction_rows,
+            (SELECT COUNT(*) FROM predictions) AS prediction_rows_not_training_labels,
+            (
+                SELECT COUNT(*)
+                FROM raw_match_data
+                WHERE collected_at IS NULL
+            ) AS raw_match_data_missing_collected_at,
+            (
+                SELECT COUNT(*)
+                FROM bookmaker_odds_history
+                WHERE collected_at IS NULL
+            ) AS odds_history_missing_collected_at,
+            (
+                SELECT COUNT(*)
+                FROM l3_features
+                WHERE computed_at IS NULL
+            ) AS l3_features_missing_computed_at,
+            (
+                SELECT COUNT(*)
+                FROM match_features_training
+                WHERE created_at IS NULL OR updated_at IS NULL
+            ) AS training_features_missing_audit_timestamps
+    `;
+    const result = await safeSelect(pool, sql, [FINISHED_STATUSES]);
+    return {
+        ...normalizeCounts(result.rows[0]),
+        caveat: 'Feature timing must be proven against kickoff cutoff before any real training.',
+    };
+}
+
+async function fetchMatchFocus(pool, matchId) {
+    if (!matchId) return null;
+
+    const sql = `
+        SELECT
+            m.match_id,
+            m.league_name,
+            m.season,
+            m.home_team,
+            m.away_team,
+            m.match_date,
+            m.status,
+            m.is_finished,
+            m.actual_result,
+            m.home_score IS NOT NULL AND m.away_score IS NOT NULL AS scores_complete,
+            EXISTS (SELECT 1 FROM raw_match_data r WHERE r.match_id = m.match_id) AS has_raw_match_data,
+            EXISTS (SELECT 1 FROM l3_features l3 WHERE l3.match_id = m.match_id) AS has_l3_features,
+            EXISTS (SELECT 1 FROM match_features_training mt WHERE mt.match_id = m.match_id) AS has_training_features,
+            EXISTS (SELECT 1 FROM bookmaker_odds_history bo WHERE bo.match_id = m.match_id) AS has_odds_history,
+            EXISTS (SELECT 1 FROM predictions p WHERE p.match_id = m.match_id) AS has_prediction,
+            (
+                (m.is_finished IS TRUE OR LOWER(COALESCE(m.status, '')) = ANY($2))
+                AND (
+                    (m.actual_result IS NOT NULL AND TRIM(m.actual_result) <> '')
+                    OR (m.home_score IS NOT NULL AND m.away_score IS NOT NULL)
+                )
+            ) AS trainable_label
+        FROM matches m
+        WHERE m.match_id = $1
+    `;
+    const result = await safeSelect(pool, sql, [matchId, FINISHED_STATUSES]);
+    return normalizeMatchFocus(result.rows[0]);
+}
+
+async function buildAudit(pool, args) {
+    const db = await fetchDbCounts(pool);
+    const matchStatusDistribution = await fetchStatusDistribution(pool);
+    const labelReadiness = await fetchLabelReadiness(pool);
+    const featureReadiness = await fetchFeatureReadiness(pool);
+    const leakageRiskFlags = await fetchLeakageRiskFlags(pool);
+    const matchFocus = await fetchMatchFocus(pool, args.matchId);
+
+    return {
+        mode: 'dataset-status',
+        filters: {
+            match_id: args.matchId,
+        },
+        db,
+        match_status_distribution: matchStatusDistribution,
+        label_readiness: labelReadiness,
+        feature_readiness: featureReadiness,
+        leakage_risk_flags: leakageRiskFlags,
+        training_readiness: buildTrainingReadiness({
+            db,
+            labelReadiness,
+            featureReadiness,
+        }),
+        match_focus: matchFocus,
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const payload = await buildAudit(pool, args);
+        if (args.json) {
+            console.log(JSON.stringify(payload, null, 2));
+        } else {
+            console.log(formatText(payload));
+        }
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dataset-status',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a safe dataset status / sample audit gate for training readiness.

Changes:
- Adds scripts/ops/dataset_status_audit.js
- Adds make data-dataset-status
- Adds make data-training-dataset-dry-run
- Adds blocked make data-training-dataset-export
- Updates data-help
- Updates AGENTS.md with dataset readiness safety rules
- Adds Phase 4.36 report

Safety:
- SELECT-only dataset audit
- No DB writes
- No training
- No prediction execution
- No model artifact loading
- No external data access
- No dataset export

Validation:
- make data-dataset-status succeeds
- make data-training-dataset-dry-run succeeds
- make data-training-dataset-export remains blocked with and without CONFIRM_DATASET_EXPORT=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/dataset_status_audit.js
- docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md