### PR TITLE
test(data): add acquisition gate no-network coverage

### DIFF
--- a/docs/_reports/ACQUISITION_GATE_NO_NETWORK_TESTS_PHASE4_55B.md
+++ b/docs/_reports/ACQUISITION_GATE_NO_NETWORK_TESTS_PHASE4_55B.md
@@ -1,0 +1,117 @@
+# Phase 4.55B Acquisition Gate No-Network Tests
+
+Date: 2026-05-05
+
+## 1. Current Head / Branch
+
+- Starting HEAD: `7238b2ec4497c416b1c65f7c33d4214bd24dc45e`
+- Working branch: `test/acquisition-gate-no-network-phase455b`
+- Base branch: `main`
+
+## 2. Why Phase 4.55B Came First
+
+Phase 4.54 added the acquisition registry and scaffold-only network gate, but the gate still needed direct no-network / no-db test coverage before any future real single-target network work.
+
+## 3. Test Coverage Added
+
+Added [tests/unit/acquisition_engine_gate.test.js](/home/xupeng/FootballPrediction.clean-dev/tests/unit/acquisition_engine_gate.test.js) to cover:
+
+- registry JSON parse
+- required engine fields
+- `--list`
+- `--audit`
+- high-risk `run_production` blocked behavior
+- `--commit` blocked behavior
+- missing `SOURCE_MANIFEST`
+- missing `TARGET_MATCH_ID`
+- missing mode arguments
+
+## 4. Registry Validation Result
+
+- registry parse: passed
+- registry engine count: `13`
+- required fields: present
+
+## 5. High-Risk Blocked Result
+
+`run_production` remained blocked in `--engine` mode and reported:
+
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+
+## 6. Scaffold Dry-Run Result
+
+The scaffold gate remained blocked in Phase 4.54 / 4.55B and did not:
+
+- access external network
+- write DB
+- execute the real engine
+
+## 7. Commit Gate Result
+
+`--commit` remained blocked, including with `CONFIRM_SINGLE_TARGET_NETWORK=1`.
+
+## 8. DB Before / After
+
+Before validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 9. Test / Gate Results
+
+- `node --test tests/unit/acquisition_engine_gate.test.js`: passed
+- `make data-acquisition-engines`: passed
+- `make data-acquisition-engine-audit`: passed
+- `make data-single-target-network-dry-run`: blocked as expected
+- `make data-single-target-network-commit`: blocked as expected
+- `npm test`: passed
+
+## 10. Next Step
+
+Phase 4.56A can only start after the user explicitly provides:
+
+- `TARGET_SOURCE`
+- `TARGET_ENGINE`
+- `TARGET_MATCH_ID`
+- `SOURCE_MANIFEST`
+- `TERMS_APPROVAL=yes`
+- `NETWORK_DRY_RUN_AUTHORIZATION=yes`
+
+Without those, do not touch network.
+
+## 11. Explicit Non-Execution
+
+Not executed:
+
+- DB writes
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- real network dry-run execution
+- bulk harvest
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/tests/unit/acquisition_engine_gate.test.js
+++ b/tests/unit/acquisition_engine_gate.test.js
@@ -1,0 +1,184 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/acquisition_engine_gate.js');
+const REGISTRY_PATH = path.join(PROJECT_ROOT, 'config/acquisition_engines.phase454.json');
+const SOURCE_MANIFEST = 'tests/fixtures/real_source_manifests/local_sample_history_phase452.json';
+const REQUIRED_ENGINE_FIELDS = [
+    'id',
+    'category',
+    'entrypoint',
+    'accesses_network',
+    'writes_db',
+    'supports_dry_run',
+    'dry_run_trust_level',
+    'supports_commit',
+    'bulk_risk',
+    'tos_license_risk',
+    'provenance_required',
+    'safe_for_ai_default',
+    'phase454_policy',
+];
+
+function runGate(args) {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+
+    return {
+        status: result.status ?? 1,
+        stdout: result.stdout || '',
+        stderr: result.stderr || '',
+    };
+}
+
+function parseJsonOutput(result) {
+    const payload = (result.stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload in stdout');
+    return JSON.parse(payload);
+}
+
+function assertNoExecutionFlags(payload) {
+    assert.ok(Array.isArray(payload.non_execution_confirmations));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('no_engine_execution'));
+}
+
+test('acquisition_engine_gate registry JSON 可解析且包含必需字段', () => {
+    const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+
+    assert.equal(registry.phase, '4.54');
+    assert.equal(registry.registry_type, 'acquisition_engine_risk_registry');
+    assert.ok(Array.isArray(registry.engines));
+    assert.ok(registry.engines.length >= 13);
+
+    for (const engine of registry.engines) {
+        for (const field of REQUIRED_ENGINE_FIELDS) {
+            assert.ok(field in engine, `missing field ${field} for engine ${engine.id}`);
+        }
+    }
+});
+
+test('acquisition_engine_gate --list 应成功并暴露 registry 摘要', () => {
+    const result = runGate(['--list', '--json']);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.mode, 'acquisition-engine-list');
+    assert.equal(payload.registry_found, true);
+    assert.equal(payload.registry_valid, true);
+    assert.ok(payload.total_engines >= 13);
+    assert.ok(payload.safe_for_ai_default_count >= 1);
+    assert.ok(payload.blocked_count >= 1);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition_engine_gate --audit 应成功并标记高风险 engine', () => {
+    const result = runGate(['--audit', '--json']);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.mode, 'acquisition-engine-audit');
+    assert.equal(payload.registry_found, true);
+    assert.equal(payload.registry_valid, true);
+    assert.ok(payload.high_risk_engines.includes('run_production'));
+    assert.ok(payload.blocked_engines.includes('run_production'));
+    assert.ok(payload.allowed_read_only_engines.includes('real_finished_csv_staging_dry_run'));
+    assert.deepEqual(payload.engines_missing_provenance_requirement, []);
+    assertNoExecutionFlags(payload);
+});
+
+test('高风险 engine run_production 在 --engine 模式下必须 blocked 且不触网不写库', () => {
+    const result = runGate([
+        '--engine',
+        'run_production',
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.mode, 'single-target-network-scaffold');
+    assert.equal(payload.engine_found, true);
+    assert.equal(payload.engine_id, 'run_production');
+    assert.equal(payload.phase454_policy, 'blocked');
+    assert.equal(payload.accesses_network, true);
+    assert.equal(payload.writes_db, true);
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.missing_source_manifest, false);
+    assert.equal(payload.missing_target_scope, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.match(payload.blocked_reason, /Phase 4\.54 is scaffold-only/);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition_engine_gate --commit 必须立即 blocked', () => {
+    const result = runGate([
+        '--engine',
+        'run_production',
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--commit',
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.mode, 'blocked-commit');
+    assert.equal(payload.engine_id, 'run_production');
+    assert.match(payload.blocked_reason, /not wired in Phase 4\.54/);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition_engine_gate 缺少 SOURCE_MANIFEST 时必须失败且不执行引擎', () => {
+    const result = runGate(['--engine', 'run_production', '--target-match-id', '47_20242025_900002', '--json']);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.engine_found, true);
+    assert.equal(payload.missing_source_manifest, true);
+    assert.equal(payload.missing_target_scope, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.match(payload.blocked_reason, /missing SOURCE_MANIFEST/);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition_engine_gate 缺少 TARGET_MATCH_ID 时必须失败且不执行引擎', () => {
+    const result = runGate(['--engine', 'run_production', '--source-manifest', SOURCE_MANIFEST, '--json']);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.engine_found, true);
+    assert.equal(payload.missing_source_manifest, false);
+    assert.equal(payload.missing_target_scope, true);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.match(payload.blocked_reason, /missing TARGET_MATCH_ID/);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition_engine_gate 缺少模式参数时必须失败', () => {
+    const result = runGate([]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /ERROR: provide --list, --audit, or --engine <id>/);
+    assert.match(result.stderr, /Usage:/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.55B no-network/no-db coverage for the acquisition engine gate.

Scope:
- Validates acquisition registry shape
- Validates list/audit modes
- Validates high-risk engines remain blocked
- Validates scaffold dry-run does not access network, write DB, or execute real engines
- Validates commit path remains blocked
- Adds Phase 4.55B report

Safety:
- No DB writes
- No external downloads
- No external data access
- No scraping / harvest / ingest
- No training
- No prediction execution
- No model artifact loading

Validation:
- acquisition gate tests passed
- data-acquisition-engines passed
- data-acquisition-engine-audit passed
- scaffold dry-run remained blocked
- commit gate remained blocked
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed