### PR TITLE
test(data): harden odds harvest no-network path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -558,6 +558,16 @@ Phase 4.58C titan discovery rules：
 - 任何 titan discovery network dry-run 都必须单独授权；不得把 legacy discovery runtime 直接接到 DB / staging / training。
 - 当前只允许通过 acquisition registry / gate 检查 `titan_discovery` 的 readiness，不允许直接复用其 legacy runtime。
 
+Phase 4.59C odds harvest rules：
+
+- `odds_harvest_pipeline` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。
+- Codex 不得直接运行 `node scripts/ops/odds_harvest_pipeline.js`、`npm run odds:harvest` 或任何 odds harvest / bulk odds pipeline。
+- 当前 `odds_harvest_pipeline` dry-run trust 不足，不能被当作安全 dry-run 使用。
+- 未来如要使用 odds harvest 能力，必须先抽取成 single-target odds acquisition adapter，并先具备本地 `source manifest`、单场或极小 date window、以及人工确认的 license / terms / ToS。
+- 任何 odds network dry-run 都必须单独授权；不得绕过 login / paywall / anti-bot / rate limit；不得把 legacy odds runtime 直接接到 DB / training。
+- 赔率必须带 `captured_at`、`bookmaker`、`market`、`source_url` 和 provenance；closing odds / post-match odds 不能冒充赛前赔率。
+- 当前只允许通过 acquisition registry / gate 检查 `odds_harvest_pipeline` 的 readiness，不允许直接复用其 legacy runtime。
+
 执行 `make data-finished-backfill-dry-run MATCH_ID=<id>` 的前提：
 
 - 用户明确授权

--- a/config/acquisition_engines.phase454.json
+++ b/config/acquisition_engines.phase454.json
@@ -329,15 +329,15 @@
             "safe_for_ai_default": false,
             "requires_user_authorization": true,
             "phase454_policy": "blocked",
-            "notes": "Playwright and fetch based OddsPortal pipeline with DB upserts and optional downstream L3 work.",
+            "notes": "Legacy odds_harvest_pipeline may access external OddsPortal odds sources, launch Playwright browser automation, use fetch/proxy-adjacent recon code, query Postgres, upsert odds/mapping rows, and trigger downstream L3. Current dry-run trust is insufficient, bulk harvest is possible, and odds without captured_at/bookmaker/market provenance can create training leakage risk.",
             "owner": "data-governance",
             "status": "adapter_candidate",
             "intended_layer": "layer_3_single_target_acquisition",
-            "replacement_plan": "Refactor into a single-target odds adapter after manifest binding, no-db dry-run support, and source isolation are in place.",
+            "replacement_plan": "Do not directly reuse the legacy odds_harvest_pipeline runtime. Extract a Layer 3 single-target odds acquisition adapter only after source manifest support, strict target scope, bookmaker/market/captured_at/source_url/sha256/provenance capture, no-db dry-run tests, and source isolation are in place; any future network dry-run remains separately authorized, and any later DB write requires separate authorization plus pg_dump.",
             "deprecation_status": "watch",
             "canonical_entrypoint": false,
             "allowed_next_phase": "requires_future_network_dry_run_authorization",
-            "test_coverage": "needs_unit_tests"
+            "test_coverage": "gate_covered"
         },
         {
             "id": "total_war_pipeline",

--- a/docs/_reports/ODDS_HARVEST_PIPELINE_NO_NETWORK_PHASE4_59C.md
+++ b/docs/_reports/ODDS_HARVEST_PIPELINE_NO_NETWORK_PHASE4_59C.md
@@ -1,0 +1,190 @@
+# Phase 4.59C Odds Harvest Pipeline No-Network Hardening
+
+Date: 2026-05-05
+
+## 1. Current Head / Branch
+
+- Starting HEAD: `53d0d7685e71539d116762dd83398f57409f667e`
+- Working branch: `test/odds-harvest-no-network-phase459c`
+- Base branch: `main`
+
+## 2. Why This Engine Was Chosen
+
+`odds_harvest_pipeline` was chosen because odds data is important to prediction quality and this pipeline has a higher risk profile than local CSV adapters. It may touch external odds sources, launch browser automation, use network fetches, read and write Postgres, and optionally trigger downstream L3 work.
+
+Phase 4.59C does not execute odds harvest. It only improves no-network / no-db governance around the legacy runtime.
+
+## 3. Read-Only Source Audit Summary
+
+Read-only inspection of `scripts/ops/odds_harvest_pipeline.js` and `scripts/ops/odds_harvest_pipeline.shared.js` shows:
+
+- `odds_harvest_pipeline.js` exists and is wired from `npm run odds:harvest`
+- the script creates a `pg` Pool at module scope
+- it imports Playwright `chromium` and launches a browser in `enumerateLeagueEvents()`
+- it builds OddsPortal results URLs from route config
+- it uses global `fetch()` in `fetchText()` for OddsPortal pages and ajax payloads
+- it uses `ReconPureDecryptor` for OddsPortal payload decoding
+- it reads target matches and coverage from Postgres
+- it upserts mapping and odds rows through `UPSERT_MAPPING_SQL` and `UPSERT_ODDS_SQL`
+- it can spawn `scripts/ops/l3_stitch_pipeline.js` after odds processing
+- `parseArgs()` recognizes `--dry-run`, but dry-run is not a safe no-network mode because enumeration, fetch/decrypt, DB reads, and optional L3 behavior remain part of the runtime path
+
+Relevant risk points found in code:
+
+- top-level `new Pool(...)`
+- Playwright `chromium.launch(...)`
+- `page.goto(...)` and pagination over OddsPortal results pages
+- `fetchText()` calling external URLs through `fetch()`
+- `createDecryptor()` loading a bundle URL
+- `fetchAjaxEventData()` and `fetchPreMatchData()` requesting OddsPortal ajax payloads
+- `upsertMappingAndOdds()` writing mapping and odds rows unless `options.dryRun`
+- `runL3Stitch()` spawning L3 pipeline unless disabled or mapping-only
+- default route selection covers all configured routes when no league is provided
+
+## 4. Current Risk Assessment
+
+Current risks remain:
+
+- may access external network
+- may access external OddsPortal odds sources
+- may use browser automation
+- may use proxy-adjacent recon/decryptor runtime
+- may read and write Postgres
+- may trigger downstream L3 work
+- may batch harvest multiple leagues by default
+- current dry-run trust is insufficient
+- odds without clear `captured_at`, bookmaker, market, source URL, and provenance can create training leakage risk
+- closing odds or post-match odds must not be treated as pre-match features
+- not suitable for direct Codex execution
+
+Because of that, this engine remains an `adapter_candidate`, not a canonical entrypoint.
+
+## 5. Registry Update Summary
+
+`config/acquisition_engines.phase454.json` was updated only for `odds_harvest_pipeline`:
+
+- kept `status=adapter_candidate`
+- kept `safe_for_ai_default=false`
+- kept `canonical_entrypoint=false`
+- kept `allowed_next_phase=requires_future_network_dry_run_authorization`
+- strengthened `notes` to state that the legacy runtime may touch external odds sources, browser automation, Postgres writes, and downstream L3
+- strengthened `notes` with timestamp / closing-odds leakage risk
+- strengthened `replacement_plan` to explicitly forbid direct reuse of the legacy runtime
+- required a future Layer 3 single-target odds acquisition adapter
+- required source manifest, target scope, bookmaker / market / captured_at / source_url / sha256 / provenance capture
+- kept any future network dry-run separately authorized
+- required separate authorization plus `pg_dump` before any future DB write
+- updated `test_coverage` from `needs_unit_tests` to `gate_covered`
+
+## 6. No-Network / No-DB Test Coverage
+
+Added:
+
+- `tests/unit/odds_harvest_pipeline_no_network.test.js`
+
+Coverage added:
+
+- registry contains `odds_harvest_pipeline`
+- governance state stays `adapter_candidate`
+- `safe_for_ai_default=false`
+- `canonical_entrypoint=false`
+- `allowed_next_phase=requires_future_network_dry_run_authorization`
+- acquisition gate engine mode stays blocked
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+- `--commit` stays blocked
+- the test does not import or execute the legacy runtime
+
+## 7. Acquisition Gate Blocked Validation
+
+Validated with:
+
+```bash
+make data-single-target-network-dry-run \
+  ENGINE=odds_harvest_pipeline \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json
+```
+
+Observed blocked semantics:
+
+- `engine_found=true`
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+
+## 8. Commit Blocked Validation
+
+Validated with:
+
+```bash
+make data-single-target-network-commit \
+  ENGINE=odds_harvest_pipeline \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json \
+  CONFIRM_SINGLE_TARGET_NETWORK=1
+```
+
+Observed result:
+
+- blocked
+- no external network
+- no DB writes
+- no engine execution
+
+## 9. Preflight Scaffold
+
+No `odds_harvest_preflight.js` scaffold was added in Phase 4.59C. The smallest safe change is to keep the legacy runtime fully blocked and covered by registry / acquisition gate tests.
+
+## 10. DB Before / After
+
+Before validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+`make data-dataset-status` remained `trainable=false`.
+
+## 11. Next Step Recommendation
+
+Two clean next steps remain:
+
+1. Phase 4.60C: summarize adapter candidates and confirm `fetch_and_adapt_euro_leagues`, `titan_discovery`, and `odds_harvest_pipeline` are all `gate_covered`.
+2. Phase 4.56A: only after the user provides the six real network dry-run parameters, prepare a runbook without actually touching the network.
+
+## 12. Explicit Non-Execution
+
+Not executed in Phase 4.59C:
+
+- DB writes
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- external odds data access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- real network dry-run execution
+- bulk harvest
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/tests/unit/odds_harvest_pipeline_no_network.test.js
+++ b/tests/unit/odds_harvest_pipeline_no_network.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const GATE_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/acquisition_engine_gate.js');
+const LEGACY_SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/odds_harvest_pipeline.js');
+const REGISTRY_PATH = path.join(PROJECT_ROOT, 'config/acquisition_engines.phase454.json');
+const SOURCE_MANIFEST = 'tests/fixtures/real_source_manifests/local_sample_history_phase452.json';
+const ENGINE_ID = 'odds_harvest_pipeline';
+
+function loadRegistryEngine(engineId) {
+    const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+    const engines = Array.isArray(registry?.engines) ? registry.engines : [];
+    return engines.find(engine => engine.id === engineId) || null;
+}
+
+function runGate(args) {
+    return spawnSync(process.execPath, [GATE_SCRIPT_PATH, ...args], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+}
+
+function parseJsonOutput(result) {
+    const payload = String(result.stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload in stdout');
+    return JSON.parse(payload);
+}
+
+function assertNoExecutionFlags(payload) {
+    assert.ok(Array.isArray(payload.non_execution_confirmations));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('no_engine_execution'));
+}
+
+test('odds_harvest_pipeline 在 registry 中保持 adapter_candidate 治理状态', () => {
+    const engine = loadRegistryEngine(ENGINE_ID);
+
+    assert.ok(engine, 'registry should contain odds_harvest_pipeline');
+    assert.equal(engine.status, 'adapter_candidate');
+    assert.equal(engine.safe_for_ai_default, false);
+    assert.equal(engine.canonical_entrypoint, false);
+    assert.equal(engine.allowed_next_phase, 'requires_future_network_dry_run_authorization');
+    assert.equal(engine.phase454_policy, 'blocked');
+    assert.equal(engine.accesses_network, true);
+    assert.equal(engine.writes_db, true);
+    assert.equal(engine.writes_files, true);
+    assert.equal(engine.supports_dry_run, false);
+    assert.equal(engine.dry_run_trust_level, 'low');
+    assert.equal(engine.test_coverage, 'gate_covered');
+    assert.match(engine.notes, /external OddsPortal odds sources/i);
+    assert.match(engine.notes, /training leakage risk/i);
+    assert.match(engine.replacement_plan, /Layer 3 single-target odds acquisition adapter/i);
+    assert.match(engine.replacement_plan, /pg_dump/i);
+});
+
+test('odds_harvest_pipeline legacy runtime file 存在但不得在测试中执行', () => {
+    assert.equal(fs.existsSync(LEGACY_SCRIPT_PATH), true);
+});
+
+test('acquisition gate 对 odds_harvest_pipeline 保持 scaffold-only blocked 且不触网不写库', () => {
+    const result = runGate([
+        '--engine',
+        ENGINE_ID,
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.mode, 'single-target-network-scaffold');
+    assert.equal(payload.engine_found, true);
+    assert.equal(payload.engine_id, ENGINE_ID);
+    assert.equal(payload.phase454_policy, 'blocked');
+    assert.equal(payload.accesses_network, true);
+    assert.equal(payload.writes_db, true);
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.missing_source_manifest, false);
+    assert.equal(payload.missing_target_scope, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.match(payload.blocked_reason, /Phase 4\.54 is scaffold-only/);
+    assertNoExecutionFlags(payload);
+});
+
+test('acquisition gate 对 odds_harvest_pipeline 的 --commit 必须 blocked', () => {
+    const result = runGate([
+        '--engine',
+        ENGINE_ID,
+        '--target-match-id',
+        '47_20242025_900002',
+        '--source-manifest',
+        SOURCE_MANIFEST,
+        '--commit',
+        '--json',
+    ]);
+    const payload = parseJsonOutput(result);
+
+    assert.notEqual(result.status, 0);
+    assert.equal(payload.mode, 'blocked-commit');
+    assert.equal(payload.engine_id, ENGINE_ID);
+    assert.match(payload.blocked_reason, /not wired in Phase 4\.54/);
+    assertNoExecutionFlags(payload);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.59C no-network/no-db hardening for odds_harvest_pipeline as an odds acquisition adapter candidate.

Scope:
- Audits odds_harvest_pipeline read-only
- Keeps legacy odds harvest runtime blocked
- Adds no-network / no-db tests for the odds harvest candidate path
- Updates acquisition registry metadata for odds_harvest_pipeline
- Updates AGENTS.md with odds harvest safety rules
- Adds Phase 4.59C report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No curl / wget / git clone
- No scraping / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- registry JSON parse passed
- acquisition gate audit passed
- odds_harvest_pipeline gate path remained blocked
- no-network/no-db tests passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed