### PR TITLE
feat(data): add raw fixture adapter dry-run gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,7 @@ AI / Codex 默认只能执行：
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-training-dataset-dry-run`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
+- 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
 
 AI / Codex 不能直接执行：
 
@@ -268,6 +269,9 @@ AI / Codex 不能直接执行：
 - `make data-finished-backfill-commit`
 - `make data-finished-backfill-commit CONFIRM_FINISHED_BACKFILL=1`
 - `node scripts/ops/finished_match_backfill_preflight.js --commit`
+- `make data-raw-fixture-commit`
+- `make data-raw-fixture-commit CONFIRM_RAW_FIXTURE_COMMIT=1`
+- `node scripts/ops/raw_fixture_adapter_dry_run.js --commit`
 - `csv_bulk_loader --commit`
 - 任何 finished CSV 直接写 DB 的命令
 - `make data-l3-write-commit`
@@ -372,6 +376,23 @@ Phase 4.38 中 `make data-finished-csv-commit`、`make data-finished-csv-commit 
 - 不导出数据集或大文件
 
 Phase 4.40 中 `make data-finished-backfill-commit`、`make data-finished-backfill-commit CONFIRM_FINISHED_BACKFILL=1` 和 `node scripts/ops/finished_match_backfill_preflight.js --commit` 仍是 blocked / not wired。finished match backfill 必须按 `raw_match_data -> l3_features -> match_features_training -> predictions` 顺序推进；没有匹配 raw fixture 时不得伪造 `raw_match_data`；不得把相似 fixture 冒充目标比赛；scheduled / baseline sample 不可混入真实训练；任何真实 write 前必须单独授权并完成 pg_dump。相关背景见：`docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md`、`docs/_reports/FINISHED_CSV_DRY_RUN_GATE_PHASE4_38.md` 和 `docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md`
+
+执行 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>` 的前提：
+
+- 用户明确授权
+- 入口只做 SELECT-only DB 审计和本地 JSON 只读检查
+- 不写 DB
+- 不创建 fixture 文件
+- 不执行 raw ingest
+- 不写 `l3_features`
+- 不写 `match_features_training`
+- 不写 `predictions`
+- 不训练模型
+- 不执行预测
+- 不加载模型 artifact
+- 不访问外网
+
+Phase 4.41 中 `make data-raw-fixture-commit`、`make data-raw-fixture-commit CONFIRM_RAW_FIXTURE_COMMIT=1`、`node scripts/ops/raw_fixture_adapter_dry_run.js --commit` 和 `node scripts/ops/raw_match_data_local_ingest.js --commit` 仍是 blocked / not wired。raw fixture 必须与目标 `match_id`、teams、score、status 匹配；不匹配 fixture 不能冒充目标 match；synthetic fixture 只能用于 engineering test，不能用于真实训练；synthetic raw_data 不能标记为真实 external / FotMob data；任何 `raw_match_data` 写入前必须单独授权并完成 pg_dump。相关背景见：`docs/_reports/FINISHED_MATCH_BACKFILL_PREFLIGHT_PHASE4_40.md`、`docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
 
 执行 `make data-l3-write-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
+        data-raw-fixture-dry-run data-raw-fixture-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -252,8 +253,11 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
+	@echo "  make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path>"
+	@echo "  make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path> ALLOW_SYNTHETIC=1"
 	@echo ""
 	@echo "Requires explicit authorization:"
+	@echo "  make data-raw-fixture-commit MATCH_ID=<id> FIXTURE=<path> CONFIRM_RAW_FIXTURE_COMMIT=1  # blocked in Phase 4.41"
 	@echo "  make data-finished-backfill-commit MATCH_ID=<id> CONFIRM_FINISHED_BACKFILL=1  # blocked in Phase 4.40"
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
@@ -451,6 +455,27 @@ data-finished-backfill-commit: ## Blocked finished match backfill gate. Requires
 		exit 1; \
 	fi
 	@echo "BLOCKED: finished match backfill commit is not wired in Phase 4.40."
+	@exit 1
+
+data-raw-fixture-dry-run: ## Run raw fixture adapter dry-run. Requires MATCH_ID and FIXTURE.
+	@if [ -z "$(MATCH_ID)" ] || [ -z "$(FIXTURE)" ]; then \
+		echo "ERROR: provide MATCH_ID=<id> and FIXTURE=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running safe raw fixture adapter dry-run: MATCH_ID=$(MATCH_ID), FIXTURE=$(FIXTURE)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(FIXTURE)"
+	@if [ "$(ALLOW_SYNTHETIC)" = "1" ]; then \
+		$(COMPOSE_DEV) exec -T dev node scripts/ops/raw_fixture_adapter_dry_run.js --match-id "$(MATCH_ID)" --fixture "$(FIXTURE)" --allow-synthetic; \
+	else \
+		$(COMPOSE_DEV) exec -T dev node scripts/ops/raw_fixture_adapter_dry_run.js --match-id "$(MATCH_ID)" --fixture "$(FIXTURE)"; \
+	fi
+
+data-raw-fixture-commit: ## Blocked raw fixture adapter gate. Requires MATCH_ID, FIXTURE, CONFIRM_RAW_FIXTURE_COMMIT=1.
+	@if [ "$(CONFIRM_RAW_FIXTURE_COMMIT)" != "1" ]; then \
+		echo "BLOCKED: raw fixture commit requires CONFIRM_RAW_FIXTURE_COMMIT=1 and is not wired in Phase 4.41."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: raw fixture adapter commit is not wired in Phase 4.41."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/RAW_FIXTURE_ADAPTER_DRY_RUN_PHASE4_41.md
+++ b/docs/_reports/RAW_FIXTURE_ADAPTER_DRY_RUN_PHASE4_41.md
@@ -1,0 +1,340 @@
+# Phase 4.41 - Raw Fixture Adapter Dry-Run Gate
+
+## Current HEAD
+
+- Base HEAD: `a280badf44552c9700d00f89871264a18cbf256f`
+- Working branch: `feat/raw-fixture-adapter-dry-run-gate`
+- Phase 4.40 report present: `docs/_reports/FINISHED_MATCH_BACKFILL_PREFLIGHT_PHASE4_40.md`
+- Phase 4.39 report present: `docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md`
+
+## Current DB Row Counts
+
+Row counts before and after the Phase 4.41 dry-run validations remained unchanged:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+`make data-dataset-status` remained SELECT-only and reported:
+
+- `finished_matches = 1`
+- `matches_with_actual_result = 1`
+- `matches_with_scores = 1`
+- `trainable_label_rows = 1`
+- `full_feature_chain_rows = 1`
+- `trainable = false`
+- reason: current DB has only `1` trainable labeled row and `1` full feature-chain row; minimum pre-training discussion threshold is `200`
+
+## Target Finished Match
+
+Target:
+
+| field                 | value                    |
+| --------------------- | ------------------------ |
+| match_id              | `47_20242025_900002`     |
+| league_name           | `Segunda`                |
+| season                | `2024/2025`              |
+| home_team             | `Burgos`                 |
+| away_team             | `Oviedo`                 |
+| home_score            | `1`                      |
+| away_score            | `0`                      |
+| actual_result         | `home_win`               |
+| match_date            | `2024-08-17 17:30:00+00` |
+| status                | `finished`               |
+| is_finished           | `true`                   |
+| has_raw_match_data    | `false`                  |
+| has_l3_features       | `false`                  |
+| has_training_features | `false`                  |
+| has_predictions       | `false`                  |
+
+The match is a valid finished label row, but it still has no downstream raw/L3/training/prediction chain.
+
+## raw_match_data Schema Summary
+
+Read-only schema inspection showed:
+
+| column         | type                       | nullable | default             |
+| -------------- | -------------------------- | -------- | ------------------- |
+| `id`           | `bigint`                   | `NO`     | sequence            |
+| `match_id`     | `character varying`        | `NO`     | none                |
+| `external_id`  | `character varying`        | `YES`    | none                |
+| `raw_data`     | `jsonb`                    | `NO`     | none                |
+| `collected_at` | `timestamp with time zone` | `YES`    | `CURRENT_TIMESTAMP` |
+| `data_version` | `character varying`        | `YES`    | `V26.1`             |
+| `data_hash`    | `character varying`        | `YES`    | none                |
+
+Relevant constraints:
+
+- primary key: `raw_match_data_pkey`
+- unique match: `raw_match_data_match_id_key UNIQUE (match_id)`
+- FK: `raw_match_data_match_id_fkey` references `matches(match_id)` with cascade delete
+- `match_id_format`: match id must match numeric or league/season/external id format
+- `raw_data_not_empty`: `raw_data IS NOT NULL` and not empty JSON
+- `raw_data_has_match_id`: `raw_data` must contain `matchId`, `general`, or `header`
+- `collected_at_not_null`: collected timestamp must not be null
+
+Implication:
+
+- a future raw write must provide exact target `match_id`
+- raw JSON cannot be empty
+- raw JSON must carry at least `matchId`, `general`, or `header`
+- duplicate raw rows for the target are blocked by the unique constraint
+
+## Raw Fixture Strategy
+
+Path A: real local raw fixture
+
+- fixture must come from a legal and documented source
+- fixture must correspond to `47_20242025_900002`
+- `match_id`, teams, score, and finished status must match the target
+- only then can it become a future raw write candidate
+
+Path B: synthetic local fixture
+
+- must be explicitly marked synthetic
+- engineering test only
+- not real external data
+- not production data
+- not for training
+- cannot be labeled as FotMob or another external data source
+- must carry provenance in `data_source`, `data_version`, and metadata
+
+No fixture file was created in this phase.
+
+## New Script Behavior
+
+Added:
+
+```text
+scripts/ops/raw_fixture_adapter_dry_run.js
+```
+
+Supported commands:
+
+```bash
+node scripts/ops/raw_fixture_adapter_dry_run.js --match-id <id> --fixture <path>
+node scripts/ops/raw_fixture_adapter_dry_run.js --match-id <id> --fixture <path> --allow-synthetic
+node scripts/ops/raw_fixture_adapter_dry_run.js --match-id <id> --fixture <path> --json
+```
+
+Behavior:
+
+- reads target match via SELECT-only query
+- reads one local JSON fixture
+- extracts fixture match id, teams, score, status, and raw structure fields
+- checks `general`, `header`, `content`, `stats`, `lineup`, `shotmap`, and `momentum` presence
+- checks whether the fixture satisfies the raw JSON constraint shape
+- emits `direct_fixture_match`
+- emits `fixture_can_be_used_for_target`
+- emits `synthetic_required`
+- emits `would_insert_raw_match_data=false`
+- emits `would_update_matches=false`
+- emits `would_trigger_l3=false`
+- does not call raw ingest, L3 write, training feature write, prediction write, training, prediction, model artifact loading, harvest, scrape, or external network
+
+`--commit` behavior:
+
+```text
+BLOCKED: raw fixture adapter commit is not wired in Phase 4.41.
+```
+
+## Makefile Entrypoints
+
+Added:
+
+```text
+make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path>
+make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path> ALLOW_SYNTHETIC=1
+make data-raw-fixture-commit MATCH_ID=<id> FIXTURE=<path> CONFIRM_RAW_FIXTURE_COMMIT=1  # blocked in Phase 4.41
+```
+
+`data-raw-fixture-dry-run` requires both `MATCH_ID` and `FIXTURE`.
+
+`data-raw-fixture-commit` is intentionally blocked even when `CONFIRM_RAW_FIXTURE_COMMIT=1` is provided.
+
+## AGENTS.md Update
+
+Updated safety rules to allow only:
+
+```text
+make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>
+```
+
+Only under these conditions:
+
+- explicit user authorization
+- SELECT-only DB checks
+- local JSON read-only checks
+- no DB writes
+- no file creation
+- no raw ingest
+- no training
+- no prediction
+- no external network
+
+Added explicit prohibitions for:
+
+- `make data-raw-fixture-commit`
+- `make data-raw-fixture-commit CONFIRM_RAW_FIXTURE_COMMIT=1`
+- `node scripts/ops/raw_fixture_adapter_dry_run.js --commit`
+- `node scripts/ops/raw_match_data_local_ingest.js --commit`
+
+Added raw fixture rules:
+
+- raw fixture must match target match id, teams, score, and status
+- mismatched fixture cannot impersonate target match
+- synthetic fixture is engineering-test-only and not for training
+- synthetic raw data cannot be labeled as real external or FotMob data
+- any real `raw_match_data` write requires separate authorization and pg_dump
+
+## Mismatch Fixture Validation
+
+Command:
+
+```bash
+make data-raw-fixture-dry-run \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/match_success.json
+```
+
+Result:
+
+- `match_found = true`
+- `fixture.exists = true`
+- fixture identity: `55_20242025_4803413`
+- fixture teams: Chelsea vs Arsenal
+- fixture score: `2-0`
+- fixture status: `FINISHED`
+- target identity: `47_20242025_900002`
+- target teams: Burgos vs Oviedo
+- target score: `1-0`
+- `direct_fixture_match = false`
+- `fixture_can_be_used_for_target = false`
+- `synthetic_required = true`
+- `would_insert_raw_match_data = false`
+- `would_update_matches = false`
+- `would_trigger_l3 = false`
+
+Warnings:
+
+- `fixture_mismatch:match_id`
+- `fixture_mismatch:home_team`
+- `fixture_mismatch:away_team`
+- `fixture_mismatch:score`
+- `cannot_use_this_fixture_as_raw_data_for_target_match`
+- `do_not_impersonate_another_match`
+
+Conclusion:
+
+- `tests/fixtures/match_success.json` cannot be used as raw data for `47_20242025_900002`
+- no direct fixture currently exists for the target
+
+## Synthetic Preview Validation
+
+Command:
+
+```bash
+make data-raw-fixture-dry-run \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/match_success.json \
+  ALLOW_SYNTHETIC=1
+```
+
+Result:
+
+- synthetic preview only
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_production_data = true`
+- `would_create_fixture_file = false`
+- `would_insert_raw_match_data = false`
+
+Required provenance preview:
+
+- `data_source = synthetic_local_fixture`
+- `data_version = PHASE4.41_SYNTHETIC_PREVIEW_ONLY`
+- metadata must include:
+    - `synthetic=true`
+    - `engineering_test_only=true`
+    - `not_real_external_data=true`
+    - `not_for_training=true`
+
+The synthetic preview did not create a fixture file and did not write DB.
+
+## Commit Gate Validation
+
+Commands:
+
+```bash
+make data-raw-fixture-commit || true
+make data-raw-fixture-commit \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/match_success.json \
+  CONFIRM_RAW_FIXTURE_COMMIT=1 || true
+```
+
+Results:
+
+- both commands were blocked
+- commit remains not wired in Phase 4.41
+- no DB writes occurred
+- no file was created
+
+## Next Step
+
+Recommended Phase 4.42 options:
+
+- prepare a synthetic local raw fixture runbook for engineering-chain validation only
+- identify a legal real raw fixture source and document license / provenance before any local raw write
+
+Any real raw write must be separately authorized, preceded by pg_dump, and scoped to `raw_match_data` only.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `COPY / \copy`
+- DB writes
+- raw_match_data write
+- raw ingest
+- file creation
+- l3_features write
+- match_features_training write
+- predictions write
+- L3 stitch
+- smelt
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push --force`
+- `git push --mirror`
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/raw_fixture_adapter_dry_run.js
+++ b/scripts/ops/raw_fixture_adapter_dry_run.js
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+/**
+ * Safe raw fixture adapter dry-run gate.
+ *
+ * Phase 4.41 validates whether a local JSON fixture can be used as raw data
+ * for one finished match. It never writes DB rows, creates files, or calls
+ * ingest/L3/training/prediction paths.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+const FINISHED_VALUES = new Set(['finished', 'completed', 'complete', 'full_time', 'ft']);
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/raw_fixture_adapter_dry_run.js --match-id <id> --fixture <path> [--json] [--allow-synthetic]',
+        '  node scripts/ops/raw_fixture_adapter_dry_run.js --match-id <id> --fixture <path> --commit',
+        '',
+        'Safety:',
+        '  Dry-run only in Phase 4.41; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        matchId: null,
+        fixture: null,
+        json: false,
+        allowSynthetic: false,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--fixture') {
+            args.fixture = argv[index + 1];
+            index += 1;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--allow-synthetic') {
+            args.allowSynthetic = true;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function normalizeText(value) {
+    return String(value ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function normalizeName(value) {
+    return normalizeText(value)
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();
+}
+
+function normalizeStatus(value) {
+    return normalizeText(value).toLowerCase();
+}
+
+function isFinishedLike(value) {
+    if (typeof value === 'boolean') return value;
+    const normalized = normalizeStatus(value);
+    return FINISHED_VALUES.has(normalized) || TRUE_VALUES.has(normalized);
+}
+
+function toInt(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const parsed = Number.parseInt(String(value), 10);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function pickFirst(values) {
+    for (const value of values) {
+        const normalized = normalizeText(value);
+        if (normalized) return normalized;
+    }
+    return null;
+}
+
+function asObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function stableStringify(value) {
+    if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value)
+            .sort()
+            .map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+            .join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function sha256(value) {
+    return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function resolveFixture(rawPath) {
+    if (!rawPath) throw new Error('Missing required --fixture <path>');
+    const resolved = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(process.cwd(), rawPath);
+    if (!fs.existsSync(resolved)) throw new Error(`Fixture file not found: ${rawPath}`);
+    if (!fs.statSync(resolved).isFile()) throw new Error(`Fixture path is not a file: ${rawPath}`);
+    const data = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+    return { resolved, data };
+}
+
+function rootRawData(fixture) {
+    return asObject(fixture.raw_data).matchId || fixture.raw_data?.general || fixture.raw_data?.header
+        ? fixture.raw_data
+        : fixture;
+}
+
+function scoreFromObject(value) {
+    if (!value || typeof value !== 'object') return { home: null, away: null, raw: value ?? null };
+    return {
+        home: toInt(value.home ?? value.homeScore ?? value[0]),
+        away: toInt(value.away ?? value.awayScore ?? value[1]),
+        raw: value,
+    };
+}
+
+function scoreFromString(value) {
+    const normalized = normalizeText(value);
+    const match = normalized.match(/^(\d+)\s*[-:]\s*(\d+)$/);
+    if (!match) return { home: null, away: null, raw: normalized || null };
+    return {
+        home: toInt(match[1]),
+        away: toInt(match[2]),
+        raw: normalized,
+    };
+}
+
+function extractScore(rawData) {
+    const statusScore = rawData?.header?.status?.scoreStr || rawData?.data?.match?.status?.scoreStr;
+    if (statusScore) return scoreFromString(statusScore);
+    const generalScore = rawData?.general?.score || rawData?.score;
+    if (typeof generalScore === 'string') return scoreFromString(generalScore);
+    if (typeof generalScore === 'object') return scoreFromObject(generalScore);
+    const headerTeams = rawData?.header?.teams;
+    if (Array.isArray(headerTeams) && headerTeams.length >= 2) {
+        return {
+            home: toInt(headerTeams[0]?.score),
+            away: toInt(headerTeams[1]?.score),
+            raw: headerTeams.map(team => team?.score).join('-'),
+        };
+    }
+    return { home: null, away: null, raw: null };
+}
+
+function extractStatus(rawData) {
+    return pickFirst([
+        rawData?.general?.status,
+        rawData?.header?.status?.reason?.shortKey,
+        rawData?.header?.status?.reason?.short,
+        rawData?.header?.status?.finished,
+        rawData?.data?.match?.status?.status,
+        rawData?.data?.match?.status?.finished,
+    ]);
+}
+
+function extractFixtureInfo(fixture) {
+    const rawData = rootRawData(fixture);
+    const score = extractScore(rawData);
+    const status = extractStatus(rawData);
+    const content = asObject(rawData?.content);
+    const stats = content.stats || rawData?.content?.stats || rawData?.data?.match?.content?.stats;
+    const lineup = content.lineup || rawData?.content?.lineup;
+    const shotmap = content.shotmap || rawData?.content?.shotmap;
+    const momentum = content.momentum || rawData?.content?.momentum;
+
+    return {
+        fixture_match_id: pickFirst([
+            fixture?.match_id,
+            fixture?.matchId,
+            fixture?.raw_data?.matchId,
+            fixture?.raw_data?.general?.matchId,
+            rawData?.matchId,
+            rawData?.general?.matchId,
+            rawData?.data?.match?.id,
+        ]),
+        external_id: pickFirst([fixture?.external_id, rawData?.matchId, rawData?.general?.matchId]),
+        home_team: pickFirst([
+            fixture?.home_team,
+            rawData?.general?.homeTeam?.name,
+            rawData?.header?.teams?.[0]?.name,
+            rawData?.content?.lineup?.homeTeam?.teamName,
+            rawData?.content?.lineup?.homeTeam?.name,
+            rawData?.data?.match?.homeTeam?.name,
+        ]),
+        away_team: pickFirst([
+            fixture?.away_team,
+            rawData?.general?.awayTeam?.name,
+            rawData?.header?.teams?.[1]?.name,
+            rawData?.content?.lineup?.awayTeam?.teamName,
+            rawData?.content?.lineup?.awayTeam?.name,
+            rawData?.data?.match?.awayTeam?.name,
+        ]),
+        score,
+        status,
+        status_is_finished: isFinishedLike(status),
+        has_general: Boolean(rawData?.general),
+        has_header: Boolean(rawData?.header),
+        has_content: Boolean(rawData?.content),
+        has_stats: Boolean(stats),
+        has_lineup: Boolean(lineup),
+        has_shotmap: Boolean(shotmap),
+        has_momentum: Boolean(momentum),
+        raw_data_constraint_ok: Boolean(rawData?.matchId || rawData?.general || rawData?.header),
+        raw_data_not_empty: Object.keys(asObject(rawData)).length > 0,
+        raw_data_hash_preview: sha256(stableStringify(rawData)),
+        raw_data_top_level_keys: Object.keys(asObject(rawData)).sort(),
+    };
+}
+
+function buildMatchChecks(match, fixtureInfo) {
+    return {
+        match_id_matches: normalizeText(fixtureInfo.fixture_match_id) === normalizeText(match.match_id),
+        home_team_matches: normalizeName(fixtureInfo.home_team) === normalizeName(match.home_team),
+        away_team_matches: normalizeName(fixtureInfo.away_team) === normalizeName(match.away_team),
+        score_matches:
+            fixtureInfo.score.home === toInt(match.home_score) && fixtureInfo.score.away === toInt(match.away_score),
+        status_reasonable: fixtureInfo.status_is_finished === true,
+        raw_data_constraint_ok: fixtureInfo.raw_data_constraint_ok === true && fixtureInfo.raw_data_not_empty === true,
+    };
+}
+
+function buildWarnings(checks, fixtureInfo) {
+    const warnings = [];
+    if (!checks.match_id_matches) warnings.push('fixture_mismatch:match_id');
+    if (!checks.home_team_matches) warnings.push('fixture_mismatch:home_team');
+    if (!checks.away_team_matches) warnings.push('fixture_mismatch:away_team');
+    if (!checks.score_matches) warnings.push('fixture_mismatch:score');
+    if (!checks.status_reasonable) warnings.push('fixture_status_not_finished_or_unknown');
+    if (!checks.raw_data_constraint_ok) warnings.push('fixture_raw_data_constraint_not_satisfied');
+    if (!checks.match_id_matches || !checks.home_team_matches || !checks.away_team_matches || !checks.score_matches) {
+        warnings.push('cannot_use_this_fixture_as_raw_data_for_target_match');
+        warnings.push('do_not_impersonate_another_match');
+    }
+    if (!fixtureInfo.has_content) warnings.push('fixture_missing_content');
+    return warnings;
+}
+
+function buildSyntheticPreview({ args, match }) {
+    if (!args.allowSynthetic) return null;
+    return {
+        synthetic: true,
+        synthetic_preview_only: true,
+        engineering_test_only: true,
+        not_real_external_data: true,
+        not_for_training: true,
+        not_production_data: true,
+        would_create_fixture_file: false,
+        would_insert_raw_match_data: false,
+        provenance_required: {
+            data_source: 'synthetic_local_fixture',
+            data_version: 'PHASE4.41_SYNTHETIC_PREVIEW_ONLY',
+            metadata_flags: [
+                'synthetic=true',
+                'engineering_test_only=true',
+                'not_real_external_data=true',
+                'not_for_training=true',
+            ],
+        },
+        raw_data_shape_preview: {
+            matchId: match?.match_id || args.matchId,
+            general: {
+                matchId: match?.match_id || args.matchId,
+                homeTeam: { name: match?.home_team || null },
+                awayTeam: { name: match?.away_team || null },
+                finished: true,
+            },
+            header: {
+                status: {
+                    finished: true,
+                    scoreStr:
+                        match?.home_score !== null && match?.away_score !== null
+                            ? `${match.home_score}-${match.away_score}`
+                            : null,
+                },
+            },
+        },
+    };
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_raw_ingest',
+        'no_l3_write',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+        'no_file_create',
+    ];
+}
+
+function buildTargetMatchPayload(match) {
+    return {
+        match_found: Boolean(match),
+        match_id: match?.match_id || null,
+        league_name: match?.league_name || null,
+        season: match?.season || null,
+        home_team: match?.home_team || null,
+        away_team: match?.away_team || null,
+        home_score: match?.home_score ?? null,
+        away_score: match?.away_score ?? null,
+        actual_result: match?.actual_result || null,
+        status: match?.status || null,
+        is_finished: match?.is_finished === true,
+        has_raw_match_data: match?.has_raw_match_data === true,
+    };
+}
+
+function buildDecisionPayload(checks) {
+    const directFixtureMatch =
+        checks.match_id_matches &&
+        checks.home_team_matches &&
+        checks.away_team_matches &&
+        checks.score_matches &&
+        checks.status_reasonable &&
+        checks.raw_data_constraint_ok;
+
+    return {
+        direct_fixture_match: directFixtureMatch,
+        fixture_can_be_used_for_target: directFixtureMatch,
+        synthetic_required: !directFixtureMatch,
+        would_insert_raw_match_data: false,
+        would_update_matches: false,
+        would_trigger_l3: false,
+    };
+}
+
+function buildPayload({ args, match, fixturePath, fixtureInfo, checks }) {
+    const targetMatch = buildTargetMatchPayload(match);
+    const decision = buildDecisionPayload(checks);
+    const warnings = buildWarnings(checks, fixtureInfo);
+
+    return {
+        mode: 'dry-run',
+        match_id: args.matchId,
+        fixture_path: args.fixture,
+        resolved_fixture_path: fixturePath,
+        target_match: targetMatch,
+        fixture: {
+            exists: true,
+            ...fixtureInfo,
+        },
+        matching_checks: checks,
+        decision,
+        would_insert_preview: {
+            target_table: 'raw_match_data',
+            match_id: args.matchId,
+            external_id: fixtureInfo.external_id,
+            data_version_candidate: decision.direct_fixture_match
+                ? 'PHASE4.41_REAL_LOCAL_FIXTURE_DRY_RUN_ONLY'
+                : 'not_available_for_mismatched_fixture',
+            data_hash_preview: fixtureInfo.raw_data_hash_preview,
+            would_insert_raw_match_data: false,
+        },
+        synthetic_preview: buildSyntheticPreview({ args, match }),
+        warnings,
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function formatText(payload) {
+    return [
+        `mode=${payload.mode}`,
+        `match_id=${payload.match_id}`,
+        `fixture_path=${payload.fixture_path}`,
+        `fixture.exists=${payload.fixture.exists}`,
+        `match_found=${payload.target_match.match_found}`,
+        `direct_fixture_match=${payload.decision.direct_fixture_match}`,
+        `fixture_can_be_used_for_target=${payload.decision.fixture_can_be_used_for_target}`,
+        `synthetic_required=${payload.decision.synthetic_required}`,
+        `would_insert_raw_match_data=${payload.decision.would_insert_raw_match_data}`,
+        `would_update_matches=${payload.decision.would_update_matches}`,
+        `would_trigger_l3=${payload.decision.would_trigger_l3}`,
+        '',
+        'target_match:',
+        JSON.stringify(payload.target_match, null, 2),
+        '',
+        'fixture:',
+        JSON.stringify(payload.fixture, null, 2),
+        '',
+        'matching_checks:',
+        JSON.stringify(payload.matching_checks, null, 2),
+        '',
+        'decision:',
+        JSON.stringify(payload.decision, null, 2),
+        '',
+        'would_insert_preview:',
+        JSON.stringify(payload.would_insert_preview, null, 2),
+        '',
+        'synthetic_preview:',
+        payload.synthetic_preview ? JSON.stringify(payload.synthetic_preview, null, 2) : '  null',
+        '',
+        'warnings:',
+        payload.warnings.length ? payload.warnings.map(value => `  ${value}`).join('\n') : '  none',
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ].join('\n');
+}
+
+async function loadMatch(pool, matchId) {
+    const sql = `
+        SELECT
+            m.match_id,
+            m.league_name,
+            m.season,
+            m.home_team,
+            m.away_team,
+            m.home_score,
+            m.away_score,
+            m.actual_result,
+            m.status,
+            m.is_finished,
+            EXISTS (SELECT 1 FROM raw_match_data r WHERE r.match_id = m.match_id) AS has_raw_match_data
+        FROM matches m
+        WHERE m.match_id = $1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error('BLOCKED: raw fixture adapter commit is not wired in Phase 4.41.');
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.matchId || !args.fixture) {
+        console.error('ERROR: provide --match-id <id> and --fixture <path>');
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const { resolved, data: fixture } = resolveFixture(args.fixture);
+    const fixtureInfo = extractFixtureInfo(fixture);
+    const pool = new Pool(buildDbConfig());
+
+    try {
+        const match = await loadMatch(pool, args.matchId);
+        if (!match) {
+            throw new Error(`Target match not found: ${args.matchId}`);
+        }
+        const checks = buildMatchChecks(match, fixtureInfo);
+        const payload = buildPayload({ args, match, fixturePath: resolved, fixtureInfo, checks });
+
+        console.log(args.json ? JSON.stringify(payload, null, 2) : formatText(payload));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a safe raw fixture adapter dry-run gate for finished-match backfill planning.

Changes:
- Adds scripts/ops/raw_fixture_adapter_dry_run.js
- Adds make data-raw-fixture-dry-run
- Adds blocked make data-raw-fixture-commit
- Updates data-help
- Updates AGENTS.md with raw fixture safety rules
- Adds Phase 4.41 report

Safety:
- SELECT-only DB checks
- Local fixture read-only checks
- No DB writes
- No raw ingest
- No file creation
- No L3/training/prediction writes
- No training
- No prediction execution
- No external data access
- Commit gate remains blocked

Validation:
- make data-raw-fixture-dry-run without args fails as expected
- mismatch fixture is detected and rejected for target match
- synthetic preview is clearly marked engineering-test-only / not real external data / not for training
- make data-raw-fixture-commit remains blocked with and without CONFIRM_RAW_FIXTURE_COMMIT=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/raw_fixture_adapter_dry_run.js
- docs/_reports/RAW_FIXTURE_ADAPTER_DRY_RUN_PHASE4_41.md