### PR TITLE
test(data): harden titan discovery no-network path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,15 @@ Phase 4.57C football-data adapter rules：
 - 任何 football-data network dry-run 都必须单独授权；不得把 legacy downloader 直接接到 DB / training。
 - 当前只允许通过 acquisition registry / gate 检查 `fetch_and_adapt_euro_leagues` 的 readiness，不允许直接复用其 legacy downloader runtime。
 
+Phase 4.58C titan discovery rules：
+
+- `titan_discovery` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。
+- Codex 不得直接运行 `node scripts/ops/titan_discovery.js`，也不得运行 `node scripts/ops/titan_discovery.js --dry-run`。
+- 当前 `titan_discovery` dry-run trust 不足，不能被当作安全 dry-run 使用。
+- 未来如要使用 titan discovery 能力，必须先抽取成 Layer 2 discovery-only adapter，并先具备本地 `source manifest`、单场或极小 date window 限制、以及人工确认的 license / terms。
+- 任何 titan discovery network dry-run 都必须单独授权；不得把 legacy discovery runtime 直接接到 DB / staging / training。
+- 当前只允许通过 acquisition registry / gate 检查 `titan_discovery` 的 readiness，不允许直接复用其 legacy runtime。
+
 执行 `make data-finished-backfill-dry-run MATCH_ID=<id>` 的前提：
 
 - 用户明确授权

--- a/config/acquisition_engines.phase454.json
+++ b/config/acquisition_engines.phase454.json
@@ -206,15 +206,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Discovery dry-run trust is low until the CLI flag is proven to suppress writes end to end.",
+            "notes": "Legacy titan_discovery may touch external network, call DiscoveryService, and batch-discover leagues. Current --dry-run trust is insufficient and CLI flag propagation is not proven end to end.",
             "owner": "data-governance",
             "status": "adapter_candidate",
             "intended_layer": "layer_2_discovery",
-            "replacement_plan": "Refactor into a discovery-only adapter after dry-run trust and CLI flag propagation are proven with no-network/no-db tests.",
+            "replacement_plan": "Do not directly reuse the legacy titan_discovery runtime. Extract a Layer 2 discovery-only adapter only after CLI flag propagation, source manifest support, and single-target or very small-window scope controls are proven with no-network/no-db tests; any future network dry-run remains separately authorized.",
             "deprecation_status": "watch",
             "canonical_entrypoint": false,
             "allowed_next_phase": "requires_future_network_dry_run_authorization",
-            "test_coverage": "needs_unit_tests"
+            "test_coverage": "gate_covered"
         },
         {
             "id": "recon_scanner",

--- a/docs/_reports/TITAN_DISCOVERY_NO_NETWORK_PHASE4_58C.md
+++ b/docs/_reports/TITAN_DISCOVERY_NO_NETWORK_PHASE4_58C.md
@@ -1,0 +1,170 @@
+# Phase 4.58C Titan Discovery No-Network Hardening
+
+Date: 2026-05-05
+
+## 1. Current Head / Branch
+
+- Starting HEAD: `cbeb856514381e6c03dcd201827b763ea9e3e380`
+- Working branch: `test/titan-discovery-no-network-phase458c`
+- Base branch: `main`
+
+## 2. Why This Engine Was Chosen
+
+`titan_discovery` was chosen next because it is the clearest current candidate for a future Layer 2 discovery-only adapter. Discovery sits before later acquisition and staging steps, so its trust boundaries should be hardened early.
+
+Phase 4.58C does not execute discovery. It only improves no-network / no-db governance around the legacy runtime.
+
+## 3. Read-Only Source Audit Summary
+
+Read-only inspection of `scripts/ops/titan_discovery.js` and `src/infrastructure/services/DiscoveryService.js` shows:
+
+- `titan_discovery.js` exists and exposes a thin CLI around `DiscoveryService`
+- it supports `--dry-run` at CLI parse level, but the flag is not clearly propagated into `DiscoveryService` construction or `service.discover(...)`
+- the CLI defaults to `--all` when no scope is provided, so batch discovery is possible by default
+- `DiscoveryService` builds a `pg` pool, `BrowserProvider`, `HttpClient`, `FixtureRepository`, and proxy-backed browser/network runtime
+- `DiscoveryService._fetchFixtures()` performs API requests and can fall back to webpage extraction
+- `DiscoveryService._scanLeague()` persists fixtures through `fixtureRepository.persist(...)`
+
+Relevant risk points found in code:
+
+- CLI `--dry-run` parsed but only used for console warning in `scripts/ops/titan_discovery.js`
+- default batch scope when no target is provided in `parseArgs()`
+- `new DiscoveryService(...)` in `titan_discovery.js`
+- DB pool setup in `DiscoveryService` constructor
+- browser/network runtime setup in `BrowserProvider`, `HttpClient`, and extractor wiring
+- persistence through `fixtureRepository.persist(...)` in `_scanLeague()`
+
+## 4. Current Risk Assessment
+
+Current risks remain:
+
+- may access external network
+- may call `DiscoveryService`
+- may use browser / HTTP / proxy-backed runtime
+- may write DB through fixture persistence
+- may scan multiple leagues by default
+- current dry-run trust is insufficient
+- CLI flag propagation is not clearly proven end to end
+- not suitable for direct Codex execution
+
+Because of that, this engine remains an `adapter_candidate`, not a canonical entrypoint.
+
+## 5. Registry Update Summary
+
+`config/acquisition_engines.phase454.json` was updated only for `titan_discovery`:
+
+- kept `status=adapter_candidate`
+- kept `safe_for_ai_default=false`
+- kept `canonical_entrypoint=false`
+- kept `allowed_next_phase=requires_future_network_dry_run_authorization`
+- strengthened `notes` to state that the legacy runtime may touch network, call `DiscoveryService`, and batch-discover leagues
+- strengthened `replacement_plan` to explicitly forbid direct reuse of the legacy runtime and require a future Layer 2 discovery-only adapter
+- updated `test_coverage` from `needs_unit_tests` to `gate_covered`
+
+## 6. No-Network / No-DB Test Coverage
+
+Added:
+
+- `tests/unit/titan_discovery_no_network.test.js`
+
+Coverage added:
+
+- registry contains `titan_discovery`
+- governance state stays `adapter_candidate`
+- `safe_for_ai_default=false`
+- `canonical_entrypoint=false`
+- `allowed_next_phase=requires_future_network_dry_run_authorization`
+- acquisition gate engine mode stays blocked
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+- `--commit` stays blocked
+- the test does not import or execute the legacy runtime
+
+## 7. Acquisition Gate Blocked Validation
+
+Validated with:
+
+```bash
+make data-single-target-network-dry-run \
+  ENGINE=titan_discovery \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json
+```
+
+Observed blocked semantics:
+
+- `engine_found=true`
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+
+## 8. Commit Blocked Validation
+
+Validated with:
+
+```bash
+make data-single-target-network-commit \
+  ENGINE=titan_discovery \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json \
+  CONFIRM_SINGLE_TARGET_NETWORK=1
+```
+
+Result:
+
+- blocked
+- no external network
+- no DB writes
+- no engine execution
+
+## 9. DB Before / After
+
+Before validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+`make data-dataset-status` remained `trainable=false`.
+
+## 10. Next Step Recommendation
+
+Two clean next steps remain:
+
+1. Phase 4.59C: continue with `odds_harvest_pipeline` and add the same no-network / dry-run trust hardening.
+2. Phase 4.56A: only after the user provides the six real network dry-run parameters, prepare a runbook without actually touching the network.
+
+## 11. Explicit Non-Execution
+
+Not executed in Phase 4.58C:
+
+- DB writes
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- real network dry-run execution
+- bulk harvest
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/tests/unit/titan_discovery_no_network.test.js
+++ b/tests/unit/titan_discovery_no_network.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const GATE_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/acquisition_engine_gate.js');
+const LEGACY_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/titan_discovery.js');
+const REGISTRY_PATH = path.join(PROJECT_ROOT, 'config/acquisition_engines.phase454.json');
+const SOURCE_MANIFEST = 'tests/fixtures/real_source_manifests/local_sample_history_phase452.json';
+const ENGINE_ID = 'titan_discovery';
+
+function loadRegistryEngine(engineId) {
+    const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+    const engines = Array.isArray(registry?.engines) ? registry.engines : [];
+    return engines.find(engine => engine.id === engineId) || null;
+}
+
+function runGate(args) {
+    return spawnSync(process.execPath, [GATE_SCRIPT_PATH, ...args], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+}
+
+function parseJsonOutput(result) {
+    const payload = String(result.stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload in stdout');
+    return JSON.parse(payload);
+}
+
+function assertNoExecutionFlags(payload) {
+    assert.ok(Array.isArray(payload.non_execution_confirmations));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('no_engine_execution'));
+}
+
+test('titan_discovery 在 registry 中保持 adapter_candidate 治理状态', () => {
+    const engine = loadRegistryEngine(ENGINE_ID);
+
+    assert.ok(engine, 'registry should contain titan_discovery');
+    assert.equal(engine.status, 'adapter_candidate');
+    assert.equal(engine.safe_for_ai_default, false);
+    assert.equal(engine.canonical_entrypoint, false);
+    assert.equal(engine.allowed_next_phase, 'requires_future_network_dry_run_authorization');
+    assert.equal(engine.phase454_policy, 'blocked');
+    assert.equal(engine.accesses_network, true);
+    assert.equal(engine.writes_db, true);
+    assert.equal(engine.supports_dry_run, true);
+    assert.equal(engine.dry_run_trust_level, 'low');
+    assert.equal(engine.test_coverage, 'gate_covered');
+    assert.match(engine.notes, /dry-run trust is insufficient/i);
+    assert.match(engine.replacement_plan, /Layer 2 discovery-only adapter/i);
+});
+
+test('titan_discovery legacy runtime file 存在但不得在测试中执行', () => {
+    assert.equal(fs.existsSync(LEGACY_SCRIPT_PATH), true);
+});
+
+test('acquisition gate 对 titan_discovery 保持 scaffold-only blocked 且不触网不写库', () => {
+    const result = runGate([
+        '--engine',
+        ENGINE_ID,
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.mode, 'single-target-network-scaffold');
+    assert.equal(payload.engine_found, true);
+    assert.equal(payload.engine_id, ENGINE_ID);
+    assert.equal(payload.phase454_policy, 'blocked');
+    assert.equal(payload.accesses_network, true);
+    assert.equal(payload.writes_db, true);
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.missing_source_manifest, false);
+    assert.equal(payload.missing_target_scope, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.match(payload.blocked_reason, /Phase 4\.54 is scaffold-only/);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition gate 对 titan_discovery 的 --commit 必须 blocked', () => {
+    const result = runGate([
+        '--engine',
+        ENGINE_ID,
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--commit',
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.notEqual(result.status, 0);
+    assert.equal(payload.mode, 'blocked-commit');
+    assert.equal(payload.engine_id, ENGINE_ID);
+    assert.match(payload.blocked_reason, /not wired in Phase 4\.54/);
+    assertNoExecutionFlags(payload);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.58C no-network/no-db hardening for titan_discovery as a discovery adapter candidate.

Scope:
- Audits titan_discovery read-only
- Keeps legacy discovery runtime blocked
- Adds no-network / no-db tests for the titan discovery candidate path
- Updates acquisition registry metadata for titan_discovery
- Updates AGENTS.md with titan discovery safety rules
- Adds Phase 4.58C report

Safety:
- No DB writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- registry JSON parse passed
- acquisition gate audit passed
- titan_discovery gate path remained blocked
- no-network/no-db tests passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed