### PR TITLE
test(data): add synthetic raw fixture for finished match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,6 +394,26 @@ Phase 4.40 中 `make data-finished-backfill-commit`、`make data-finished-backfi
 
 Phase 4.41 中 `make data-raw-fixture-commit`、`make data-raw-fixture-commit CONFIRM_RAW_FIXTURE_COMMIT=1`、`node scripts/ops/raw_fixture_adapter_dry_run.js --commit` 和 `node scripts/ops/raw_match_data_local_ingest.js --commit` 仍是 blocked / not wired。raw fixture 必须与目标 `match_id`、teams、score、status 匹配；不匹配 fixture 不能冒充目标 match；synthetic fixture 只能用于 engineering test，不能用于真实训练；synthetic raw_data 不能标记为真实 external / FotMob data；任何 `raw_match_data` 写入前必须单独授权并完成 pg_dump。相关背景见：`docs/_reports/FINISHED_MATCH_BACKFILL_PREFLIGHT_PHASE4_40.md`、`docs/_reports/FINISHED_CSV_SINGLE_MATCH_INSERT_PHASE4_39.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
 
+AI / Codex 仅在用户明确授权时允许创建 synthetic raw fixture，且必须满足：
+
+- fixture 路径位于 `tests/fixtures/synthetic/`
+- 明确标记 `synthetic=true`
+- 明确标记 `engineering_test_only=true`
+- 明确标记 `not_real_external_data=true`
+- 明确标记 `not_for_training=true`
+- 明确标记 `not_for_production=true`
+- 只用于工程链路测试
+- 不写 DB
+- 不用于真实训练
+
+AI / Codex 禁止：
+
+- 把 synthetic fixture 标记为真实 external / FotMob / OddsPortal 数据
+- 用 synthetic fixture 训练模型
+- 用 synthetic fixture 写 production data
+- 在未授权时写 `raw_match_data`
+- 用不匹配 fixture 冒充目标比赛
+
 执行 `make data-l3-write-dry-run` 的前提：
 
 - 用户明确授权

--- a/docs/_reports/SYNTHETIC_RAW_FIXTURE_PHASE4_42.md
+++ b/docs/_reports/SYNTHETIC_RAW_FIXTURE_PHASE4_42.md
@@ -1,0 +1,343 @@
+# Phase 4.42 - Synthetic Raw Fixture For Finished Match
+
+## Current HEAD
+
+- Base HEAD: `78a95fed9d855813fe69295130617fcaa9f62215`
+- Working branch: `feat/synthetic-raw-fixture-phase442`
+- Phase 4.41 report present: `docs/_reports/RAW_FIXTURE_ADAPTER_DRY_RUN_PHASE4_41.md`
+- Phase 4.40 report present: `docs/_reports/FINISHED_MATCH_BACKFILL_PREFLIGHT_PHASE4_40.md`
+
+## Current DB Row Counts
+
+Row counts before and after Phase 4.42 validation remained unchanged:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+`make data-dataset-status` remains SELECT-only and reports:
+
+- `finished_matches = 1`
+- `matches_with_actual_result = 1`
+- `matches_with_scores = 1`
+- `trainable_label_rows = 1`
+- `full_feature_chain_rows = 1`
+- `trainable = false`
+- reason: current DB has only `1` trainable labeled row and `1` full feature-chain row; minimum pre-training discussion threshold is `200`
+
+## Target Finished Match
+
+Target:
+
+| field                 | value                    |
+| --------------------- | ------------------------ |
+| match_id              | `47_20242025_900002`     |
+| league_name           | `Segunda`                |
+| season                | `2024/2025`              |
+| home_team             | `Burgos`                 |
+| away_team             | `Oviedo`                 |
+| home_score            | `1`                      |
+| away_score            | `0`                      |
+| actual_result         | `home_win`               |
+| match_date            | `2024-08-17 17:30:00+00` |
+| status                | `finished`               |
+| is_finished           | `true`                   |
+| has_raw_match_data    | `false`                  |
+| has_l3_features       | `false`                  |
+| has_training_features | `false`                  |
+| has_predictions       | `false`                  |
+
+The match is a valid finished label row but still has no downstream raw/L3/training/prediction rows.
+
+## Synthetic Fixture
+
+Added:
+
+```text
+tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json
+```
+
+The fixture matches the target match shape:
+
+- `matchId = 47_20242025_900002`
+- home team: `Burgos`
+- away team: `Oviedo`
+- score: `1-0`
+- status: `finished`
+- includes `general`
+- includes `header`
+- includes `content`
+- includes minimal `stats`, `lineup`, `shotmap`, and `momentum`
+
+Synthetic metadata:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `source = phase4.42_synthetic_local_fixture`
+- `target_match_id = 47_20242025_900002`
+- provenance note explicitly says it is locally created synthetic data for engineering validation only
+
+This fixture does not claim to come from FotMob, OddsPortal, or any external provider.
+
+## Why This Is Synthetic Only
+
+This fixture was created locally to validate adapter and pipeline shape behavior after Phase 4.41 confirmed there is no direct raw fixture for Burgos vs Oviedo.
+
+It is not real match data because:
+
+- it was not downloaded from an external source
+- it was not harvested by the production pipeline
+- its stats, lineup, shotmap, and momentum are minimal test-shape placeholders
+- its metadata explicitly marks it synthetic and engineering-test-only
+
+It cannot be used for real training because:
+
+- synthetic values would contaminate model labels/features
+- it does not represent real event, lineup, odds, or feature data
+- Phase 4.35 and Phase 4.36 require real finished historical samples and feature timing proof before training
+- the dataset remains far below training threshold
+
+## Adapter Enhancement
+
+Updated `scripts/ops/raw_fixture_adapter_dry_run.js` to recognize `metadata.synthetic`.
+
+New synthetic behavior:
+
+- synthetic fixtures are always `preview_only=true`
+- synthetic fixtures do not become usable real raw fixtures
+- without `ALLOW_SYNTHETIC=1`, the adapter emits explicit warnings
+- with `ALLOW_SYNTHETIC=1`, the adapter emits preview-only synthetic metadata
+- `would_insert_raw_match_data=false` in all cases
+- `would_update_matches=false`
+- `would_trigger_l3=false`
+- `no_db_writes`
+- `no_file_create`
+
+Makefile already supported:
+
+```text
+make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path> ALLOW_SYNTHETIC=1
+```
+
+so no Makefile change was required.
+
+## AGENTS.md Update
+
+Updated safety rules to allow synthetic raw fixture creation only when:
+
+- user explicitly authorizes it
+- fixture path is under `tests/fixtures/synthetic/`
+- fixture marks `synthetic=true`
+- fixture marks `engineering_test_only=true`
+- fixture marks `not_real_external_data=true`
+- fixture marks `not_for_training=true`
+- fixture marks `not_for_production=true`
+- fixture is only for engineering-chain tests
+- no DB writes occur
+- fixture is not used for real training
+
+Added prohibitions:
+
+- do not mark synthetic fixture as real external / FotMob / OddsPortal data
+- do not train with synthetic fixture
+- do not write synthetic fixture as production data
+- do not write `raw_match_data` without separate authorization
+- do not use mismatched fixtures to impersonate target matches
+
+## Validation: Missing Args
+
+Command:
+
+```bash
+make data-raw-fixture-dry-run || true
+```
+
+Result:
+
+- failed as expected
+- message: `ERROR: provide MATCH_ID=<id> and FIXTURE=<path>`
+
+## Validation: Synthetic Fixture Without ALLOW_SYNTHETIC
+
+Command:
+
+```bash
+make data-raw-fixture-dry-run \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json || true
+```
+
+Result:
+
+- `match_found = true`
+- `fixture.exists = true`
+- `direct_fixture_match = true`
+- `fixture_can_be_used_for_target = false`
+- `synthetic = true`
+- `preview_only = true`
+- `synthetic_preview_allowed = false`
+- `would_insert_raw_match_data = false`
+- `would_update_matches = false`
+- `would_trigger_l3 = false`
+
+Warnings:
+
+- `synthetic_fixture_requires_explicit_ALLOW_SYNTHETIC_1`
+- `synthetic_fixture_not_for_training`
+
+Conclusion:
+
+- fixture identity matches target match
+- fixture is synthetic and cannot be used as real raw data without explicit synthetic preview authorization
+- no DB writes occurred
+
+## Validation: Synthetic Fixture With ALLOW_SYNTHETIC
+
+Command:
+
+```bash
+make data-raw-fixture-dry-run \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json \
+  ALLOW_SYNTHETIC=1
+```
+
+Result:
+
+- `match_found = true`
+- `fixture.exists = true`
+- `direct_fixture_match = true`
+- `fixture_can_be_used_for_target = false`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `preview_only = true`
+- `synthetic_preview_allowed = true`
+- `would_insert_raw_match_data = false`
+- `would_update_matches = false`
+- `would_trigger_l3 = false`
+- no warnings
+
+Non-execution confirmations included:
+
+- `no_db_writes`
+- `no_insert`
+- `no_update`
+- `no_delete`
+- `no_raw_ingest`
+- `no_l3_write`
+- `no_training`
+- `no_prediction_execution`
+- `no_model_artifact_load`
+- `no_external_network`
+- `no_file_create`
+
+## Validation: Mismatch Fixture Still Rejected
+
+Command:
+
+```bash
+make data-raw-fixture-dry-run \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/match_success.json || true
+```
+
+Result:
+
+- fixture identity: `55_20242025_4803413`
+- fixture teams: Chelsea vs Arsenal
+- fixture score: `2-0`
+- target teams: Burgos vs Oviedo
+- target score: `1-0`
+- `direct_fixture_match = false`
+- `fixture_can_be_used_for_target = false`
+- `would_insert_raw_match_data = false`
+
+Warnings:
+
+- `fixture_mismatch:match_id`
+- `fixture_mismatch:home_team`
+- `fixture_mismatch:away_team`
+- `fixture_mismatch:score`
+- `cannot_use_this_fixture_as_raw_data_for_target_match`
+- `do_not_impersonate_another_match`
+
+## Commit Gate Validation
+
+Commands:
+
+```bash
+make data-raw-fixture-commit || true
+make data-raw-fixture-commit \
+  MATCH_ID=47_20242025_900002 \
+  FIXTURE=tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json \
+  CONFIRM_RAW_FIXTURE_COMMIT=1 || true
+```
+
+Results:
+
+- both commands were blocked
+- commit remains not wired
+- no DB writes occurred
+- no extra files were created
+
+## Next Step
+
+Recommended Phase 4.43 options:
+
+- manually authorize one synthetic `raw_match_data` insert for engineering-chain validation only
+- continue searching for a legal real raw fixture source before any real-data backfill
+
+Any real DB write must be separately authorized, preceded by pg_dump, and must remain scoped to one table and one match.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `COPY / \copy`
+- DB writes
+- raw_match_data write
+- raw ingest
+- l3_features write
+- match_features_training write
+- predictions write
+- L3 stitch
+- smelt
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push --force`
+- `git push --mirror`
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/raw_fixture_adapter_dry_run.js
+++ b/scripts/ops/raw_fixture_adapter_dry_run.js
@@ -202,12 +202,45 @@ function extractScore(rawData) {
 function extractStatus(rawData) {
     return pickFirst([
         rawData?.general?.status,
+        rawData?.general?.finished,
         rawData?.header?.status?.reason?.shortKey,
         rawData?.header?.status?.reason?.short,
+        rawData?.header?.status?.short,
         rawData?.header?.status?.finished,
         rawData?.data?.match?.status?.status,
         rawData?.data?.match?.status?.finished,
     ]);
+}
+
+function hasSyntheticMetadata(fixture, rawData) {
+    return (
+        fixture?.metadata?.synthetic === true ||
+        rawData?.metadata?.synthetic === true ||
+        fixture?.synthetic === true ||
+        rawData?.synthetic === true
+    );
+}
+
+function buildSyntheticMetadata(fixture, rawData) {
+    const metadata = asObject(fixture?.metadata || rawData?.metadata);
+    const synthetic = hasSyntheticMetadata(fixture, rawData);
+
+    return {
+        synthetic,
+        engineering_test_only: metadata.engineering_test_only === true,
+        not_real_external_data: metadata.not_real_external_data === true,
+        not_for_training: metadata.not_for_training === true,
+        not_for_production: metadata.not_for_production === true,
+        source: metadata.source || null,
+        target_match_id: metadata.target_match_id || null,
+        provenance_note: metadata.provenance_note || null,
+        synthetic_safety_complete:
+            synthetic &&
+            metadata.engineering_test_only === true &&
+            metadata.not_real_external_data === true &&
+            metadata.not_for_training === true &&
+            metadata.not_for_production === true,
+    };
 }
 
 function extractFixtureInfo(fixture) {
@@ -261,6 +294,7 @@ function extractFixtureInfo(fixture) {
         raw_data_not_empty: Object.keys(asObject(rawData)).length > 0,
         raw_data_hash_preview: sha256(stableStringify(rawData)),
         raw_data_top_level_keys: Object.keys(asObject(rawData)).sort(),
+        synthetic_metadata: buildSyntheticMetadata(fixture, rawData),
     };
 }
 
@@ -278,12 +312,17 @@ function buildMatchChecks(match, fixtureInfo) {
 
 function buildWarnings(checks, fixtureInfo) {
     const warnings = [];
+    const syntheticMetadata = fixtureInfo.synthetic_metadata;
+
     if (!checks.match_id_matches) warnings.push('fixture_mismatch:match_id');
     if (!checks.home_team_matches) warnings.push('fixture_mismatch:home_team');
     if (!checks.away_team_matches) warnings.push('fixture_mismatch:away_team');
     if (!checks.score_matches) warnings.push('fixture_mismatch:score');
     if (!checks.status_reasonable) warnings.push('fixture_status_not_finished_or_unknown');
     if (!checks.raw_data_constraint_ok) warnings.push('fixture_raw_data_constraint_not_satisfied');
+    if (syntheticMetadata.synthetic && !syntheticMetadata.synthetic_safety_complete) {
+        warnings.push('synthetic_fixture_missing_required_safety_metadata');
+    }
     if (!checks.match_id_matches || !checks.home_team_matches || !checks.away_team_matches || !checks.score_matches) {
         warnings.push('cannot_use_this_fixture_as_raw_data_for_target_match');
         warnings.push('do_not_impersonate_another_match');
@@ -292,14 +331,41 @@ function buildWarnings(checks, fixtureInfo) {
     return warnings;
 }
 
-function buildSyntheticPreview({ args, match }) {
-    if (!args.allowSynthetic) return null;
+function buildSyntheticPreview({ args, match, fixtureInfo }) {
+    const syntheticMetadata = fixtureInfo.synthetic_metadata;
+    if (!args.allowSynthetic && !syntheticMetadata.synthetic) return null;
+
+    if (syntheticMetadata.synthetic) {
+        return {
+            synthetic: true,
+            synthetic_preview_only: true,
+            preview_only: true,
+            allow_synthetic: args.allowSynthetic,
+            synthetic_requires_allow_synthetic: !args.allowSynthetic,
+            engineering_test_only: syntheticMetadata.engineering_test_only,
+            not_real_external_data: syntheticMetadata.not_real_external_data,
+            not_for_training: syntheticMetadata.not_for_training,
+            not_for_production: syntheticMetadata.not_for_production,
+            not_production_data: syntheticMetadata.not_for_production,
+            would_create_fixture_file: false,
+            would_insert_raw_match_data: false,
+            provenance: {
+                source: syntheticMetadata.source,
+                target_match_id: syntheticMetadata.target_match_id,
+                provenance_note: syntheticMetadata.provenance_note,
+            },
+        };
+    }
+
     return {
         synthetic: true,
         synthetic_preview_only: true,
+        preview_only: true,
+        allow_synthetic: args.allowSynthetic,
         engineering_test_only: true,
         not_real_external_data: true,
         not_for_training: true,
+        not_for_production: true,
         not_production_data: true,
         would_create_fixture_file: false,
         would_insert_raw_match_data: false,
@@ -367,7 +433,7 @@ function buildTargetMatchPayload(match) {
     };
 }
 
-function buildDecisionPayload(checks) {
+function buildDecisionPayload(checks, fixtureInfo, args) {
     const directFixtureMatch =
         checks.match_id_matches &&
         checks.home_team_matches &&
@@ -375,10 +441,17 @@ function buildDecisionPayload(checks) {
         checks.score_matches &&
         checks.status_reasonable &&
         checks.raw_data_constraint_ok;
+    const synthetic = fixtureInfo.synthetic_metadata.synthetic;
+    const syntheticSafetyComplete = fixtureInfo.synthetic_metadata.synthetic_safety_complete;
+    const syntheticPreviewAllowed = synthetic && args.allowSynthetic && syntheticSafetyComplete;
+    const fixtureCanBeUsedForTarget = directFixtureMatch && !synthetic;
 
     return {
         direct_fixture_match: directFixtureMatch,
-        fixture_can_be_used_for_target: directFixtureMatch,
+        fixture_can_be_used_for_target: fixtureCanBeUsedForTarget,
+        synthetic_fixture: synthetic,
+        synthetic_preview_allowed: syntheticPreviewAllowed,
+        preview_only: synthetic,
         synthetic_required: !directFixtureMatch,
         would_insert_raw_match_data: false,
         would_update_matches: false,
@@ -388,8 +461,12 @@ function buildDecisionPayload(checks) {
 
 function buildPayload({ args, match, fixturePath, fixtureInfo, checks }) {
     const targetMatch = buildTargetMatchPayload(match);
-    const decision = buildDecisionPayload(checks);
+    const decision = buildDecisionPayload(checks, fixtureInfo, args);
     const warnings = buildWarnings(checks, fixtureInfo);
+    if (fixtureInfo.synthetic_metadata.synthetic && !args.allowSynthetic) {
+        warnings.push('synthetic_fixture_requires_explicit_ALLOW_SYNTHETIC_1');
+        warnings.push('synthetic_fixture_not_for_training');
+    }
 
     return {
         mode: 'dry-run',
@@ -407,13 +484,15 @@ function buildPayload({ args, match, fixturePath, fixtureInfo, checks }) {
             target_table: 'raw_match_data',
             match_id: args.matchId,
             external_id: fixtureInfo.external_id,
-            data_version_candidate: decision.direct_fixture_match
+            data_version_candidate: decision.fixture_can_be_used_for_target
                 ? 'PHASE4.41_REAL_LOCAL_FIXTURE_DRY_RUN_ONLY'
-                : 'not_available_for_mismatched_fixture',
+                : decision.synthetic_fixture
+                  ? 'PHASE4.42_SYNTHETIC_PREVIEW_ONLY'
+                  : 'not_available_for_mismatched_fixture',
             data_hash_preview: fixtureInfo.raw_data_hash_preview,
             would_insert_raw_match_data: false,
         },
-        synthetic_preview: buildSyntheticPreview({ args, match }),
+        synthetic_preview: buildSyntheticPreview({ args, match, fixtureInfo }),
         warnings,
         non_execution_confirmations: buildNonExecutionConfirmations(),
     };
@@ -428,6 +507,8 @@ function formatText(payload) {
         `match_found=${payload.target_match.match_found}`,
         `direct_fixture_match=${payload.decision.direct_fixture_match}`,
         `fixture_can_be_used_for_target=${payload.decision.fixture_can_be_used_for_target}`,
+        `synthetic=${payload.decision.synthetic_fixture}`,
+        `preview_only=${payload.decision.preview_only}`,
         `synthetic_required=${payload.decision.synthetic_required}`,
         `would_insert_raw_match_data=${payload.decision.would_insert_raw_match_data}`,
         `would_update_matches=${payload.decision.would_update_matches}`,

--- a/tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json
+++ b/tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json
@@ -1,0 +1,90 @@
+{
+    "metadata": {
+        "synthetic": true,
+        "engineering_test_only": true,
+        "not_real_external_data": true,
+        "not_for_training": true,
+        "not_for_production": true,
+        "source": "phase4.42_synthetic_local_fixture",
+        "target_match_id": "47_20242025_900002",
+        "created_for": "raw_fixture_adapter_dry_run_and_pipeline_shape_testing",
+        "provenance_note": "Synthetic fixture created locally for engineering validation only. Do not use as real match data or model training data."
+    },
+    "matchId": "47_20242025_900002",
+    "general": {
+        "matchId": "47_20242025_900002",
+        "leagueName": "Segunda",
+        "season": "2024/2025",
+        "homeTeam": {
+            "name": "Burgos"
+        },
+        "awayTeam": {
+            "name": "Oviedo"
+        },
+        "status": "finished",
+        "matchDate": "2024-08-17T17:30:00Z",
+        "score": {
+            "home": 1,
+            "away": 0
+        }
+    },
+    "header": {
+        "teams": [
+            {
+                "name": "Burgos",
+                "score": 1
+            },
+            {
+                "name": "Oviedo",
+                "score": 0
+            }
+        ],
+        "status": {
+            "finished": true,
+            "short": "FT",
+            "long": "Full time",
+            "scoreStr": "1-0"
+        }
+    },
+    "content": {
+        "stats": {
+            "synthetic": true,
+            "items": [
+                {
+                    "title": "Possession",
+                    "home": "51%",
+                    "away": "49%"
+                },
+                {
+                    "title": "Shots",
+                    "home": 8,
+                    "away": 7
+                },
+                {
+                    "title": "Shots on target",
+                    "home": 3,
+                    "away": 2
+                }
+            ]
+        },
+        "lineup": {
+            "synthetic": true,
+            "homeTeam": {
+                "name": "Burgos",
+                "players": []
+            },
+            "awayTeam": {
+                "name": "Oviedo",
+                "players": []
+            }
+        },
+        "shotmap": {
+            "synthetic": true,
+            "shots": []
+        },
+        "momentum": {
+            "synthetic": true,
+            "data": []
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a synthetic local raw fixture for the finished CSV match and validates it through the raw fixture adapter dry-run gate.

Changes:
- Adds tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json
- Adds Phase 4.42 report
- Updates AGENTS.md with synthetic raw fixture safety rules
- Optionally strengthens raw fixture adapter / Makefile synthetic handling if needed

Safety:
- Synthetic fixture is clearly marked engineering-test-only
- Synthetic fixture is not real external data
- Synthetic fixture is not for training or production
- No DB writes
- No raw ingest
- No L3/training/prediction writes
- No training
- No prediction execution
- No external data access
- Commit gates remain blocked

Validation:
- synthetic fixture without ALLOW_SYNTHETIC=1 is rejected/warned appropriately
- synthetic fixture with ALLOW_SYNTHETIC=1 previews only
- mismatch fixture remains rejected
- data-raw-fixture-commit remains blocked with and without CONFIRM_RAW_FIXTURE_COMMIT=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed