### PR TITLE
feat(training): add synthetic training feature preflight gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,6 +443,32 @@ AI / Codex 禁止执行：
 
 synthetic raw 生成的 L3 preview 只能用于工程验证，不可用于真实训练，不可进入 production，也不能被当作真实特征。任何真实 `l3_features` 写入前必须有单独授权、pg_dump 备份和写入前后统计。相关背景见：`docs/_reports/SYNTHETIC_RAW_MATCH_DATA_SINGLE_INSERT_PHASE4_43.md`、`docs/_reports/SYNTHETIC_RAW_FIXTURE_PHASE4_42.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
 
+执行 `make data-synthetic-training-feature-dry-run MATCH_ID=<id>` 的前提：
+
+- 用户明确授权
+- 入口只做 SELECT-only DB 审计
+- 输入 `l3_features` 必须明确标记 `synthetic=true`
+- 输入 `l3_features` 必须明确标记 `engineering_test_only=true`
+- 输入 `l3_features` 必须明确标记 `not_for_training=true`
+- 不写 DB
+- 不写 `match_features_training`
+- 不写 `predictions`
+- 不训练模型
+- 不执行预测
+- 不加载模型 artifact
+- 不访问外网
+
+AI / Codex 禁止执行：
+
+- `make data-synthetic-training-feature-commit`
+- `make data-synthetic-training-feature-commit CONFIRM_SYNTHETIC_TRAINING_FEATURE=1`
+- `node scripts/ops/synthetic_training_feature_preflight.js --commit`
+- `node scripts/ops/match_features_training_local_write_gate.js --commit`
+- `npm run train`
+- `npm run predict`
+
+synthetic training feature preview 只能用于工程验证，不可用于真实训练，不可进入 production，也不能被当作真实训练数据。任何真实 `match_features_training` 写入前必须有单独授权、pg_dump 备份和写入前后统计。相关背景见：`docs/_reports/SYNTHETIC_L3_FEATURES_SINGLE_INSERT_PHASE4_45.md`、`docs/_reports/SYNTHETIC_L3_PREFLIGHT_PHASE4_44.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
+
 执行 `make data-l3-write-dry-run` 的前提：
 
 - 用户明确授权

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
         data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-fixture-dry-run data-raw-fixture-commit \
         data-synthetic-l3-dry-run data-synthetic-l3-commit \
+        data-synthetic-training-feature-dry-run data-synthetic-training-feature-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -257,11 +258,13 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path>"
 	@echo "  make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path> ALLOW_SYNTHETIC=1"
 	@echo "  make data-synthetic-l3-dry-run MATCH_ID=<id>"
+	@echo "  make data-synthetic-training-feature-dry-run MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
 	@echo "  make data-raw-fixture-commit MATCH_ID=<id> FIXTURE=<path> CONFIRM_RAW_FIXTURE_COMMIT=1  # blocked in Phase 4.41"
 	@echo "  make data-finished-backfill-commit MATCH_ID=<id> CONFIRM_FINISHED_BACKFILL=1  # blocked in Phase 4.40"
 	@echo "  make data-synthetic-l3-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_L3=1  # blocked in Phase 4.44"
+	@echo "  make data-synthetic-training-feature-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_TRAINING_FEATURE=1  # blocked in Phase 4.46"
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
@@ -386,6 +389,22 @@ data-training-feature-commit: ## Blocked match_features_training write gate. Req
 		exit 1; \
 	fi
 	@echo "BLOCKED: match_features_training commit is not wired in Phase 4.30."
+	@exit 1
+
+data-synthetic-training-feature-dry-run: ## Run safe synthetic L3 to training feature preflight. Requires MATCH_ID.
+	@if [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe synthetic L3 to training feature preflight: MATCH_ID=$(MATCH_ID)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/synthetic_training_feature_preflight.js --match-id "$(MATCH_ID)"
+
+data-synthetic-training-feature-commit: ## Blocked synthetic training feature gate. Requires MATCH_ID, CONFIRM_SYNTHETIC_TRAINING_FEATURE=1.
+	@if [ "$(CONFIRM_SYNTHETIC_TRAINING_FEATURE)" != "1" ]; then \
+		echo "BLOCKED: synthetic training feature commit requires CONFIRM_SYNTHETIC_TRAINING_FEATURE=1 and is not wired in Phase 4.46."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: synthetic training feature commit is not wired in Phase 4.46."
 	@exit 1
 
 data-prediction-write-dry-run: ## Run safe local predictions write preview. Requires MATCH_ID.

--- a/docs/_reports/SYNTHETIC_L3_FEATURES_SINGLE_INSERT_PHASE4_45.md
+++ b/docs/_reports/SYNTHETIC_L3_FEATURES_SINGLE_INSERT_PHASE4_45.md
@@ -1,0 +1,334 @@
+# Phase 4.45 - Synthetic l3_features Single Insert
+
+## Current HEAD
+
+- Branch: `main`
+- HEAD: `643e3fa34a7e4c8df81a200136b3dc2e5b950c49`
+- HEAD summary: `643e3fa feat(l3): add synthetic L3 preflight gate`
+- Git status before report generation: clean
+
+## Backup
+
+- backup file: `data/backups/phase445_pre_synthetic_l3_features_insert_20260504_040526.dump`
+- backup size: `71K`
+
+## Write Scope
+
+Human-authorized write scope:
+
+- table: `l3_features`
+- operation: one explicit `INSERT`
+- match_id: `47_20242025_900002`
+- source raw data version: `PHASE4.43_SYNTHETIC`
+- feature data version: `PHASE4.45_SYNTHETIC_L3`
+
+This was synthetic L3 data only:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+
+It is engineering-test-only, not real external data, not production data, and not suitable for real model training.
+
+## Write Before State
+
+DB row counts before insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    1 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Target match before insert:
+
+| field                 | value                |
+| --------------------- | -------------------- |
+| match_id              | `47_20242025_900002` |
+| home_team             | `Burgos`             |
+| away_team             | `Oviedo`             |
+| home_score            | `1`                  |
+| away_score            | `0`                  |
+| actual_result         | `home_win`           |
+| status                | `finished`           |
+| is_finished           | `true`               |
+| has_raw_match_data    | `true`               |
+| has_l3_features       | `false`              |
+| has_training_features | `false`              |
+| has_predictions       | `false`              |
+
+Synthetic raw status before insert:
+
+| field                  | value                 |
+| ---------------------- | --------------------- |
+| match_id               | `47_20242025_900002`  |
+| data_version           | `PHASE4.43_SYNTHETIC` |
+| synthetic              | `true`                |
+| engineering_test_only  | `true`                |
+| not_real_external_data | `true`                |
+| not_for_training       | `true`                |
+| not_for_production     | `true`                |
+
+Target L3 row count before insert:
+
+- `target_l3_rows = 0`
+
+## l3_features Schema Confirmation
+
+Read-only schema inspection confirmed:
+
+- `match_id` is the primary key
+- `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+- `external_id` exists and is nullable
+- JSONB feature columns exist and default to `{}`:
+    - `golden_features`
+    - `tactical_features`
+    - `odds_movement_features`
+    - `odds_features`
+    - `elo_features`
+    - `rolling_features`
+    - `efficiency_features`
+    - `draw_features`
+    - `market_sentiment`
+    - `stitch_summary`
+- `computed_at`, `created_at`, and `updated_at` are `NOT NULL` and default to `now()`
+
+No schema modification was performed.
+
+## Synthetic L3 Dry-Run Before Insert
+
+Command:
+
+```bash
+make data-synthetic-l3-dry-run MATCH_ID=47_20242025_900002
+```
+
+Result before insert:
+
+- `match_found = true`
+- `is_finished = true`
+- `raw_match_data_found = true`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `l3_features_exists = false`
+- `match_features_training_exists = false`
+- `predictions_exists = false`
+- `would_insert_l3_features = false`
+- `would_update_matches = false`
+- `would_trigger_elo = false`
+- `can_write_l3_now = false`
+- `preview_only = true`
+- `no_db_writes`
+
+The dry-run preview included:
+
+- `golden_features`
+- `tactical_features`
+- `odds_features`
+- `elo_features`
+- `stitch_summary`
+
+## Insert Result
+
+The authorized insert succeeded.
+
+Returned row:
+
+| field       | value                           |
+| ----------- | ------------------------------- |
+| match_id    | `47_20242025_900002`            |
+| external_id | `900002`                        |
+| computed_at | `2026-05-03 20:05:54.909887+00` |
+| created_at  | `2026-05-03 20:05:54.909887+00` |
+| updated_at  | `2026-05-03 20:05:54.909887+00` |
+
+SQL behavior:
+
+- one explicit `BEGIN`
+- one explicit `INSERT INTO l3_features`
+- one explicit `COMMIT`
+- no `ON CONFLICT DO UPDATE`
+- no writes to any other table
+- no `smelt`
+- no `l3:stitch`
+- no ELO recalculation
+
+## Inserted JSONB Feature Summary
+
+Inserted JSONB columns:
+
+- `golden_features`
+- `tactical_features`
+- `odds_movement_features`
+- `odds_features`
+- `elo_features`
+- `rolling_features`
+- `efficiency_features`
+- `draw_features`
+- `market_sentiment`
+- `stitch_summary`
+
+Each inserted JSONB payload contains:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `target_match_id = 47_20242025_900002`
+- `source_raw_data_version = PHASE4.43_SYNTHETIC`
+- `feature_data_version = PHASE4.45_SYNTHETIC_L3`
+
+Feature notes:
+
+- `golden_features` includes the known finished label and score for engineering-chain validation.
+- `tactical_features` includes synthetic shape-only stat previews from the synthetic raw fixture.
+- `odds_features` and `odds_movement_features` explicitly state no target odds history is linked.
+- `elo_features` explicitly states ELO was not computed and must not be fabricated.
+- `stitch_summary` marks the write as single-row synthetic L3 only and blocks downstream training/prediction use.
+
+## Write After Verification
+
+Target L3 row:
+
+- `match_id = 47_20242025_900002`
+- `external_id = 900002`
+- `golden_features` type: `object`
+- `tactical_features` type: `object`
+- `odds_features` type: `object`
+- `elo_features` type: `object`
+- `stitch_summary` type: `object`
+
+Metadata verification:
+
+- `golden_synthetic = true`
+- `tactical_synthetic = true`
+- `odds_synthetic = true`
+- `elo_synthetic = true`
+- `stitch_synthetic = true`
+- `golden_not_for_training = true`
+- `stitch_not_for_production = true`
+- `golden_engineering_test_only = true`
+- `golden_not_real_external_data = true`
+- `feature_data_version = PHASE4.45_SYNTHETIC_L3`
+
+Target L3 row count after insert:
+
+- `target_l3_rows = 1`
+
+DB row counts after insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Result:
+
+- `l3_features` increased from `1 -> 2`
+- all other tracked tables remained unchanged
+
+## Gate Verification After Insert
+
+`make data-synthetic-l3-dry-run MATCH_ID=47_20242025_900002` reported:
+
+- `match_found = true`
+- `raw_match_data_found = true`
+- `synthetic = true`
+- `l3_features_exists = true`
+- `match_features_training_exists = false`
+- `predictions_exists = false`
+- `would_insert_l3_features = false`
+- `would_update_matches = false`
+- `would_trigger_elo = false`
+- `no_db_writes`
+
+`make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002` reported:
+
+- `has_raw_match_data = true`
+- `has_l3_features = true`
+- `has_training_features = false`
+- `has_predictions = false`
+- `match_features_training.blocked_until_l3 = false`
+- `predictions.blocked_until_training_features = true`
+- `no_db_writes`
+
+Verified blocked gates:
+
+- `make data-synthetic-l3-commit`: blocked
+- `make data-synthetic-l3-commit ... CONFIRM_SYNTHETIC_L3=1`: blocked
+- `make data-l3-write-commit`: blocked
+- `make data-l3-write-commit MATCH_ID=47_20242025_900002 CONFIRM_L3_WRITE=1`: blocked
+- `make data-training-commit`: blocked
+- `make data-training-commit CONFIRM_TRAINING=1`: blocked
+
+No training, prediction, `smelt`, `l3:stitch`, ELO recalculation, raw ingest, or model artifact loading was executed.
+
+## Risk Notes
+
+- This row is synthetic and engineering-test-only.
+- It must not be used as real external data.
+- It must not be used for real model training.
+- It must not be used for production outputs.
+- Future training-feature work must explicitly account for the synthetic provenance before any write.
+
+## Recommended Next Phase
+
+Recommended next step:
+
+```text
+Phase 4.46: synthetic l3_features -> match_features_training preflight gate
+```
+
+To reduce frequent merges, keep this Phase 4.45 report local for now and submit it together with the Phase 4.46 related gate / report in one themed PR.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `INSERT` into any table except `l3_features`
+- multiple `l3_features` inserts
+- `raw_match_data` write
+- `match_features_training` write
+- `predictions` write
+- `smelt`
+- `l3:stitch`
+- ELO recalculation
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push`
+- `git pull`
+- `git fetch --all`
+- commit

--- a/docs/_reports/SYNTHETIC_TRAINING_FEATURE_PREFLIGHT_PHASE4_46.md
+++ b/docs/_reports/SYNTHETIC_TRAINING_FEATURE_PREFLIGHT_PHASE4_46.md
@@ -1,0 +1,390 @@
+# Phase 4.46 - Synthetic Training Feature Preflight Gate
+
+## Current HEAD
+
+- Base HEAD: `643e3fa34a7e4c8df81a200136b3dc2e5b950c49`
+- Working branch: `feat/synthetic-training-feature-preflight-gate`
+- Phase 4.45 report preserved: `docs/_reports/SYNTHETIC_L3_FEATURES_SINGLE_INSERT_PHASE4_45.md`
+
+## Phase 4.45 Synthetic l3_features Status
+
+Phase 4.45 had already inserted one human-authorized synthetic `l3_features` row for:
+
+- `match_id = 47_20242025_900002`
+- `external_id = 900002`
+- `feature_data_version = PHASE4.45_SYNTHETIC_L3`
+
+The stored JSONB payloads remain:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+
+This row is engineering-test-only synthetic L3 data, not real production feature data, and not suitable for real model training.
+
+## Current DB Row Counts
+
+Row counts before and after Phase 4.46 validation remained unchanged:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+## Target Match Status
+
+Target:
+
+| field                 | value                |
+| --------------------- | -------------------- |
+| match_id              | `47_20242025_900002` |
+| home_team             | `Burgos`             |
+| away_team             | `Oviedo`             |
+| home_score            | `1`                  |
+| away_score            | `0`                  |
+| actual_result         | `home_win`           |
+| status                | `finished`           |
+| is_finished           | `true`               |
+| has_raw_match_data    | `true`               |
+| has_l3_features       | `true`               |
+| has_training_features | `false`              |
+| has_predictions       | `false`              |
+
+Conclusion:
+
+- the target finished match exists
+- it has synthetic raw and synthetic L3 rows
+- it still has no downstream `match_features_training`
+- predictions remain absent
+
+## l3_features Synthetic Metadata Summary
+
+Read-only verification of the target L3 row confirmed:
+
+- `match_id = 47_20242025_900002`
+- `external_id = 900002`
+- `golden_synthetic = true`
+- `tactical_synthetic = true`
+- `odds_synthetic = true`
+- `elo_synthetic = true`
+- `stitch_synthetic = true`
+- `golden_engineering_test_only = true`
+- `golden_not_real_external_data = true`
+- `golden_not_for_training = true`
+- `stitch_not_for_production = true`
+- `feature_data_version = PHASE4.45_SYNTHETIC_L3`
+
+## match_features_training Schema Summary
+
+Read-only schema inspection confirmed:
+
+- primary key: `PRIMARY KEY (match_id)`
+- foreign key: `FOREIGN KEY (match_id) REFERENCES matches(match_id) ON DELETE CASCADE`
+- required columns without defaults:
+    - `match_id`
+    - `season`
+    - `match_date`
+    - `home_team`
+    - `away_team`
+- `feature_version` defaults to `V25.1`
+- `adaptive_features` is nullable `jsonb`
+- `feature_count` defaults to `0`
+- `created_at` and `updated_at` default to `CURRENT_TIMESTAMP`
+
+Implication:
+
+- the target match currently has no `match_features_training`
+- a future write would still require explicit authorization and a backup phase
+- Phase 4.46 intentionally does not perform that write
+
+## Existing Training Feature / Model Entrypoint Risk Audit
+
+Relevant existing entrypoints were audited read-only:
+
+| entrypoint                                                         | current behavior               | write / train risk         |
+| ------------------------------------------------------------------ | ------------------------------ | -------------------------- |
+| `make data-training-feature-dry-run MATCH_ID=<id>`                 | local training-feature preview | dry-run only               |
+| `make data-training-feature-commit ... CONFIRM_TRAINING_FEATURE=1` | blocked                        | not wired                  |
+| `make data-training-commit`                                        | blocked placeholder            | no real training allowed   |
+| `make data-prediction-commit`                                      | blocked placeholder            | no real prediction allowed |
+| `npm run train`                                                    | real model training path       | prohibited                 |
+| `npm run predict`                                                  | real model inference path      | prohibited                 |
+
+Decision:
+
+- the new synthetic gate must not call `match_features_training_local_write_gate.js --commit`
+- the new synthetic gate must not call `npm run train`
+- the new synthetic gate must not call `npm run predict`
+- the new synthetic gate must stay SELECT-only and preview-only
+
+## New Script Behavior
+
+Added:
+
+```text
+scripts/ops/synthetic_training_feature_preflight.js
+```
+
+Supported commands:
+
+```bash
+node scripts/ops/synthetic_training_feature_preflight.js --match-id 47_20242025_900002
+node scripts/ops/synthetic_training_feature_preflight.js --match-id 47_20242025_900002 --json
+node scripts/ops/synthetic_training_feature_preflight.js --match-id 47_20242025_900002 --commit
+```
+
+Behavior:
+
+- performs SELECT-only DB checks
+- reads the target `matches`, `raw_match_data`, and `l3_features` rows
+- checks synthetic L3 provenance flags
+- checks existing downstream presence for `match_features_training` and `predictions`
+- emits a preview-only `match_features_training` shape
+- emits an `adaptive_features` preview derived from synthetic L3 payload groups
+- emits `would_insert_match_features_training=false`
+- emits `would_train_model=false`
+- emits `would_write_predictions=false`
+- emits `preview_only=true`
+- emits `synthetic_input=true`
+- emits `can_write_training_features_now=false`
+- emits `real_training_allowed=false`
+- emits `prediction_allowed=false`
+- does not write `match_features_training`
+- does not write `predictions`
+- does not train a model
+- does not load model artifacts
+- does not access external network
+
+`--commit` behavior:
+
+```text
+BLOCKED: synthetic training feature commit is not wired in Phase 4.46.
+```
+
+## Makefile Entrypoints
+
+Added:
+
+```text
+make data-synthetic-training-feature-dry-run MATCH_ID=<id>
+make data-synthetic-training-feature-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_TRAINING_FEATURE=1  # blocked in Phase 4.46
+```
+
+Behavior:
+
+- `data-synthetic-training-feature-dry-run` requires `MATCH_ID`
+- `data-synthetic-training-feature-dry-run` runs `scripts/ops/synthetic_training_feature_preflight.js`
+- `data-synthetic-training-feature-commit` is blocked by default
+- `data-synthetic-training-feature-commit` remains blocked even with `CONFIRM_SYNTHETIC_TRAINING_FEATURE=1`
+
+`data-help` was updated to list both entries.
+
+## AGENTS.md Update
+
+Added synthetic training feature safety rules:
+
+- `make data-synthetic-training-feature-dry-run MATCH_ID=<id>` is only allowed with explicit user authorization
+- input `l3_features` must already be marked synthetic and engineering-test-only
+- input `l3_features` must already be marked not-for-training
+- the gate must remain SELECT-only
+- no DB writes
+- no model training
+- no prediction execution
+- no model artifact loading
+- no external network
+
+Added explicit prohibitions for:
+
+- `make data-synthetic-training-feature-commit`
+- `make data-synthetic-training-feature-commit CONFIRM_SYNTHETIC_TRAINING_FEATURE=1`
+- `node scripts/ops/synthetic_training_feature_preflight.js --commit`
+- `node scripts/ops/match_features_training_local_write_gate.js --commit`
+- `npm run train`
+- `npm run predict`
+
+Added policy statement:
+
+- synthetic training feature preview is engineering-only
+- synthetic training feature preview is not for real training
+- synthetic training feature preview must not enter production
+- real `match_features_training` write still requires separate authorization and `pg_dump`
+
+## Dry-Run Validation
+
+Missing argument gate:
+
+```bash
+make data-synthetic-training-feature-dry-run || true
+```
+
+Result:
+
+- failed as expected
+- message: `ERROR: provide MATCH_ID=<id>`
+
+Target synthetic training feature dry-run:
+
+```bash
+make data-synthetic-training-feature-dry-run MATCH_ID=47_20242025_900002
+```
+
+Result:
+
+- `mode = dry-run`
+- `phase = 4.46`
+- `match_found = true`
+- `is_finished = true`
+- `has_actual_result = true`
+- `has_score = true`
+- `raw_match_data_found = true`
+- `l3_features_found = true`
+- `l3_features_synthetic = true`
+- `l3_features_not_for_training = true`
+- `l3_features_not_for_production = true`
+- `match_features_training_exists = false`
+- `predictions_exists = false`
+- `would_insert_match_features_training = false`
+- `would_train_model = false`
+- `would_write_predictions = false`
+- `preview_only = true`
+- `synthetic_input = true`
+- `can_write_training_features_now = false`
+- `real_training_allowed = false`
+- `prediction_allowed = false`
+- `no_db_writes`
+- `no_training_feature_write`
+- `no_prediction_write`
+- `no_model_training`
+- `no_prediction_execution`
+- `no_external_network`
+
+## adaptive_features Preview Summary
+
+The new preview emits a conservative future-shape payload for `adaptive_features` with:
+
+- `source = PHASE4.45_SYNTHETIC_L3`
+- `feature_data_version = PHASE4.46_SYNTHETIC_TRAINING_PREFLIGHT`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `target_match_id = 47_20242025_900002`
+
+The preview includes summarized groups for:
+
+- `golden_features`
+- `tactical_features`
+- `odds_features`
+- `elo_features`
+- `stitch_summary`
+
+This keeps the preview useful for engineering-shape validation without pretending real training data is available.
+
+## Commit Gate Validation
+
+Validated:
+
+```bash
+make data-synthetic-training-feature-commit || true
+make data-synthetic-training-feature-commit MATCH_ID=47_20242025_900002 CONFIRM_SYNTHETIC_TRAINING_FEATURE=1 || true
+```
+
+Result:
+
+- both commands were blocked
+- no DB writes occurred
+- no training or prediction path was invoked
+
+## Existing Gate Recheck
+
+`make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002` remained read-only and reported:
+
+- `has_raw_match_data = true`
+- `has_l3_features = true`
+- `has_training_features = false`
+- `has_predictions = false`
+- `no_db_writes`
+
+`make data-synthetic-l3-dry-run MATCH_ID=47_20242025_900002` remained read-only and reported:
+
+- `l3_features_exists = true`
+- `match_features_training_exists = false`
+- `predictions_exists = false`
+- `no_db_writes`
+
+## DB Before/After Summary
+
+DB row counts were unchanged across all Phase 4.46 validations:
+
+| table                   | rows before | rows after |
+| ----------------------- | ----------: | ---------: |
+| matches                 |           2 |          2 |
+| bookmaker_odds_history  |           2 |          2 |
+| raw_match_data          |           2 |          2 |
+| l3_features             |           2 |          2 |
+| match_features_training |           1 |          1 |
+| predictions             |           1 |          1 |
+
+## Recommended Next Phase
+
+Recommended next step:
+
+```text
+Phase 4.47: artificial authorization for one synthetic match_features_training write
+```
+
+Alternative:
+
+```text
+continue searching for a legal real raw / L3 source before any downstream training-feature write
+```
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `COPY`
+- export
+- DB writes
+- `match_features_training` write
+- `l3_features` write
+- `raw_match_data` write
+- `predictions` write
+- `smelt`
+- `l3:stitch`
+- ELO recalculation
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push --force`
+- `git push --mirror`
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/synthetic_training_feature_preflight.js
+++ b/scripts/ops/synthetic_training_feature_preflight.js
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+/**
+ * Safe synthetic L3 to training-feature preflight gate.
+ *
+ * Phase 4.46 reads the target match and existing synthetic l3_features row,
+ * then emits a match_features_training preview without training or writes.
+ */
+
+'use strict';
+
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/synthetic_training_feature_preflight.js --match-id <id> [--json]',
+        '  node scripts/ops/synthetic_training_feature_preflight.js --match-id <id> --commit',
+        '',
+        'Safety:',
+        '  Preflight only in Phase 4.46; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        matchId: null,
+        json: false,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function normalizeText(value) {
+    return String(value ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function asBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    return TRUE_VALUES.has(normalizeText(value).toLowerCase());
+}
+
+function asObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function hasValue(value) {
+    return normalizeText(value).length > 0;
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_create',
+        'no_alter',
+        'no_training_feature_write',
+        'no_prediction_write',
+        'no_model_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+    ];
+}
+
+function buildBlockedCommitPayload() {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        error: 'BLOCKED: synthetic training feature commit is not wired in Phase 4.46.',
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function buildTargetMatchStatus(match) {
+    return {
+        match_found: Boolean(match),
+        match_id: match?.match_id || null,
+        season: match?.season || null,
+        match_date: match?.match_date ? new Date(match.match_date).toISOString() : null,
+        home_team: match?.home_team || null,
+        away_team: match?.away_team || null,
+        home_score: match?.home_score ?? null,
+        away_score: match?.away_score ?? null,
+        actual_result: match?.actual_result || null,
+        status: match?.status || null,
+        is_finished: match?.is_finished === true,
+        has_actual_result: hasValue(match?.actual_result),
+        has_score:
+            match?.home_score !== null &&
+            match?.home_score !== undefined &&
+            match?.away_score !== null &&
+            match?.away_score !== undefined,
+    };
+}
+
+function featureFlag(l3Row, featureName, key) {
+    return asBoolean(asObject(l3Row?.[featureName])?.[key]);
+}
+
+function buildUpstreamStatus(rawRow, l3Row) {
+    const goldenFeatures = asObject(l3Row?.golden_features);
+    const stitchSummary = asObject(l3Row?.stitch_summary);
+
+    return {
+        raw_match_data_found: Boolean(rawRow),
+        raw_data_version: rawRow?.data_version || null,
+        raw_synthetic: asBoolean(asObject(rawRow?.raw_data)?.metadata?.synthetic),
+        l3_features_found: Boolean(l3Row),
+        l3_external_id: l3Row?.external_id || null,
+        l3_computed_at: l3Row?.computed_at ? new Date(l3Row.computed_at).toISOString() : null,
+        l3_features_synthetic:
+            featureFlag(l3Row, 'golden_features', 'synthetic') &&
+            featureFlag(l3Row, 'tactical_features', 'synthetic') &&
+            featureFlag(l3Row, 'odds_features', 'synthetic') &&
+            featureFlag(l3Row, 'elo_features', 'synthetic') &&
+            featureFlag(l3Row, 'stitch_summary', 'synthetic'),
+        l3_features_engineering_test_only: featureFlag(l3Row, 'golden_features', 'engineering_test_only'),
+        l3_features_not_real_external_data: featureFlag(l3Row, 'golden_features', 'not_real_external_data'),
+        l3_features_not_for_training: featureFlag(l3Row, 'golden_features', 'not_for_training'),
+        l3_features_not_for_production: featureFlag(l3Row, 'stitch_summary', 'not_for_production'),
+        l3_feature_data_version: stitchSummary.feature_data_version || goldenFeatures.feature_data_version || null,
+    };
+}
+
+function buildDownstreamStatus(statusRow) {
+    return {
+        match_features_training_exists: statusRow?.match_features_training_exists === true,
+        predictions_exists: statusRow?.predictions_exists === true,
+    };
+}
+
+function summarizeFeatureGroup(value) {
+    const feature = asObject(value);
+    return {
+        synthetic: asBoolean(feature.synthetic),
+        not_for_training: asBoolean(feature.not_for_training),
+        not_for_production: asBoolean(feature.not_for_production),
+        feature_group: feature.feature_group || null,
+        key_count: Object.keys(feature).length,
+        keys: Object.keys(feature).sort(),
+    };
+}
+
+function buildAdaptiveFeaturesPreview(matchId, l3Row) {
+    return {
+        source: 'PHASE4.45_SYNTHETIC_L3',
+        feature_data_version: 'PHASE4.46_SYNTHETIC_TRAINING_PREFLIGHT',
+        synthetic: true,
+        engineering_test_only: true,
+        not_real_external_data: true,
+        not_for_training: true,
+        not_for_production: true,
+        target_match_id: matchId,
+        golden_features: summarizeFeatureGroup(l3Row?.golden_features),
+        tactical_features: summarizeFeatureGroup(l3Row?.tactical_features),
+        odds_features: summarizeFeatureGroup(l3Row?.odds_features),
+        elo_features: summarizeFeatureGroup(l3Row?.elo_features),
+        stitch_summary: summarizeFeatureGroup(l3Row?.stitch_summary),
+    };
+}
+
+function buildTrainingFeaturePreview({ matchId, matchRow, l3Row }) {
+    return {
+        target_table: 'match_features_training',
+        would_insert_match_features_training: false,
+        would_train_model: false,
+        would_write_predictions: false,
+        preview_only: true,
+        synthetic_input: true,
+        not_for_training: true,
+        not_for_production: true,
+        candidate_required_fields: {
+            match_id: matchId,
+            season: matchRow?.season || null,
+            match_date: matchRow?.match_date ? new Date(matchRow.match_date).toISOString() : null,
+            home_team: matchRow?.home_team || null,
+            away_team: matchRow?.away_team || null,
+            actual_result: matchRow?.actual_result || null,
+            feature_version: 'PHASE4.46_SYNTHETIC_TRAINING_PREFLIGHT',
+        },
+        adaptive_features_preview: buildAdaptiveFeaturesPreview(matchId, l3Row),
+    };
+}
+
+function buildGatingDecision(upstreamStatus) {
+    const syntheticSafetyComplete =
+        upstreamStatus.l3_features_synthetic === true &&
+        upstreamStatus.l3_features_engineering_test_only === true &&
+        upstreamStatus.l3_features_not_real_external_data === true &&
+        upstreamStatus.l3_features_not_for_training === true &&
+        upstreamStatus.l3_features_not_for_production === true;
+
+    return {
+        can_write_training_features_now: false,
+        reason: 'synthetic l3_features require separate manual authorization',
+        real_training_allowed: false,
+        prediction_allowed: false,
+        synthetic_l3_safety_complete: syntheticSafetyComplete,
+    };
+}
+
+function buildPayload({ args, matchRow, rawRow, l3Row, statusRow }) {
+    const upstreamStatus = buildUpstreamStatus(rawRow, l3Row);
+
+    return {
+        mode: 'dry-run',
+        phase: '4.46',
+        match_id: args.matchId,
+        target_match: buildTargetMatchStatus(matchRow),
+        upstream_chain_status: upstreamStatus,
+        downstream_status: buildDownstreamStatus(statusRow),
+        training_feature_preview: buildTrainingFeaturePreview({
+            matchId: args.matchId,
+            matchRow,
+            l3Row,
+        }),
+        gating_decision: buildGatingDecision(upstreamStatus),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function formatText(payload) {
+    return [
+        `mode=${payload.mode}`,
+        `phase=${payload.phase}`,
+        `match_id=${payload.match_id}`,
+        `match_found=${payload.target_match.match_found}`,
+        `is_finished=${payload.target_match.is_finished}`,
+        `has_actual_result=${payload.target_match.has_actual_result}`,
+        `has_score=${payload.target_match.has_score}`,
+        `raw_match_data_found=${payload.upstream_chain_status.raw_match_data_found}`,
+        `l3_features_found=${payload.upstream_chain_status.l3_features_found}`,
+        `l3_features_synthetic=${payload.upstream_chain_status.l3_features_synthetic}`,
+        `l3_features_not_for_training=${payload.upstream_chain_status.l3_features_not_for_training}`,
+        `l3_features_not_for_production=${payload.upstream_chain_status.l3_features_not_for_production}`,
+        `match_features_training_exists=${payload.downstream_status.match_features_training_exists}`,
+        `predictions_exists=${payload.downstream_status.predictions_exists}`,
+        `would_insert_match_features_training=${payload.training_feature_preview.would_insert_match_features_training}`,
+        `would_train_model=${payload.training_feature_preview.would_train_model}`,
+        `would_write_predictions=${payload.training_feature_preview.would_write_predictions}`,
+        `preview_only=${payload.training_feature_preview.preview_only}`,
+        `synthetic_input=${payload.training_feature_preview.synthetic_input}`,
+        `can_write_training_features_now=${payload.gating_decision.can_write_training_features_now}`,
+        `real_training_allowed=${payload.gating_decision.real_training_allowed}`,
+        `prediction_allowed=${payload.gating_decision.prediction_allowed}`,
+        '',
+        'target_match:',
+        JSON.stringify(payload.target_match, null, 2),
+        '',
+        'upstream_chain_status:',
+        JSON.stringify(payload.upstream_chain_status, null, 2),
+        '',
+        'downstream_status:',
+        JSON.stringify(payload.downstream_status, null, 2),
+        '',
+        'training_feature_preview:',
+        JSON.stringify(payload.training_feature_preview, null, 2),
+        '',
+        'gating_decision:',
+        JSON.stringify(payload.gating_decision, null, 2),
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ].join('\n');
+}
+
+async function loadMatch(pool, matchId) {
+    const sql = `
+        SELECT
+            match_id,
+            season,
+            home_team,
+            away_team,
+            home_score,
+            away_score,
+            actual_result,
+            match_date,
+            status,
+            is_finished
+        FROM matches
+        WHERE match_id = $1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function loadRawMatchData(pool, matchId) {
+    const sql = `
+        SELECT
+            match_id,
+            raw_data,
+            data_version
+        FROM raw_match_data
+        WHERE match_id = $1
+        ORDER BY collected_at DESC
+        LIMIT 1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function loadL3Features(pool, matchId) {
+    const sql = `
+        SELECT
+            match_id,
+            external_id,
+            golden_features,
+            tactical_features,
+            odds_features,
+            elo_features,
+            stitch_summary,
+            computed_at
+        FROM l3_features
+        WHERE match_id = $1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function loadDownstreamStatus(pool, matchId) {
+    const sql = `
+        SELECT
+            EXISTS (SELECT 1 FROM match_features_training WHERE match_id = $1) AS match_features_training_exists,
+            EXISTS (SELECT 1 FROM predictions WHERE match_id = $1) AS predictions_exists
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || {};
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error('BLOCKED: synthetic training feature commit is not wired in Phase 4.46.');
+        console.error(JSON.stringify(buildBlockedCommitPayload(), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.matchId) {
+        console.error('ERROR: provide --match-id <id>');
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const matchRow = await loadMatch(pool, args.matchId);
+        const rawRow = await loadRawMatchData(pool, args.matchId);
+        const l3Row = await loadL3Features(pool, args.matchId);
+        const statusRow = await loadDownstreamStatus(pool, args.matchId);
+        const payload = buildPayload({ args, matchRow, rawRow, l3Row, statusRow });
+
+        console.log(args.json ? JSON.stringify(payload, null, 2) : formatText(payload));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a safe synthetic l3_features to match_features_training preflight gate and commits the Phase 4.45 synthetic l3_features single insert report.

Changes:
- Adds scripts/ops/synthetic_training_feature_preflight.js
- Adds make data-synthetic-training-feature-dry-run
- Adds blocked make data-synthetic-training-feature-commit
- Updates data-help
- Updates AGENTS.md with synthetic training feature safety rules
- Adds Phase 4.45 report
- Adds Phase 4.46 report

Safety:
- SELECT-only DB checks
- No DB writes
- No match_features_training writes
- No predictions writes
- No model training
- No prediction execution
- No model artifact loading
- No external data access
- Commit gate remains blocked

Validation:
- make data-synthetic-training-feature-dry-run without args fails as expected
- make data-synthetic-training-feature-dry-run MATCH_ID=47_20242025_900002 succeeds
- make data-synthetic-training-feature-commit remains blocked with and without CONFIRM_SYNTHETIC_TRAINING_FEATURE=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/synthetic_training_feature_preflight.js
- docs/_reports/SYNTHETIC_L3_FEATURES_SINGLE_INSERT_PHASE4_45.md
- docs/_reports/SYNTHETIC_TRAINING_FEATURE_PREFLIGHT_PHASE4_46.md