### PR TITLE
test(data): harden football-data adapter no-network path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -541,6 +541,14 @@ Phase 4.56C registry governance rules：
 - `allowed_next_phase` 决定 Codex 是否可进入下一阶段；任何从 `blocked` 升级到可用状态都必须先补测试和报告。
 - network dry-run 仍需单独授权；DB write 仍需单独授权并完成 `pg_dump`。
 
+Phase 4.57C football-data adapter rules：
+
+- `fetch_and_adapt_euro_leagues` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。
+- Codex 不得直接运行 `node scripts/ops/fetch_and_adapt_euro_leagues.js`。
+- 未来如要使用 Football-Data 类 CSV 来源，必须先有本地 `source manifest`，再人工确认 license / terms，再做 local staging / dry-run。
+- 任何 football-data network dry-run 都必须单独授权；不得把 legacy downloader 直接接到 DB / training。
+- 当前只允许通过 acquisition registry / gate 检查 `fetch_and_adapt_euro_leagues` 的 readiness，不允许直接复用其 legacy downloader runtime。
+
 执行 `make data-finished-backfill-dry-run MATCH_ID=<id>` 的前提：
 
 - 用户明确授权

--- a/config/acquisition_engines.phase454.json
+++ b/config/acquisition_engines.phase454.json
@@ -300,15 +300,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Always downloads external CSV and writes adapted output. No safe no-network mode exists.",
+            "notes": "Legacy football-data downloader always fetches external CSV, reads DB for alignment, and writes adapted output. No safe no-network mode exists.",
             "owner": "data-governance",
             "status": "adapter_candidate",
             "intended_layer": "layer_3_single_target_acquisition",
-            "replacement_plan": "Refactor into a manifest-bound single-target adapter with explicit local staging output and no-network/no-db tests.",
+            "replacement_plan": "Do not directly reuse the legacy downloader runtime. Extract a source-specific adapter only after source manifest, license review, and local staging dry-run are in place; any future network dry-run remains separately authorized.",
             "deprecation_status": "watch",
             "canonical_entrypoint": false,
             "allowed_next_phase": "requires_future_network_dry_run_authorization",
-            "test_coverage": "needs_unit_tests"
+            "test_coverage": "gate_covered"
         },
         {
             "id": "odds_harvest_pipeline",

--- a/docs/_reports/FETCH_ADAPT_EURO_LEAGUES_NO_NETWORK_PHASE4_57C.md
+++ b/docs/_reports/FETCH_ADAPT_EURO_LEAGUES_NO_NETWORK_PHASE4_57C.md
@@ -1,0 +1,168 @@
+# Phase 4.57C Fetch And Adapt Euro Leagues No-Network Hardening
+
+Date: 2026-05-05
+
+## 1. Current Head / Branch
+
+- Starting HEAD: `f181a5301aadb2236ac831846a10dc71fafa76aa`
+- Working branch: `test/football-data-adapter-no-network-phase457c`
+- Base branch: `main`
+
+## 2. Why This Engine Was Chosen
+
+`fetch_and_adapt_euro_leagues` was chosen first among the current `adapter_candidate` engines because it is source-specific, its source family is relatively clear, and its runtime is easier to classify than `titan_discovery` or `odds_harvest_pipeline`.
+
+The goal in Phase 4.57C is not to download anything. The goal is to improve dry-run trust governance around this legacy downloader and make its blocked state explicit and test-protected.
+
+## 3. Read-Only Source Audit Summary
+
+Read-only inspection of `scripts/ops/fetch_and_adapt_euro_leagues.js` shows:
+
+- it builds football-data URLs under `https://www.football-data.co.uk/mmz4281/...`
+- it uses `fetch(...)` to download CSV content
+- it writes a temporary CSV file under a temp directory
+- it reads the local DB through `pg` to align matches
+- it writes an adapted CSV to `data/mock/real_euro_league_adapted.csv` by default
+- it has no safe no-network dry-run mode
+- it has no source manifest input
+- it does not emit the provenance / hash / manifest discipline required by the current canonical route
+
+Relevant risk points found in code:
+
+- network fetch: `downloadToTempFile()` around lines 540-553
+- football-data URL construction: `resolveCandidateList()` around lines 562-583
+- DB read alignment: `ExistingMatchResolver.load()` around lines 311-340
+- adapted CSV write: `writeAdaptedCsv()` around lines 714-722
+
+## 4. Current Risk Assessment
+
+Current risks remain:
+
+- may access external network
+- may download external CSV
+- may write adapted CSV
+- may read DB for alignment
+- has no trusted dry-run
+- is not suitable for direct Codex execution
+
+Because of that, this engine remains an `adapter_candidate`, not a canonical entrypoint.
+
+## 5. Registry Update Summary
+
+`config/acquisition_engines.phase454.json` was updated only for `fetch_and_adapt_euro_leagues`:
+
+- kept `status=adapter_candidate`
+- kept `safe_for_ai_default=false`
+- kept `canonical_entrypoint=false`
+- kept `allowed_next_phase=requires_future_network_dry_run_authorization`
+- strengthened `notes` to state that the legacy runtime fetches external CSV, reads DB, and writes adapted output
+- strengthened `replacement_plan` to explicitly forbid direct reuse of the legacy downloader runtime
+- updated `test_coverage` from `needs_unit_tests` to `gate_covered`
+
+## 6. No-Network / No-DB Test Coverage
+
+Added:
+
+- `tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js`
+
+Coverage added:
+
+- registry contains `fetch_and_adapt_euro_leagues`
+- governance state stays `adapter_candidate`
+- `safe_for_ai_default=false`
+- `canonical_entrypoint=false`
+- `allowed_next_phase=requires_future_network_dry_run_authorization`
+- acquisition gate engine mode stays blocked
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+- `--commit` stays blocked
+- the test does not import or execute the legacy downloader runtime
+
+## 7. Acquisition Gate Blocked Validation
+
+Validated with:
+
+```bash
+make data-single-target-network-dry-run \
+  ENGINE=fetch_and_adapt_euro_leagues \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json
+```
+
+Observed blocked semantics:
+
+- `engine_found=true`
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+
+## 8. Commit Blocked Validation
+
+Validated with:
+
+```bash
+make data-single-target-network-commit \
+  ENGINE=fetch_and_adapt_euro_leagues \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json \
+  CONFIRM_SINGLE_TARGET_NETWORK=1
+```
+
+Result:
+
+- blocked
+- no external network
+- no DB writes
+- no engine execution
+
+## 9. DB Before / After
+
+Before validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+`make data-dataset-status` remained `trainable=false`.
+
+## 10. Next Step Recommendation
+
+Two clean next steps remain:
+
+1. Phase 4.58C: continue with `titan_discovery` or `odds_harvest_pipeline` and add the same no-network / dry-run trust hardening.
+2. Phase 4.56A: only after the user provides the six real network dry-run parameters, prepare a runbook without actually touching the network.
+
+## 11. Explicit Non-Execution
+
+Not executed in Phase 4.57C:
+
+- DB writes
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- real network dry-run execution
+- bulk harvest
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js
+++ b/tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const GATE_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/acquisition_engine_gate.js');
+const LEGACY_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const REGISTRY_PATH = path.join(PROJECT_ROOT, 'config/acquisition_engines.phase454.json');
+const SOURCE_MANIFEST = 'tests/fixtures/real_source_manifests/local_sample_history_phase452.json';
+const ENGINE_ID = 'fetch_and_adapt_euro_leagues';
+
+function loadRegistryEngine(engineId) {
+    const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+    const engines = Array.isArray(registry?.engines) ? registry.engines : [];
+    return engines.find(engine => engine.id === engineId) || null;
+}
+
+function runGate(args) {
+    return spawnSync(process.execPath, [GATE_SCRIPT_PATH, ...args], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+}
+
+function parseJsonOutput(result) {
+    const payload = String(result.stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload in stdout');
+    return JSON.parse(payload);
+}
+
+function assertNoExecutionFlags(payload) {
+    assert.ok(Array.isArray(payload.non_execution_confirmations));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('no_engine_execution'));
+}
+
+test('fetch_and_adapt_euro_leagues 在 registry 中保持 adapter_candidate 治理状态', () => {
+    const engine = loadRegistryEngine(ENGINE_ID);
+
+    assert.ok(engine, 'registry should contain fetch_and_adapt_euro_leagues');
+    assert.equal(engine.status, 'adapter_candidate');
+    assert.equal(engine.safe_for_ai_default, false);
+    assert.equal(engine.canonical_entrypoint, false);
+    assert.equal(engine.allowed_next_phase, 'requires_future_network_dry_run_authorization');
+    assert.equal(engine.phase454_policy, 'blocked');
+    assert.equal(engine.accesses_network, true);
+    assert.equal(engine.writes_db, false);
+    assert.equal(engine.writes_files, true);
+    assert.equal(engine.supports_dry_run, false);
+    assert.equal(engine.test_coverage, 'gate_covered');
+    assert.match(engine.notes, /fetches external CSV/i);
+    assert.match(engine.replacement_plan, /Do not directly reuse the legacy downloader runtime/i);
+});
+
+test('fetch_and_adapt_euro_leagues legacy runtime file 存在但不得在测试中执行', () => {
+    assert.equal(fs.existsSync(LEGACY_SCRIPT_PATH), true);
+});
+
+test('acquisition gate 对 fetch_and_adapt_euro_leagues 保持 scaffold-only blocked 且不触网不写库', () => {
+    const result = runGate([
+        '--engine',
+        ENGINE_ID,
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.mode, 'single-target-network-scaffold');
+    assert.equal(payload.engine_found, true);
+    assert.equal(payload.engine_id, ENGINE_ID);
+    assert.equal(payload.phase454_policy, 'blocked');
+    assert.equal(payload.accesses_network, true);
+    assert.equal(payload.writes_db, false);
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.missing_source_manifest, false);
+    assert.equal(payload.missing_target_scope, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.match(payload.blocked_reason, /Phase 4\.54 is scaffold-only/);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition gate 对 fetch_and_adapt_euro_leagues 的 --commit 必须 blocked', () => {
+    const result = runGate([
+        '--engine',
+        ENGINE_ID,
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--commit',
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.notEqual(result.status, 0);
+    assert.equal(payload.mode, 'blocked-commit');
+    assert.equal(payload.engine_id, ENGINE_ID);
+    assert.match(payload.blocked_reason, /not wired in Phase 4\.54/);
+    assertNoExecutionFlags(payload);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.57C no-network/no-db hardening for fetch_and_adapt_euro_leagues as an adapter candidate.

Scope:
- Audits fetch_and_adapt_euro_leagues read-only
- Keeps legacy downloader blocked
- Adds no-network / no-db tests for the adapter candidate path
- Updates acquisition registry metadata for fetch_and_adapt_euro_leagues
- Updates AGENTS.md with football-data adapter safety rules
- Adds Phase 4.57C report

Safety:
- No DB writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- registry JSON parse passed
- acquisition gate audit passed
- fetch_and_adapt_euro_leagues gate path remained blocked
- no-network/no-db tests passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed