### PR TITLE
feat(data): add finished CSV dry-run gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读 DB 的 `make data-prediction-write-dry-run MATCH_ID=<id>`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-dataset-status`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-training-dataset-dry-run`
+- 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 
 AI / Codex 不能直接执行：
 
@@ -260,6 +261,11 @@ AI / Codex 不能直接执行：
 - `node scripts/ops/prediction_local_write_gate.js --commit`
 - `make data-training-dataset-export`
 - `make data-training-dataset-export CONFIRM_DATASET_EXPORT=1`
+- `make data-finished-csv-commit`
+- `make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1`
+- `node scripts/ops/finished_csv_local_dry_run.js --commit`
+- `csv_bulk_loader --commit`
+- 任何 finished CSV 直接写 DB 的命令
 - `make data-l3-write-commit`
 - `make data-l3-write-commit CONFIRM_L3_WRITE=1`
 - `node scripts/ops/l3_features_local_write_gate.js --commit`
@@ -332,6 +338,19 @@ Phase 4.32 中 `make data-prediction-write-commit`、`make data-prediction-write
 - 不访问外网
 
 Phase 4.36 中 `make data-training-dataset-export` 和 `make data-training-dataset-export CONFIRM_DATASET_EXPORT=1` 仍是 blocked / not wired。真实训练前必须先通过 dataset readiness report；单条 local sample 不能作为真实训练集；scheduled match 不能作为训练 label；`P4_LOCAL_BASELINE` manual / baseline prediction 不是模型输出；`predictions` 表不能反哺训练。相关背景见：`docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md` 和 `docs/_reports/PREDICTION_SINGLE_INSERT_PHASE4_34B.md`
+
+执行 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>` 的前提：
+
+- 用户明确授权
+- CSV 是本地文件
+- 入口只做 dry-run 解析和可选 SELECT-only DB 查重
+- 不写 DB
+- 不训练模型
+- 不执行预测
+- 不访问外网
+- 不导出数据集或大文件
+
+Phase 4.38 中 `make data-finished-csv-commit`、`make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1` 和 `node scripts/ops/finished_csv_local_dry_run.js --commit` 仍是 blocked / not wired。finished CSV import 必须先 dry-run；label mapping 必须在报告中确认；scheduled / unlabeled rows 不可作为训练样本；外部 CSV 下载仍禁止，公开数据源也必须先人工确认许可和用途。相关背景见：`docs/_reports/FINISHED_MATCH_SOURCE_AUDIT_PHASE4_37.md`、`docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
 
 执行 `make data-l3-write-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
         data-training-feature-dry-run data-training-feature-commit \
         data-prediction-write-dry-run data-prediction-write-commit \
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
+        data-finished-csv-dry-run data-finished-csv-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -247,8 +248,10 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-prediction-write-dry-run MATCH_ID=<id>"
 	@echo "  make data-dataset-status"
 	@echo "  make data-training-dataset-dry-run"
+	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -406,6 +409,23 @@ data-training-dataset-export: ## Blocked dataset export gate. Remains not wired 
 		exit 1; \
 	fi
 	@echo "BLOCKED: dataset export is not wired in Phase 4.36."
+	@exit 1
+
+data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.
+	@if [ -z "$(SAMPLE_CSV)" ]; then \
+		echo "ERROR: provide SAMPLE_CSV=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running safe local finished CSV dry-run: SAMPLE_CSV=$(SAMPLE_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_CSV)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/finished_csv_local_dry_run.js --csv "$(SAMPLE_CSV)"
+
+data-finished-csv-commit: ## Blocked finished CSV commit gate. Requires SAMPLE_CSV, CONFIRM_FINISHED_CSV_COMMIT=1.
+	@if [ "$(CONFIRM_FINISHED_CSV_COMMIT)" != "1" ]; then \
+		echo "BLOCKED: finished CSV commit requires CONFIRM_FINISHED_CSV_COMMIT=1 and is not wired in Phase 4.38."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: finished CSV commit is not wired in Phase 4.38."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/FINISHED_CSV_DRY_RUN_GATE_PHASE4_38.md
+++ b/docs/_reports/FINISHED_CSV_DRY_RUN_GATE_PHASE4_38.md
@@ -1,0 +1,326 @@
+# Phase 4.38 - Local Finished CSV Sample Import Dry-Run Gate
+
+## Current HEAD
+
+- Base HEAD: `d3f1f89f68907bfc2fd63ef3fda8a411d2c21e56`
+- Working branch: `feat/finished-csv-dry-run-gate`
+
+## Current DB / Dataset Status
+
+Current dev DB remained unchanged before and after Phase 4.38 validation:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    1 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+`make data-dataset-status` still reports:
+
+- `trainable = false`
+- `finished_matches = 0`
+- `matches_with_actual_result = 0`
+- `matches_with_scores = 0`
+- `trainable_label_rows = 0`
+
+This phase does not change DB state. It only adds a local finished CSV preview gate.
+
+## `data/mock/sample_history.csv` Structure
+
+Observed sample:
+
+- path: `data/mock/sample_history.csv`
+- rows: `4`
+- columns:
+    - `match_id`
+    - `external_id`
+    - `league_name`
+    - `season`
+    - `home_team`
+    - `away_team`
+    - `match_date`
+    - `status`
+    - `bookmaker_name`
+    - `market_type`
+    - `open_home`
+    - `open_draw`
+    - `open_away`
+    - `close_home`
+    - `close_draw`
+    - `close_away`
+    - `home_score`
+    - `away_score`
+
+Important sample properties:
+
+- rows 1-2 are duplicate scheduled rows for the same `match_id`
+- row 3 is a finished row with full score
+- row 4 contains `match_date=not-a-date`
+
+## Dry-Run Summary
+
+`make data-finished-csv-dry-run SAMPLE_CSV=data/mock/sample_history.csv` produced:
+
+- `mode = dry-run`
+- `csv_path = data/mock/sample_history.csv`
+- `total_rows = 4`
+- `finished_rows = 1`
+- `trainable_label_rows = 1`
+- `skipped_rows = 3`
+- `would_insert_matches = false`
+- `would_update_matches = false`
+- `would_write_db = false`
+- `db_existing_rows = 0`
+
+## Label Mapping Rules
+
+Implemented mapping order:
+
+1. direct result fields:
+    - `actual_result`
+    - `FTR`
+    - `result`
+2. score-derived result:
+    - `home_score` / `away_score`
+    - `FTHG` / `FTAG`
+    - `home_goals` / `away_goals`
+
+Normalization:
+
+- `H` / `home` / `home_win` / `1` => `home_win`
+- `D` / `draw` / `x` => `draw`
+- `A` / `away` / `away_win` / `2` => `away_win`
+
+Score-derived rules:
+
+- `home_score > away_score` => `home_win`
+- `home_score = away_score` => `draw`
+- `home_score < away_score` => `away_win`
+
+Finished detection:
+
+- `status in finished|completed|full_time|ft`
+- or `is_finished=true`
+- or complete score plus label
+
+Non-trainable rows:
+
+- scheduled rows
+- rows without label
+- rows without complete score
+- rows with invalid dates
+
+## Candidate Preview Summary
+
+### Row 2
+
+- `match_id_preview = 47_20242025_900001`
+- `status = scheduled`
+- `trainable = false`
+- `skip_reason = not_finished`
+
+Warnings:
+
+- `not_finished`
+- `missing_label`
+- `missing_complete_score`
+
+### Row 3
+
+- `match_id_preview = 47_20242025_900001`
+- `status = scheduled`
+- `trainable = false`
+- `skip_reason = not_finished`
+
+Warnings:
+
+- `not_finished`
+- `missing_label`
+- `missing_complete_score`
+
+### Row 4
+
+- `match_id_preview = 47_20242025_900002`
+- `league_name = Segunda`
+- `season = 2024_2025`
+- `home_team = Burgos`
+- `away_team = Oviedo`
+- `home_score = 1`
+- `away_score = 0`
+- `actual_result = home_win`
+- `label_source = score`
+- `status = finished`
+- `trainable = true`
+
+This is the single trainable finished preview row in the sample.
+
+### Row 5
+
+- `match_id_preview = 47_20242025_900003`
+- `status = scheduled`
+- `match_date = not-a-date`
+- `trainable = false`
+- `skip_reason = not_finished`
+
+Warnings:
+
+- `invalid_match_date`
+- `not_finished`
+- `missing_label`
+- `missing_complete_score`
+
+## Mapping Warnings
+
+Observed warnings:
+
+- duplicate preview match id:
+    - `47_20242025_900001`
+- scheduled rows without labels:
+    - rows 2 and 3
+- invalid date:
+    - row 5
+
+These warnings confirm that future write phases must isolate malformed or non-trainable rows instead of assuming the whole CSV is safe.
+
+## New Script
+
+Added:
+
+- `scripts/ops/finished_csv_local_dry_run.js`
+
+Behavior:
+
+- reads only a local CSV
+- identifies compatible columns
+- derives finished / trainable label status
+- builds candidate preview rows
+- optionally performs SELECT-only DB duplicate check for `match_id`
+- blocks `--commit`
+
+The script does not:
+
+- write DB
+- call `csv_bulk_loader --commit`
+- train
+- predict
+- load model artifacts
+- export files
+- access external network
+
+## Makefile Entrypoints
+
+Added:
+
+- `make data-finished-csv-dry-run SAMPLE_CSV=<path>`
+- `make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1`
+
+Behavior:
+
+- dry-run requires `SAMPLE_CSV`
+- commit gate is blocked both:
+    - without `CONFIRM_FINISHED_CSV_COMMIT=1`
+    - with `CONFIRM_FINISHED_CSV_COMMIT=1`
+
+Phase 4.38 still does not wire any real finished CSV DB write path.
+
+## AGENTS.md Update
+
+Updated `AGENTS.md` to document:
+
+- `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>` is allowed only with explicit user authorization
+- CSV must be local
+- dry-run only
+- no DB writes
+- no training
+- no prediction
+- no external network
+- no large export
+
+Also documented:
+
+- `make data-finished-csv-commit` is blocked
+- `node scripts/ops/finished_csv_local_dry_run.js --commit` is blocked
+- `csv_bulk_loader --commit` remains prohibited
+- finished CSV import must confirm label mapping in reports first
+- scheduled / unlabeled rows are not training samples
+- external CSV download remains prohibited without separate authorization
+
+## Validation
+
+Executed:
+
+```bash
+make data-finished-csv-dry-run || true
+make data-finished-csv-dry-run SAMPLE_CSV=data/mock/sample_history.csv
+make data-finished-csv-commit || true
+make data-finished-csv-commit \
+  SAMPLE_CSV=data/mock/sample_history.csv \
+  CONFIRM_FINISHED_CSV_COMMIT=1 || true
+```
+
+Results:
+
+- missing `SAMPLE_CSV`: fails as expected
+- dry-run: succeeds
+- commit without confirm: blocked
+- commit with confirm: still blocked
+
+## DB Before / After
+
+DB row counts were unchanged:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    1 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+## Recommended Next Phase
+
+Recommended next steps:
+
+```text
+Phase 4.39: human-authorized single-row or small-batch finished CSV matches write runbook
+```
+
+Alternative:
+
+```text
+Phase 4.39: extend CSV mapping to support more result/date/status field variants
+```
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT / UPDATE / DELETE / CREATE / ALTER / DROP / TRUNCATE`
+- `COPY / \copy`
+- DB writes
+- `csv_bulk_loader --commit`
+- `local_dom_ingestor --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- model training
+- real prediction execution
+- model artifact loading
+- `npm run train`
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run predict:json`
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup

--- a/scripts/ops/finished_csv_local_dry_run.js
+++ b/scripts/ops/finished_csv_local_dry_run.js
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.38 local finished CSV dry-run gate.
+ *
+ * Reads a local CSV and reports match / label readiness preview only. The
+ * commit path is intentionally blocked and not wired in this phase.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const csv = require('csv-parser');
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+const FINISHED_STATUSES = new Set(['finished', 'completed', 'complete', 'full_time', 'ft']);
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+
+const FIELD_ALIASES = {
+    matchId: ['match_id', 'matchid', 'matchId', 'id'],
+    externalId: ['external_id', 'externalId'],
+    matchDate: ['match_date', 'date', 'Date'],
+    homeTeam: ['home_team', 'HomeTeam', 'home', 'homeTeam'],
+    awayTeam: ['away_team', 'AwayTeam', 'away', 'awayTeam'],
+    homeScore: ['home_score', 'FTHG', 'home_goals'],
+    awayScore: ['away_score', 'FTAG', 'away_goals'],
+    actualResult: ['actual_result', 'FTR', 'result'],
+    status: ['status'],
+    isFinished: ['is_finished', 'finished'],
+    leagueName: ['league_name', 'league'],
+    season: ['season'],
+};
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/finished_csv_local_dry_run.js --csv <path> [--json] [--limit <n>]',
+        '  node scripts/ops/finished_csv_local_dry_run.js --csv <path> --commit',
+        '',
+        'Safety:',
+        '  Dry-run only in Phase 4.38; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        csvPath: null,
+        json: false,
+        limit: null,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--csv') {
+            args.csvPath = argv[index + 1];
+            index += 1;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--limit') {
+            args.limit = parseLimit(argv[index + 1]);
+            index += 1;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function parseLimit(value) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error('--limit must be a positive integer');
+    }
+    return parsed;
+}
+
+function buildBlockedCommitPayload(csvPath) {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        csv_path: csvPath || null,
+        error: 'BLOCKED: finished CSV commit is not wired in Phase 4.38.',
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function resolveLocalCsvPath(rawPath) {
+    if (!rawPath) {
+        throw new Error('Missing required --csv <path>');
+    }
+    const resolved = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(process.cwd(), rawPath);
+    if (!fs.existsSync(resolved)) {
+        throw new Error(`CSV file not found: ${rawPath}`);
+    }
+    const stats = fs.statSync(resolved);
+    if (!stats.isFile()) {
+        throw new Error(`CSV path is not a file: ${rawPath}`);
+    }
+    return resolved;
+}
+
+function readCsvRows(resolvedPath, limit) {
+    return new Promise((resolve, reject) => {
+        const rows = [];
+        const headers = [];
+        let sourceRow = 1;
+
+        fs.createReadStream(resolvedPath)
+            .pipe(csv())
+            .on('headers', parsedHeaders => {
+                headers.push(...parsedHeaders);
+            })
+            .on('data', row => {
+                if (limit && rows.length >= limit) {
+                    return;
+                }
+                sourceRow += 1;
+                rows.push({
+                    source_row: sourceRow,
+                    row,
+                });
+            })
+            .on('error', reject)
+            .on('end', () => resolve({ headers, rows }));
+    });
+}
+
+function normalizeKey(value) {
+    return String(value || '')
+        .replace(/[^a-z0-9]/gi, '')
+        .toLowerCase();
+}
+
+function getRowValue(row, aliases) {
+    const normalizedMap = new Map(Object.keys(row).map(key => [normalizeKey(key), key]));
+    for (const alias of aliases) {
+        const actualKey = normalizedMap.get(normalizeKey(alias));
+        if (actualKey) {
+            const value = normalizeText(row[actualKey]);
+            if (value !== '') {
+                return value;
+            }
+        }
+    }
+    return null;
+}
+
+function normalizeText(value) {
+    return String(value ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function normalizeStatus(value) {
+    return normalizeText(value).toLowerCase();
+}
+
+function parseScore(value) {
+    const normalized = normalizeText(value);
+    if (normalized === '') return null;
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseCsvDate(value) {
+    const normalized = normalizeText(value);
+    if (!normalized) {
+        return { value: null, valid: false };
+    }
+    const parsed = new Date(normalized);
+    if (Number.isNaN(parsed.getTime())) {
+        return { value: normalized, valid: false };
+    }
+    return { value: parsed.toISOString(), valid: true };
+}
+
+function normalizeActualResult(value) {
+    const normalized = normalizeText(value).toLowerCase();
+    if (!normalized) return null;
+    if (['h', 'home', 'home_win', 'home win', '1'].includes(normalized)) return 'home_win';
+    if (['d', 'draw', 'x'].includes(normalized)) return 'draw';
+    if (['a', 'away', 'away_win', 'away win', '2'].includes(normalized)) return 'away_win';
+    return null;
+}
+
+function deriveLabel({ actualResultRaw, homeScore, awayScore }) {
+    const directLabel = normalizeActualResult(actualResultRaw);
+    if (directLabel) {
+        return { label: directLabel, source: 'actual_result' };
+    }
+    if (homeScore === null || awayScore === null) {
+        return { label: null, source: null };
+    }
+    if (homeScore > awayScore) return { label: 'home_win', source: 'score' };
+    if (homeScore < awayScore) return { label: 'away_win', source: 'score' };
+    return { label: 'draw', source: 'score' };
+}
+
+function isFinishedLike({ status, isFinishedRaw, hasCompleteScore, label }) {
+    if (FINISHED_STATUSES.has(status)) return true;
+    if (TRUE_VALUES.has(normalizeStatus(isFinishedRaw))) return true;
+    return hasCompleteScore && Boolean(label);
+}
+
+function buildPreviewId(row, sourceRow) {
+    const source = [
+        row.match_date || 'unknown_date',
+        row.home_team || 'unknown_home',
+        row.away_team || 'unknown_away',
+        sourceRow,
+    ].join('|');
+    return `csv_${crypto.createHash('sha1').update(source).digest('hex').slice(0, 12)}`;
+}
+
+function analyzeRow(record) {
+    const row = record.row;
+    const homeScore = parseScore(getRowValue(row, FIELD_ALIASES.homeScore));
+    const awayScore = parseScore(getRowValue(row, FIELD_ALIASES.awayScore));
+    const actualResultRaw = getRowValue(row, FIELD_ALIASES.actualResult);
+    const label = deriveLabel({ actualResultRaw, homeScore, awayScore });
+    const status = normalizeStatus(getRowValue(row, FIELD_ALIASES.status));
+    const date = parseCsvDate(getRowValue(row, FIELD_ALIASES.matchDate));
+    const previewBase = buildPreviewBase(record, { homeScore, awayScore, label, status, date });
+    const hasCompleteScore = homeScore !== null && awayScore !== null;
+    const finished = isFinishedLike({
+        status,
+        isFinishedRaw: getRowValue(row, FIELD_ALIASES.isFinished),
+        hasCompleteScore,
+        label: label.label,
+    });
+    const warnings = buildRowWarnings(previewBase, { date, finished, label: label.label, hasCompleteScore });
+
+    return {
+        ...previewBase,
+        finished,
+        trainable: finished && Boolean(label.label) && date.valid,
+        skip_reason: buildSkipReason({ finished, label: label.label, dateValid: date.valid }),
+        warnings,
+    };
+}
+
+function buildPreviewBase(record, derived) {
+    const row = record.row;
+    const base = {
+        source_row: record.source_row,
+        match_id_preview: getRowValue(row, FIELD_ALIASES.matchId),
+        external_id: getRowValue(row, FIELD_ALIASES.externalId),
+        match_date: derived.date.value,
+        league_name: getRowValue(row, FIELD_ALIASES.leagueName),
+        season: getRowValue(row, FIELD_ALIASES.season),
+        home_team: getRowValue(row, FIELD_ALIASES.homeTeam),
+        away_team: getRowValue(row, FIELD_ALIASES.awayTeam),
+        home_score: derived.homeScore,
+        away_score: derived.awayScore,
+        actual_result: derived.label.label,
+        label_source: derived.label.source,
+        status: derived.status || null,
+        db_match_exists: null,
+    };
+    return {
+        ...base,
+        match_id_preview: base.match_id_preview || buildPreviewId(base, record.source_row),
+    };
+}
+
+function buildRowWarnings(preview, context) {
+    const warnings = [];
+    if (!preview.match_id_preview) warnings.push('missing_match_id_preview');
+    if (!preview.home_team) warnings.push('missing_home_team');
+    if (!preview.away_team) warnings.push('missing_away_team');
+    if (!preview.match_date) warnings.push('missing_match_date');
+    if (preview.match_date && !context.date.valid) warnings.push('invalid_match_date');
+    if (!context.finished) warnings.push('not_finished');
+    if (!context.label) warnings.push('missing_label');
+    if (!context.hasCompleteScore) warnings.push('missing_complete_score');
+    return warnings;
+}
+
+function buildSkipReason({ finished, label, dateValid }) {
+    if (!finished) return 'not_finished';
+    if (!label) return 'missing_label';
+    if (!dateValid) return 'invalid_match_date';
+    return null;
+}
+
+function summarizePreviews(previews) {
+    const mappingWarnings = [];
+    const duplicateIds = findDuplicateIds(previews);
+    for (const matchId of duplicateIds) {
+        mappingWarnings.push(`duplicate_match_id_preview:${matchId}`);
+    }
+    for (const preview of previews) {
+        for (const warning of preview.warnings) {
+            mappingWarnings.push(`row_${preview.source_row}:${warning}`);
+        }
+    }
+
+    return {
+        total_rows: previews.length,
+        finished_rows: previews.filter(row => row.finished).length,
+        trainable_label_rows: previews.filter(row => row.trainable).length,
+        skipped_rows: previews.filter(row => !row.trainable).length,
+        would_insert_matches: false,
+        would_update_matches: false,
+        would_write_db: false,
+        mapping_warnings: mappingWarnings,
+    };
+}
+
+function findDuplicateIds(previews) {
+    const counts = new Map();
+    for (const preview of previews) {
+        counts.set(preview.match_id_preview, (counts.get(preview.match_id_preview) || 0) + 1);
+    }
+    return [...counts.entries()].filter(([, count]) => count > 1).map(([matchId]) => matchId);
+}
+
+async function fetchExistingMatchIds(previews) {
+    const ids = [...new Set(previews.map(row => row.match_id_preview).filter(Boolean))];
+    if (ids.length === 0) return new Set();
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const sql = `
+            SELECT match_id
+            FROM matches
+            WHERE match_id = ANY($1)
+        `;
+        const result = await safeSelect(pool, sql, [ids]);
+        return new Set(result.rows.map(row => row.match_id));
+    } finally {
+        await pool.end();
+    }
+}
+
+function applyDbExistence(previews, existingIds) {
+    return previews.map(preview => ({
+        ...preview,
+        db_match_exists: existingIds.has(preview.match_id_preview),
+    }));
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_copy',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+        'no_file_export',
+    ];
+}
+
+function buildPayload({ args, resolvedCsvPath, headers, previews }) {
+    const summary = summarizePreviews(previews);
+    return {
+        mode: 'dry-run',
+        csv_path: args.csvPath,
+        resolved_csv_path: resolvedCsvPath,
+        columns: headers,
+        limit: args.limit,
+        ...summary,
+        label_mapping: {
+            direct_result_fields: FIELD_ALIASES.actualResult,
+            score_fields: [...FIELD_ALIASES.homeScore, ...FIELD_ALIASES.awayScore],
+            result_values: {
+                H: 'home_win',
+                D: 'draw',
+                A: 'away_win',
+                score_home_gt_away: 'home_win',
+                score_equal: 'draw',
+                score_home_lt_away: 'away_win',
+            },
+        },
+        candidate_preview: previews,
+        db_existing_rows: previews.filter(row => row.db_match_exists).length,
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function formatText(payload) {
+    return [
+        'mode=dry-run',
+        `csv_path=${payload.csv_path}`,
+        `total_rows=${payload.total_rows}`,
+        `finished_rows=${payload.finished_rows}`,
+        `trainable_label_rows=${payload.trainable_label_rows}`,
+        `skipped_rows=${payload.skipped_rows}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_update_matches=${payload.would_update_matches}`,
+        `would_write_db=${payload.would_write_db}`,
+        `db_existing_rows=${payload.db_existing_rows}`,
+        '',
+        'candidate_preview:',
+        JSON.stringify(payload.candidate_preview, null, 2),
+        '',
+        'mapping_warnings:',
+        payload.mapping_warnings.length ? payload.mapping_warnings.map(value => `  ${value}`).join('\n') : '  none',
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ].join('\n');
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error(JSON.stringify(buildBlockedCommitPayload(args.csvPath), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+    const resolvedCsvPath = resolveLocalCsvPath(args.csvPath);
+    const { headers, rows } = await readCsvRows(resolvedCsvPath, args.limit);
+    const previews = rows.map(analyzeRow);
+    const existingIds = await fetchExistingMatchIds(previews);
+    const payload = buildPayload({
+        args,
+        resolvedCsvPath,
+        headers,
+        previews: applyDbExistence(previews, existingIds),
+    });
+
+    console.log(args.json ? JSON.stringify(payload, null, 2) : formatText(payload));
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a safe local finished CSV dry-run gate.

Changes:
- Adds scripts/ops/finished_csv_local_dry_run.js
- Adds make data-finished-csv-dry-run
- Adds blocked make data-finished-csv-commit
- Updates data-help
- Updates AGENTS.md with finished CSV import safety rules
- Adds Phase 4.38 report

Safety:
- Reads only local CSV
- Dry-run only
- No DB writes
- No COPY/export
- No training
- No prediction execution
- No external data access
- Commit gate remains blocked

Validation:
- make data-finished-csv-dry-run without args fails as expected
- make data-finished-csv-dry-run SAMPLE_CSV=data/mock/sample_history.csv succeeds
- make data-finished-csv-commit remains blocked with and without CONFIRM_FINISHED_CSV_COMMIT=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/finished_csv_local_dry_run.js
- docs/_reports/FINISHED_CSV_DRY_RUN_GATE_PHASE4_38.md