### PR TITLE
feat(prediction): add synthetic prediction preflight gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,6 +469,31 @@ AI / Codex 禁止执行：
 
 synthetic training feature preview 只能用于工程验证，不可用于真实训练，不可进入 production，也不能被当作真实训练数据。任何真实 `match_features_training` 写入前必须有单独授权、pg_dump 备份和写入前后统计。相关背景见：`docs/_reports/SYNTHETIC_L3_FEATURES_SINGLE_INSERT_PHASE4_45.md`、`docs/_reports/SYNTHETIC_L3_PREFLIGHT_PHASE4_44.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
 
+执行 `make data-synthetic-prediction-dry-run MATCH_ID=<id>` 的前提：
+
+- 用户明确授权
+- 只读 DB
+- 输入 `match_features_training` 必须明确标记 `synthetic=true`、`engineering_test_only=true`、`not_for_training=true`
+- 不写 DB
+- 不写 `predictions`
+- 不训练模型
+- 不执行真实预测
+- 不加载 model artifact
+- 不访问外网
+
+AI / Codex 禁止执行：
+
+- `make data-synthetic-prediction-commit`
+- `make data-synthetic-prediction-commit CONFIRM_SYNTHETIC_PREDICTION=1`
+- `node scripts/ops/synthetic_prediction_preflight.js --commit`
+- `node scripts/ops/prediction_local_write_gate.js --commit`
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run predict:json`
+- `npm run train`
+
+synthetic prediction preview 只能用于工程验证，不是真实模型输出，不可进入 production，也不能被当作真实预测。真实 `predictions` 写入前必须有单独授权、pg_dump 备份和写入前后统计。相关背景见：`docs/_reports/SYNTHETIC_TRAINING_FEATURE_SINGLE_INSERT_PHASE4_47.md`、`docs/_reports/SYNTHETIC_TRAINING_FEATURE_PREFLIGHT_PHASE4_46.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
+
 执行 `make data-l3-write-dry-run` 的前提：
 
 - 用户明确授权

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
         data-raw-fixture-dry-run data-raw-fixture-commit \
         data-synthetic-l3-dry-run data-synthetic-l3-commit \
         data-synthetic-training-feature-dry-run data-synthetic-training-feature-commit \
+        data-synthetic-prediction-dry-run data-synthetic-prediction-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate
 
@@ -259,12 +260,14 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<path> ALLOW_SYNTHETIC=1"
 	@echo "  make data-synthetic-l3-dry-run MATCH_ID=<id>"
 	@echo "  make data-synthetic-training-feature-dry-run MATCH_ID=<id>"
+	@echo "  make data-synthetic-prediction-dry-run MATCH_ID=<id>"
 	@echo ""
 	@echo "Requires explicit authorization:"
 	@echo "  make data-raw-fixture-commit MATCH_ID=<id> FIXTURE=<path> CONFIRM_RAW_FIXTURE_COMMIT=1  # blocked in Phase 4.41"
 	@echo "  make data-finished-backfill-commit MATCH_ID=<id> CONFIRM_FINISHED_BACKFILL=1  # blocked in Phase 4.40"
 	@echo "  make data-synthetic-l3-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_L3=1  # blocked in Phase 4.44"
 	@echo "  make data-synthetic-training-feature-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_TRAINING_FEATURE=1  # blocked in Phase 4.46"
+	@echo "  make data-synthetic-prediction-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_PREDICTION=1  # blocked in Phase 4.48"
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
@@ -405,6 +408,22 @@ data-synthetic-training-feature-commit: ## Blocked synthetic training feature ga
 		exit 1; \
 	fi
 	@echo "BLOCKED: synthetic training feature commit is not wired in Phase 4.46."
+	@exit 1
+
+data-synthetic-prediction-dry-run: ## Run safe synthetic training feature to prediction preflight. Requires MATCH_ID.
+	@if [ -z "$(MATCH_ID)" ]; then \
+		echo "ERROR: provide MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Running safe synthetic training feature to prediction preflight: MATCH_ID=$(MATCH_ID)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/synthetic_prediction_preflight.js --match-id "$(MATCH_ID)"
+
+data-synthetic-prediction-commit: ## Blocked synthetic prediction gate. Requires MATCH_ID, CONFIRM_SYNTHETIC_PREDICTION=1.
+	@if [ "$(CONFIRM_SYNTHETIC_PREDICTION)" != "1" ]; then \
+		echo "BLOCKED: synthetic prediction commit requires CONFIRM_SYNTHETIC_PREDICTION=1 and is not wired in Phase 4.48."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: synthetic prediction commit is not wired in Phase 4.48."
 	@exit 1
 
 data-prediction-write-dry-run: ## Run safe local predictions write preview. Requires MATCH_ID.

--- a/docs/_reports/SYNTHETIC_PREDICTION_PREFLIGHT_PHASE4_48.md
+++ b/docs/_reports/SYNTHETIC_PREDICTION_PREFLIGHT_PHASE4_48.md
@@ -1,0 +1,365 @@
+# Phase 4.48 - Synthetic match_features_training to Prediction Preflight Gate
+
+## Current HEAD
+
+- start branch: `main`
+- start HEAD: `20152e8e35c82ea773ed6dec5f02b59a5a80cc5b`
+- work branch: `feat/synthetic-prediction-preflight-gate`
+- base summary: `20152e8 feat(training): add synthetic training feature preflight gate`
+
+Phase 4.47 local report was preserved:
+
+- `docs/_reports/SYNTHETIC_TRAINING_FEATURE_SINGLE_INSERT_PHASE4_47.md`
+
+No `git reset --hard`, `git clean`, or file deletion was performed.
+
+## Phase 4.47 Synthetic Training Feature Status Summary
+
+The target finished match already has one synthetic `match_features_training` row written under the prior human-authorized Phase 4.47 step:
+
+- `match_id = 47_20242025_900002`
+- `feature_data_version = PHASE4.47_SYNTHETIC_TRAINING_FEATURE`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `downstream_training_allowed = false`
+- `downstream_prediction_allowed = false`
+
+That row remains engineering-only and must not be treated as a real training input or real model-output source.
+
+## Current DB Row Counts
+
+Read-only checks during Phase 4.48 confirmed:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    2 |
+| predictions             |    1 |
+
+Phase 4.48 performed no DB writes and the counts remained unchanged before and after validation.
+
+## Target Match Status
+
+Target match:
+
+| field                 | value                    |
+| --------------------- | ------------------------ |
+| match_id              | `47_20242025_900002`     |
+| season                | `2024/2025`              |
+| match_date            | `2024-08-17 17:30:00+00` |
+| home_team             | `Burgos`                 |
+| away_team             | `Oviedo`                 |
+| home_score            | `1`                      |
+| away_score            | `0`                      |
+| actual_result         | `home_win`               |
+| status                | `finished`               |
+| is_finished           | `true`                   |
+| has_raw_match_data    | `true`                   |
+| has_l3_features       | `true`                   |
+| has_training_features | `true`                   |
+| has_predictions       | `false`                  |
+
+## match_features_training Synthetic Metadata Summary
+
+Read-only inspection of `match_features_training` for the target match confirmed:
+
+| field                         | value                                  |
+| ----------------------------- | -------------------------------------- |
+| match_id                      | `47_20242025_900002`                   |
+| synthetic                     | `true`                                 |
+| engineering_test_only         | `true`                                 |
+| not_real_external_data        | `true`                                 |
+| not_for_training              | `true`                                 |
+| not_for_production            | `true`                                 |
+| feature_data_version          | `PHASE4.47_SYNTHETIC_TRAINING_FEATURE` |
+| downstream_training_allowed   | `false`                                |
+| downstream_prediction_allowed | `false`                                |
+
+This synthetic provenance is explicit and remains intact.
+
+## predictions Schema Summary
+
+Read-only schema inspection confirmed:
+
+- `match_id` is `NOT NULL` and references `matches(match_id)`
+- `model_version` is `character varying(20)` in practice through the unique index and existing application expectations
+- `predicted_result` is `NOT NULL`
+- unique constraint exists on `(match_id, model_version)`
+- current target match has no prediction rows
+
+This is why the synthetic preview recommends `model_version = P4_SYNTH_BASELINE`, which fits within the 20-character limit.
+
+## Existing Prediction / Model Entrypoint Risk Audit
+
+Read-only audit confirmed these remain dangerous or prohibited for this phase:
+
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run predict:json`
+- `npm run train`
+- `scripts/ops/predict_pipeline.py`
+- `node scripts/ops/prediction_local_write_gate.js --commit`
+- `make data-prediction-commit`
+- `make data-prediction-write-commit`
+
+Phase 4.48 therefore adds a separate SELECT-only synthetic preview gate instead of calling any real prediction, model artifact, training, or write path.
+
+## New synthetic_prediction_preflight.js Behavior
+
+Added:
+
+```text
+scripts/ops/synthetic_prediction_preflight.js
+```
+
+Supported usage:
+
+```bash
+node scripts/ops/synthetic_prediction_preflight.js --match-id 47_20242025_900002
+node scripts/ops/synthetic_prediction_preflight.js --match-id 47_20242025_900002 --json
+node scripts/ops/synthetic_prediction_preflight.js --match-id 47_20242025_900002 --commit
+```
+
+Behavior:
+
+- only executes guarded `SELECT` queries
+- blocks any non-`SELECT` SQL through a forbidden verb check
+- uses container DB defaults (`db`, `POSTGRES_*`, `DB_*`)
+- emits match status, upstream synthetic-chain status, prediction status, preview payload, gating decision, and non-execution confirmations
+- never writes `predictions`
+- never trains a model
+- never loads a model artifact
+- never executes real prediction logic
+- never accesses external network
+
+If `--commit` is passed, it immediately fails with:
+
+```text
+BLOCKED: synthetic prediction commit is not wired in Phase 4.48.
+```
+
+## Makefile Entrypoints
+
+Added safe entrypoints:
+
+```text
+make data-synthetic-prediction-dry-run MATCH_ID=<id>
+make data-synthetic-prediction-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_PREDICTION=1
+```
+
+Behavior:
+
+- dry-run requires `MATCH_ID`
+- commit target is blocked without `CONFIRM_SYNTHETIC_PREDICTION=1`
+- commit target remains blocked even with `CONFIRM_SYNTHETIC_PREDICTION=1`
+- no DB writes are wired behind the commit target in Phase 4.48
+
+## AGENTS.md Update
+
+Added Phase 4.48 synthetic prediction rules:
+
+- AI / Codex may run `make data-synthetic-prediction-dry-run MATCH_ID=<id>` only with explicit user authorization
+- input `match_features_training` must already be marked synthetic / engineering-test-only / not-for-training
+- no DB writes, no prediction writes, no model training, no prediction execution, no model artifact loading, no external network access
+- `make data-synthetic-prediction-commit` and `node scripts/ops/synthetic_prediction_preflight.js --commit` remain prohibited until a future separately authorized phase
+
+Referenced reports:
+
+- `docs/_reports/SYNTHETIC_TRAINING_FEATURE_SINGLE_INSERT_PHASE4_47.md`
+- `docs/_reports/SYNTHETIC_TRAINING_FEATURE_PREFLIGHT_PHASE4_46.md`
+- `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
+
+## Dry-Run Validation Results
+
+Missing-argument validation:
+
+```bash
+make data-synthetic-prediction-dry-run
+```
+
+Result:
+
+- failed as expected
+- error text: `ERROR: provide MATCH_ID=<id>`
+
+Target dry-run:
+
+```bash
+make data-synthetic-prediction-dry-run MATCH_ID=47_20242025_900002
+```
+
+Confirmed output semantics:
+
+- `mode = dry-run / preflight`
+- `match_found = true`
+- `is_finished = true`
+- `raw_match_data_found = true`
+- `l3_features_found = true`
+- `match_features_training_found = true`
+- `training_features_synthetic = true`
+- `training_features_not_for_training = true`
+- `training_features_not_for_production = true`
+- `downstream_prediction_allowed = false`
+- `predictions_exists = false`
+- `target_model_version_exists = false`
+- `recommended_model_version = P4_SYNTH_BASELINE`
+- `model_version_length<=20 = true`
+- `would_write_predictions = false`
+- `would_train_model = false`
+- `would_load_model_artifact = false`
+- `would_execute_real_prediction = false`
+- `preview_only = true`
+- `synthetic_input = true`
+- `not_real_model_output = true`
+- `prediction_allowed = false`
+- `can_write_prediction_now = false`
+- `real_prediction_allowed = false`
+- `model_training_allowed = false`
+- `no_db_writes`
+- `no_prediction_write`
+- `no_model_training`
+- `no_prediction_execution`
+- `no_model_artifact_load`
+- `no_external_network`
+
+## Synthetic Prediction Preview Summary
+
+The dry-run emits an engineering-only baseline preview with:
+
+- `target_table = predictions`
+- `model_version = P4_SYNTH_BASELINE`
+- `predicted_result = home_win`
+- `preview_only = true`
+- `not_real_model_output = true`
+- `based_on_synthetic_chain = true`
+- `not_for_production = true`
+- note explaining this is not a real model prediction
+
+The preview uses the known `actual_result = home_win` only for engineering visibility and explicitly states that it must not be treated as real model output.
+
+## Commit Gate Blocked Results
+
+Verified blocked behavior:
+
+```bash
+make data-synthetic-prediction-commit
+make data-synthetic-prediction-commit MATCH_ID=47_20242025_900002 CONFIRM_SYNTHETIC_PREDICTION=1
+```
+
+Both commands were blocked:
+
+- first command requires `CONFIRM_SYNTHETIC_PREDICTION=1`
+- second command still reports `synthetic prediction commit is not wired in Phase 4.48`
+
+No prediction write, model training, prediction execution, model artifact loading, or DB write occurred.
+
+## Old Gate Rechecks
+
+Rechecked:
+
+```bash
+make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002
+make data-synthetic-training-feature-dry-run MATCH_ID=47_20242025_900002
+```
+
+Confirmed:
+
+- `has_training_features = true`
+- `has_predictions = false`
+- `match_features_training_exists = true`
+- `predictions_exists = false`
+- `no_db_writes`
+
+This confirms the upstream synthetic chain remains intact and Phase 4.48 introduced no writes.
+
+## DB Before / After Statistics
+
+Before validation:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    2 |
+| predictions             |    1 |
+
+After validation:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    2 |
+| predictions             |    1 |
+
+Result:
+
+- DB row counts were unchanged
+- no business table write occurred
+
+## Recommended Next Phase
+
+Recommended next step:
+
+```text
+Phase 4.49: artificial authorization for one synthetic baseline prediction insert
+```
+
+Alternative:
+
+```text
+Stop the synthetic chain and move back to a real data-source strategy.
+```
+
+## Explicit Non-Execution
+
+Phase 4.48 did not execute:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `COPY`
+- export
+- DB writes
+- `predictions` write
+- `match_features_training` write
+- `l3_features` write
+- `raw_match_data` write
+- `smelt`
+- `l3:stitch`
+- ELO recalculation
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push --force`
+- `git push --mirror`
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/_reports/SYNTHETIC_TRAINING_FEATURE_SINGLE_INSERT_PHASE4_47.md
+++ b/docs/_reports/SYNTHETIC_TRAINING_FEATURE_SINGLE_INSERT_PHASE4_47.md
@@ -1,0 +1,318 @@
+# Phase 4.47 - Synthetic match_features_training Single Insert
+
+## Current HEAD
+
+- Branch: `main`
+- HEAD: `20152e8e35c82ea773ed6dec5f02b59a5a80cc5b`
+- HEAD summary: `20152e8 feat(training): add synthetic training feature preflight gate`
+- Git status before report generation: clean
+
+## Backup
+
+- backup file: `data/backups/phase447_pre_synthetic_training_features_insert_20260504_114525.dump`
+- backup size: `72K`
+
+## Write Scope
+
+Human-authorized write scope:
+
+- table: `match_features_training`
+- operation: one explicit `INSERT`
+- match_id: `47_20242025_900002`
+- source L3 feature data version: `PHASE4.45_SYNTHETIC_L3`
+- training feature data version: `PHASE4.47_SYNTHETIC_TRAINING_FEATURE`
+
+This was synthetic training-feature data only:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `downstream_training_allowed = false`
+- `downstream_prediction_allowed = false`
+
+It is engineering-test-only, not real external data, not production data, and not suitable for real model training or production prediction.
+
+## Write Before State
+
+DB row counts before insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    1 |
+| predictions             |    1 |
+
+Target match before insert:
+
+| field                 | value                    |
+| --------------------- | ------------------------ |
+| match_id              | `47_20242025_900002`     |
+| season                | `2024/2025`              |
+| match_date            | `2024-08-17 17:30:00+00` |
+| home_team             | `Burgos`                 |
+| away_team             | `Oviedo`                 |
+| home_score            | `1`                      |
+| away_score            | `0`                      |
+| actual_result         | `home_win`               |
+| status                | `finished`               |
+| is_finished           | `true`                   |
+| has_raw_match_data    | `true`                   |
+| has_l3_features       | `true`                   |
+| has_training_features | `false`                  |
+| has_predictions       | `false`                  |
+
+Synthetic L3 status before insert:
+
+| field                     | value                    |
+| ------------------------- | ------------------------ |
+| match_id                  | `47_20242025_900002`     |
+| external_id               | `900002`                 |
+| golden_synthetic          | `true`                   |
+| tactical_synthetic        | `true`                   |
+| odds_synthetic            | `true`                   |
+| elo_synthetic             | `true`                   |
+| stitch_synthetic          | `true`                   |
+| golden_not_for_training   | `true`                   |
+| stitch_not_for_production | `true`                   |
+| feature_data_version      | `PHASE4.45_SYNTHETIC_L3` |
+
+Target training row count before insert:
+
+- `target_training_rows = 0`
+
+## match_features_training Schema Confirmation
+
+Read-only schema inspection confirmed:
+
+- `match_id` is the primary key
+- `match_id` references `matches(match_id)` with `ON DELETE CASCADE`
+- required columns without defaults:
+    - `match_id`
+    - `season`
+    - `match_date`
+    - `home_team`
+    - `away_team`
+- `adaptive_features` exists and is nullable `jsonb`
+- `feature_version` defaults to `V25.1`
+- `feature_count` defaults to `0`
+- `created_at` and `updated_at` default to `CURRENT_TIMESTAMP`
+
+No schema modification was performed.
+
+## Synthetic Training Feature Dry-Run Before Insert
+
+Command:
+
+```bash
+make data-synthetic-training-feature-dry-run MATCH_ID=47_20242025_900002
+```
+
+Result before insert:
+
+- `match_found = true`
+- `is_finished = true`
+- `raw_match_data_found = true`
+- `l3_features_found = true`
+- `l3_features_synthetic = true`
+- `l3_features_not_for_training = true`
+- `match_features_training_exists = false`
+- `predictions_exists = false`
+- `would_insert_match_features_training = false`
+- `would_train_model = false`
+- `would_write_predictions = false`
+- `preview_only = true`
+- `synthetic_input = true`
+- `can_write_training_features_now = false`
+- `real_training_allowed = false`
+- `prediction_allowed = false`
+- `no_db_writes`
+
+## Insert Result
+
+The authorized insert succeeded.
+
+Returned row:
+
+| field      | value                           |
+| ---------- | ------------------------------- |
+| match_id   | `47_20242025_900002`            |
+| season     | `2024/2025`                     |
+| match_date | `2024-08-17 17:30:00+00`        |
+| home_team  | `Burgos`                        |
+| away_team  | `Oviedo`                        |
+| created_at | `2026-05-04 03:45:42.236299+00` |
+| updated_at | `2026-05-04 03:45:42.236299+00` |
+
+SQL behavior:
+
+- one explicit `BEGIN`
+- one explicit `INSERT INTO match_features_training`
+- one explicit `COMMIT`
+- no `ON CONFLICT DO UPDATE`
+- no writes to any other table
+- no model training
+- no prediction execution
+- no model artifact loading
+
+## adaptive_features Summary
+
+Inserted `adaptive_features` contains:
+
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `target_match_id = 47_20242025_900002`
+- `source_l3_feature_data_version = PHASE4.45_SYNTHETIC_L3`
+- `feature_data_version = PHASE4.47_SYNTHETIC_TRAINING_FEATURE`
+- `downstream_training_allowed = false`
+- `downstream_prediction_allowed = false`
+- `source = synthetic_l3_features`
+
+Included synthetic feature groups:
+
+- `golden_features`
+- `tactical_features`
+- `odds_features`
+- `elo_features`
+- `stitch_summary`
+
+## Write After Verification
+
+Target `match_features_training` row:
+
+- `match_id = 47_20242025_900002`
+- `season = 2024/2025`
+- `match_date = 2024-08-17 17:30:00+00`
+- `home_team = Burgos`
+- `away_team = Oviedo`
+- `adaptive_features_type = object`
+- `synthetic = true`
+- `engineering_test_only = true`
+- `not_real_external_data = true`
+- `not_for_training = true`
+- `not_for_production = true`
+- `feature_data_version = PHASE4.47_SYNTHETIC_TRAINING_FEATURE`
+- `downstream_training_allowed = false`
+- `downstream_prediction_allowed = false`
+
+Target training row count after insert:
+
+- `target_training_rows = 1`
+
+DB row counts after insert:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    2 |
+| predictions             |    1 |
+
+Result:
+
+- `match_features_training` increased from `1 -> 2`
+- all other tracked tables remained unchanged
+
+## Gate Verification After Insert
+
+`make data-synthetic-training-feature-dry-run MATCH_ID=47_20242025_900002` reported:
+
+- `match_found = true`
+- `raw_match_data_found = true`
+- `l3_features_found = true`
+- `l3_features_synthetic = true`
+- `match_features_training_exists = true`
+- `predictions_exists = false`
+- `would_insert_match_features_training = false`
+- `would_train_model = false`
+- `would_write_predictions = false`
+- `no_db_writes`
+
+`make data-finished-backfill-dry-run MATCH_ID=47_20242025_900002` reported:
+
+- `has_raw_match_data = true`
+- `has_l3_features = true`
+- `has_training_features = true`
+- `has_predictions = false`
+- `predictions.blocked_until_training_features = false`
+- `predictions.must_not_predict_without_approved_artifact = true`
+- `no_db_writes`
+
+Verified blocked gates:
+
+- `make data-synthetic-training-feature-commit`: blocked
+- `make data-synthetic-training-feature-commit ... CONFIRM_SYNTHETIC_TRAINING_FEATURE=1`: blocked
+- `make data-training-feature-commit`: blocked
+- `make data-training-feature-commit MATCH_ID=47_20242025_900002 CONFIRM_TRAINING_FEATURE=1`: blocked
+- `make data-prediction-commit`: blocked
+- `make data-prediction-commit CONFIRM_PREDICTION=1`: blocked
+
+No training, prediction, model artifact loading, `smelt`, `l3:stitch`, ELO recalculation, raw ingest, or external network access was executed.
+
+## Risk Notes
+
+- This row is synthetic and engineering-test-only.
+- It must not be used as real external data.
+- It must not be used for real model training.
+- It must not be used for production outputs.
+- `downstream_training_allowed=false` is explicit.
+- `downstream_prediction_allowed=false` is explicit.
+- Future prediction work must account for synthetic provenance before any preview or write.
+
+## Recommended Next Phase
+
+Recommended next step:
+
+```text
+Phase 4.48: synthetic match_features_training -> prediction preflight gate
+```
+
+To reduce frequent merges, keep this Phase 4.47 report local for now and submit it together with the Phase 4.48 related gate / report in one themed PR.
+
+## Explicit Non-Execution
+
+This phase did not execute:
+
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `INSERT` into any table except `match_features_training`
+- multiple `match_features_training` inserts
+- `raw_match_data` write
+- `l3_features` write
+- `predictions` write
+- `smelt`
+- `l3:stitch`
+- ELO recalculation
+- model training
+- real prediction execution
+- model artifact loading
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external network access
+- real harvest / scrape / ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume cleanup
+- `git push`
+- `git pull`
+- `git fetch --all`
+- commit

--- a/scripts/ops/synthetic_prediction_preflight.js
+++ b/scripts/ops/synthetic_prediction_preflight.js
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+/**
+ * Safe synthetic training-feature to prediction preflight gate.
+ *
+ * Phase 4.48 reads the target match and existing synthetic
+ * match_features_training row, then emits a prediction preview without model
+ * loading, inference, training, prediction writes, or any DB writes.
+ */
+
+'use strict';
+
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+const RECOMMENDED_MODEL_VERSION = 'P4_SYNTH_BASELINE';
+const MODEL_VERSION_LENGTH_LIMIT = 20;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/synthetic_prediction_preflight.js --match-id <id> [--json]',
+        '  node scripts/ops/synthetic_prediction_preflight.js --match-id <id> --commit',
+        '',
+        'Safety:',
+        '  Preflight only in Phase 4.48; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        matchId: null,
+        json: false,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--match-id') {
+            args.matchId = argv[index + 1];
+            index += 1;
+        } else if (token.startsWith('--match-id=')) {
+            args.matchId = token.slice('--match-id='.length);
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function normalizeText(value) {
+    return String(value ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function asBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    return TRUE_VALUES.has(normalizeText(value).toLowerCase());
+}
+
+function asObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function hasValue(value) {
+    return normalizeText(value).length > 0;
+}
+
+function toIso(value) {
+    return value ? new Date(value).toISOString() : null;
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_create',
+        'no_alter',
+        'no_drop',
+        'no_truncate',
+        'no_copy_export',
+        'no_prediction_write',
+        'no_training_feature_write',
+        'no_l3_write',
+        'no_raw_match_data_write',
+        'no_model_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+    ];
+}
+
+function buildBlockedCommitPayload() {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        error: 'BLOCKED: synthetic prediction commit is not wired in Phase 4.48.',
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function buildTargetMatchStatus(match) {
+    return {
+        match_found: Boolean(match),
+        match_id: match?.match_id || null,
+        season: match?.season || null,
+        match_date: toIso(match?.match_date),
+        home_team: match?.home_team || null,
+        away_team: match?.away_team || null,
+        home_score: match?.home_score ?? null,
+        away_score: match?.away_score ?? null,
+        actual_result: match?.actual_result || null,
+        status: match?.status || null,
+        is_finished: match?.is_finished === true,
+        has_actual_result: hasValue(match?.actual_result),
+        has_score:
+            match?.home_score !== null &&
+            match?.home_score !== undefined &&
+            match?.away_score !== null &&
+            match?.away_score !== undefined,
+    };
+}
+
+function buildUpstreamChainStatus(matchRow, trainingRow) {
+    const adaptiveFeatures = asObject(trainingRow?.adaptive_features);
+
+    return {
+        raw_match_data_found: matchRow?.has_raw_match_data === true,
+        l3_features_found: matchRow?.has_l3_features === true,
+        match_features_training_found: Boolean(trainingRow),
+        training_feature_version: trainingRow?.feature_version || null,
+        training_feature_count: trainingRow?.feature_count ?? null,
+        training_features_created_at: toIso(trainingRow?.created_at),
+        training_features_updated_at: toIso(trainingRow?.updated_at),
+        training_features_synthetic: asBoolean(adaptiveFeatures.synthetic),
+        training_features_engineering_test_only: asBoolean(adaptiveFeatures.engineering_test_only),
+        training_features_not_real_external_data: asBoolean(adaptiveFeatures.not_real_external_data),
+        training_features_not_for_training: asBoolean(adaptiveFeatures.not_for_training),
+        training_features_not_for_production: asBoolean(adaptiveFeatures.not_for_production),
+        source_l3_feature_data_version: adaptiveFeatures.source_l3_feature_data_version || null,
+        feature_data_version: adaptiveFeatures.feature_data_version || null,
+        downstream_training_allowed: asBoolean(adaptiveFeatures.downstream_training_allowed),
+        downstream_prediction_allowed: asBoolean(adaptiveFeatures.downstream_prediction_allowed),
+    };
+}
+
+function buildPredictionStatus(predictionRows) {
+    const targetModelVersionExists = predictionRows.some(row => row.model_version === RECOMMENDED_MODEL_VERSION);
+    const recommendedModelVersionLength = RECOMMENDED_MODEL_VERSION.length;
+
+    return {
+        predictions_exists: predictionRows.length > 0,
+        existing_predictions_count: predictionRows.length,
+        existing_model_versions: predictionRows.map(row => row.model_version),
+        target_model_version: RECOMMENDED_MODEL_VERSION,
+        target_model_version_exists: targetModelVersionExists,
+        recommended_model_version: RECOMMENDED_MODEL_VERSION,
+        recommended_model_version_length: recommendedModelVersionLength,
+        model_version_length_limit: MODEL_VERSION_LENGTH_LIMIT,
+        model_version_length_lte_20: recommendedModelVersionLength <= MODEL_VERSION_LENGTH_LIMIT,
+    };
+}
+
+function choosePreviewResult(matchRow) {
+    return matchRow?.actual_result === 'home_win' ? 'home_win' : 'draw';
+}
+
+function summarizeAdaptiveFeatures(trainingRow) {
+    const adaptiveFeatures = asObject(trainingRow?.adaptive_features);
+
+    return {
+        type: Array.isArray(trainingRow?.adaptive_features) ? 'array' : typeof trainingRow?.adaptive_features,
+        key_count: Object.keys(adaptiveFeatures).length,
+        keys: Object.keys(adaptiveFeatures).sort(),
+        source: adaptiveFeatures.source || null,
+        source_l3_feature_data_version: adaptiveFeatures.source_l3_feature_data_version || null,
+        feature_data_version: adaptiveFeatures.feature_data_version || null,
+        synthetic: asBoolean(adaptiveFeatures.synthetic),
+        not_for_training: asBoolean(adaptiveFeatures.not_for_training),
+        not_for_production: asBoolean(adaptiveFeatures.not_for_production),
+        downstream_prediction_allowed: asBoolean(adaptiveFeatures.downstream_prediction_allowed),
+    };
+}
+
+function buildPredictionPreview({ matchRow, trainingRow }) {
+    const predictedResult = choosePreviewResult(matchRow);
+
+    return {
+        target_table: 'predictions',
+        would_write_predictions: false,
+        would_train_model: false,
+        would_load_model_artifact: false,
+        would_execute_real_prediction: false,
+        preview_only: true,
+        synthetic_input: true,
+        not_real_model_output: true,
+        not_for_training: true,
+        not_for_production: true,
+        prediction_allowed: false,
+        synthetic_baseline_preview: {
+            model_version: RECOMMENDED_MODEL_VERSION,
+            predicted_result: predictedResult,
+            preview_only: true,
+            not_real_model_output: true,
+            based_on_synthetic_chain: true,
+            not_for_production: true,
+            actual_result_used_for_engineering_preview: matchRow?.actual_result || null,
+            note: 'Engineering preview only. This uses synthetic-chain context and must not be treated as a real model prediction.',
+        },
+        training_feature_summary: summarizeAdaptiveFeatures(trainingRow),
+    };
+}
+
+function buildGatingDecision(upstreamStatus) {
+    const syntheticTrainingSafetyComplete =
+        upstreamStatus.training_features_synthetic === true &&
+        upstreamStatus.training_features_engineering_test_only === true &&
+        upstreamStatus.training_features_not_real_external_data === true &&
+        upstreamStatus.training_features_not_for_training === true &&
+        upstreamStatus.training_features_not_for_production === true &&
+        upstreamStatus.downstream_prediction_allowed === false;
+
+    return {
+        can_write_prediction_now: false,
+        reason: 'synthetic training features require separate manual authorization and cannot be treated as real model output',
+        real_prediction_allowed: false,
+        model_training_allowed: false,
+        synthetic_training_safety_complete: syntheticTrainingSafetyComplete,
+    };
+}
+
+function buildPayload({ args, matchRow, trainingRow, predictionRows }) {
+    const upstreamStatus = buildUpstreamChainStatus(matchRow, trainingRow);
+
+    return {
+        mode: 'dry-run / preflight',
+        phase: '4.48',
+        match_id: args.matchId,
+        target_match: buildTargetMatchStatus(matchRow),
+        upstream_chain_status: upstreamStatus,
+        prediction_status: buildPredictionStatus(predictionRows),
+        prediction_preview: buildPredictionPreview({ matchRow, trainingRow }),
+        gating_decision: buildGatingDecision(upstreamStatus),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function formatText(payload) {
+    return [
+        `mode=${payload.mode}`,
+        `phase=${payload.phase}`,
+        `match_id=${payload.match_id}`,
+        `match_found=${payload.target_match.match_found}`,
+        `is_finished=${payload.target_match.is_finished}`,
+        `has_actual_result=${payload.target_match.has_actual_result}`,
+        `has_score=${payload.target_match.has_score}`,
+        `raw_match_data_found=${payload.upstream_chain_status.raw_match_data_found}`,
+        `l3_features_found=${payload.upstream_chain_status.l3_features_found}`,
+        `match_features_training_found=${payload.upstream_chain_status.match_features_training_found}`,
+        `training_features_synthetic=${payload.upstream_chain_status.training_features_synthetic}`,
+        `training_features_not_for_training=${payload.upstream_chain_status.training_features_not_for_training}`,
+        `training_features_not_for_production=${payload.upstream_chain_status.training_features_not_for_production}`,
+        `downstream_prediction_allowed=${payload.upstream_chain_status.downstream_prediction_allowed}`,
+        `predictions_exists=${payload.prediction_status.predictions_exists}`,
+        `target_model_version_exists=${payload.prediction_status.target_model_version_exists}`,
+        `recommended_model_version=${payload.prediction_status.recommended_model_version}`,
+        `model_version_length<=20=${payload.prediction_status.model_version_length_lte_20}`,
+        `would_write_predictions=${payload.prediction_preview.would_write_predictions}`,
+        `would_train_model=${payload.prediction_preview.would_train_model}`,
+        `would_load_model_artifact=${payload.prediction_preview.would_load_model_artifact}`,
+        `would_execute_real_prediction=${payload.prediction_preview.would_execute_real_prediction}`,
+        `preview_only=${payload.prediction_preview.preview_only}`,
+        `synthetic_input=${payload.prediction_preview.synthetic_input}`,
+        `not_real_model_output=${payload.prediction_preview.not_real_model_output}`,
+        `not_for_training=${payload.prediction_preview.not_for_training}`,
+        `not_for_production=${payload.prediction_preview.not_for_production}`,
+        `prediction_allowed=${payload.prediction_preview.prediction_allowed}`,
+        `can_write_prediction_now=${payload.gating_decision.can_write_prediction_now}`,
+        `real_prediction_allowed=${payload.gating_decision.real_prediction_allowed}`,
+        `model_training_allowed=${payload.gating_decision.model_training_allowed}`,
+        '',
+        'target_match:',
+        JSON.stringify(payload.target_match, null, 2),
+        '',
+        'upstream_chain_status:',
+        JSON.stringify(payload.upstream_chain_status, null, 2),
+        '',
+        'prediction_status:',
+        JSON.stringify(payload.prediction_status, null, 2),
+        '',
+        'prediction_preview:',
+        JSON.stringify(payload.prediction_preview, null, 2),
+        '',
+        'gating_decision:',
+        JSON.stringify(payload.gating_decision, null, 2),
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ].join('\n');
+}
+
+async function loadMatch(pool, matchId) {
+    const sql = `
+        SELECT
+            m.match_id,
+            m.season,
+            m.match_date,
+            m.home_team,
+            m.away_team,
+            m.home_score,
+            m.away_score,
+            m.actual_result,
+            m.status,
+            m.is_finished,
+            EXISTS (SELECT 1 FROM raw_match_data r WHERE r.match_id = m.match_id) AS has_raw_match_data,
+            EXISTS (SELECT 1 FROM l3_features l WHERE l.match_id = m.match_id) AS has_l3_features
+        FROM matches m
+        WHERE m.match_id = $1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function loadTrainingFeatures(pool, matchId) {
+    const sql = `
+        SELECT
+            match_id,
+            season,
+            match_date,
+            home_team,
+            away_team,
+            feature_version,
+            feature_count,
+            adaptive_features,
+            created_at,
+            updated_at
+        FROM match_features_training
+        WHERE match_id = $1
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows[0] || null;
+}
+
+async function loadPredictionRows(pool, matchId) {
+    const sql = `
+        SELECT
+            match_id,
+            model_version,
+            predicted_result,
+            prediction_date
+        FROM predictions
+        WHERE match_id = $1
+        ORDER BY model_version
+    `;
+    const result = await safeSelect(pool, sql, [matchId]);
+    return result.rows;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error('BLOCKED: synthetic prediction commit is not wired in Phase 4.48.');
+        console.error(JSON.stringify(buildBlockedCommitPayload(), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+    if (!args.matchId) {
+        console.error('ERROR: provide --match-id <id>');
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const matchRow = await loadMatch(pool, args.matchId);
+        const trainingRow = await loadTrainingFeatures(pool, args.matchId);
+        const predictionRows = await loadPredictionRows(pool, args.matchId);
+        const payload = buildPayload({ args, matchRow, trainingRow, predictionRows });
+
+        console.log(args.json ? JSON.stringify(payload, null, 2) : formatText(payload));
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'dry-run / preflight',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a safe synthetic match_features_training to prediction preflight gate and commits the Phase 4.47 synthetic match_features_training single insert report.

Changes:
- Adds scripts/ops/synthetic_prediction_preflight.js
- Adds make data-synthetic-prediction-dry-run
- Adds blocked make data-synthetic-prediction-commit
- Updates data-help
- Updates AGENTS.md with synthetic prediction safety rules
- Adds Phase 4.47 report
- Adds Phase 4.48 report

Safety:
- SELECT-only DB checks
- No DB writes
- No predictions writes
- No model training
- No prediction execution
- No model artifact loading
- No external data access
- Commit gate remains blocked

Validation:
- make data-synthetic-prediction-dry-run without args fails as expected
- make data-synthetic-prediction-dry-run MATCH_ID=47_20242025_900002 succeeds
- make data-synthetic-prediction-commit remains blocked with and without CONFIRM_SYNTHETIC_PREDICTION=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed

Changed files:
- AGENTS.md
- Makefile
- scripts/ops/synthetic_prediction_preflight.js
- docs/_reports/SYNTHETIC_TRAINING_FEATURE_SINGLE_INSERT_PHASE4_47.md
- docs/_reports/SYNTHETIC_PREDICTION_PREFLIGHT_PHASE4_48.md