### PR TITLE
feat(data): add real finished CSV staging dry-run gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,8 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读 DB 的 `make data-prediction-write-dry-run MATCH_ID=<id>`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-dataset-status`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-training-dataset-dry-run`
+- 用户明确授权且只读本地 source manifest、不写 DB、不训练、不预测的 `make data-real-source-audit SOURCE_MANIFEST=<local json>`
+- 用户明确授权且只读本地 source manifest + 本地 CSV、不写 DB、不训练、不预测的 `make data-real-finished-csv-dry-run SOURCE_MANIFEST=<local json> SAMPLE_CSV=<local csv>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 - 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
@@ -263,6 +265,9 @@ AI / Codex 不能直接执行：
 - `node scripts/ops/prediction_local_write_gate.js --commit`
 - `make data-training-dataset-export`
 - `make data-training-dataset-export CONFIRM_DATASET_EXPORT=1`
+- `make data-real-finished-csv-commit`
+- `make data-real-finished-csv-commit CONFIRM_REAL_CSV_COMMIT=1`
+- `node scripts/ops/real_finished_csv_staging_dry_run.js --commit`
 - `make data-finished-csv-commit`
 - `make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1`
 - `node scripts/ops/finished_csv_local_dry_run.js --commit`
@@ -359,6 +364,36 @@ Phase 4.36 中 `make data-training-dataset-export` 和 `make data-training-datas
 - 不导出数据集或大文件
 
 Phase 4.38 中 `make data-finished-csv-commit`、`make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1` 和 `node scripts/ops/finished_csv_local_dry_run.js --commit` 仍是 blocked / not wired。finished CSV import 必须先 dry-run；label mapping 必须在报告中确认；scheduled / unlabeled rows 不可作为训练样本；外部 CSV 下载仍禁止，公开数据源也必须先人工确认许可和用途。相关背景见：`docs/_reports/FINISHED_MATCH_SOURCE_AUDIT_PHASE4_37.md`、`docs/_reports/DATASET_STATUS_AUDIT_GATE_PHASE4_36.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
+
+执行 `make data-real-source-audit SOURCE_MANIFEST=<local json>` 的前提：
+
+- 用户明确授权
+- source manifest 是本地文件
+- 入口只做 manifest 完整性和 provenance 只读检查
+- 不写 DB
+- 不训练模型
+- 不执行预测
+- 不访问外部足球数据源
+- 不导出数据
+
+执行 `make data-real-finished-csv-dry-run SOURCE_MANIFEST=<local json> SAMPLE_CSV=<local csv>` 的前提：
+
+- 用户明确授权
+- source manifest 和 CSV 都是本地文件
+- 入口只做 manifest + CSV 只读解析
+- DB duplicate check 仅允许 SELECT-only
+- 不写 DB
+- 不训练模型
+- 不执行预测
+- 不加载 model artifact
+- 不下载外部数据
+- 不访问外部足球数据源
+- finished score / `actual_result` 只能做 label
+- post-match stats 不得作为赛前 feature
+- synthetic rows 不得混入真实训练
+- `predictions` 表不得反哺训练
+
+Phase 4.52 中 `make data-real-finished-csv-commit`、`make data-real-finished-csv-commit CONFIRM_REAL_CSV_COMMIT=1` 和 `node scripts/ops/real_finished_csv_staging_dry_run.js --commit` 仍是 blocked / not wired。没有完整 source manifest，不得 dry-run；没有 license / provenance，不得 commit；真实写库前必须 `pg_dump` + 小批量授权。相关背景见：`docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md`、`docs/_reports/REAL_DATA_SOURCE_STRATEGY_PHASE4_51.md`、`docs/_reports/SYNTHETIC_CHAIN_CLOSURE_PHASE4_50.md` 和 `docs/_reports/MULTISAMPLE_TRAINING_STRATEGY_PHASE4_35.md`
 
 真实 finished match 数据源接入前置规则：
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
         data-training-feature-dry-run data-training-feature-commit \
         data-prediction-write-dry-run data-prediction-write-commit \
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
+        data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-fixture-dry-run data-raw-fixture-commit \
@@ -253,6 +254,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-prediction-write-dry-run MATCH_ID=<id>"
 	@echo "  make data-dataset-status"
 	@echo "  make data-training-dataset-dry-run"
+	@echo "  make data-real-source-audit SOURCE_MANIFEST=<path>"
+	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
@@ -269,6 +272,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-synthetic-training-feature-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_TRAINING_FEATURE=1  # blocked in Phase 4.46"
 	@echo "  make data-synthetic-prediction-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_PREDICTION=1  # blocked in Phase 4.48"
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
+	@echo "  make data-real-finished-csv-commit SOURCE_MANIFEST=<path> SAMPLE_CSV=<path> CONFIRM_REAL_CSV_COMMIT=1  # blocked in Phase 4.52"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -458,6 +462,33 @@ data-training-dataset-export: ## Blocked dataset export gate. Remains not wired 
 		exit 1; \
 	fi
 	@echo "BLOCKED: dataset export is not wired in Phase 4.36."
+	@exit 1
+
+data-real-source-audit: ## Run local source manifest audit for real finished CSV staging. Requires SOURCE_MANIFEST.
+	@if [ -z "$(SOURCE_MANIFEST)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running safe real source manifest audit: SOURCE_MANIFEST=$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/real_finished_csv_staging_dry_run.js --source-manifest "$(SOURCE_MANIFEST)" --audit-source
+
+data-real-finished-csv-dry-run: ## Run local real finished CSV staging dry-run. Requires SOURCE_MANIFEST and SAMPLE_CSV.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(SAMPLE_CSV)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path> and SAMPLE_CSV=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running safe real finished CSV staging dry-run: SOURCE_MANIFEST=$(SOURCE_MANIFEST), SAMPLE_CSV=$(SAMPLE_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SAMPLE_CSV)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/real_finished_csv_staging_dry_run.js --source-manifest "$(SOURCE_MANIFEST)" --sample-csv "$(SAMPLE_CSV)"
+
+data-real-finished-csv-commit: ## Blocked real finished CSV commit gate. Requires SOURCE_MANIFEST, SAMPLE_CSV, CONFIRM_REAL_CSV_COMMIT=1.
+	@if [ "$(CONFIRM_REAL_CSV_COMMIT)" != "1" ]; then \
+		echo "BLOCKED: real finished CSV commit requires CONFIRM_REAL_CSV_COMMIT=1 and is not wired in Phase 4.52."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: real finished CSV commit is not wired in Phase 4.52."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md
+++ b/docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md
@@ -1,0 +1,368 @@
+# Phase 4.52 - source manifest + real finished CSV staging dry-run gate
+
+## 1. 当前 HEAD
+
+- 当前分支：`feat/real-source-staging-dry-run-gate`
+- 起始 HEAD：`4893452985f8b6f28e9aeefdcb88a91d10391421`
+- HEAD 摘要：`4893452 docs(data): add real data source strategy`
+
+本阶段目标是实现本地 source manifest + 本地 finished CSV 的 staging dry-run gate，不涉及任何数据库写入、外部下载、训练或预测。
+
+## 2. 当前 DB / dataset status
+
+只读确认结果：
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |    2 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+`make data-dataset-status` 关键结果：
+
+- `trainable = false`
+- `finished_matches = 1`
+- `trainable_label_rows = 1`
+- `full_feature_chain_rows = 1`
+- `baseline_prediction_rows = 1`
+- `prediction_rows_not_training_labels = 2`
+
+结论：
+
+- 当前只有 1 条真实 finished label
+- 当前完整工程闭环仍是 synthetic-derived
+- 当前 dev DB 仍不能用于真实训练
+
+## 3. Phase 4.51 strategy 摘要
+
+Phase 4.51 已明确：
+
+- 停止继续堆 synthetic 数据
+- 真实数据必须经过 source / license / provenance / schema mapping / leakage 防护
+- 下一阶段需要一个只读的 real source staging dry-run gate
+
+Phase 4.52 实现了这一 gate，但仍保持：
+
+- local files only
+- SELECT-only DB duplicate check
+- no DB writes
+- no external downloads
+- no training
+- no prediction execution
+
+## 4. source manifest path / summary
+
+新增本地 sample manifest：
+
+`tests/fixtures/real_source_manifests/local_sample_history_phase452.json`
+
+对应本地 CSV：
+
+`data/mock/sample_history.csv`
+
+manifest 摘要：
+
+| field             | value                                |
+| ----------------- | ------------------------------------ |
+| `source_name`     | `local_sample_history`               |
+| `source_type`     | `local_staging_csv`                  |
+| `source_url`      | `local:data/mock/sample_history.csv` |
+| `license_type`    | `local_fixture_for_dry_run_only`     |
+| `allowed_use`     | `dry_run_gate_validation_only`       |
+| `approval_status` | `dry_run_only`                       |
+| `mapping_version` | `PHASE4.52_REAL_CSV_DRY_RUN`         |
+
+说明：
+
+- 这是本地 staging / gate 测试 manifest
+- 不是外部真实数据下载
+- 不代表真实外部数据 license 已完成
+
+## 5. manifest required fields audit
+
+执行：
+
+```bash
+make data-real-source-audit \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json
+```
+
+关键结果：
+
+- `manifest_found = true`
+- `required_fields_complete = true`
+- `field_dictionary_present = true`
+- `human_approval_note_present = true`
+- `approval_status = dry_run_only`
+- `dry_run_only = true`
+- `can_use_for_db_write = false`
+- `no_db_writes`
+
+manifest 必填字段审计通过。
+
+## 6. CSV file integrity audit
+
+执行：
+
+```bash
+make data-real-finished-csv-dry-run \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json \
+  SAMPLE_CSV=data/mock/sample_history.csv
+```
+
+关键结果：
+
+- `sample_csv_found = true`
+- `sha256_matches_manifest = true`
+- `row_count_matches_manifest = true`
+
+CSV 完整性摘要：
+
+| field                | value                                                              |
+| -------------------- | ------------------------------------------------------------------ |
+| `sample_csv`         | `data/mock/sample_history.csv`                                     |
+| `sha256`             | `6cdb9e6a2df94c2c6bd8dc718f26e95fbb431526a54e659ee6fb24b2ae98d5ea` |
+| `manifest_row_count` | `4`                                                                |
+| `actual_row_count`   | `4`                                                                |
+
+## 7. schema detection / mapping summary
+
+检测到的列：
+
+- `match_id`
+- `external_id`
+- `league_name`
+- `season`
+- `home_team`
+- `away_team`
+- `match_date`
+- `status`
+- `bookmaker_name`
+- `market_type`
+- `open_home`
+- `open_draw`
+- `open_away`
+- `close_home`
+- `close_draw`
+- `close_away`
+- `home_score`
+- `away_score`
+
+映射检测命中：
+
+- `match_date -> match_date`
+- `home_team -> home_team`
+- `away_team -> away_team`
+- `home_score -> home_score`
+- `away_score -> away_score`
+- `league -> league_name`
+- `season -> season`
+- `bookmaker -> bookmaker_name`
+- `market_type -> market_type`
+- `home_odds -> open_home`
+- `draw_odds -> open_draw`
+- `away_odds -> open_away`
+
+结果：
+
+- `mapping_columns_missing = []`
+- 该本地 sample CSV 能完成 `matches` / labels / odds preview 的基本 schema 检测
+- 当前 sample 没有独立 `actual_result` / `FTR` 列，因此 finished label 由比分在 finished 条件下推导
+
+## 8. row classification summary
+
+row classification 结果：
+
+| field                         | value |
+| ----------------------------- | ----: |
+| `total_rows`                  |     4 |
+| `finished_rows`               |     1 |
+| `trainable_label_rows`        |     1 |
+| `skipped_rows`                |     3 |
+| `duplicate_source_rows`       |     1 |
+| `invalid_date_rows`           |     1 |
+| `missing_team_rows`           |     0 |
+| `missing_score_rows`          |     3 |
+| `scheduled_or_unlabeled_rows` |     3 |
+
+解释：
+
+- 2 条 `Man Utd vs Liverpool` scheduled rows 共享同一 `match_id`
+- 1 条 `Burgos vs Oviedo` finished row 可形成 trainable label preview
+- 1 条 `Spurs vs Arsenal` 行带有 `not-a-date`
+
+## 9. candidate preview summary
+
+dry-run 预览中的关键候选：
+
+### Row 2 / Row 3
+
+- `generated_match_id_preview = 47_20242025_900001`
+- `status = scheduled`
+- `trainable = false`
+- `skip_reason = not_finished`
+- warnings:
+    - `not_finished`
+    - `missing_label`
+    - `missing_complete_score`
+
+### Row 4
+
+- `generated_match_id_preview = 47_20242025_900002`
+- `match_date = 2024-08-17T17:30:00.000Z`
+- `league_name = Segunda`
+- `season = 2024_2025`
+- `home_team = Burgos`
+- `away_team = Oviedo`
+- `home_score = 1`
+- `away_score = 0`
+- `actual_result = home_win`
+- `label_source = score`
+- `data_source = local_sample_history`
+- `data_version = PHASE4.52_REAL_CSV_DRY_RUN`
+- `would_insert_matches = false`
+- `would_insert_odds = false`
+- `trainable = true`
+
+### Row 5
+
+- `generated_match_id_preview = 47_20242025_900003`
+- `match_date = not-a-date`
+- `status = scheduled`
+- `trainable = false`
+- warnings:
+    - `invalid_match_date`
+    - `not_finished`
+    - `missing_label`
+    - `missing_complete_score`
+
+## 10. duplicate / existing match check
+
+SELECT-only duplicate / existing match 结果：
+
+- `existing_matches_count = 1`
+- `db_match_exists = true` 的候选为：
+    - `47_20242025_900002`
+
+结果说明：
+
+- 本地 dry-run 只做 DB existence preview
+- 没有任何 DB write
+- 没有自动 dedupe / upsert
+
+## 11. leakage guard result
+
+脚本明确输出：
+
+- `final_score_used_only_as_label = true`
+- `no_post_match_features_inserted = true`
+- `no_predictions_used = true`
+- `no_synthetic_rows_used_for_real_training = true`
+- `training_features_require_kickoff_cutoff_before_future_use = true`
+
+结论：
+
+- finished score / `actual_result` 只用于 label preview
+- 本阶段没有构造任何赛前 feature 写入
+- 没有把 `predictions` 表数据反哺训练
+- 没有把 synthetic rows 混入真实训练
+
+## 12. commit gate blocked result
+
+缺确认变量时：
+
+```bash
+make data-real-finished-csv-commit
+```
+
+结果：
+
+- `BLOCKED: real finished CSV commit requires CONFIRM_REAL_CSV_COMMIT=1 and is not wired in Phase 4.52.`
+
+带确认变量时：
+
+```bash
+make data-real-finished-csv-commit \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json \
+  SAMPLE_CSV=data/mock/sample_history.csv \
+  CONFIRM_REAL_CSV_COMMIT=1
+```
+
+结果：
+
+- `BLOCKED: real finished CSV commit is not wired in Phase 4.52.`
+
+结论：
+
+- commit gate 在有无确认变量两种路径下都仍然 blocked
+- 没有写 DB
+
+## 13. DB 前后统计
+
+Phase 4.52 前后 DB 行数一致：
+
+| table                     | rows_before | rows_after |
+| ------------------------- | ----------: | ---------: |
+| `matches`                 |           2 |          2 |
+| `bookmaker_odds_history`  |           2 |          2 |
+| `raw_match_data`          |           2 |          2 |
+| `l3_features`             |           2 |          2 |
+| `match_features_training` |           2 |          2 |
+| `predictions`             |           2 |          2 |
+
+结论：本阶段为纯 dry-run / audit，没有任何 DB side effect。
+
+## 14. 下一步建议
+
+- Phase 4.53：用户提供真实 staging CSV + source manifest 后，运行同一套 dry-run gate
+- 或 Phase 4.53：人工授权某个来源下载前的 license / terms 审计
+- 仍不建议直接写库
+- 仍不训练
+- 仍不预测
+
+## 15. 明确未执行事项
+
+本阶段明确未执行：
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `CREATE`
+- `ALTER`
+- `DROP`
+- `TRUNCATE`
+- `COPY`
+- `\copy`
+- DB writes
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- 外部足球数据源访问
+- scraping / browser automation
+- harvest / ingest
+- `local_dom_ingestor --commit`
+- `csv_bulk_loader --commit`
+- `raw_match_data_local_ingest --commit`
+- `npm run smelt`
+- `npm run l3:stitch`
+- `npm run elo:recalc`
+- model training
+- real prediction execution
+- model artifact loading
+- `npm run train`
+- `npm run predict`
+- `npm run predict:dry`
+- `npm run predict:json`
+- batch backfill
+- network dry-run
+- bulk harvest
+- Docker volume 清理
+- `git push --force`
+- `git push --mirror`
+- `git fetch --all`
+- `git pull`
+- 删除文件

--- a/scripts/ops/real_finished_csv_staging_dry_run.js
+++ b/scripts/ops/real_finished_csv_staging_dry_run.js
@@ -1,0 +1,747 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.52 real finished CSV staging dry-run gate.
+ *
+ * Reads a local source manifest and optional local CSV, then reports source,
+ * integrity, schema, label, duplicate, and leakage-readiness previews only.
+ * The commit path is intentionally blocked and not wired in this phase.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const csv = require('csv-parser');
+const { Pool } = require('pg');
+
+const FORBIDDEN_SQL =
+    /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|UPSERT|MERGE|GRANT|REVOKE|CREATE\s+INDEX)\b/i;
+const FINISHED_STATUSES = new Set(['finished', 'completed', 'complete', 'full_time', 'ft']);
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+const REQUIRED_MANIFEST_FIELDS = [
+    'source_name',
+    'source_type',
+    'source_url',
+    'license_url',
+    'terms_url',
+    'license_type',
+    'allowed_use',
+    'attribution_required',
+    'commercial_use_allowed',
+    'redistribution_allowed',
+    'data_owner',
+    'downloaded_by',
+    'downloaded_at',
+    'original_filename',
+    'sha256',
+    'row_count',
+    'field_dictionary',
+    'mapping_version',
+    'approval_status',
+    'human_approval_note',
+];
+
+const DEFAULT_FIELD_ALIASES = {
+    matchId: ['match_id', 'matchid', 'matchId', 'id'],
+    externalId: ['external_id', 'externalId'],
+    matchDate: ['match_date', 'date', 'Date'],
+    homeTeam: ['home_team', 'HomeTeam', 'home', 'homeTeam'],
+    awayTeam: ['away_team', 'AwayTeam', 'away', 'awayTeam'],
+    homeScore: ['home_score', 'FTHG', 'home_goals'],
+    awayScore: ['away_score', 'FTAG', 'away_goals'],
+    actualResult: ['actual_result', 'FTR', 'result'],
+    status: ['status'],
+    isFinished: ['is_finished', 'finished'],
+    leagueName: ['league_name', 'league', 'Div'],
+    season: ['season'],
+    bookmaker: ['bookmaker_name', 'bookmaker'],
+    marketType: ['market_type', 'market'],
+    homeOdds: ['B365H', 'PSH', 'open_home', 'close_home', 'odds_home'],
+    drawOdds: ['B365D', 'PSD', 'open_draw', 'close_draw', 'odds_draw'],
+    awayOdds: ['B365A', 'PSA', 'open_away', 'close_away', 'odds_away'],
+};
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/real_finished_csv_staging_dry_run.js --source-manifest <path> --audit-source [--json]',
+        '  node scripts/ops/real_finished_csv_staging_dry_run.js --source-manifest <path> --sample-csv <path> [--json]',
+        '  node scripts/ops/real_finished_csv_staging_dry_run.js --source-manifest <path> --sample-csv <path> --commit',
+        '',
+        'Safety:',
+        '  Dry-run only in Phase 4.52; --commit is blocked and not wired.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        sourceManifest: null,
+        sampleCsv: null,
+        auditSource: false,
+        json: false,
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--source-manifest') {
+            args.sourceManifest = argv[index + 1];
+            index += 1;
+        } else if (token === '--sample-csv') {
+            args.sampleCsv = argv[index + 1];
+            index += 1;
+        } else if (token === '--audit-source') {
+            args.auditSource = true;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildBlockedCommitPayload(sourceManifest, sampleCsv) {
+    return {
+        mode: 'blocked-commit',
+        ok: false,
+        source_manifest: sourceManifest || null,
+        sample_csv: sampleCsv || null,
+        error: 'BLOCKED: real finished CSV commit is not wired in Phase 4.52.',
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function resolveLocalFile(rawPath, label) {
+    if (!rawPath) {
+        throw new Error(`Missing required ${label}`);
+    }
+    const resolved = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(process.cwd(), rawPath);
+    if (!fs.existsSync(resolved)) {
+        throw new Error(`${label} not found: ${rawPath}`);
+    }
+    const stats = fs.statSync(resolved);
+    if (!stats.isFile()) {
+        throw new Error(`${label} is not a file: ${rawPath}`);
+    }
+    return resolved;
+}
+
+function readJsonFile(resolvedPath) {
+    return JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+}
+
+function sha256File(resolvedPath) {
+    return crypto.createHash('sha256').update(fs.readFileSync(resolvedPath)).digest('hex');
+}
+
+function isPresent(value) {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.trim() !== '';
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+function validateManifest(manifest) {
+    const missing = REQUIRED_MANIFEST_FIELDS.filter(field => !isPresent(manifest[field]));
+    return {
+        required_fields_complete: missing.length === 0,
+        missing_required_fields: missing,
+    };
+}
+
+function buildSourceAuditPayload({ args, resolvedManifestPath, manifest, validation }) {
+    return {
+        mode: 'source-audit',
+        phase: '4.52',
+        manifest_found: true,
+        source_manifest: args.sourceManifest,
+        resolved_source_manifest: resolvedManifestPath,
+        required_fields_complete: validation.required_fields_complete,
+        missing_required_fields: validation.missing_required_fields,
+        source_name: manifest.source_name,
+        source_type: manifest.source_type,
+        source_url: manifest.source_url,
+        license_type: manifest.license_type,
+        allowed_use: manifest.allowed_use,
+        approval_status: manifest.approval_status,
+        original_filename: manifest.original_filename,
+        sha256: manifest.sha256,
+        row_count: manifest.row_count,
+        field_dictionary_present: isPresent(manifest.field_dictionary),
+        mapping_version: manifest.mapping_version,
+        human_approval_note_present: isPresent(manifest.human_approval_note),
+        can_use_for_db_write: false,
+        dry_run_only: true,
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 2,
+        connectionTimeoutMillis: 5000,
+        idleTimeoutMillis: 5000,
+    };
+}
+
+function assertSafeSelect(sql) {
+    if (!/^\s*SELECT\b/i.test(sql)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (FORBIDDEN_SQL.test(sql)) {
+        throw new Error('Unsafe SQL blocked: write/schema/export verb detected');
+    }
+}
+
+async function safeSelect(pool, sql, params = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, params);
+}
+
+function readCsvRows(resolvedPath) {
+    return new Promise((resolve, reject) => {
+        const rows = [];
+        const headers = [];
+        let sourceRow = 1;
+
+        fs.createReadStream(resolvedPath)
+            .pipe(csv())
+            .on('headers', parsedHeaders => {
+                headers.push(...parsedHeaders);
+            })
+            .on('data', row => {
+                sourceRow += 1;
+                rows.push({
+                    source_row: sourceRow,
+                    row,
+                });
+            })
+            .on('error', reject)
+            .on('end', () => resolve({ headers, rows }));
+    });
+}
+
+function normalizeKey(value) {
+    return String(value || '')
+        .replace(/[^a-z0-9]/gi, '')
+        .toLowerCase();
+}
+
+function normalizeText(value) {
+    return String(value ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function normalizeStatus(value) {
+    return normalizeText(value).toLowerCase();
+}
+
+function normalizeAliases(aliases) {
+    if (!Array.isArray(aliases)) return [];
+    return aliases.map(value => String(value));
+}
+
+function buildFieldAliases(manifest) {
+    const dictionary = manifest.field_dictionary || {};
+    return {
+        ...DEFAULT_FIELD_ALIASES,
+        matchDate: [...normalizeAliases(dictionary.date), ...DEFAULT_FIELD_ALIASES.matchDate],
+        homeTeam: [...normalizeAliases(dictionary.home_team), ...DEFAULT_FIELD_ALIASES.homeTeam],
+        awayTeam: [...normalizeAliases(dictionary.away_team), ...DEFAULT_FIELD_ALIASES.awayTeam],
+        homeScore: [...normalizeAliases(dictionary.home_score), ...DEFAULT_FIELD_ALIASES.homeScore],
+        awayScore: [...normalizeAliases(dictionary.away_score), ...DEFAULT_FIELD_ALIASES.awayScore],
+        actualResult: [...normalizeAliases(dictionary.result), ...DEFAULT_FIELD_ALIASES.actualResult],
+        leagueName: [...normalizeAliases(dictionary.league), ...DEFAULT_FIELD_ALIASES.leagueName],
+        season: [...normalizeAliases(dictionary.season), ...DEFAULT_FIELD_ALIASES.season],
+    };
+}
+
+function findColumn(headers, aliases) {
+    const normalizedMap = new Map(headers.map(header => [normalizeKey(header), header]));
+    for (const alias of aliases) {
+        const actual = normalizedMap.get(normalizeKey(alias));
+        if (actual) return actual;
+    }
+    return null;
+}
+
+function getRowValue(row, aliases) {
+    const normalizedMap = new Map(Object.keys(row).map(key => [normalizeKey(key), key]));
+    for (const alias of aliases) {
+        const actualKey = normalizedMap.get(normalizeKey(alias));
+        if (actualKey) {
+            const value = normalizeText(row[actualKey]);
+            if (value !== '') {
+                return value;
+            }
+        }
+    }
+    return null;
+}
+
+function parseScore(value) {
+    const normalized = normalizeText(value);
+    if (normalized === '') return null;
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseCsvDate(value) {
+    const normalized = normalizeText(value);
+    if (!normalized) {
+        return { value: null, valid: false };
+    }
+    const parsed = new Date(normalized);
+    if (Number.isNaN(parsed.getTime())) {
+        return { value: normalized, valid: false };
+    }
+    return { value: parsed.toISOString(), valid: true };
+}
+
+function normalizeActualResult(value) {
+    const normalized = normalizeText(value).toLowerCase();
+    if (!normalized) return null;
+    if (['h', 'home', 'home_win', 'home win', '1'].includes(normalized)) return 'home_win';
+    if (['d', 'draw', 'x'].includes(normalized)) return 'draw';
+    if (['a', 'away', 'away_win', 'away win', '2'].includes(normalized)) return 'away_win';
+    return null;
+}
+
+function deriveLabel({ actualResultRaw, homeScore, awayScore, finished }) {
+    const directLabel = normalizeActualResult(actualResultRaw);
+    if (directLabel) {
+        return { label: directLabel, source: 'actual_result' };
+    }
+    if (!finished || homeScore === null || awayScore === null) {
+        return { label: null, source: null };
+    }
+    if (homeScore > awayScore) return { label: 'home_win', source: 'score' };
+    if (homeScore < awayScore) return { label: 'away_win', source: 'score' };
+    return { label: 'draw', source: 'score' };
+}
+
+function isFinishedLike({ status, isFinishedRaw }) {
+    if (FINISHED_STATUSES.has(status)) return true;
+    return TRUE_VALUES.has(normalizeStatus(isFinishedRaw));
+}
+
+function buildPreviewId(row, sourceRow, manifest) {
+    if (row.match_id) return row.match_id;
+    const source = [
+        manifest.source_name || 'unknown_source',
+        row.match_date || 'unknown_date',
+        row.home_team || 'unknown_home',
+        row.away_team || 'unknown_away',
+        sourceRow,
+    ].join('|');
+    return `realcsv_${crypto.createHash('sha1').update(source).digest('hex').slice(0, 12)}`;
+}
+
+function analyzeRow(record, aliases, manifest) {
+    const row = record.row;
+    const status = normalizeStatus(getRowValue(row, aliases.status));
+    const finished = isFinishedLike({
+        status,
+        isFinishedRaw: getRowValue(row, aliases.isFinished),
+    });
+    const homeScore = parseScore(getRowValue(row, aliases.homeScore));
+    const awayScore = parseScore(getRowValue(row, aliases.awayScore));
+    const actualResultRaw = getRowValue(row, aliases.actualResult);
+    const label = deriveLabel({ actualResultRaw, homeScore, awayScore, finished });
+    const date = parseCsvDate(getRowValue(row, aliases.matchDate));
+    const base = {
+        row_number: record.source_row,
+        source_row: record.source_row,
+        match_id: getRowValue(row, aliases.matchId),
+        external_id: getRowValue(row, aliases.externalId),
+        match_date: date.value,
+        league_name: getRowValue(row, aliases.leagueName),
+        season: getRowValue(row, aliases.season),
+        home_team: getRowValue(row, aliases.homeTeam),
+        away_team: getRowValue(row, aliases.awayTeam),
+        home_score: homeScore,
+        away_score: awayScore,
+        actual_result: label.label,
+        label_source: label.source,
+        status: status || null,
+        data_source: manifest.source_name,
+        data_version: manifest.mapping_version,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        db_match_exists: null,
+    };
+    const candidate = {
+        ...base,
+        generated_match_id_preview: buildPreviewId(base, record.source_row, manifest),
+    };
+    const warnings = buildRowWarnings(candidate, {
+        date,
+        finished,
+        label: label.label,
+        hasCompleteScore: homeScore !== null && awayScore !== null,
+    });
+
+    return {
+        ...candidate,
+        finished,
+        trainable: finished && Boolean(label.label) && date.valid && warnings.length === 0,
+        skip_reason: buildSkipReason({ finished, label: label.label, dateValid: date.valid, warnings }),
+        warnings,
+    };
+}
+
+function buildRowWarnings(preview, context) {
+    const warnings = [];
+    if (!preview.home_team) warnings.push('missing_home_team');
+    if (!preview.away_team) warnings.push('missing_away_team');
+    if (!preview.match_date) warnings.push('missing_match_date');
+    if (preview.match_date && !context.date.valid) warnings.push('invalid_match_date');
+    if (!context.finished) warnings.push('not_finished');
+    if (!context.label) warnings.push('missing_label');
+    if (!context.hasCompleteScore) warnings.push('missing_complete_score');
+    return warnings;
+}
+
+function buildSkipReason({ finished, label, dateValid, warnings }) {
+    if (!finished) return 'not_finished';
+    if (!label) return 'missing_label';
+    if (!dateValid) return 'invalid_match_date';
+    const blockingWarning = warnings.find(warning => warning.startsWith('missing_'));
+    return blockingWarning || null;
+}
+
+function detectSchema(headers, aliases) {
+    const checks = {
+        match_date: findColumn(headers, aliases.matchDate),
+        home_team: findColumn(headers, aliases.homeTeam),
+        away_team: findColumn(headers, aliases.awayTeam),
+        home_score: findColumn(headers, aliases.homeScore),
+        away_score: findColumn(headers, aliases.awayScore),
+        result: findColumn(headers, aliases.actualResult),
+        league: findColumn(headers, aliases.leagueName),
+        season: findColumn(headers, aliases.season),
+        bookmaker: findColumn(headers, aliases.bookmaker),
+        market_type: findColumn(headers, aliases.marketType),
+        home_odds: findColumn(headers, aliases.homeOdds),
+        draw_odds: findColumn(headers, aliases.drawOdds),
+        away_odds: findColumn(headers, aliases.awayOdds),
+    };
+    const required = ['match_date', 'home_team', 'away_team', 'home_score', 'away_score'];
+    return {
+        detected_columns: headers,
+        mapping_columns_found: Object.fromEntries(Object.entries(checks).filter(([, value]) => Boolean(value))),
+        mapping_columns_missing: required.filter(field => !checks[field]),
+    };
+}
+
+function findDuplicateIds(previews) {
+    const counts = new Map();
+    for (const preview of previews) {
+        const id = preview.generated_match_id_preview;
+        counts.set(id, (counts.get(id) || 0) + 1);
+    }
+    return [...counts.entries()].filter(([, count]) => count > 1).map(([matchId]) => matchId);
+}
+
+function summarizeRows(previews) {
+    const duplicateIds = findDuplicateIds(previews);
+    return {
+        total_rows: previews.length,
+        finished_rows: previews.filter(row => row.finished).length,
+        trainable_label_rows: previews.filter(row => row.trainable).length,
+        skipped_rows: previews.filter(row => !row.trainable).length,
+        duplicate_source_rows: duplicateIds.length,
+        duplicate_match_ids: duplicateIds,
+        invalid_date_rows: previews.filter(row => row.warnings.includes('invalid_match_date')).length,
+        missing_team_rows: previews.filter(
+            row => row.warnings.includes('missing_home_team') || row.warnings.includes('missing_away_team')
+        ).length,
+        missing_score_rows: previews.filter(row => row.warnings.includes('missing_complete_score')).length,
+        scheduled_or_unlabeled_rows: previews.filter(
+            row => row.warnings.includes('not_finished') || row.warnings.includes('missing_label')
+        ).length,
+        would_insert_matches: false,
+        would_insert_odds: false,
+    };
+}
+
+async function fetchExistingMatchIds(previews) {
+    const ids = [...new Set(previews.map(row => row.generated_match_id_preview).filter(Boolean))];
+    if (ids.length === 0) return new Set();
+
+    const pool = new Pool(buildDbConfig());
+    try {
+        const sql = `
+            SELECT match_id
+            FROM matches
+            WHERE match_id = ANY($1)
+        `;
+        const result = await safeSelect(pool, sql, [ids]);
+        return new Set(result.rows.map(row => row.match_id));
+    } finally {
+        await pool.end();
+    }
+}
+
+function applyDbExistence(previews, existingIds) {
+    return previews.map(preview => ({
+        ...preview,
+        db_match_exists: existingIds.has(preview.generated_match_id_preview),
+    }));
+}
+
+function buildLeakageGuard() {
+    return {
+        final_score_used_only_as_label: true,
+        no_post_match_features_inserted: true,
+        no_predictions_used: true,
+        no_synthetic_rows_used_for_real_training: true,
+        training_features_require_kickoff_cutoff_before_future_use: true,
+    };
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_db_writes',
+        'no_insert',
+        'no_update',
+        'no_delete',
+        'no_copy',
+        'no_export',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_external_network',
+    ];
+}
+
+function buildDryRunPayload({
+    args,
+    resolvedManifestPath,
+    resolvedCsvPath,
+    manifest,
+    validation,
+    fileHash,
+    headers,
+    previews,
+    schema,
+}) {
+    const rowSummary = summarizeRows(previews);
+    return {
+        mode: 'real-finished-csv-staging-dry-run',
+        phase: '4.52',
+        source_manifest_summary: {
+            source_manifest: args.sourceManifest,
+            resolved_source_manifest: resolvedManifestPath,
+            source_name: manifest.source_name,
+            source_type: manifest.source_type,
+            approval_status: manifest.approval_status,
+            dry_run_only: true,
+            can_use_for_db_write: false,
+            required_fields_complete: validation.required_fields_complete,
+            missing_required_fields: validation.missing_required_fields,
+        },
+        file_integrity: {
+            sample_csv: args.sampleCsv,
+            resolved_sample_csv: resolvedCsvPath,
+            sample_csv_found: true,
+            sha256: fileHash,
+            manifest_sha256: manifest.sha256,
+            sha256_matches_manifest: fileHash === manifest.sha256,
+            row_count: previews.length,
+            manifest_row_count: manifest.row_count,
+            row_count_matches_manifest: previews.length === Number(manifest.row_count),
+        },
+        schema_detection: schema,
+        row_classification: rowSummary,
+        label_mapping: {
+            direct_result_values: {
+                H: 'home_win',
+                D: 'draw',
+                A: 'away_win',
+            },
+            score_derived_policy: 'score-derived label only when row is finished and scores are complete',
+        },
+        candidate_preview: previews,
+        duplicate_check: {
+            existing_matches_count: previews.filter(row => row.db_match_exists).length,
+            candidates: previews.map(row => ({
+                row_number: row.row_number,
+                generated_match_id_preview: row.generated_match_id_preview,
+                db_match_exists: row.db_match_exists,
+            })),
+        },
+        leakage_guard: buildLeakageGuard(),
+        would_insert_matches: false,
+        would_insert_odds: false,
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function formatScalar(value) {
+    if (Array.isArray(value)) return value.join(',');
+    if (value === null || value === undefined) return '';
+    return String(value);
+}
+
+function formatSourceAuditText(payload) {
+    return [
+        'mode=source-audit',
+        'phase=4.52',
+        `manifest_found=${payload.manifest_found}`,
+        `required_fields_complete=${payload.required_fields_complete}`,
+        `source_name=${payload.source_name}`,
+        `source_type=${payload.source_type}`,
+        `source_url=${payload.source_url}`,
+        `license_type=${payload.license_type}`,
+        `allowed_use=${payload.allowed_use}`,
+        `approval_status=${payload.approval_status}`,
+        `original_filename=${payload.original_filename}`,
+        `sha256=${payload.sha256}`,
+        `row_count=${payload.row_count}`,
+        `field_dictionary_present=${payload.field_dictionary_present}`,
+        `mapping_version=${payload.mapping_version}`,
+        `human_approval_note_present=${payload.human_approval_note_present}`,
+        `can_use_for_db_write=${payload.can_use_for_db_write}`,
+        `dry_run_only=${payload.dry_run_only}`,
+        '',
+        'missing_required_fields:',
+        payload.missing_required_fields.length
+            ? payload.missing_required_fields.map(value => `  ${value}`).join('\n')
+            : '  none',
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ].join('\n');
+}
+
+function formatDryRunText(payload) {
+    const source = payload.source_manifest_summary;
+    const integrity = payload.file_integrity;
+    const rows = payload.row_classification;
+    const duplicate = payload.duplicate_check;
+    return [
+        'mode=real-finished-csv-staging-dry-run',
+        'phase=4.52',
+        `source_name=${source.source_name}`,
+        `approval_status=${source.approval_status}`,
+        `dry_run_only=${source.dry_run_only}`,
+        `can_use_for_db_write=${source.can_use_for_db_write}`,
+        `sample_csv_found=${integrity.sample_csv_found}`,
+        `sha256_matches_manifest=${integrity.sha256_matches_manifest}`,
+        `row_count_matches_manifest=${integrity.row_count_matches_manifest}`,
+        `total_rows=${rows.total_rows}`,
+        `finished_rows=${rows.finished_rows}`,
+        `trainable_label_rows=${rows.trainable_label_rows}`,
+        `skipped_rows=${rows.skipped_rows}`,
+        `duplicate_source_rows=${rows.duplicate_source_rows}`,
+        `invalid_date_rows=${rows.invalid_date_rows}`,
+        `missing_team_rows=${rows.missing_team_rows}`,
+        `missing_score_rows=${rows.missing_score_rows}`,
+        `scheduled_or_unlabeled_rows=${rows.scheduled_or_unlabeled_rows}`,
+        `existing_matches_count=${duplicate.existing_matches_count}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        '',
+        'schema_detection:',
+        JSON.stringify(payload.schema_detection, null, 2),
+        '',
+        'candidate_preview:',
+        JSON.stringify(payload.candidate_preview, null, 2),
+        '',
+        'leakage_guard:',
+        Object.entries(payload.leakage_guard)
+            .map(([key, value]) => `  ${key}=${formatScalar(value)}`)
+            .join('\n'),
+        '',
+        'non_execution_confirmations:',
+        payload.non_execution_confirmations.map(value => `  ${value}`).join('\n'),
+    ].join('\n');
+}
+
+async function buildDryRun(args, resolvedManifestPath, manifest, validation) {
+    const resolvedCsvPath = resolveLocalFile(args.sampleCsv, '--sample-csv <path>');
+    const fileHash = sha256File(resolvedCsvPath);
+    const { headers, rows } = await readCsvRows(resolvedCsvPath);
+    const aliases = buildFieldAliases(manifest);
+    const previews = rows.map(row => analyzeRow(row, aliases, manifest));
+    const existingIds = await fetchExistingMatchIds(previews);
+    const previewsWithDb = applyDbExistence(previews, existingIds);
+    return buildDryRunPayload({
+        args,
+        resolvedManifestPath,
+        resolvedCsvPath,
+        manifest,
+        validation,
+        fileHash,
+        headers,
+        previews: previewsWithDb,
+        schema: detectSchema(headers, aliases),
+    });
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    if (args.commit) {
+        console.error(JSON.stringify(buildBlockedCommitPayload(args.sourceManifest, args.sampleCsv), null, 2));
+        process.exitCode = 1;
+        return;
+    }
+
+    const resolvedManifestPath = resolveLocalFile(args.sourceManifest, '--source-manifest <path>');
+    const manifest = readJsonFile(resolvedManifestPath);
+    const validation = validateManifest(manifest);
+    const sourcePayload = buildSourceAuditPayload({ args, resolvedManifestPath, manifest, validation });
+
+    if (!validation.required_fields_complete) {
+        console.error(args.json ? JSON.stringify(sourcePayload, null, 2) : formatSourceAuditText(sourcePayload));
+        process.exitCode = 1;
+        return;
+    }
+
+    if (args.auditSource) {
+        console.log(args.json ? JSON.stringify(sourcePayload, null, 2) : formatSourceAuditText(sourcePayload));
+        return;
+    }
+
+    if (!args.sampleCsv) {
+        throw new Error('Missing required --sample-csv <path> unless --audit-source is used');
+    }
+
+    const dryRunPayload = await buildDryRun(args, resolvedManifestPath, manifest, validation);
+    console.log(args.json ? JSON.stringify(dryRunPayload, null, 2) : formatDryRunText(dryRunPayload));
+}
+
+main().catch(error => {
+    console.error(
+        JSON.stringify(
+            {
+                mode: 'real-finished-csv-staging-dry-run',
+                ok: false,
+                error: error.message,
+                non_execution_confirmations: buildNonExecutionConfirmations(),
+            },
+            null,
+            2
+        )
+    );
+    process.exitCode = 1;
+});

--- a/tests/fixtures/real_source_manifests/local_sample_history_phase452.json
+++ b/tests/fixtures/real_source_manifests/local_sample_history_phase452.json
@@ -1,0 +1,33 @@
+{
+    "source_name": "local_sample_history",
+    "source_type": "local_staging_csv",
+    "source_url": "local:data/mock/sample_history.csv",
+    "license_url": "local",
+    "terms_url": "local",
+    "license_type": "local_fixture_for_dry_run_only",
+    "allowed_use": "dry_run_gate_validation_only",
+    "attribution_required": false,
+    "commercial_use_allowed": false,
+    "redistribution_allowed": false,
+    "data_owner": "project_local_fixture",
+    "downloaded_by": "not_applicable_local_fixture",
+    "downloaded_at": "not_applicable_local_fixture",
+    "original_filename": "data/mock/sample_history.csv",
+    "sha256": "6cdb9e6a2df94c2c6bd8dc718f26e95fbb431526a54e659ee6fb24b2ae98d5ea",
+    "row_count": 4,
+    "competition_coverage": "local sample only",
+    "season_coverage": "mixed local sample",
+    "field_dictionary": {
+        "date": ["date", "Date", "match_date"],
+        "home_team": ["home_team", "HomeTeam", "home"],
+        "away_team": ["away_team", "AwayTeam", "away"],
+        "home_score": ["home_score", "FTHG", "home_goals"],
+        "away_score": ["away_score", "FTAG", "away_goals"],
+        "result": ["actual_result", "FTR", "result"],
+        "league": ["league_name", "league", "Div"],
+        "season": ["season"]
+    },
+    "mapping_version": "PHASE4.52_REAL_CSV_DRY_RUN",
+    "approval_status": "dry_run_only",
+    "human_approval_note": "Local fixture manifest for validating real finished CSV staging dry-run gate only. Do not treat as externally licensed production data."
+}


### PR DESCRIPTION
## Summary

Adds Phase 4.52 source manifest audit and real finished CSV staging dry-run gate.

Changes:
- Adds scripts/ops/real_finished_csv_staging_dry_run.js
- Adds make data-real-source-audit
- Adds make data-real-finished-csv-dry-run
- Adds blocked make data-real-finished-csv-commit
- Adds local sample source manifest
- Updates AGENTS.md with real source staging safety rules
- Adds Phase 4.52 report

Safety:
- Local files only
- SELECT-only DB duplicate checks
- No DB writes
- No external downloads
- No curl / wget / git clone
- No scraping / harvest / ingest
- No training
- No prediction execution
- Commit gate remains blocked

Validation:
- source manifest audit passed
- finished CSV dry-run passed on data/mock/sample_history.csv
- commit gate remains blocked with and without CONFIRM_REAL_CSV_COMMIT=1
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed