### PR TITLE
feat(data): add acquisition registry governance fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -531,6 +531,16 @@ Phase 4.55C acquisition architecture rules：
 - 任何 engine 进入 `allowed_read_only` 前，必须先具备 no-network / no-db tests。
 - 任何 network dry-run 都必须单独授权；任何 DB write 都必须单独授权并先完成 `pg_dump`。
 
+Phase 4.56C registry governance rules：
+
+- acquisition registry 是治理总表，不只是风险清单。
+- 任何新增 acquisition engine 必须注册到 registry，并包含 `owner`、`status`、`intended_layer`、`replacement_plan`、`deprecation_status`、`canonical_entrypoint`、`allowed_next_phase`、`test_coverage`。
+- 只有 `canonical` engine 才能作为推荐主干入口。
+- `gate_only` engine 只能通过 gate 使用；`quarantine` / `legacy_blocked` engine 禁止 Codex 直接执行。
+- `adapter_candidate` 只能作为未来重写参考，不得直接运行旧 pipeline。
+- `allowed_next_phase` 决定 Codex 是否可进入下一阶段；任何从 `blocked` 升级到可用状态都必须先补测试和报告。
+- network dry-run 仍需单独授权；DB write 仍需单独授权并完成 `pg_dump`。
+
 执行 `make data-finished-backfill-dry-run MATCH_ID=<id>` 的前提：
 
 - 用户明确授权

--- a/config/acquisition_engines.phase454.json
+++ b/config/acquisition_engines.phase454.json
@@ -1,7 +1,8 @@
 {
     "phase": "4.54",
-    "registry_type": "acquisition_engine_risk_registry",
+    "registry_type": "acquisition_engine_governance_registry",
     "generated_from_report": "docs/_reports/ACQUISITION_ENGINE_READINESS_PHASE4_53A.md",
+    "governance_revision": "4.56C",
     "engines": [
         {
             "id": "real_finished_csv_staging_dry_run",
@@ -25,7 +26,15 @@
             "safe_for_ai_default": true,
             "requires_user_authorization": true,
             "phase454_policy": "allowed_read_only",
-            "notes": "Local staging preflight only. No DB writes."
+            "notes": "Local staging preflight only. No DB writes.",
+            "owner": "data-governance",
+            "status": "canonical",
+            "intended_layer": "layer_5_local_staging_dry_run",
+            "replacement_plan": "Keep as canonical local staging dry-run gate for source manifest and finished CSV review.",
+            "deprecation_status": "not_deprecated",
+            "canonical_entrypoint": true,
+            "allowed_next_phase": "requires_user_authorization",
+            "test_coverage": "gate_covered"
         },
         {
             "id": "raw_match_data_local_ingest",
@@ -46,7 +55,15 @@
             "safe_for_ai_default": true,
             "requires_user_authorization": true,
             "phase454_policy": "allowed_read_only",
-            "notes": "Local raw fixture preview only. Commit remains blocked."
+            "notes": "Local raw fixture preview only. Commit remains blocked.",
+            "owner": "data-governance",
+            "status": "canonical",
+            "intended_layer": "layer_5_local_staging_dry_run",
+            "replacement_plan": "Keep as canonical raw fixture preview gate until a future small-write phase is explicitly authorized.",
+            "deprecation_status": "not_deprecated",
+            "canonical_entrypoint": true,
+            "allowed_next_phase": "requires_user_authorization",
+            "test_coverage": "gate_covered"
         },
         {
             "id": "finished_match_backfill_preflight",
@@ -67,7 +84,15 @@
             "safe_for_ai_default": true,
             "requires_user_authorization": true,
             "phase454_policy": "allowed_read_only",
-            "notes": "SELECT-only chain preflight. No raw ingest, no DB writes."
+            "notes": "SELECT-only chain preflight. No raw ingest, no DB writes.",
+            "owner": "data-governance",
+            "status": "canonical",
+            "intended_layer": "layer_7_feature_dry_run",
+            "replacement_plan": "Keep as canonical downstream chain readiness gate before any raw, L3, training-feature, or prediction write phase.",
+            "deprecation_status": "not_deprecated",
+            "canonical_entrypoint": true,
+            "allowed_next_phase": "requires_user_authorization",
+            "test_coverage": "gate_covered"
         },
         {
             "id": "csv_bulk_loader",
@@ -91,7 +116,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Local CSV parser is safe in dry-run, but commit updates matches and bookmaker_odds_history."
+            "notes": "Local CSV parser is safe in dry-run, but commit updates matches and bookmaker_odds_history.",
+            "owner": "data-governance",
+            "status": "gate_only",
+            "intended_layer": "layer_6_small_db_write",
+            "replacement_plan": "Keep behind explicit commit gate for local CSV import until a manifest-bound small-write path fully replaces it.",
+            "deprecation_status": "watch",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "requires_future_db_write_authorization",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "local_dom_ingestor",
@@ -115,7 +148,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Local HTML preview only is possible, but commit writes bookmaker_odds_history."
+            "notes": "Local HTML preview only is possible, but commit writes bookmaker_odds_history.",
+            "owner": "data-governance",
+            "status": "gate_only",
+            "intended_layer": "layer_4_local_staging_normalization",
+            "replacement_plan": "Keep behind gate as a local HTML normalization helper while canonical staging paths move toward manifest-bound adapters.",
+            "deprecation_status": "watch",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "requires_future_db_write_authorization",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "run_production",
@@ -136,7 +177,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Network harvest / production path. Must not be executed by AI without explicit future authorization."
+            "notes": "Network harvest / production path. Must not be executed by AI without explicit future authorization.",
+            "owner": "data-governance",
+            "status": "legacy_blocked",
+            "intended_layer": "legacy_production_path",
+            "replacement_plan": "Do not use as canonical acquisition. Extract only narrowly scoped adapters later if the future single-target route truly needs them.",
+            "deprecation_status": "quarantine",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "blocked_legacy",
+            "test_coverage": "gate_covered"
         },
         {
             "id": "titan_discovery",
@@ -157,7 +206,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Discovery dry-run trust is low until the CLI flag is proven to suppress writes end to end."
+            "notes": "Discovery dry-run trust is low until the CLI flag is proven to suppress writes end to end.",
+            "owner": "data-governance",
+            "status": "adapter_candidate",
+            "intended_layer": "layer_2_discovery",
+            "replacement_plan": "Refactor into a discovery-only adapter after dry-run trust and CLI flag propagation are proven with no-network/no-db tests.",
+            "deprecation_status": "watch",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "requires_future_network_dry_run_authorization",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "recon_scanner",
@@ -178,7 +235,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "OddsPortal recon pipeline uses browser, proxy, Redis, and DB-backed mapping stores."
+            "notes": "OddsPortal recon pipeline uses browser, proxy, Redis, and DB-backed mapping stores.",
+            "owner": "data-governance",
+            "status": "quarantine",
+            "intended_layer": "legacy_bulk_pipeline",
+            "replacement_plan": "Isolate browser, proxy, Redis, and persistence concerns before considering any future single-target reuse.",
+            "deprecation_status": "quarantine",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "blocked_legacy",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "batch_historical_backfill",
@@ -203,7 +268,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Bulk orchestrator. Even dry-run can trigger external download and staging file writes."
+            "notes": "Bulk orchestrator. Even dry-run can trigger external download and staging file writes.",
+            "owner": "data-governance",
+            "status": "legacy_blocked",
+            "intended_layer": "legacy_bulk_pipeline",
+            "replacement_plan": "Keep blocked and do not use for early real-data onboarding; replace with single-target staging and small-write phases.",
+            "deprecation_status": "quarantine",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "blocked_legacy",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "fetch_and_adapt_euro_leagues",
@@ -227,7 +300,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Always downloads external CSV and writes adapted output. No safe no-network mode exists."
+            "notes": "Always downloads external CSV and writes adapted output. No safe no-network mode exists.",
+            "owner": "data-governance",
+            "status": "adapter_candidate",
+            "intended_layer": "layer_3_single_target_acquisition",
+            "replacement_plan": "Refactor into a manifest-bound single-target adapter with explicit local staging output and no-network/no-db tests.",
+            "deprecation_status": "watch",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "requires_future_network_dry_run_authorization",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "odds_harvest_pipeline",
@@ -248,7 +329,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Playwright and fetch based OddsPortal pipeline with DB upserts and optional downstream L3 work."
+            "notes": "Playwright and fetch based OddsPortal pipeline with DB upserts and optional downstream L3 work.",
+            "owner": "data-governance",
+            "status": "adapter_candidate",
+            "intended_layer": "layer_3_single_target_acquisition",
+            "replacement_plan": "Refactor into a single-target odds adapter after manifest binding, no-db dry-run support, and source isolation are in place.",
+            "deprecation_status": "watch",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "requires_future_network_dry_run_authorization",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "total_war_pipeline",
@@ -269,7 +358,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Discovery / Harvest / Recon / Smelt orchestrator. Phase 4.54 must not call it."
+            "notes": "Discovery / Harvest / Recon / Smelt orchestrator. Phase 4.54 must not call it.",
+            "owner": "data-governance",
+            "status": "legacy_blocked",
+            "intended_layer": "legacy_bulk_pipeline",
+            "replacement_plan": "Quarantine as a legacy bulk super-orchestrator and retire once single-target routes cover the needed sub-capabilities.",
+            "deprecation_status": "deprecation_candidate",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "blocked_legacy",
+            "test_coverage": "needs_unit_tests"
         },
         {
             "id": "titan_marathon",
@@ -290,7 +387,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Large-scale reconciliation harvester. Full mode writes raw_match_data and updates matches."
+            "notes": "Large-scale reconciliation harvester. Full mode writes raw_match_data and updates matches.",
+            "owner": "data-governance",
+            "status": "legacy_blocked",
+            "intended_layer": "legacy_bulk_pipeline",
+            "replacement_plan": "Quarantine as a legacy marathon harvester and retire after the single-target acquisition path is mature.",
+            "deprecation_status": "deprecation_candidate",
+            "canonical_entrypoint": false,
+            "allowed_next_phase": "blocked_legacy",
+            "test_coverage": "needs_unit_tests"
         }
     ]
 }

--- a/docs/_reports/ACQUISITION_REGISTRY_GOVERNANCE_PHASE4_56C.md
+++ b/docs/_reports/ACQUISITION_REGISTRY_GOVERNANCE_PHASE4_56C.md
@@ -1,0 +1,194 @@
+# Phase 4.56C Acquisition Registry Governance
+
+Date: 2026-05-05
+
+## 1. Current Head / Branch
+
+- Starting HEAD: `2df6dc548707efbe1bb2e833426b148e6c10447a`
+- Working branch: `feat/acquisition-registry-governance-phase456c`
+- Base branch: `main`
+
+## 2. Why the Registry Needed Governance Fields
+
+Phase 4.54 made the acquisition registry good enough for risk gating, and Phase 4.55C made the architectural direction explicit. What was still missing was lifecycle governance:
+
+- who owns an engine
+- whether the engine is canonical or legacy
+- which layer it belongs to
+- what replaces it
+- whether it is under watch, quarantine, or deprecation
+- whether Codex can move it to the next phase
+- whether it already has enough test protection
+
+Phase 4.56C upgrades the registry from a risk list into a governance table.
+
+## 3. New Governance Fields
+
+Each engine now carries:
+
+- `owner`
+- `status`
+- `intended_layer`
+- `replacement_plan`
+- `deprecation_status`
+- `canonical_entrypoint`
+- `allowed_next_phase`
+- `test_coverage`
+
+## 4. Status Meaning
+
+- `canonical`: recommended mainline engine
+- `gate_only`: usable only through explicit gate / authorization
+- `quarantine`: isolated high-risk engine, not for default use
+- `deprecation_candidate`: likely to be retired after replacement matures
+- `adapter_candidate`: possible source for future narrow adapter extraction
+- `legacy_blocked`: legacy path that must remain blocked
+
+## 5. Intended Layer Meaning
+
+- `layer_0_registry_policy`
+- `layer_1_source_manifest`
+- `layer_2_discovery`
+- `layer_3_single_target_acquisition`
+- `layer_4_local_staging_normalization`
+- `layer_5_local_staging_dry_run`
+- `layer_6_small_db_write`
+- `layer_7_feature_dry_run`
+- `layer_8_training_prediction`
+- `legacy_bulk_pipeline`
+- `legacy_production_path`
+- `unknown`
+
+These values let the registry describe where an engine belongs in the future canonical chain.
+
+## 6. Registry Classification Result
+
+Canonical:
+
+- `real_finished_csv_staging_dry_run`
+- `raw_match_data_local_ingest`
+- `finished_match_backfill_preflight`
+
+Gate-only:
+
+- `csv_bulk_loader`
+- `local_dom_ingestor`
+
+Quarantine:
+
+- `recon_scanner`
+
+Deprecation candidate:
+
+- none by `status`
+
+Adapter candidate:
+
+- `titan_discovery`
+- `fetch_and_adapt_euro_leagues`
+- `odds_harvest_pipeline`
+
+Legacy blocked:
+
+- `run_production`
+- `batch_historical_backfill`
+- `total_war_pipeline`
+- `titan_marathon`
+
+Additional deprecation watchlist via `deprecation_status`:
+
+- `total_war_pipeline`
+- `titan_marathon`
+
+## 7. Gate Audit Upgrade
+
+`scripts/ops/acquisition_engine_gate.js --audit` now reports:
+
+- governance field requirements
+- governance completeness
+- missing governance fields
+- canonical / gate_only / quarantine / deprecation_candidate / adapter_candidate / legacy_blocked groups
+- engines requiring user authorization
+- engines requiring future network authorization
+- engines requiring future DB write authorization
+- engines needing unit tests
+
+The audit remains read-only and still does not execute any engine.
+
+## 8. Unit Test Upgrade
+
+`tests/unit/acquisition_engine_gate.test.js` now verifies:
+
+- every engine has all governance fields
+- every governance enum is in the allowed value set
+- `canonical_entrypoint` is boolean
+- audit returns `governance_fields_complete=true`
+- audit returns the expected engine category groups
+- high-risk blocked behavior still holds
+- no-network / no-db / no-engine-execution behavior still holds
+
+## 9. No-Network / No-DB Validation
+
+Validation completed:
+
+- registry JSON parse: passed
+- `make data-acquisition-engines`: passed
+- `make data-acquisition-engine-audit`: passed with governance completeness
+- scaffold dry-run stayed blocked
+- `node --test tests/unit/acquisition_engine_gate.test.js`: passed
+- `npm test`: passed
+
+Observed scaffold guarantees still hold:
+
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+
+## 10. DB Before / After
+
+Before validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 11. Next Step Recommendation
+
+Two clean next steps remain:
+
+1. Phase 4.57C: choose one `adapter_candidate`, such as `titan_discovery` or `fetch_and_adapt_euro_leagues`, and repair dry-run trust plus no-network tests before any future real-data use.
+2. Phase 4.56A: only after the user provides the six real network dry-run parameters, prepare a runbook without immediately touching the network.
+
+## 12. Explicit Non-Execution
+
+Not executed in Phase 4.56C:
+
+- DB writes
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- real network dry-run execution
+- bulk harvest
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/acquisition_engine_gate.js
+++ b/scripts/ops/acquisition_engine_gate.js
@@ -24,6 +24,60 @@ const REQUIRED_ENGINE_FIELDS = [
     'phase454_policy',
     'notes',
 ];
+const REQUIRED_GOVERNANCE_FIELDS = [
+    'owner',
+    'status',
+    'intended_layer',
+    'replacement_plan',
+    'deprecation_status',
+    'canonical_entrypoint',
+    'allowed_next_phase',
+    'test_coverage',
+];
+const ALLOWED_STATUS_VALUES = new Set([
+    'canonical',
+    'gate_only',
+    'quarantine',
+    'deprecation_candidate',
+    'adapter_candidate',
+    'legacy_blocked',
+]);
+const ALLOWED_INTENDED_LAYER_VALUES = new Set([
+    'layer_0_registry_policy',
+    'layer_1_source_manifest',
+    'layer_2_discovery',
+    'layer_3_single_target_acquisition',
+    'layer_4_local_staging_normalization',
+    'layer_5_local_staging_dry_run',
+    'layer_6_small_db_write',
+    'layer_7_feature_dry_run',
+    'layer_8_training_prediction',
+    'legacy_bulk_pipeline',
+    'legacy_production_path',
+    'unknown',
+]);
+const ALLOWED_DEPRECATION_STATUS_VALUES = new Set([
+    'not_deprecated',
+    'watch',
+    'quarantine',
+    'deprecation_candidate',
+    'deprecated_do_not_use',
+]);
+const ALLOWED_NEXT_PHASE_VALUES = new Set([
+    'allowed_read_only',
+    'requires_user_authorization',
+    'requires_future_network_dry_run_authorization',
+    'requires_future_db_write_authorization',
+    'blocked',
+    'blocked_legacy',
+]);
+const ALLOWED_TEST_COVERAGE_VALUES = new Set([
+    'unit_covered',
+    'gate_covered',
+    'needs_unit_tests',
+    'needs_integration_tests',
+    'not_covered',
+]);
 
 function usage() {
     return [
@@ -150,23 +204,7 @@ function validateRegistry(registry) {
 
     const seenIds = new Set();
     registry.engines.forEach((engine, index) => {
-        REQUIRED_ENGINE_FIELDS.forEach(field => {
-            if (!(field in engine)) {
-                errors.push(`engine[${index}] missing field: ${field}`);
-            }
-        });
-
-        if (typeof engine.id !== 'string' || engine.id.trim() === '') {
-            errors.push(`engine[${index}] id must be a non-empty string`);
-        } else if (seenIds.has(engine.id)) {
-            errors.push(`duplicate engine id: ${engine.id}`);
-        } else {
-            seenIds.add(engine.id);
-        }
-
-        if (!Array.isArray(engine.commands) || engine.commands.length === 0) {
-            errors.push(`engine[${index}] commands must be a non-empty array`);
-        }
+        validateEngine(engine, index, seenIds, errors);
     });
 
     return {
@@ -175,8 +213,75 @@ function validateRegistry(registry) {
     };
 }
 
+function validateMissingFields(engine, index, fields, errorPrefix, errors) {
+    fields.forEach(field => {
+        if (!(field in engine)) {
+            errors.push(`engine[${index}] ${errorPrefix}: ${field}`);
+        }
+    });
+}
+
+function validateEngineId(engine, index, seenIds, errors) {
+    if (typeof engine.id !== 'string' || engine.id.trim() === '') {
+        errors.push(`engine[${index}] id must be a non-empty string`);
+        return;
+    }
+    if (seenIds.has(engine.id)) {
+        errors.push(`duplicate engine id: ${engine.id}`);
+        return;
+    }
+    seenIds.add(engine.id);
+}
+
+function validateEnumField(engine, index, fieldName, allowedValues, errors) {
+    if (fieldName in engine && !allowedValues.has(engine[fieldName])) {
+        errors.push(`engine[${index}] invalid ${fieldName}: ${engine[fieldName]}`);
+    }
+}
+
+function validateEngine(engine, index, seenIds, errors) {
+    validateMissingFields(engine, index, REQUIRED_ENGINE_FIELDS, 'missing field', errors);
+    validateMissingFields(engine, index, REQUIRED_GOVERNANCE_FIELDS, 'missing governance field', errors);
+    validateEngineId(engine, index, seenIds, errors);
+
+    if (!Array.isArray(engine.commands) || engine.commands.length === 0) {
+        errors.push(`engine[${index}] commands must be a non-empty array`);
+    }
+
+    validateEnumField(engine, index, 'status', ALLOWED_STATUS_VALUES, errors);
+    validateEnumField(engine, index, 'intended_layer', ALLOWED_INTENDED_LAYER_VALUES, errors);
+    validateEnumField(engine, index, 'deprecation_status', ALLOWED_DEPRECATION_STATUS_VALUES, errors);
+    validateEnumField(engine, index, 'allowed_next_phase', ALLOWED_NEXT_PHASE_VALUES, errors);
+    validateEnumField(engine, index, 'test_coverage', ALLOWED_TEST_COVERAGE_VALUES, errors);
+
+    if ('canonical_entrypoint' in engine && typeof engine.canonical_entrypoint !== 'boolean') {
+        errors.push(`engine[${index}] canonical_entrypoint must be boolean`);
+    }
+}
+
 function getEngines(registry) {
     return Array.isArray(registry?.engines) ? registry.engines : [];
+}
+
+function collectGovernanceFieldGaps(engines) {
+    return engines
+        .map(engine => ({
+            id: engine.id,
+            missing_fields: REQUIRED_GOVERNANCE_FIELDS.filter(field => !(field in engine)),
+        }))
+        .filter(entry => entry.missing_fields.length > 0);
+}
+
+function collectEnginesByStatus(engines, status) {
+    return engines.filter(engine => engine.status === status).map(engine => engine.id);
+}
+
+function collectEnginesByNextPhase(engines, allowedNextPhase) {
+    return engines.filter(engine => engine.allowed_next_phase === allowedNextPhase).map(engine => engine.id);
+}
+
+function collectEnginesByTestCoverage(engines, testCoverage) {
+    return engines.filter(engine => engine.test_coverage === testCoverage).map(engine => engine.id);
 }
 
 function buildListPayload(loaded) {
@@ -213,6 +318,7 @@ function buildAuditPayload(loaded) {
         .map(engine => engine.id);
     const blocked = engines.filter(engine => engine.phase454_policy === 'blocked').map(engine => engine.id);
     const missingProvenance = engines.filter(engine => engine.provenance_required !== true).map(engine => engine.id);
+    const missingGovernanceFields = collectGovernanceFieldGaps(engines);
 
     return {
         mode: 'acquisition-engine-audit',
@@ -220,9 +326,28 @@ function buildAuditPayload(loaded) {
         registry_valid: loaded.registry_valid,
         registry_path: loaded.registry_path,
         total_engines: engines.length,
+        governance_fields_required: REQUIRED_GOVERNANCE_FIELDS,
+        governance_fields_complete: missingGovernanceFields.length === 0,
+        missing_governance_fields: missingGovernanceFields,
         high_risk_engines: highRisk,
         allowed_read_only_engines: allowedReadOnly,
         blocked_engines: blocked,
+        canonical_engines: collectEnginesByStatus(engines, 'canonical'),
+        gate_only_engines: collectEnginesByStatus(engines, 'gate_only'),
+        quarantine_engines: collectEnginesByStatus(engines, 'quarantine'),
+        deprecation_candidate_engines: collectEnginesByStatus(engines, 'deprecation_candidate'),
+        adapter_candidate_engines: collectEnginesByStatus(engines, 'adapter_candidate'),
+        legacy_blocked_engines: collectEnginesByStatus(engines, 'legacy_blocked'),
+        engines_requiring_user_authorization: collectEnginesByNextPhase(engines, 'requires_user_authorization'),
+        engines_requiring_future_network_authorization: collectEnginesByNextPhase(
+            engines,
+            'requires_future_network_dry_run_authorization'
+        ),
+        engines_requiring_future_db_write_authorization: collectEnginesByNextPhase(
+            engines,
+            'requires_future_db_write_authorization'
+        ),
+        engines_needing_unit_tests: collectEnginesByTestCoverage(engines, 'needs_unit_tests'),
         engines_missing_provenance_requirement: missingProvenance,
         non_execution_confirmations: buildNonExecutionConfirmations(),
         errors: loaded.errors,
@@ -361,9 +486,22 @@ function formatAuditText(payload) {
         `registry_valid=${boolToText(payload.registry_valid)}`,
         `registry_path=${payload.registry_path}`,
         `total_engines=${payload.total_engines}`,
+        `governance_fields_required=${listToText(payload.governance_fields_required)}`,
+        `governance_fields_complete=${boolToText(payload.governance_fields_complete)}`,
+        `missing_governance_fields=${payload.missing_governance_fields.length === 0 ? 'none' : JSON.stringify(payload.missing_governance_fields)}`,
         `high_risk_engines=${listToText(payload.high_risk_engines)}`,
         `allowed_read_only_engines=${listToText(payload.allowed_read_only_engines)}`,
         `blocked_engines=${listToText(payload.blocked_engines)}`,
+        `canonical_engines=${listToText(payload.canonical_engines)}`,
+        `gate_only_engines=${listToText(payload.gate_only_engines)}`,
+        `quarantine_engines=${listToText(payload.quarantine_engines)}`,
+        `deprecation_candidate_engines=${listToText(payload.deprecation_candidate_engines)}`,
+        `adapter_candidate_engines=${listToText(payload.adapter_candidate_engines)}`,
+        `legacy_blocked_engines=${listToText(payload.legacy_blocked_engines)}`,
+        `engines_requiring_user_authorization=${listToText(payload.engines_requiring_user_authorization)}`,
+        `engines_requiring_future_network_authorization=${listToText(payload.engines_requiring_future_network_authorization)}`,
+        `engines_requiring_future_db_write_authorization=${listToText(payload.engines_requiring_future_db_write_authorization)}`,
+        `engines_needing_unit_tests=${listToText(payload.engines_needing_unit_tests)}`,
         `engines_missing_provenance_requirement=${listToText(payload.engines_missing_provenance_requirement)}`,
         'no_db_writes',
         'no_external_network',
@@ -505,4 +643,10 @@ module.exports = {
     resolveEngineRequirements,
     resolveManifestState,
     validateRegistry,
+    REQUIRED_GOVERNANCE_FIELDS,
+    ALLOWED_STATUS_VALUES,
+    ALLOWED_INTENDED_LAYER_VALUES,
+    ALLOWED_DEPRECATION_STATUS_VALUES,
+    ALLOWED_NEXT_PHASE_VALUES,
+    ALLOWED_TEST_COVERAGE_VALUES,
 };

--- a/tests/unit/acquisition_engine_gate.test.js
+++ b/tests/unit/acquisition_engine_gate.test.js
@@ -25,6 +25,60 @@ const REQUIRED_ENGINE_FIELDS = [
     'safe_for_ai_default',
     'phase454_policy',
 ];
+const REQUIRED_GOVERNANCE_FIELDS = [
+    'owner',
+    'status',
+    'intended_layer',
+    'replacement_plan',
+    'deprecation_status',
+    'canonical_entrypoint',
+    'allowed_next_phase',
+    'test_coverage',
+];
+const ALLOWED_STATUS_VALUES = new Set([
+    'canonical',
+    'gate_only',
+    'quarantine',
+    'deprecation_candidate',
+    'adapter_candidate',
+    'legacy_blocked',
+]);
+const ALLOWED_INTENDED_LAYER_VALUES = new Set([
+    'layer_0_registry_policy',
+    'layer_1_source_manifest',
+    'layer_2_discovery',
+    'layer_3_single_target_acquisition',
+    'layer_4_local_staging_normalization',
+    'layer_5_local_staging_dry_run',
+    'layer_6_small_db_write',
+    'layer_7_feature_dry_run',
+    'layer_8_training_prediction',
+    'legacy_bulk_pipeline',
+    'legacy_production_path',
+    'unknown',
+]);
+const ALLOWED_DEPRECATION_STATUS_VALUES = new Set([
+    'not_deprecated',
+    'watch',
+    'quarantine',
+    'deprecation_candidate',
+    'deprecated_do_not_use',
+]);
+const ALLOWED_NEXT_PHASE_VALUES = new Set([
+    'allowed_read_only',
+    'requires_user_authorization',
+    'requires_future_network_dry_run_authorization',
+    'requires_future_db_write_authorization',
+    'blocked',
+    'blocked_legacy',
+]);
+const ALLOWED_TEST_COVERAGE_VALUES = new Set([
+    'unit_covered',
+    'gate_covered',
+    'needs_unit_tests',
+    'needs_integration_tests',
+    'not_covered',
+]);
 
 function runGate(args) {
     const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
@@ -56,7 +110,7 @@ test('acquisition_engine_gate registry JSON 可解析且包含必需字段', () 
     const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
 
     assert.equal(registry.phase, '4.54');
-    assert.equal(registry.registry_type, 'acquisition_engine_risk_registry');
+    assert.equal(registry.registry_type, 'acquisition_engine_governance_registry');
     assert.ok(Array.isArray(registry.engines));
     assert.ok(registry.engines.length >= 13);
 
@@ -64,6 +118,27 @@ test('acquisition_engine_gate registry JSON 可解析且包含必需字段', () 
         for (const field of REQUIRED_ENGINE_FIELDS) {
             assert.ok(field in engine, `missing field ${field} for engine ${engine.id}`);
         }
+        for (const field of REQUIRED_GOVERNANCE_FIELDS) {
+            assert.ok(field in engine, `missing governance field ${field} for engine ${engine.id}`);
+        }
+        assert.ok(ALLOWED_STATUS_VALUES.has(engine.status), `invalid status for ${engine.id}: ${engine.status}`);
+        assert.ok(
+            ALLOWED_INTENDED_LAYER_VALUES.has(engine.intended_layer),
+            `invalid intended_layer for ${engine.id}: ${engine.intended_layer}`
+        );
+        assert.ok(
+            ALLOWED_DEPRECATION_STATUS_VALUES.has(engine.deprecation_status),
+            `invalid deprecation_status for ${engine.id}: ${engine.deprecation_status}`
+        );
+        assert.ok(
+            ALLOWED_NEXT_PHASE_VALUES.has(engine.allowed_next_phase),
+            `invalid allowed_next_phase for ${engine.id}: ${engine.allowed_next_phase}`
+        );
+        assert.ok(
+            ALLOWED_TEST_COVERAGE_VALUES.has(engine.test_coverage),
+            `invalid test_coverage for ${engine.id}: ${engine.test_coverage}`
+        );
+        assert.equal(typeof engine.canonical_entrypoint, 'boolean');
     }
 });
 
@@ -89,9 +164,20 @@ test('acquisition_engine_gate --audit 应成功并标记高风险 engine', () =>
     assert.equal(payload.mode, 'acquisition-engine-audit');
     assert.equal(payload.registry_found, true);
     assert.equal(payload.registry_valid, true);
+    assert.equal(payload.governance_fields_complete, true);
+    assert.deepEqual(payload.missing_governance_fields, []);
     assert.ok(payload.high_risk_engines.includes('run_production'));
     assert.ok(payload.blocked_engines.includes('run_production'));
     assert.ok(payload.allowed_read_only_engines.includes('real_finished_csv_staging_dry_run'));
+    assert.ok(payload.canonical_engines.includes('real_finished_csv_staging_dry_run'));
+    assert.ok(payload.gate_only_engines.includes('csv_bulk_loader'));
+    assert.ok(payload.quarantine_engines.includes('recon_scanner'));
+    assert.ok(payload.adapter_candidate_engines.includes('titan_discovery'));
+    assert.ok(payload.legacy_blocked_engines.includes('run_production'));
+    assert.ok(payload.engines_requiring_user_authorization.includes('real_finished_csv_staging_dry_run'));
+    assert.ok(payload.engines_requiring_future_network_authorization.includes('titan_discovery'));
+    assert.ok(payload.engines_requiring_future_db_write_authorization.includes('csv_bulk_loader'));
+    assert.ok(payload.engines_needing_unit_tests.includes('csv_bulk_loader'));
     assert.deepEqual(payload.engines_missing_provenance_requirement, []);
     assertNoExecutionFlags(payload);
 });


### PR DESCRIPTION
## Summary

Upgrades the acquisition engine registry from a risk list into a governance table.

Changes:
- Adds governance fields to config/acquisition_engines.phase454.json
- Updates acquisition_engine_gate audit output for governance completeness and engine categories
- Extends acquisition gate unit tests
- Updates AGENTS.md with registry governance rules
- Adds Phase 4.56C report

Safety:
- No DB writes
- No external downloads
- No external data access
- No scraping / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- registry JSON parse passed
- data-acquisition-engine-audit passed with governance_fields_complete=true
- acquisition gate tests passed
- scaffold dry-run remained blocked
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed