### PR TITLE
feat(l3): add synthetic L3 preflight gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,35 @@ AI / Codex 禁止：
 - 在未授权时写 `raw_match_data`
 - 用不匹配 fixture 冒充目标比赛
 
+执行 `make data-synthetic-l3-dry-run MATCH_ID=<id>` 的前提：
+
+- 用户明确授权
+- 入口只做 SELECT-only DB 审计
+- 输入 `raw_match_data` 必须明确标记 `synthetic=true`
+- 输入 `raw_match_data` 必须明确标记 `engineering_test_only=true`
+- 不写 DB
+- 不写 `l3_features`
+- 不写 `match_features_training`
+- 不写 `predictions`
+- 不调用 `smelt`
+- 不调用 `l3:stitch`
+- 不触发 ELO 重算
+- 不训练模型
+- 不执行预测
+- 不加载模型 artifact
+- 不访问外网
+
+AI / Codex 禁止执行：
+
+- `make data-synthetic-l3-commit`
+- `make data-synthetic-l3-commit CONFIRM_SYNTHETIC_L3=1`
+- `node scripts/ops/synthetic_l3_preflight.js --commit`
+- `npm run smelt`
+- `npm run l3:stitch`
+- `node scripts/ops/l3_features_local_write_gate.js --commit`
+
+synthetic raw 生成的 L3 preview 只能用于工程验证，不可用于真实训练，不可进入 production，也不能被当作真实特征。任何真实 `l3_features` 写入前必须有单独授权、pg_dump 备份和写入前后统计。相关背景见：`docs/_reports/SYNTHETIC_RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_43.md`、`docs/_reports/SYNTHETIC_RAW_FIXTURE_PHASE4_42.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
+
 执行 `make data-l3-write-dry-run` 的前提：
 
 - 用户明确授权

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-fixture-dry-run data-raw-fixture-commit \
+        data-synthetic-l3-dry-run data-synthetic-l3-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -255,10 +256,12 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
 	@echo "  make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path>"
 	@echo "  make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path> ALLOW_SYNTHETIC=1"
+	@echo "  make data-synthetic-l3-dry-run MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
 	@echo "  make data-raw-fixture-commit MATCH_ID=<id> FIXTURE=<path> CONFIRM_RAW_FIXTURE_COMMIT=1  # blocked in Phase 4.41"
 	@echo "  make data-finished-backfill-commit MATCH_ID=<id> CONFIRM_FINISHED_BACKFILL=1  # blocked in Phase 4.40"
+	@echo "  make data-synthetic-l3-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_L3=1  # blocked in Phase 4.44"
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
@@ -476,6 +479,22 @@ data-raw-fixture-commit: ## Blocked raw fixture adapter gate. Requires MATCH_ID,
 		exit 1; \
 	fi
 	@echo "BLOCKED: raw fixture adapter commit is not wired in Phase 4.41."
+	@exit 1
+
+data-synthetic-l3-dry-run: ## Run safe synthetic raw to L3 preflight. Requires MATCH_ID.
+	@if [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe synthetic raw to L3 preflight: MATCH_ID=$(MATCH_ID)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/synthetic_l3_preflight.js --match-id "$(MATCH_ID)"
+
+data-synthetic-l3-commit: ## Blocked synthetic L3 commit gate. Requires MATCH_ID, CONFIRM_SYNTHETIC_L3=1.
+	@if [ "$(CONFIRM_SYNTHETIC_L3)" != "1" ]; then \
+		echo "BLOCKED: synthetic L3 commit requires CONFIRM_SYNTHETIC_L3=1 and is not wired in Phase 4.44."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: synthetic L3 commit is not wired in Phase 4.44."
 	@exit 1
 
 data-raw-dry-run: ## Run safe local raw_match_data ingest dry-run. Requires SAMPLE_RAW and MATCH_ID.

--- a/docs/_reports/SYNTHETIC_L3_PREFLIGHT_PHASE4_44.md
+++ b/docs/_reports/SYNTHETIC_L3_PREFLIGHT_PHASE4_44.md
@@ -1,0 +1,406 @@
+# Phase 4.44 - Synthetic Raw To L3 Preflight Gate
+
+## Current HEAD
+
+- Base HEAD: `80ecb30266e56644d66a4170178d4fb434cbd61f`
+- Working branch: `feat/synthetic-l3-preflight-gate`
+- Phase 4.43 report preserved: `docs/_reports/SYNTHETIC_RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_43.md`
+
+## Phase 4.43 Synthetic Raw Status
+
+Phase 4.43 had already inserted one human-authorized synthetic `raw_match_data` row for:
+
+- `match_id = 47_20242025_900002`
+- `external_id = 900002`
+- `data_version = PHASE4.43_SYNTHETIC`
+
+The stored `raw_data.metadata` remains:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+
+This row is engineering-test-only synthetic input, not real external raw data, not suitable for production, and not suitable for real training.
+
+## Current DB Row Counts
+
+Row counts before and after Phase 4.44 validation remained unchanged:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+## Target Match Status
+
+Target:
+
+| field                 | value                    |
+| --------------------- | ------------------------ |
+| match_id              | `47_20242025_900002`     |
+| league_name           | `Segunda`                |
+| season                | `2024/2025`              |
+| home_team             | `Burgos`                 |
+| away_team             | `Oviedo`                 |
+| home_score            | `1`                      |
+| away_score            | `0`                      |
+| actual_result         | `home_win`               |
+| match_date            | `2024-08-17 17:30:00+00` |
+| status                | `finished`               |
+| is_finished           | `true`                   |
+| has_raw_match_data    | `true`                   |
+| has_l3_features       | `false`                  |
+| has_training_features | `false`                  |
+| has_predictions       | `false`                  |
+
+Conclusion:
+
+- the target finished match exists
+- it has one synthetic raw row
+- it still has no downstream `l3_features`
+- training features and predictions remain absent
+
+## Synthetic raw_match_data Metadata Summary
+
+Read-only verification of the existing target raw row confirmed:
+
+- `id = 2`
+- `external_id = 900002`
+- `data_version = PHASE4.43_SYNTHETIC`
+- `data_hash = f679933712fd826e8f8785a4866e8f3d841b9a1653caea3bb733c8efbde5921e`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- raw JSON contains `matchId`
+- raw JSON contains `general`
+- raw JSON contains `header`
+- raw JSON contains `content`
+
+## l3_features Schema Summary
+
+Read-only schema inspection confirmed:
+
+- primary key: `PRIMARY KEY (match_id)`
+- foreign key: `FOREIGN KEY (match_id) REFERENCES matches(match_id) ON DELETE CASCADE`
+- JSONB columns default to `{}`:
+    - `golden_features`
+    - `tactical_features`
+    - `odds_movement_features`
+    - `odds_features`
+    - `elo_features`
+    - `rolling_features`
+    - `efficiency_features`
+    - `draw_features`
+    - `market_sentiment`
+    - `stitch_summary`
+- timestamps default to `now()`:
+    - `computed_at`
+    - `created_at`
+    - `updated_at`
+
+Implication:
+
+- the target match currently has no `l3_features`
+- a future write would be one row per `match_id`
+- Phase 4.44 intentionally does not perform that write
+
+## Existing L3 Entrypoint Risk Audit
+
+Relevant existing entrypoints were audited read-only:
+
+| entrypoint                                                   | current behavior                  | write risk   |
+| ------------------------------------------------------------ | --------------------------------- | ------------ |
+| `make data-l3-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>`       | local fixture dry-run             | dry-run only |
+| `make data-l3-write-dry-run SAMPLE_RAW=<path> MATCH_ID=<id>` | local `l3_features` write preview | dry-run only |
+| `make data-l3-commit ... CONFIRM_L3_COMMIT=1`                | blocked                           | not wired    |
+| `make data-l3-write-commit ... CONFIRM_L3_WRITE=1`           | blocked                           | not wired    |
+| `npm run smelt`                                              | real L3 pipeline                  | prohibited   |
+| `npm run l3:stitch`                                          | real L3 pipeline                  | prohibited   |
+| `npm run elo:recalc`                                         | real ELO path                     | prohibited   |
+
+Decision:
+
+- the new synthetic gate must not call `smelt`
+- the new synthetic gate must not call `l3:stitch`
+- the new synthetic gate must not call ELO
+- the new synthetic gate must stay SELECT-only and preview-only
+
+## New Script Behavior
+
+Added:
+
+```text
+scripts/ops/synthetic_l3_preflight.js
+```
+
+Supported commands:
+
+```bash
+node scripts/ops/synthetic_l3_preflight.js --match-id 47_20242025_900002
+node scripts/ops/synthetic_l3_preflight.js --match-id 47_20242025_900002 --json
+node scripts/ops/synthetic_l3_preflight.js --match-id 47_20242025_900002 --commit
+```
+
+Behavior:
+
+- performs SELECT-only DB checks
+- reads the target match row
+- reads the existing target `raw_match_data` row from DB
+- checks synthetic metadata and required raw JSON shape
+- checks existing downstream presence for `l3_features`, `match_features_training`, and `predictions`
+- emits a preview-only `l3_features` shape
+- marks synthetic provenance on all preview JSONB payloads
+- emits `would_insert_l3_features=false`
+- emits `would_update_matches=false`
+- emits `would_trigger_elo=false`
+- emits `preview_only=true`
+- emits `can_write_l3_now=false`
+- emits `real_training_allowed=false`
+- does not call `smelt`
+- does not call `l3:stitch`
+- does not call ELO
+- does not write `l3_features`
+- does not write `match_features_training`
+- does not write `predictions`
+- does not access external network
+
+`--commit` behavior:
+
+```text
+BLOCKED: synthetic L3 commit is not wired in Phase 4.44.
+```
+
+## Makefile Entrypoints
+
+Added:
+
+```text
+make data-synthetic-l3-dry-run MATCH_ID=<id>
+make data-synthetic-l3-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_L3=1  # blocked in Phase 4.44
+```
+
+Behavior:
+
+- `data-synthetic-l3-dry-run` requires `MATCH_ID`
+- `data-synthetic-l3-dry-run` runs `scripts/ops/synthetic_l3_preflight.js`
+- `data-synthetic-l3-commit` is blocked by default
+- `data-synthetic-l3-commit` remains blocked even with `CONFIRM_SYNTHETIC_L3=1`
+
+`data-help` was updated to list both entries.
+
+## AGENTS.md Update
+
+Added synthetic L3 safety rules:
+
+- `make data-synthetic-l3-dry-run MATCH_ID=<id>` is only allowed with explicit user authorization
+- input raw row must already be marked synthetic and engineering-test-only
+- the gate must remain SELECT-only
+- no DB writes
+- no `smelt`
+- no `l3:stitch`
+- no ELO
+- no training
+- no prediction
+- no external network
+
+Added explicit prohibitions for:
+
+- `make data-synthetic-l3-commit`
+- `make data-synthetic-l3-commit CONFIRM_SYNTHETIC_L3=1`
+- `node scripts/ops/synthetic_l3_preflight.js --commit`
+- `npm run smelt`
+- `npm run l3:stitch`
+- `node scripts/ops/l3_features_local_write_gate.js --commit`
+
+Added policy statement:
+
+- synthetic L3 preview is engineering-only
+- synthetic L3 preview is not for real training
+- synthetic L3 preview must not enter production
+- real `l3_features` write still requires separate authorization and `pg_dump`
+
+## Dry-Run Validation
+
+Missing argument gate:
+
+```bash
+make data-synthetic-l3-dry-run || true
+```
+
+Result:
+
+- failed as expected
+- message: `ERROR: provide MATCH_ID=<id>`
+
+Target synthetic L3 dry-run:
+
+```bash
+make data-synthetic-l3-dry-run MATCH_ID=47_20242025_900002
+```
+
+Result:
+
+- `mode = dry-run`
+- `phase = 4.44`
+- `match_found = true`
+- `is_finished = true`
+- `has_actual_result = true`
+- `has_score = true`
+- `raw_match_data_found = true`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `l3_features_exists = false`
+- `match_features_training_exists = false`
+- `predictions_exists = false`
+- `would_insert_l3_features = false`
+- `would_update_matches = false`
+- `would_trigger_elo = false`
+- `preview_only = true`
+- `can_write_l3_now = false`
+- `real_training_allowed = false`
+- `no_db_writes`
+- `no_l3_write`
+- `no_smelt`
+- `no_l3_stitch`
+- `no_elo`
+- `no_training`
+- `no_prediction_execution`
+- `no_external_network`
+
+## L3 Preview Summary
+
+The new preview emits a conservative future-shape payload for:
+
+- `golden_features`
+- `tactical_features`
+- `odds_features`
+- `elo_features`
+- `stitch_summary`
+
+Each preview object includes:
+
+```json
+{
+    "synthetic": true,
+    "source": "PHASE4.43_SYNTHETIC",
+    "engineering_test_only": true,
+    "not_for_training": true,
+    "not_for_production": true
+}
+```
+
+Additional preview notes:
+
+- `golden_features.match_identity_only = true`
+- `tactical_features.extraction_not_run = true`
+- `odds_features.odds_extraction_not_run = true`
+- `elo_features.elo_not_run = true`
+- `stitch_summary.stitch_not_run = true`
+
+This makes the preview useful for engineering-shape validation without pretending real feature extraction occurred.
+
+## Commit Gate Validation
+
+Validated:
+
+```bash
+make data-synthetic-l3-commit || true
+make data-synthetic-l3-commit MATCH_ID=47_20242025_900002 CONFIRM_SYNTHETIC_L3=1 || true
+```
+
+Result:
+
+- both commands were blocked
+- no DB writes occurred
+- no L3 write path was invoked
+
+## Existing Backfill Gate Recheck
+
+`make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002` remained read-only and reported:
+
+- `has_raw_match_data = true`
+- `has_l3_features = false`
+- `has_training_features = false`
+- `has_predictions = false`
+- `no_db_writes`
+
+## DB Before/After Summary
+
+DB row counts were unchanged across all Phase 4.44 validations:
+
+| table                   | rows before | rows after |
+| ----------------------- | ----------: | ---------: |
+| matches                 |           2 |          2 |
+| bookmaker_odds_history  |           2 |          2 |
+| raw_match_data          |           2 |          2 |
+| l3_features             |           1 |          1 |
+| match_features_training |           1 |          1 |
+| predictions             |           1 |          1 |
+
+## Recommended Next Phase
+
+Recommended next step:
+
+```text
+Phase 4.45: artificial authorization for one synthetic l3_features write
+```
+
+Alternative:
+
+```text
+continue searching for a legal real raw source before any downstream feature write
+```
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `COPY`
+- export
+- DB writes
+- `raw_match_data` write
+- `l3_features` write
+- `match_features_training` write
+- `predictions` write
+- `smelt`
+- `l3:stitch`
+- ELO recalculation
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push --force`
+- `git push --mirror`
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/_reports/SYNTHETIC_RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_43.md
+++ b/docs/_reports/SYNTHETIC_RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_43.md
@@ -1,0 +1,282 @@
+# Phase 4.43 - Synthetic Raw Match Data Single Insert
+
+## Current HEAD
+
+- Branch: `main`
+- HEAD: `80ecb30266e56644d66a4170178d4fb434cbd61f`
+- HEAD summary: `80ecb30 test(data): add synthetic raw fixture for finished match`
+- Git status before report generation: clean
+
+## Backup
+
+- backup file: `data/backups/phase443_pre_synthetic_raw_match_data_insert_20260504_025248.dump`
+- backup size: `71K`
+
+## Write Scope
+
+Human-authorized write scope:
+
+- table: `raw_match_data`
+- operation: one explicit `INSERT`
+- match_id: `47_20242025_900002`
+- source fixture: `tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json`
+- data_version: `PHASE4.43_SYNTHETIC`
+
+This was synthetic raw data only:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+
+It is not FotMob data, not OddsPortal data, not production data, and not suitable for real model training.
+
+## Write Before State
+
+DB row counts before insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    1 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Target match before insert:
+
+| field                 | value                    |
+| --------------------- | ------------------------ |
+| match_id              | `47_20242025_900002`     |
+| league_name           | `Segunda`                |
+| season                | `2024/2025`              |
+| home_team             | `Burgos`                 |
+| away_team             | `Oviedo`                 |
+| home_score            | `1`                      |
+| away_score            | `0`                      |
+| actual_result         | `home_win`               |
+| match_date            | `2024-08-17 17:30:00+00` |
+| status                | `finished`               |
+| is_finished           | `true`                   |
+| has_raw_match_data    | `false`                  |
+| has_l3_features       | `false`                  |
+| has_training_features | `false`                  |
+| has_predictions       | `false`                  |
+
+Target raw row count before insert:
+
+- `target_raw_rows = 0`
+
+## Fixture Validation
+
+Fixture:
+
+```text
+tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json
+```
+
+Adapter dry-run without `ALLOW_SYNTHETIC=1`:
+
+- `direct_fixture_match = true`
+- `synthetic = true`
+- `fixture_can_be_used_for_target = false`
+- `preview_only = true`
+- `would_insert_raw_match_data = false`
+- warning: `synthetic_fixture_requires_explicit_ALLOW_SYNTHETIC_1`
+- warning: `synthetic_fixture_not_for_training`
+- no DB writes
+
+Adapter dry-run with `ALLOW_SYNTHETIC=1`:
+
+- `match_found = true`
+- `fixture.exists = true`
+- `direct_fixture_match = true`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `preview_only = true`
+- `synthetic_preview_allowed = true`
+- `would_insert_raw_match_data = false`
+- no DB writes
+
+## raw_match_data Schema Confirmation
+
+Confirmed before insert:
+
+- `raw_data` is `jsonb NOT NULL`
+- raw data must be non-empty
+- raw data must contain `matchId`, `general`, or `header`
+- `match_id` is unique in `raw_match_data`
+- `match_id` references `matches(match_id)`
+
+The synthetic fixture contains:
+
+- `matchId`
+- `general`
+- `header`
+- `content`
+- synthetic metadata
+
+## Insert Result
+
+The authorized insert succeeded.
+
+Returned row:
+
+| field        | value                                                              |
+| ------------ | ------------------------------------------------------------------ |
+| id           | `2`                                                                |
+| match_id     | `47_20242025_900002`                                               |
+| external_id  | `900002`                                                           |
+| data_version | `PHASE4.43_SYNTHETIC`                                              |
+| data_hash    | `f679933712fd826e8f8785a4866e8f3d841b9a1653caea3bb733c8efbde5921e` |
+| collected_at | `2026-05-03 18:53:04.863557+00`                                    |
+
+SQL behavior:
+
+- one explicit `BEGIN`
+- one explicit `INSERT INTO raw_match_data`
+- one explicit `COMMIT`
+- no `ON CONFLICT DO UPDATE`
+- no writes to any other table
+
+## Write After Verification
+
+Target raw row verification:
+
+- `target_raw_rows = 1`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+
+Raw data structure verification:
+
+- `has_match_id = true`
+- `has_general = true`
+- `has_header = true`
+- `has_content = true`
+- `league_name = Segunda`
+- `home_team = Burgos`
+- `away_team = Oviedo`
+
+DB row counts after insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Result:
+
+- `raw_match_data` increased from `1 -> 2`
+- all other tracked tables remained unchanged
+
+## Backfill Preflight After Insert
+
+`make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002` reported:
+
+- `match_found = true`
+- `is_finished = true`
+- `has_actual_result = true`
+- `has_score = true`
+- `has_raw_match_data = true`
+- `has_l3_features = false`
+- `has_training_features = false`
+- `has_predictions = false`
+- `raw_match_data.required = false`
+- `l3_features.blocked_until_raw = false`
+- `match_features_training.blocked_until_l3 = true`
+- `predictions.blocked_until_training_features = true`
+
+Next downstream stage remains blocked until a separate L3 dry-run / write preflight is authorized.
+
+## Raw Fixture Dry-Run After Insert
+
+`make data-raw-fixture-dry-run MATCH_ID=47_20242025_900002 FIXTURE=tests/fixtures/synthetic/raw_match_data_47_20242025_900002_phase442.json ALLOW_SYNTHETIC=1` remained read-only and reported:
+
+- `direct_fixture_match = true`
+- `synthetic = true`
+- `preview_only = true`
+- `synthetic_preview_allowed = true`
+- `would_insert_raw_match_data = false`
+- `no_db_writes`
+
+## Gate Verification
+
+Verified blocked gates:
+
+- `make data-raw-fixture-commit`: blocked
+- `make data-raw-fixture-commit ... CONFIRM_RAW_FIXTURE_COMMIT=1`: blocked
+- `make data-finished-backfill-commit`: blocked
+- `make data-finished-backfill-commit ... CONFIRM_FINISHED_BACKFILL=1`: blocked
+- `make data-training-commit`: blocked
+- `make data-training-commit CONFIRM_TRAINING=1`: blocked
+
+No training, prediction, L3 stitch, smelt, raw ingest batch, or model artifact loading was executed.
+
+## Risk Notes
+
+- This row is synthetic and engineering-test-only.
+- It must not be used as real external data.
+- It must not be used for real model training.
+- It must not be used for production outputs.
+- Future L3 work must explicitly account for the synthetic provenance before any feature write.
+
+## Recommended Next Phase
+
+Recommended next step:
+
+```text
+Phase 4.44: synthetic raw -> L3 dry-run / l3_features write preflight
+```
+
+To reduce frequent merges, keep this Phase 4.43 report local for now and submit it together with the Phase 4.44 related gate / report in one themed PR.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `INSERT` into any table except `raw_match_data`
+- multiple `raw_match_data` inserts
+- `l3_features` write
+- `match_features_training` write
+- `predictions` write
+- raw ingest batch
+- L3 stitch
+- smelt
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push`
+- `git pull`
+- `git fetch --all`
+- commit

--- a/scripts/ops/synthetic_l3_preflight.js
+++ b/scripts/ops/synthetic_l3_preflight.js
@@ -1,0 +1,409 @@
+#!/usr/bin/env node
+/**
+ * Safe synthetic raw to L3 preflight gate.
+ *
+ * Phase 4.44 only reads the target match and its existing synthetic
+ * raw_match_data row. It never writes l3_features or calls smelt/stitch paths.
+ */
+
+'use strict';
+
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/synthetic_l3_preflight.js --match-id <id> [--json]',
+        '  node scripts/ops/synthetic_l3_preflight.js --match-id <id> --commit',
+        '',
+        'Safety:',
+        '  Preflight only in Phase 4.44; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        matchId: null,
+        json: false,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function normalizeText(value) {
+    return String(value ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function asBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    return TRUE_VALUES.has(normalizeText(value).toLowerCase());
+}
+
+function hasValue(value) {
+    return normalizeText(value).length > 0;
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_create',
+        'no_alter',
+        'no_l3_write',
+        'no_training_feature_write',
+        'no_prediction_write',
+        'no_smelt',
+        'no_l3_stitch',
+        'no_elo',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+    ];
+}
+
+function buildBlockedCommitPayload() {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        error: 'BLOCKED: synthetic L3 commit is not wired in Phase 4.44.',
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function buildSyntheticMarker(source) {
+    return {
+        synthetic: true,
+        source,
+        engineering_test_only: true,
+        not_for_training: true,
+        not_for_production: true,
+    };
+}
+
+function buildL3Preview(rawRow) {
+    const source = rawRow?.data_version || 'PHASE4.43_SYNTHETIC';
+    const marker = buildSyntheticMarker(source);
+
+    return {
+        target_table: 'l3_features',
+        match_id: rawRow?.match_id || null,
+        external_id: rawRow?.external_id || null,
+        would_insert_l3_features: false,
+        would_update_matches: false,
+        would_trigger_elo: false,
+        preview_only: true,
+        synthetic_input: true,
+        not_for_training: true,
+        not_for_production: true,
+        planned_jsonb_preview: {
+            golden_features: {
+                ...marker,
+                match_identity_only: true,
+            },
+            tactical_features: {
+                ...marker,
+                extraction_not_run: true,
+            },
+            odds_features: {
+                ...marker,
+                odds_extraction_not_run: true,
+            },
+            elo_features: {
+                ...marker,
+                elo_not_run: true,
+            },
+            stitch_summary: {
+                ...marker,
+                source_raw_match_data_id: rawRow?.id || null,
+                data_hash: rawRow?.data_hash || null,
+                stitch_not_run: true,
+            },
+        },
+    };
+}
+
+function buildTargetMatchStatus(match) {
+    return {
+        match_found: Boolean(match),
+        match_id: match?.match_id || null,
+        league_name: match?.league_name || null,
+        season: match?.season || null,
+        home_team: match?.home_team || null,
+        away_team: match?.away_team || null,
+        home_score: match?.home_score ?? null,
+        away_score: match?.away_score ?? null,
+        actual_result: match?.actual_result || null,
+        match_date: match?.match_date ? new Date(match.match_date).toISOString() : null,
+        status: match?.status || null,
+        is_finished: match?.is_finished === true,
+        has_actual_result: hasValue(match?.actual_result),
+        has_score:
+            match?.home_score !== null &&
+            match?.home_score !== undefined &&
+            match?.away_score !== null &&
+            match?.away_score !== undefined,
+    };
+}
+
+function buildRawStatus(rawRow) {
+    const rawData = rawRow?.raw_data || {};
+    const metadata = rawData.metadata || {};
+
+    return {
+        raw_match_data_found: Boolean(rawRow),
+        raw_match_data_id: rawRow?.id || null,
+        match_id: rawRow?.match_id || null,
+        external_id: rawRow?.external_id || null,
+        data_version: rawRow?.data_version || null,
+        data_hash: rawRow?.data_hash || null,
+        collected_at: rawRow?.collected_at ? new Date(rawRow.collected_at).toISOString() : null,
+        synthetic: asBoolean(metadata.synthetic),
+        engineering_test_only: asBoolean(metadata.engineering_test_only),
+        not_real_external_data: asBoolean(metadata.not_real_external_data),
+        not_for_training: asBoolean(metadata.not_for_training),
+        not_for_production: asBoolean(metadata.not_for_production),
+        has_matchId: Object.hasOwn(rawData, 'matchId'),
+        has_general: Object.hasOwn(rawData, 'general'),
+        has_header: Object.hasOwn(rawData, 'header'),
+        has_content: Object.hasOwn(rawData, 'content'),
+    };
+}
+
+function buildDownstreamStatus(statusRow) {
+    return {
+        l3_features_exists: statusRow?.l3_features_exists === true,
+        match_features_training_exists: statusRow?.match_features_training_exists === true,
+        predictions_exists: statusRow?.predictions_exists === true,
+    };
+}
+
+function buildGatingDecision(rawStatus) {
+    const syntheticSafetyComplete =
+        rawStatus.synthetic === true &&
+        rawStatus.engineering_test_only === true &&
+        rawStatus.not_real_external_data === true &&
+        rawStatus.not_for_training === true &&
+        rawStatus.not_for_production === true;
+
+    return {
+        can_write_l3_now: false,
+        reason: 'synthetic raw input requires separate manual authorization',
+        real_training_allowed: false,
+        synthetic_safety_complete: syntheticSafetyComplete,
+    };
+}
+
+function buildPayload({ args, matchRow, rawRow, statusRow }) {
+    const targetMatch = buildTargetMatchStatus(matchRow);
+    const rawStatus = buildRawStatus(rawRow);
+
+    return {
+        mode: 'dry-run',
+        phase: '4.44',
+        match_id: args.matchId,
+        target_match: targetMatch,
+        raw_match_data: rawStatus,
+        downstream_status: buildDownstreamStatus(statusRow),
+        l3_preview: buildL3Preview(rawRow),
+        gating_decision: buildGatingDecision(rawStatus),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function formatText(payload) {
+    return [
+        `mode=${payload.mode}`,
+        `phase=${payload.phase}`,
+        `match_id=${payload.match_id}`,
+        `match_found=${payload.target_match.match_found}`,
+        `is_finished=${payload.target_match.is_finished}`,
+        `has_actual_result=${payload.target_match.has_actual_result}`,
+        `has_score=${payload.target_match.has_score}`,
+        `raw_match_data_found=${payload.raw_match_data.raw_match_data_found}`,
+        `synthetic=${payload.raw_match_data.synthetic}`,
+        `engineering_test_only=${payload.raw_match_data.engineering_test_only}`,
+        `not_real_external_data=${payload.raw_match_data.not_real_external_data}`,
+        `not_for_training=${payload.raw_match_data.not_for_training}`,
+        `not_for_production=${payload.raw_match_data.not_for_production}`,
+        `l3_features_exists=${payload.downstream_status.l3_features_exists}`,
+        `match_features_training_exists=${payload.downstream_status.match_features_training_exists}`,
+        `predictions_exists=${payload.downstream_status.predictions_exists}`,
+        `would_insert_l3_features=${payload.l3_preview.would_insert_l3_features}`,
+        `would_update_matches=${payload.l3_preview.would_update_matches}`,
+        `would_trigger_elo=${payload.l3_preview.would_trigger_elo}`,
+        `preview_only=${payload.l3_preview.preview_only}`,
+        `can_write_l3_now=${payload.gating_decision.can_write_l3_now}`,
+        `real_training_allowed=${payload.gating_decision.real_training_allowed}`,
+        '',
+        'target_match:',
+        JSON.stringify(payload.target_match, null, 2),
+        '',
+        'raw_match_data:',
+        JSON.stringify(payload.raw_match_data, null, 2),
+        '',
+        'downstream_status:',
+        JSON.stringify(payload.downstream_status, null, 2),
+        '',
+        'l3_preview:',
+        JSON.stringify(payload.l3_preview, null, 2),
+        '',
+        'gating_decision:',
+        JSON.stringify(payload.gating_decision, null, 2),
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ].join('\n');
+}
+
+async function loadMatch(pool, matchId) {
+    const sql = `
+        SELECT
+            match_id,
+            league_name,
+            season,
+            home_team,
+            away_team,
+            home_score,
+            away_score,
+            actual_result,
+            match_date,
+            status,
+            is_finished
+        FROM matches
+        WHERE match_id = $1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function loadRawMatchData(pool, matchId) {
+    const sql = `
+        SELECT
+            id,
+            match_id,
+            external_id,
+            raw_data,
+            data_version,
+            data_hash,
+            collected_at
+        FROM raw_match_data
+        WHERE match_id = $1
+        ORDER BY collected_at DESC
+        LIMIT 1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function loadDownstreamStatus(pool, matchId) {
+    const sql = `
+        SELECT
+            EXISTS (SELECT 1 FROM l3_features WHERE match_id = $1) AS l3_features_exists,
+            EXISTS (SELECT 1 FROM match_features_training WHERE match_id = $1) AS match_features_training_exists,
+            EXISTS (SELECT 1 FROM predictions WHERE match_id = $1) AS predictions_exists
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || {};
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error('BLOCKED: synthetic L3 commit is not wired in Phase 4.44.');
+        console.error(JSON.stringify(buildBlockedCommitPayload(), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.matchId) {
+        console.error('ERROR: provide --match-id <id>');
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const matchRow = await loadMatch(pool, args.matchId);
+        const rawRow = await loadRawMatchData(pool, args.matchId);
+        const statusRow = await loadDownstreamStatus(pool, args.matchId);
+        const payload = buildPayload({ args, matchRow, rawRow, statusRow });
+
+        console.log(args.json ? JSON.stringify(payload, null, 2) : formatText(payload));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a safe synthetic raw to L3 preflight gate and commits the Phase 4.43 synthetic raw_match_data single insert report.

Changes:
- Adds scripts/ops/synthetic_l3_preflight.js
- Adds make data-synthetic-l3-dry-run
- Adds blocked make data-synthetic-l3-commit
- Updates data-help
- Updates AGENTS.md with synthetic L3 safety rules
- Adds Phase 4.43 report
- Adds Phase 4.44 report

Safety:
- SELECT-only DB checks
- No DB writes
- No l3_features writes
- No match_features_training writes
- No predictions writes
- No smelt
- No l3:stitch
- No ELO
- No training
- No prediction execution
- No model artifact loading
- No external data access
- Commit gate remains blocked

Validation:
- make data-synthetic-l3-dry-run without args fails as expected
- make data-synthetic-l3-dry-run MATCH_ID=47_20242025_900002 succeeds
- make data-synthetic-l3-commit remains blocked with and without CONFIRM_SYNTHETIC_L3=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/synthetic_l3_preflight.js
- docs/_reports/SYNTHETIC_RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_43.md
- docs/_reports/SYNTHETIC_L3_PREFLIGHT_PHASE4_44.md