### PR TITLE
feat(data): add finished match backfill preflight gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,7 @@ AI / Codex 默认只能执行：
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-dataset-status`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-training-dataset-dry-run`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
+- 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 
 AI / Codex 不能直接执行：
 
@@ -264,6 +265,9 @@ AI / Codex 不能直接执行：
 - `make data-finished-csv-commit`
 - `make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1`
 - `node scripts/ops/finished_csv_local_dry_run.js --commit`
+- `make data-finished-backfill-commit`
+- `make data-finished-backfill-commit CONFIRM_FINISHED_BACKFILL=1`
+- `node scripts/ops/finished_match_backfill_preflight.js --commit`
 - `csv_bulk_loader --commit`
 - 任何 finished CSV 直接写 DB 的命令
 - `make data-l3-write-commit`
@@ -351,6 +355,23 @@ Phase 4.36 中 `make data-training-dataset-export` 和 `make data-training-datas
 - 不导出数据集或大文件
 
 Phase 4.38 中 `make data-finished-csv-commit`、`make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1` 和 `node scripts/ops/finished_csv_local_dry_run.js --commit` 仍是 blocked / not wired。finished CSV import 必须先 dry-run；label mapping 必须在报告中确认；scheduled / unlabeled rows 不可作为训练样本；外部 CSV 下载仍禁止，公开数据源也必须先人工确认许可和用途。相关背景见：`docs/_reports/FINISHED_MATCH_SOURCE_AUDIT_PHASE4_37.md`、`docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
+
+执行 `make data-finished-backfill-dry-run MATCH_ID=<id>` 的前提：
+
+- 用户明确授权
+- 入口只做 SELECT-only DB 审计和本地 fixture 只读检查
+- 不写 DB
+- 不执行 raw ingest
+- 不写 `l3_features`
+- 不写 `match_features_training`
+- 不写 `predictions`
+- 不训练模型
+- 不执行预测
+- 不加载模型 artifact
+- 不访问外网
+- 不导出数据集或大文件
+
+Phase 4.40 中 `make data-finished-backfill-commit`、`make data-finished-backfill-commit CONFIRM_FINISHED_BACKFILL=1` 和 `node scripts/ops/finished_match_backfill_preflight.js --commit` 仍是 blocked / not wired。finished match backfill 必须按 `raw_match_data -> l3_features -> match_features_training -> predictions` 顺序推进；没有匹配 raw fixture 时不得伪造 `raw_match_data`；不得把相似 fixture 冒充目标比赛；scheduled / baseline sample 不可混入真实训练；任何真实 write 前必须单独授权并完成 pg_dump。相关背景见：`docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md`、`docs/_reports/FINISHED_CSV_DRY_RUN_GATE_PHASE4_38.md` 和 `docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md`
 
 执行 `make data-l3-write-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
         data-prediction-write-dry-run data-prediction-write-commit \
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-finished-csv-dry-run data-finished-csv-commit \
+        data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -249,8 +250,11 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-dataset-status"
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
+	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
+	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-finished-backfill-commit MATCH_ID=<id> CONFIRM_FINISHED_BACKFILL=1  # blocked in Phase 4.40"
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
@@ -426,6 +430,27 @@ data-finished-csv-commit: ## Blocked finished CSV commit gate. Requires SAMPLE_C
 		exit 1; \
 	fi
 	@echo "BLOCKED: finished CSV commit is not wired in Phase 4.38."
+	@exit 1
+
+data-finished-backfill-dry-run: ## Run finished match raw/L3/training backfill preflight. Requires MATCH_ID.
+	@if [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe finished match backfill preflight: MATCH_ID=$(MATCH_ID)"
+	@if [ -n "$(FIXTURE)" ]; then \
+		$(COMPOSE_DEV) exec -T dev test -f "$(FIXTURE)"; \
+		$(COMPOSE_DEV) exec -T dev node scripts/ops/finished_match_backfill_preflight.js --match-id "$(MATCH_ID)" --fixture "$(FIXTURE)"; \
+	else \
+		$(COMPOSE_DEV) exec -T dev node scripts/ops/finished_match_backfill_preflight.js --match-id "$(MATCH_ID)"; \
+	fi
+
+data-finished-backfill-commit: ## Blocked finished match backfill gate. Requires MATCH_ID, CONFIRM_FINISHED_BACKFILL=1.
+	@if [ "$(CONFIRM_FINISHED_BACKFILL)" != "1" ]; then \
+		echo "BLOCKED: finished match backfill requires CONFIRM_FINISHED_BACKFILL=1 and is not wired in Phase 4.40."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: finished match backfill commit is not wired in Phase 4.40."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md
+++ b/docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md
@@ -1,0 +1,225 @@
+# Phase 4.39 - Single Finished CSV Match Insert
+
+## Current HEAD
+
+- Base HEAD: `c15038e0bc850efaedfc7e5619873c3da5a63a30`
+- Working branch: `main`
+
+## Backup
+
+- backup file: `data/backups/phase439_pre_finished_csv_match_insert_20260504_013331.dump`
+- backup size: `71K`
+
+## Write Before State
+
+Write target:
+
+- `SAMPLE_CSV = data/mock/sample_history.csv`
+- source row: `4`
+- target `match_id = 47_20242025_900002`
+
+Dry-run candidate summary before insert:
+
+- `total_rows = 4`
+- `finished_rows = 1`
+- `trainable_label_rows = 1`
+- unique trainable finished candidate:
+    - `match_id_preview = 47_20242025_900002`
+    - `home_score = 1`
+    - `away_score = 0`
+    - `actual_result = home_win`
+    - `label_source = score`
+
+DB row counts before insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    1 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Target existence before insert:
+
+- `target_match_rows = 0`
+
+Dataset baseline before insert:
+
+- `finished_matches = 0`
+- `matches_with_actual_result = 0`
+- `matches_with_scores = 0`
+
+## Insert Result
+
+Inserted one row into `matches` only.
+
+Inserted values:
+
+- `match_id = 47_20242025_900002`
+- `external_id = 900002`
+- `league_name = Segunda`
+- `season = 2024/2025`
+- `home_team = Burgos`
+- `away_team = Oviedo`
+- `home_score = 1`
+- `away_score = 0`
+- `actual_result = home_win`
+- `match_date = 2024-08-17 17:30:00+00`
+- `status = finished`
+- `is_finished = true`
+- `data_source = local_finished_csv`
+- `data_version = PHASE4.39`
+- `pipeline_status = pending`
+
+SQL behavior:
+
+- one explicit `INSERT INTO matches`
+- one explicit transaction
+- no `ON CONFLICT DO UPDATE`
+- no insert to any other table
+
+## Write After Verification
+
+Target row after insert:
+
+- exists: yes
+- `target_match_rows = 1`
+
+Target row content:
+
+| field           | value                    |
+| --------------- | ------------------------ |
+| match_id        | `47_20242025_900002`     |
+| external_id     | `900002`                 |
+| league_name     | `Segunda`                |
+| season          | `2024/2025`              |
+| home_team       | `Burgos`                 |
+| away_team       | `Oviedo`                 |
+| home_score      | `1`                      |
+| away_score      | `0`                      |
+| actual_result   | `home_win`               |
+| match_date      | `2024-08-17 17:30:00+00` |
+| status          | `finished`               |
+| is_finished     | `true`                   |
+| data_source     | `local_finished_csv`     |
+| data_version    | `PHASE4.39`              |
+| pipeline_status | `pending`                |
+
+DB row counts after insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Result:
+
+- `matches` increased from `1 -> 2`
+- all other tracked tables remained unchanged
+
+## Dataset Status Improvement
+
+`make data-dataset-status` after insert reported:
+
+- `matches = 2`
+- `finished_matches = 1`
+- `matches_with_actual_result = 1`
+- `matches_with_scores = 1`
+- `trainable_label_rows = 1`
+- `scheduled_or_unlabeled_rows = 1`
+
+Training readiness remained:
+
+- `trainable = false`
+
+Reason:
+
+- there is now one finished trainable row
+- but the sample count is still far below the minimum threshold for real training
+
+## Finished CSV Dry-Run After Insert
+
+`make data-finished-csv-dry-run SAMPLE_CSV=data/mock/sample_history.csv` remained read-only and reported:
+
+- `finished_rows = 1`
+- `trainable_label_rows = 1`
+- `db_existing_rows = 1`
+- target row `47_20242025_900002` now shows `db_match_exists = true`
+
+Warnings remained unchanged:
+
+- duplicate `47_20242025_900001`
+- scheduled unlabeled rows
+- invalid date on row 5
+
+## Gate Verification
+
+Verified blocked / safe gates:
+
+- `make data-finished-csv-commit`: blocked
+- `make data-finished-csv-commit ... CONFIRM_FINISHED_CSV_COMMIT=1`: blocked
+- `make data-training-dataset-export`: blocked
+- `make data-training-dataset-export CONFIRM_DATASET_EXPORT=1`: blocked
+- `make data-training-dry-run`: safe preview only
+- `make data-training-commit`: blocked
+- `make data-training-commit CONFIRM_TRAINING=1`: blocked
+
+## Risk Notes
+
+- The inserted finished match does not yet have matching local `raw_match_data`, `l3_features`, or `match_features_training` rows.
+- The row is intentionally marked `pipeline_status = pending` to avoid implying that downstream feature stages already ran.
+- Future phases should keep write scope narrow and avoid bulk import before a dedicated runbook exists.
+
+## Recommended Next Phase
+
+Recommended next phase:
+
+```text
+Phase 4.40: submit Phase 4.39 report, or design raw/l3/training feature backfill dry-run for the new finished match
+```
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `INSERT` into any table except `matches`
+- multiple `matches` inserts
+- `csv_bulk_loader --commit`
+- `local_dom_ingestor --commit`
+- `COPY / \copy`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- model training
+- real prediction execution
+- model artifact loading
+- `npm run train`
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run predict:json`
+- `npm run smelt`
+- `npm run l3:stitch`
+- ELO recalculation
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push`
+- `git pull`
+- `git fetch --all`
+- commit

--- a/docs/_reports/FINISHED_MATCH_BACKFILL_PREFLIGHT_PHASE4_40.md
+++ b/docs/_reports/FINISHED_MATCH_BACKFILL_PREFLIGHT_PHASE4_40.md
@@ -1,0 +1,338 @@
+# Phase 4.40 - Finished Match Backfill Preflight Gate
+
+## Current HEAD
+
+- Base HEAD: `c15038e0bc850efaedfc7e5619873c3da5a63a30`
+- Working branch: `feat/finished-match-backfill-preflight-gate`
+- Phase 4.39 report preserved: `docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md`
+
+## Phase 4.39 Finished Match State
+
+Target finished match inserted in Phase 4.39:
+
+| field           | value                    |
+| --------------- | ------------------------ |
+| match_id        | `47_20242025_900002`     |
+| league_name     | `Segunda`                |
+| season          | `2024/2025`              |
+| home_team       | `Burgos`                 |
+| away_team       | `Oviedo`                 |
+| home_score      | `1`                      |
+| away_score      | `0`                      |
+| actual_result   | `home_win`               |
+| match_date      | `2024-08-17 17:30:00+00` |
+| status          | `finished`               |
+| is_finished     | `true`                   |
+| data_source     | `local_finished_csv`     |
+| data_version    | `PHASE4.39`              |
+| pipeline_status | `pending`                |
+
+## DB Row Counts
+
+Row counts before and after this Phase 4.40 preflight work remained unchanged:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+`make data-dataset-status` remains SELECT-only and reports:
+
+- `finished_matches = 1`
+- `matches_with_actual_result = 1`
+- `matches_with_scores = 1`
+- `trainable_label_rows = 1`
+- `scheduled_or_unlabeled_rows = 1`
+- `full_feature_chain_rows = 1`
+- `trainable = false`
+- reason: current DB has only `1` trainable labeled row and `1` full feature-chain row; minimum pre-training discussion threshold is `200`
+
+## Target Chain Status
+
+SELECT-only chain check for `47_20242025_900002`:
+
+| field                 | value   |
+| --------------------- | ------- |
+| match_found           | `true`  |
+| is_finished           | `true`  |
+| has_actual_result     | `true`  |
+| has_score             | `true`  |
+| has_raw_match_data    | `false` |
+| has_l3_features       | `false` |
+| has_training_features | `false` |
+| has_predictions       | `false` |
+
+Conclusion:
+
+- the target finished match exists and has a valid label
+- the target has no raw/L3/training/prediction downstream records yet
+- the next safe step must start with an exact raw fixture strategy
+
+## Local JSON Fixture Audit
+
+Read-only scan covered `15` JSON files under `tests` and `data`, excluding `data/postgres` and `data/backups`.
+
+Candidate-like files were identified only by schema terms such as `score` or `finished`, not by direct target identity:
+
+| file                                                                             | observed identity                                     | assessment                                  |
+| -------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------- |
+| `tests/fixtures/l3/raw_match_data_phase419_sample.json`                          | `140_20252026_4837496`, Cultural Leonesa vs Burgos CF | schema reference only, not Burgos vs Oviedo |
+| `tests/fixtures/match_success.json`                                              | `55_20242025_4803413`, Chelsea vs Arsenal             | schema reference only, not target match     |
+| `tests/Z_LEGACY_ARCHIVE_PRE_V4.46.8/fixtures/premium_match_sample.json`          | `4813415`, AFC Bournemouth vs Newcastle United        | schema reference only, not target match     |
+| `tests/Z_LEGACY_ARCHIVE_PRE_V4.46.8/fixtures/mock_responses/fotmob_success.json` | `4147463`, Manchester City vs Liverpool               | schema reference only, not target match     |
+
+No direct local raw fixture was found for:
+
+- `match_id = 47_20242025_900002`
+- `home_team = Burgos`
+- `away_team = Oviedo`
+
+Additional observations:
+
+- `tests/Z_LEGACY_ARCHIVE_PRE_V4.46.8/test_data/quality_test_sample_20251130.json` was skipped as large during the shallow audit.
+- `tests/fixtures/l1-config-5XOks7/broken.json` is intentionally malformed and produced a JSON parse error.
+- No fixture was imported or written to DB.
+
+## Backfill Entrypoint Risk Audit
+
+Existing relevant entrypoints:
+
+| entrypoint                                                         | current behavior                                                                      | write risk                       |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------- | -------------------------------- |
+| `make data-raw-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>`            | local fixture dry-run via `scripts/ops/raw_match_data_local_ingest.js`                | dry-run only; `--commit` blocked |
+| `make data-raw-commit ... CONFIRM_RAW_COMMIT=1`                    | blocked in Makefile                                                                   | not wired                        |
+| `make data-l3-write-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>`       | local L3 write preview via `scripts/ops/l3_features_local_write_gate.js`              | dry-run only; `--commit` blocked |
+| `make data-l3-write-commit ... CONFIRM_L3_WRITE=1`                 | blocked in Makefile                                                                   | not wired                        |
+| `make data-training-feature-dry-run MATCH_ID=<id>`                 | SELECT-only preview via `scripts/ops/match_features_training_local_write_gate.js`     | dry-run only; `--commit` blocked |
+| `make data-training-feature-commit ... CONFIRM_TRAINING_FEATURE=1` | blocked in Makefile                                                                   | not wired                        |
+| `make data-prediction-write-dry-run MATCH_ID=<id>`                 | SELECT-only prediction write preview via `scripts/ops/prediction_local_write_gate.js` | dry-run only; no model load      |
+| `make data-prediction-write-commit ... CONFIRM_PREDICTION_WRITE=1` | blocked in Makefile                                                                   | not wired                        |
+| `npm run smelt` / `npm run l3:stitch`                              | real L3 pipeline entrypoints                                                          | prohibited for this phase        |
+| `node scripts/ops/batch_historical_backfill.js`                    | batch backfill entrypoint                                                             | prohibited for this phase        |
+
+Assessment:
+
+- raw/L3/training/prediction each already has a narrow dry-run or blocked commit gate.
+- none should be used as an implicit orchestration path for this finished match.
+- Phase 4.40 adds a preflight gate that only reports the dependency chain and prevents out-of-order writes.
+
+## New Script Behavior
+
+Added:
+
+```text
+scripts/ops/finished_match_backfill_preflight.js
+```
+
+Supported commands:
+
+```bash
+node scripts/ops/finished_match_backfill_preflight.js --match-id 47_20242025_900002
+node scripts/ops/finished_match_backfill_preflight.js --match-id 47_20242025_900002 --fixture tests/fixtures/match_success.json
+node scripts/ops/finished_match_backfill_preflight.js --match-id 47_20242025_900002 --json
+```
+
+Behavior:
+
+- default mode is `preflight`
+- performs SELECT-only DB checks
+- optionally reads one local JSON fixture
+- reports target chain status
+- reports fixture direct-match status
+- reports ordered backfill plan: `raw_match_data -> l3_features -> match_features_training -> predictions`
+- does not call raw ingest, L3 write, training feature write, prediction write, training, prediction, model artifact loading, harvest, scrape, or external network
+
+`--commit` behavior:
+
+```text
+BLOCKED: finished match backfill commit is not wired in Phase 4.40.
+```
+
+## Makefile Entrypoints
+
+Added:
+
+```text
+make data-finished-backfill-dry-run MATCH_ID=<id>
+make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>
+make data-finished-backfill-commit MATCH_ID=<id> CONFIRM_FINISHED_BACKFILL=1  # blocked in Phase 4.40
+```
+
+`data-finished-backfill-dry-run` requires `MATCH_ID` and remains read-only.
+
+`data-finished-backfill-commit` is intentionally blocked even when `CONFIRM_FINISHED_BACKFILL=1` is provided.
+
+## AGENTS.md Update
+
+Updated safety rules to allow only:
+
+```text
+make data-finished-backfill-dry-run MATCH_ID=<id>
+```
+
+Only under these conditions:
+
+- explicit user authorization
+- SELECT-only DB checks
+- local fixture read-only checks
+- no DB writes
+- no training
+- no prediction
+- no external network
+- no large export
+
+Added explicit prohibitions for:
+
+- `make data-finished-backfill-commit`
+- `make data-finished-backfill-commit CONFIRM_FINISHED_BACKFILL=1`
+- `node scripts/ops/finished_match_backfill_preflight.js --commit`
+- raw/L3/training/prediction local write commit commands
+
+Added sequencing rule:
+
+```text
+raw_match_data -> l3_features -> match_features_training -> predictions
+```
+
+and clarified that similar fixtures must not be used as target raw data.
+
+## Dry-Run Validation
+
+Missing argument gate:
+
+```bash
+make data-finished-backfill-dry-run || true
+```
+
+Result:
+
+- failed as expected
+- message: `ERROR: provide MATCH_ID=<id>`
+
+Target preflight:
+
+```bash
+make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002
+```
+
+Result:
+
+- `mode = preflight`
+- `match_found = true`
+- `is_finished = true`
+- `has_actual_result = true`
+- `has_score = true`
+- `has_raw_match_data = false`
+- `has_l3_features = false`
+- `has_training_features = false`
+- `has_predictions = false`
+- `raw_match_data.required = true`
+- `raw_match_data.available_direct_fixture = false`
+- `l3_features.blocked_until_raw = true`
+- `match_features_training.blocked_until_l3 = true`
+- `predictions.blocked_until_training_features = true`
+- `predictions.must_not_predict_without_approved_artifact = true`
+
+Non-execution confirmations included:
+
+- `no_db_writes`
+- `no_insert`
+- `no_update`
+- `no_delete`
+- `no_raw_ingest`
+- `no_l3_write`
+- `no_training_feature_write`
+- `no_prediction_write`
+- `no_training`
+- `no_prediction_execution`
+- `no_model_artifact_load`
+- `no_external_network`
+
+## Optional Fixture Mismatch Validation
+
+Command:
+
+```bash
+make data-finished-backfill-dry-run \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/match_success.json || true
+```
+
+Result:
+
+- fixture was read locally only
+- fixture parsed successfully
+- fixture identity: `55_20242025_4803413`, Chelsea vs Arsenal
+- target identity: `47_20242025_900002`, Burgos vs Oviedo
+- `available_direct_fixture = false`
+- warning: `fixture_mismatch_target_match`
+- no DB writes
+
+## Commit Gate Validation
+
+Commands:
+
+```bash
+make data-finished-backfill-commit || true
+make data-finished-backfill-commit MATCH_ID=47_20242025_900002 CONFIRM_FINISHED_BACKFILL=1 || true
+```
+
+Results:
+
+- both commands were blocked
+- commit remains not wired in Phase 4.40
+- no DB writes occurred
+
+## Next Step
+
+Recommended Phase 4.41 options:
+
+- prepare a legal local raw fixture runbook for `47_20242025_900002`
+- implement raw fixture matching / adapter dry-run before any raw write
+
+Any real write must be separately authorized, preceded by pg_dump, and scoped to one table/stage at a time.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `COPY / \copy`
+- DB writes
+- raw_match_data write
+- l3_features write
+- match_features_training write
+- predictions write
+- raw ingest
+- L3 stitch
+- smelt
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push --force`
+- `git push --mirror`
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/finished_match_backfill_preflight.js
+++ b/scripts/ops/finished_match_backfill_preflight.js
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+/**
+ * Safe finished match backfill preflight gate.
+ *
+ * Phase 4.40 keeps all commit paths blocked. The script only performs
+ * SELECT-only DB checks and local fixture read-only analysis for a finished
+ * match that is missing downstream raw/L3/training/prediction records.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+const FINISHED_VALUES = new Set(['finished', 'completed', 'complete', 'full_time', 'ft']);
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/finished_match_backfill_preflight.js --match-id <id> [--json] [--fixture <path>]',
+        '  node scripts/ops/finished_match_backfill_preflight.js --match-id <id> --commit',
+        '',
+        'Safety:',
+        '  Preflight only in Phase 4.40; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        matchId: null,
+        json: false,
+        fixture: null,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--fixture') {
+            args.fixture = argv[index + 1];
+            index += 1;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function normalizeText(value) {
+    return String(value ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function normalizeName(value) {
+    return normalizeText(value)
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();
+}
+
+function asBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    const normalized = normalizeText(value).toLowerCase();
+    return TRUE_VALUES.has(normalized);
+}
+
+function isFinishedFlag(value) {
+    if (typeof value === 'boolean') return value;
+    const normalized = normalizeText(value).toLowerCase();
+    return FINISHED_VALUES.has(normalized) || TRUE_VALUES.has(normalized);
+}
+
+function pickFirst(values) {
+    for (const value of values) {
+        const normalized = normalizeText(value);
+        if (normalized) {
+            return normalized;
+        }
+    }
+    return null;
+}
+
+function readOptionalFixture(rawPath, target) {
+    if (!rawPath) {
+        return {
+            provided: false,
+            requested_path: null,
+            resolved_path: null,
+            exists: false,
+            parse_ok: false,
+            match_id_in_fixture: null,
+            home_team_in_fixture: null,
+            away_team_in_fixture: null,
+            finished_flag_in_fixture: null,
+            score_in_fixture: null,
+            team_match: false,
+            direct_match: false,
+            available_direct_fixture: false,
+            warnings: ['no_fixture_provided'],
+        };
+    }
+
+    const resolvedPath = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(process.cwd(), rawPath);
+    if (!fs.existsSync(resolvedPath)) {
+        return {
+            provided: true,
+            requested_path: rawPath,
+            resolved_path: resolvedPath,
+            exists: false,
+            parse_ok: false,
+            match_id_in_fixture: null,
+            home_team_in_fixture: null,
+            away_team_in_fixture: null,
+            finished_flag_in_fixture: null,
+            score_in_fixture: null,
+            team_match: false,
+            direct_match: false,
+            available_direct_fixture: false,
+            warnings: ['fixture_not_found'],
+        };
+    }
+
+    if (!fs.statSync(resolvedPath).isFile()) {
+        return {
+            provided: true,
+            requested_path: rawPath,
+            resolved_path: resolvedPath,
+            exists: true,
+            parse_ok: false,
+            match_id_in_fixture: null,
+            home_team_in_fixture: null,
+            away_team_in_fixture: null,
+            finished_flag_in_fixture: null,
+            score_in_fixture: null,
+            team_match: false,
+            direct_match: false,
+            available_direct_fixture: false,
+            warnings: ['fixture_not_a_file'],
+        };
+    }
+
+    let fixture;
+    try {
+        fixture = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+    } catch (error) {
+        return {
+            provided: true,
+            requested_path: rawPath,
+            resolved_path: resolvedPath,
+            exists: true,
+            parse_ok: false,
+            match_id_in_fixture: null,
+            home_team_in_fixture: null,
+            away_team_in_fixture: null,
+            finished_flag_in_fixture: null,
+            score_in_fixture: null,
+            team_match: false,
+            direct_match: false,
+            available_direct_fixture: false,
+            warnings: [`fixture_parse_error:${error.message}`],
+        };
+    }
+
+    const matchIdInFixture = pickFirst([
+        fixture?.match_id,
+        fixture?.matchId,
+        fixture?.raw_data?.matchId,
+        fixture?.raw_data?.general?.matchId,
+        fixture?.general?.matchId,
+        fixture?.data?.match?.id,
+    ]);
+    const homeTeamInFixture = pickFirst([
+        fixture?.home_team,
+        fixture?.raw_data?.general?.homeTeam?.name,
+        fixture?.raw_data?.header?.teams?.[0]?.name,
+        fixture?.general?.homeTeam?.name,
+        fixture?.content?.lineup?.homeTeam?.teamName,
+        fixture?.data?.match?.homeTeam?.name,
+    ]);
+    const awayTeamInFixture = pickFirst([
+        fixture?.away_team,
+        fixture?.raw_data?.general?.awayTeam?.name,
+        fixture?.raw_data?.header?.teams?.[1]?.name,
+        fixture?.general?.awayTeam?.name,
+        fixture?.content?.lineup?.awayTeam?.teamName,
+        fixture?.data?.match?.awayTeam?.name,
+    ]);
+    const finishedFlag = [
+        fixture?.raw_data?.general?.finished,
+        fixture?.raw_data?.header?.status?.finished,
+        fixture?.general?.status?.finished,
+        fixture?.general?.status,
+        fixture?.data?.match?.status?.finished,
+        fixture?.data?.match?.status?.status,
+    ]
+        .map(value => (value === undefined ? null : value))
+        .find(value => value !== null);
+    const scoreInFixture = pickFirst([
+        fixture?.raw_data?.header?.status?.scoreStr,
+        fixture?.general?.score,
+        fixture?.data?.match?.status?.scoreStr,
+    ]);
+
+    const teamMatch =
+        normalizeName(homeTeamInFixture) === normalizeName(target.home_team) &&
+        normalizeName(awayTeamInFixture) === normalizeName(target.away_team);
+    const directMatch = normalizeText(matchIdInFixture) === normalizeText(target.match_id);
+    const warnings = [];
+
+    if (!directMatch) {
+        if (teamMatch) {
+            warnings.push('fixture_team_match_only_not_direct_match_id');
+        } else {
+            warnings.push('fixture_mismatch_target_match');
+        }
+    }
+    if (!isFinishedFlag(finishedFlag)) {
+        warnings.push('fixture_not_marked_finished');
+    }
+
+    return {
+        provided: true,
+        requested_path: rawPath,
+        resolved_path: resolvedPath,
+        exists: true,
+        parse_ok: true,
+        match_id_in_fixture: matchIdInFixture,
+        home_team_in_fixture: homeTeamInFixture,
+        away_team_in_fixture: awayTeamInFixture,
+        finished_flag_in_fixture: finishedFlag,
+        score_in_fixture: scoreInFixture,
+        team_match: teamMatch,
+        direct_match: directMatch,
+        available_direct_fixture: directMatch,
+        warnings,
+    };
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_raw_ingest',
+        'no_l3_write',
+        'no_training_feature_write',
+        'no_prediction_write',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+    ];
+}
+
+function buildBackfillPlan(chain, fixtureSummary) {
+    const hasRaw = chain.has_raw_match_data === true;
+    const hasL3 = chain.has_l3_features === true;
+    const hasTraining = chain.has_training_features === true;
+
+    return {
+        raw_match_data: {
+            required: !hasRaw,
+            available_direct_fixture: fixtureSummary.available_direct_fixture === true,
+            recommended_next_step: hasRaw
+                ? 'raw_match_data already exists; do not schedule raw backfill unless a dedicated corrective runbook is approved.'
+                : fixtureSummary.available_direct_fixture
+                  ? 'Run make data-raw-dry-run SAMPLE_RAW=<fixture> MATCH_ID=<id> first; any write requires a separate authorized phase.'
+                  : 'No direct raw fixture is available yet. Prepare or approve a local raw fixture for this exact match before any downstream backfill.',
+        },
+        l3_features: {
+            blocked_until_raw: !hasRaw,
+            recommended_next_step: hasRaw
+                ? 'Use make data-l3-write-dry-run SAMPLE_RAW=<fixture> MATCH_ID=<id> only after confirming a matching raw fixture strategy.'
+                : 'Blocked until raw_match_data exists for the target match.',
+        },
+        match_features_training: {
+            blocked_until_l3: !hasL3,
+            recommended_next_step: hasL3
+                ? 'Use make data-training-feature-dry-run MATCH_ID=<id> after L3 is present and validated.'
+                : 'Blocked until l3_features exists for the target match.',
+        },
+        predictions: {
+            blocked_until_training_features: !hasTraining,
+            must_not_predict_without_approved_artifact: true,
+            recommended_next_step: hasTraining
+                ? 'Use make data-prediction-write-dry-run MATCH_ID=<id> only after an approved model artifact policy exists.'
+                : 'Blocked until match_features_training exists for the target match.',
+        },
+    };
+}
+
+function buildPayload({ args, chain, fixtureSummary }) {
+    const chainStatus = chain
+        ? {
+              match_found: true,
+              is_finished: chain.is_finished === true,
+              has_actual_result: Boolean(chain.actual_result),
+              has_score: chain.home_score !== null && chain.away_score !== null,
+              has_raw_match_data: chain.has_raw_match_data === true,
+              has_l3_features: chain.has_l3_features === true,
+              has_training_features: chain.has_training_features === true,
+              has_predictions: chain.has_predictions === true,
+          }
+        : {
+              match_found: false,
+              is_finished: false,
+              has_actual_result: false,
+              has_score: false,
+              has_raw_match_data: false,
+              has_l3_features: false,
+              has_training_features: false,
+              has_predictions: false,
+          };
+
+    return {
+        mode: 'preflight',
+        match_id: args.matchId,
+        fixture_path: args.fixture || null,
+        chain_status: chainStatus,
+        target_match: chain
+            ? {
+                  match_id: chain.match_id,
+                  league_name: chain.league_name,
+                  season: chain.season,
+                  home_team: chain.home_team,
+                  away_team: chain.away_team,
+                  home_score: chain.home_score,
+                  away_score: chain.away_score,
+                  actual_result: chain.actual_result,
+                  match_date: chain.match_date ? new Date(chain.match_date).toISOString() : null,
+                  status: chain.status,
+                  is_finished: chain.is_finished === true,
+              }
+            : null,
+        backfill_plan: buildBackfillPlan(chainStatus, fixtureSummary),
+        fixture_candidate_summary: fixtureSummary,
+        warnings: [...(chainStatus.match_found ? [] : ['match_not_found']), ...fixtureSummary.warnings],
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function formatText(payload) {
+    const lines = [
+        `mode=${payload.mode}`,
+        `match_id=${payload.match_id}`,
+        `fixture_path=${payload.fixture_path || ''}`,
+        `match_found=${payload.chain_status.match_found}`,
+        `is_finished=${payload.chain_status.is_finished}`,
+        `has_actual_result=${payload.chain_status.has_actual_result}`,
+        `has_score=${payload.chain_status.has_score}`,
+        `has_raw_match_data=${payload.chain_status.has_raw_match_data}`,
+        `has_l3_features=${payload.chain_status.has_l3_features}`,
+        `has_training_features=${payload.chain_status.has_training_features}`,
+        `has_predictions=${payload.chain_status.has_predictions}`,
+        `raw_match_data.required=${payload.backfill_plan.raw_match_data.required}`,
+        `raw_match_data.available_direct_fixture=${payload.backfill_plan.raw_match_data.available_direct_fixture}`,
+        `l3_features.blocked_until_raw=${payload.backfill_plan.l3_features.blocked_until_raw}`,
+        `match_features_training.blocked_until_l3=${payload.backfill_plan.match_features_training.blocked_until_l3}`,
+        `predictions.blocked_until_training_features=${payload.backfill_plan.predictions.blocked_until_training_features}`,
+        `predictions.must_not_predict_without_approved_artifact=${payload.backfill_plan.predictions.must_not_predict_without_approved_artifact}`,
+        '',
+        'target_match:',
+        JSON.stringify(payload.target_match, null, 2),
+        '',
+        'fixture_candidate_summary:',
+        JSON.stringify(payload.fixture_candidate_summary, null, 2),
+        '',
+        'warnings:',
+        payload.warnings.length ? payload.warnings.map(value => `  ${value}`).join('\n') : '  none',
+        '',
+        'backfill_plan:',
+        JSON.stringify(payload.backfill_plan, null, 2),
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ];
+
+    return lines.join('\n');
+}
+
+async function loadChain(pool, matchId) {
+    const sql = `
+        SELECT
+            m.match_id,
+            m.league_name,
+            m.season,
+            m.home_team,
+            m.away_team,
+            m.home_score,
+            m.away_score,
+            m.actual_result,
+            m.match_date,
+            m.status,
+            m.is_finished,
+            EXISTS (SELECT 1 FROM raw_match_data r WHERE r.match_id = m.match_id) AS has_raw_match_data,
+            EXISTS (SELECT 1 FROM l3_features l WHERE l.match_id = m.match_id) AS has_l3_features,
+            EXISTS (SELECT 1 FROM match_features_training t WHERE t.match_id = m.match_id) AS has_training_features,
+            EXISTS (SELECT 1 FROM predictions p WHERE p.match_id = m.match_id) AS has_predictions
+        FROM matches m
+        WHERE m.match_id = $1
+    `;
+
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error('BLOCKED: finished match backfill commit is not wired in Phase 4.40.');
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.matchId) {
+        console.error('ERROR: provide --match-id <id>');
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const chain = await loadChain(pool, args.matchId);
+        const fixtureSummary = readOptionalFixture(args.fixture, {
+            match_id: args.matchId,
+            home_team: chain?.home_team || '',
+            away_team: chain?.away_team || '',
+        });
+        const payload = buildPayload({ args, chain, fixtureSummary });
+
+        console.log(args.json ? JSON.stringify(payload, null, 2) : formatText(payload));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'preflight',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a safe finished match backfill preflight gate for the newly inserted finished CSV match.

Changes:
- Adds scripts/ops/finished_match_backfill_preflight.js
- Adds make data-finished-backfill-dry-run
- Adds blocked make data-finished-backfill-commit
- Updates data-help
- Updates AGENTS.md with finished match backfill safety rules
- Adds Phase 4.39 report
- Adds Phase 4.40 report

Safety:
- SELECT-only DB checks
- Local fixture read-only checks
- No DB writes
- No raw ingest
- No L3 write
- No training feature write
- No prediction write
- No training
- No prediction execution
- No external data access
- Commit gate remains blocked

Validation:
- make data-finished-backfill-dry-run without args fails as expected
- make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002 succeeds
- optional fixture mismatch is reported without writing DB
- make data-finished-backfill-commit remains blocked with and without CONFIRM_FINISHED_BACKFILL=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/finished_match_backfill_preflight.js
- docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md
- docs/_reports/FINISHED_MATCH_BACKFILL_PREFLIGHT_PHASE4_40.md