### PR TITLE
feat(data): add football-data local CSV parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,11 @@ Phase 4.57C football-data adapter rules：
 - 任何 football-data network dry-run 都必须单独授权；不得把 legacy downloader 直接接到 DB / training。
 - 当前只允许通过 acquisition registry / gate 检查 `fetch_and_adapt_euro_leagues` 的 readiness，不允许直接复用其 legacy downloader runtime。
 - Phase 4.61C 后，`fetch_and_adapt_euro_leagues` 只能作为 pure parser / local CSV adapter 的抽取参考；parser 必须 no-network / no-db / no-file-write。
+- Phase 4.62C 的 `scripts/lib/football_data_local_csv_parser.js` 是 pure parser，只能处理调用方提供的本地 CSV text / rows 或本地 fixture。
+- 在用户明确授权下，Codex 可以运行 `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_local_csv_parser.test.js`。
+- `football_data_local_csv_parser` 不得访问外网、不得读 / 写 DB、不得写文件、不得 import `scripts/ops/fetch_and_adapt_euro_leagues.js` legacy runtime。
+- `FTHG` / `FTAG` / `FTR` 只能用于 finished label 映射，不得作为赛前 feature；`B365H/B365D/B365A`、`PSH/PSD/PSA` 等 odds columns 只能 preview，不得写 `odds` 或 `bookmaker_odds_history`。
+- 未来 football-data network dry-run 仍需单独授权；未来任何 DB write 仍需单独授权并先完成 `pg_dump`。
 - 未来 local CSV adapter 必须由 source manifest + 本地 CSV 驱动，不得下载 Football-Data CSV，不得写 staging / DB，不得训练或预测。
 - 任何 DB write 必须另行授权并先完成 `pg_dump`；不得把 legacy downloader 直接接到 training / prediction。
 

--- a/docs/_reports/FOOTBALL_DATA_LOCAL_CSV_PARSER_PHASE4_62C.md
+++ b/docs/_reports/FOOTBALL_DATA_LOCAL_CSV_PARSER_PHASE4_62C.md
@@ -1,0 +1,296 @@
+# Phase 4.62C Football-Data Local CSV Parser
+
+Date: 2026-05-06
+
+## 1. Current Head / Branch
+
+- Starting HEAD: `7640fc16bec86a8f7999179828de50fd723b3af7`
+- Working branch: `feat/football-data-local-csv-parser-phase462c`
+- Report timestamp (UTC): `2026-05-06T07:37:16Z`
+
+## 2. Why This Phase Implements a Pure Parser
+
+Phase 4.61C defined the extraction route for `fetch_and_adapt_euro_leagues`:
+
+```text
+source manifest
+  -> local CSV staging input
+  -> pure CSV parser
+  -> schema mapper
+  -> local staging dry-run
+  -> future controlled network dry-run
+  -> future small DB write
+```
+
+Phase 4.62C implements only the pure parser layer.
+
+This keeps the current phase inside the approved boundary:
+
+- local synthetic CSV fixture only
+- no external football-data access
+- no external odds source access
+- no downloader reuse
+- no DB reads from parser
+- no DB writes
+- no adapted CSV writes
+- no training
+- no prediction execution
+
+## 3. Added / Updated Files
+
+- `scripts/lib/football_data_local_csv_parser.js`
+- `tests/fixtures/football_data/football_data_sample_phase462c.csv`
+- `tests/unit/football_data_local_csv_parser.test.js`
+- `AGENTS.md`
+- `docs/_reports/FOOTBALL_DATA_LOCAL_CSV_PARSER_PHASE4_62C.md`
+
+## 4. Parser Design
+
+`scripts/lib/football_data_local_csv_parser.js` is a pure parser module.
+
+It accepts CSV text or already parsed rows and returns structured parser output.
+
+It does not:
+
+- access the network
+- read DB
+- write DB
+- write files
+- spawn child processes
+- import `scripts/ops/fetch_and_adapt_euro_leagues.js`
+- import `pg`
+
+Parser output includes:
+
+- `parser_version`
+- `source_name`
+- `total_rows`
+- `parsed_rows`
+- `candidate_rows`
+- `row_classification`
+- `warnings`
+- `errors`
+- `non_execution_confirmations`
+
+Safety confirmations returned by the parser:
+
+- `no_external_network`
+- `no_db_reads`
+- `no_db_writes`
+- `no_file_writes`
+- `no_legacy_runtime`
+- `no_training`
+- `no_prediction_execution`
+
+## 5. Supported Fields
+
+The parser recognizes these Football-Data style columns in Phase 4.62C:
+
+- `Div`
+- `Date`
+- `Time`
+- `HomeTeam`
+- `AwayTeam`
+- `FTHG`
+- `FTAG`
+- `FTR`
+- `B365H`
+- `B365D`
+- `B365A`
+- `PSH`
+- `PSD`
+- `PSA`
+
+The parser maps:
+
+- `Div` -> `league_name`
+- `Date` + `Time` -> `match_date`
+- `HomeTeam` -> `home_team`
+- `AwayTeam` -> `away_team`
+- `FTHG` -> `home_score`
+- `FTAG` -> `away_score`
+- `FTR` -> `actual_result`
+
+## 6. Label Mapping
+
+Supported label mapping:
+
+- `H` -> `home_win`
+- `D` -> `draw`
+- `A` -> `away_win`
+
+Fallback when `FTR` is missing but the final score is complete:
+
+- `home_score > away_score` -> `home_win`
+- `home_score = away_score` -> `draw`
+- `home_score < away_score` -> `away_win`
+
+`FTHG`, `FTAG`, and `FTR` are treated as label-only fields in this phase. They are not treated as features.
+
+## 7. Fixture Test Summary
+
+Local synthetic parser fixture:
+
+`tests/fixtures/football_data/football_data_sample_phase462c.csv`
+
+Fixture coverage:
+
+- 1 valid `home_win`
+- 1 valid `draw`
+- 1 valid `away_win`
+- 1 invalid date row
+- 1 missing score row
+- Bet365 odds columns present
+- Pinnacle odds columns present
+
+Fixture results:
+
+- `total_rows=5`
+- `candidate_rows=3`
+- `finished_rows=3`
+- `trainable_label_rows=3`
+- `skipped_rows=2`
+- `invalid_date_rows=1`
+- `missing_score_rows=1`
+- `odds_preview_rows=3`
+
+## 8. Unit Test Results
+
+Validated commands:
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_local_csv_parser.test.js
+docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js
+docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/acquisition_engine_gate.test.js
+docker compose -f docker-compose.dev.yml exec -T dev npm test
+```
+
+Observed results:
+
+- `tests/unit/football_data_local_csv_parser.test.js`: 5/5 passed
+- `tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js`: 4/4 passed
+- `tests/unit/acquisition_engine_gate.test.js`: 8/8 passed
+- `npm test`: exited `0`; default gate passed
+
+The new parser unit test explicitly monkey patches and blocks:
+
+- `http.request`
+- `https.request`
+- `global.fetch`
+- `child_process.spawn`
+- `child_process.exec`
+- `child_process.execFile`
+
+It also blocks parser-time imports of:
+
+- `pg`
+- `fs`
+- `http`
+- `https`
+- `child_process`
+- `fetch_and_adapt_euro_leagues`
+
+## 9. Gate Blocked Verification
+
+Validated commands:
+
+```bash
+make data-acquisition-engine-audit
+
+make data-single-target-network-dry-run \
+  ENGINE=fetch_and_adapt_euro_leagues \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json || true
+
+make data-single-target-network-commit \
+  ENGINE=fetch_and_adapt_euro_leagues \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json \
+  CONFIRM_SINGLE_TARGET_NETWORK=1 || true
+```
+
+Expected safety properties that remain required:
+
+- `engine_found=true`
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+- dry-run gate blocked
+- commit gate blocked
+
+Observed Phase 4.62C result:
+
+- `make data-acquisition-engine-audit`: passed, `fetch_and_adapt_euro_leagues` remained an `adapter_candidate`
+- scaffold gate: `engine_found=true`
+- scaffold gate: `would_access_network=false`
+- scaffold gate: `would_write_db=false`
+- scaffold gate: `would_execute_engine=false`
+- scaffold gate: blocked with `Phase 4.54 is scaffold-only`
+- commit gate: blocked with `acquisition network commit is not wired in Phase 4.54`
+
+## 10. DB Before / After
+
+Before implementation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After validation the counts must remain unchanged:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+Observed after validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 11. Next Step Recommendation
+
+Preferred next step:
+
+- Phase 4.63C: implement `football_data_adapter_dry_run`, connect the parser to local `source manifest` + local CSV dry-run, and keep `would_insert_matches=false` / `would_insert_odds=false`
+
+Alternative only if the user later provides the six required real network dry-run parameters:
+
+- Phase 4.56A: write a controlled football-data network dry-run runbook first, without touching the network
+
+Without real parameters and separate authorization, no network access is allowed.
+
+## 12. Explicit Non-Execution
+
+Not executed in Phase 4.62C:
+
+- DB writes
+- DB reads from the parser
+- parser file writes
+- adapted CSV writes
+- external download
+- `curl` / `wget` / `git clone`
+- external football data source access
+- external odds data source access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- real network dry-run execution
+- bulk harvest
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/lib/football_data_local_csv_parser.js
+++ b/scripts/lib/football_data_local_csv_parser.js
@@ -1,0 +1,546 @@
+'use strict';
+
+const PARSER_VERSION = 'PHASE4.62C_FOOTBALL_DATA_LOCAL_CSV_PARSER';
+const DEFAULT_SOURCE_NAME = 'football_data_local_csv';
+const DEFAULT_DATA_VERSION = 'PHASE4.62C_LOCAL_PARSER';
+const DEFAULT_SEASON = 'UNKNOWN_SEASON';
+const DEFAULT_TIMEZONE = 'UTC';
+const NON_EXECUTION_CONFIRMATIONS = [
+    'no_external_network',
+    'no_db_reads',
+    'no_db_writes',
+    'no_file_writes',
+    'no_legacy_runtime',
+    'no_training',
+    'no_prediction_execution',
+];
+const DIVISION_NAME_MAP = {
+    E0: 'Premier League',
+    E1: 'Championship',
+    SP1: 'La Liga',
+    SP2: 'Segunda Division',
+    D1: 'Bundesliga',
+    D2: '2. Bundesliga',
+    I1: 'Serie A',
+    I2: 'Serie B',
+    F1: 'Ligue 1',
+    F2: 'Ligue 2',
+    N1: 'Eredivisie',
+    P1: 'Liga Portugal',
+};
+const SUPPORTED_ODDS_BOOKMAKERS = [
+    {
+        bookmaker: 'Bet365',
+        columns: {
+            home: 'B365H',
+            draw: 'B365D',
+            away: 'B365A',
+        },
+    },
+    {
+        bookmaker: 'Pinnacle',
+        columns: {
+            home: 'PSH',
+            draw: 'PSD',
+            away: 'PSA',
+        },
+    },
+];
+
+function normalizeText(value) {
+    return String(value || '').trim();
+}
+
+function normalizeTeamName(value) {
+    return normalizeText(value).replace(/\s+/g, ' ');
+}
+
+function toIntegerOrNull(value) {
+    const text = normalizeText(value);
+    if (!text) {
+        return null;
+    }
+    if (!/^-?\d+$/.test(text)) {
+        return null;
+    }
+    return Number.parseInt(text, 10);
+}
+
+function toFloatOrNull(value) {
+    const text = normalizeText(value);
+    if (!text) {
+        return null;
+    }
+    const parsed = Number.parseFloat(text);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function mapDivisionToLeagueName(divisionCode) {
+    const normalizedCode = normalizeText(divisionCode).toUpperCase();
+    return DIVISION_NAME_MAP[normalizedCode] || normalizedCode || 'UNKNOWN_LEAGUE';
+}
+
+function deriveSeasonFromIsoDate(matchDate) {
+    const date = new Date(matchDate);
+    if (Number.isNaN(date.getTime())) {
+        return DEFAULT_SEASON;
+    }
+    const month = date.getUTCMonth() + 1;
+    const startYear = month >= 7 ? date.getUTCFullYear() : date.getUTCFullYear() - 1;
+    const endYear = startYear + 1;
+    return `${startYear}/${endYear}`;
+}
+
+function mapFtrToActualResult(ftr) {
+    const normalized = normalizeText(ftr).toUpperCase();
+    if (normalized === 'H') {
+        return 'home_win';
+    }
+    if (normalized === 'D') {
+        return 'draw';
+    }
+    if (normalized === 'A') {
+        return 'away_win';
+    }
+    return null;
+}
+
+function deriveActualResultFromScores(homeScore, awayScore) {
+    if (!Number.isInteger(homeScore) || !Number.isInteger(awayScore)) {
+        return null;
+    }
+    if (homeScore > awayScore) {
+        return 'home_win';
+    }
+    if (homeScore < awayScore) {
+        return 'away_win';
+    }
+    return 'draw';
+}
+
+function splitCsvLine(line) {
+    const values = [];
+    let current = '';
+    let insideQuotes = false;
+
+    for (let index = 0; index < line.length; index++) {
+        const character = line[index];
+        const nextCharacter = line[index + 1];
+
+        if (character === '"') {
+            if (insideQuotes && nextCharacter === '"') {
+                current += '"';
+                index += 1;
+                continue;
+            }
+            insideQuotes = !insideQuotes;
+            continue;
+        }
+
+        if (character === ',' && !insideQuotes) {
+            values.push(current);
+            current = '';
+            continue;
+        }
+
+        current += character;
+    }
+
+    values.push(current);
+    return values;
+}
+
+function parseCsvText(csvText) {
+    const normalizedText = String(csvText || '')
+        .replace(/^\uFEFF/, '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n');
+    const lines = normalizedText
+        .split('\n')
+        .map(line => line.trimEnd())
+        .filter(line => line.trim() !== '');
+
+    if (lines.length === 0) {
+        return [];
+    }
+
+    const headers = splitCsvLine(lines[0]).map(header => normalizeText(header));
+    return lines.slice(1).map(line => {
+        const cells = splitCsvLine(line);
+        return headers.reduce((row, header, index) => {
+            row[header] = cells[index] !== undefined ? cells[index] : '';
+            return row;
+        }, {});
+    });
+}
+
+function normalizeRowsInput(csvTextOrRows) {
+    if (Array.isArray(csvTextOrRows)) {
+        return csvTextOrRows.map(row => ({ ...row }));
+    }
+    return parseCsvText(csvTextOrRows);
+}
+
+function parseDateParts(dateText) {
+    const normalized = normalizeText(dateText);
+    const match = normalized.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/);
+    if (!match) {
+        return null;
+    }
+
+    const day = Number.parseInt(match[1], 10);
+    const month = Number.parseInt(match[2], 10);
+    const yearText = match[3];
+    const year = yearText.length === 2 ? 2000 + Number.parseInt(yearText, 10) : Number.parseInt(yearText, 10);
+
+    return { day, month, year };
+}
+
+function parseTimeParts(timeText) {
+    const normalized = normalizeText(timeText);
+    if (!normalized) {
+        return { hour: 0, minute: 0 };
+    }
+    const match = normalized.match(/^(\d{1,2}):(\d{2})$/);
+    if (!match) {
+        return null;
+    }
+    return {
+        hour: Number.parseInt(match[1], 10),
+        minute: Number.parseInt(match[2], 10),
+    };
+}
+
+function parseFootballDataDate(dateText, timeText, options = {}) {
+    const dateParts = parseDateParts(dateText);
+    const timeParts = parseTimeParts(timeText);
+
+    if (!dateParts || !timeParts) {
+        return null;
+    }
+
+    const { day, month, year } = dateParts;
+    const { hour, minute } = timeParts;
+    const utcDate = new Date(Date.UTC(year, month - 1, day, hour, minute, 0, 0));
+
+    if (
+        utcDate.getUTCFullYear() !== year
+        || utcDate.getUTCMonth() + 1 !== month
+        || utcDate.getUTCDate() !== day
+        || utcDate.getUTCHours() !== hour
+        || utcDate.getUTCMinutes() !== minute
+    ) {
+        return null;
+    }
+
+    if (normalizeText(options.timezone || DEFAULT_TIMEZONE).toUpperCase() !== 'UTC') {
+        return utcDate.toISOString();
+    }
+
+    return utcDate.toISOString();
+}
+
+function buildOddsBookmakerPreview(row, config) {
+    const homePresent = Object.prototype.hasOwnProperty.call(row, config.columns.home);
+    const drawPresent = Object.prototype.hasOwnProperty.call(row, config.columns.draw);
+    const awayPresent = Object.prototype.hasOwnProperty.call(row, config.columns.away);
+    const recognizedColumns = [config.columns.home, config.columns.draw, config.columns.away].filter(column =>
+        Object.prototype.hasOwnProperty.call(row, column)
+    );
+
+    if (!homePresent && !drawPresent && !awayPresent) {
+        return null;
+    }
+
+    const values = {
+        home: toFloatOrNull(row[config.columns.home]),
+        draw: toFloatOrNull(row[config.columns.draw]),
+        away: toFloatOrNull(row[config.columns.away]),
+    };
+    const hasAnyValue = Object.values(values).some(value => value !== null);
+    const completeTriplet = Object.values(values).every(value => value !== null);
+
+    return {
+        bookmaker: config.bookmaker,
+        recognized_columns: recognizedColumns,
+        supported_columns_present: homePresent && drawPresent && awayPresent,
+        has_any_value: hasAnyValue,
+        complete_triplet: completeTriplet,
+        values,
+    };
+}
+
+function detectOddsColumns(row) {
+    const bookmakers = SUPPORTED_ODDS_BOOKMAKERS.map(config => buildOddsBookmakerPreview(row, config)).filter(Boolean);
+    return {
+        available: bookmakers.length > 0,
+        odds_preview_only: true,
+        bookmakers,
+    };
+}
+
+function buildWarning(rowNumber, code, message) {
+    return {
+        row_number: rowNumber,
+        code,
+        message,
+    };
+}
+
+function buildBaseMeta(context = {}) {
+    return {
+        sourceName: normalizeText(context.sourceName) || DEFAULT_SOURCE_NAME,
+        dataVersion: normalizeText(context.dataVersion) || DEFAULT_DATA_VERSION,
+        defaultSeason: normalizeText(context.defaultSeason) || DEFAULT_SEASON,
+        timezone: normalizeText(context.timezone) || DEFAULT_TIMEZONE,
+    };
+}
+
+function resolveResult(homeScore, awayScore, ftrValue) {
+    const resultFromFtr = mapFtrToActualResult(ftrValue);
+    const resultFromScore = deriveActualResultFromScores(homeScore, awayScore);
+
+    if (resultFromFtr && resultFromScore && resultFromFtr !== resultFromScore) {
+        return {
+            actualResult: null,
+            resultSource: null,
+            invalidResult: true,
+            mismatch: true,
+        };
+    }
+
+    if (resultFromFtr) {
+        return {
+            actualResult: resultFromFtr,
+            resultSource: 'FTR',
+            invalidResult: false,
+            mismatch: false,
+        };
+    }
+
+    if (resultFromScore) {
+        return {
+            actualResult: resultFromScore,
+            resultSource: 'score_derived',
+            invalidResult: false,
+            mismatch: false,
+        };
+    }
+
+    return {
+        actualResult: null,
+        resultSource: null,
+        invalidResult: true,
+        mismatch: false,
+    };
+}
+
+function buildRowCore(row, meta) {
+    const homeTeam = normalizeTeamName(row.HomeTeam);
+    const awayTeam = normalizeTeamName(row.AwayTeam);
+    const homeScore = toIntegerOrNull(row.FTHG);
+    const awayScore = toIntegerOrNull(row.FTAG);
+    const oddsPreview = detectOddsColumns(row);
+    const matchDate = parseFootballDataDate(row.Date, row.Time, { timezone: meta.timezone });
+    const resolvedResult = resolveResult(homeScore, awayScore, row.FTR);
+
+    return {
+        homeTeam,
+        awayTeam,
+        homeScore,
+        awayScore,
+        oddsPreview,
+        matchDate,
+        resolvedResult,
+    };
+}
+
+function buildRowDiagnostics(row, rowNumber, rowCore) {
+    const warnings = [];
+    const flags = {
+        invalid_date: false,
+        missing_team: false,
+        missing_score: false,
+        invalid_result: false,
+        odds_preview_available: rowCore.oddsPreview.available,
+    };
+
+    if (!rowCore.homeTeam || !rowCore.awayTeam) {
+        flags.missing_team = true;
+        warnings.push(buildWarning(rowNumber, 'missing_team', 'HomeTeam or AwayTeam is missing; row skipped.'));
+    }
+
+    if (!rowCore.matchDate) {
+        flags.invalid_date = true;
+        warnings.push(buildWarning(rowNumber, 'invalid_date', `Unable to parse Date/Time: Date=${row.Date || ''} Time=${row.Time || ''}`));
+    }
+
+    if (!Number.isInteger(rowCore.homeScore) || !Number.isInteger(rowCore.awayScore)) {
+        flags.missing_score = true;
+        warnings.push(buildWarning(rowNumber, 'missing_score', 'FTHG / FTAG is missing or invalid; row is not a finished label candidate.'));
+    }
+
+    if (rowCore.resolvedResult.invalidResult) {
+        flags.invalid_result = true;
+        warnings.push(
+            buildWarning(
+                rowNumber,
+                rowCore.resolvedResult.mismatch ? 'result_score_mismatch' : 'invalid_result',
+                rowCore.resolvedResult.mismatch
+                    ? 'FTR conflicts with the score-derived result; row skipped.'
+                    : 'Unable to derive actual_result from FTR or score; row skipped.'
+            )
+        );
+    }
+
+    return {
+        warnings,
+        flags,
+    };
+}
+
+function normalizeFootballDataRow(row, context = {}) {
+    const meta = buildBaseMeta(context);
+    const rowNumber = Number.isInteger(context.rowNumber) ? context.rowNumber : 0;
+    const rowCore = buildRowCore(row, meta);
+    const diagnostics = buildRowDiagnostics(row, rowNumber, rowCore);
+    const errors = [];
+    const { warnings, flags } = diagnostics;
+    const shouldSkip = flags.invalid_date || flags.missing_team || flags.missing_score || flags.invalid_result;
+    if (shouldSkip) {
+        return {
+            row_number: rowNumber,
+            status: 'skipped',
+            skip_reason: resolveSkipReason(flags),
+            normalized_row: null,
+            warnings,
+            errors,
+            flags,
+            odds_preview: rowCore.oddsPreview,
+        };
+    }
+
+    const normalizedRow = {
+        row_number: rowNumber,
+        league_code: normalizeText(row.Div).toUpperCase(),
+        league_name: mapDivisionToLeagueName(row.Div),
+        season: meta.defaultSeason !== DEFAULT_SEASON ? meta.defaultSeason : deriveSeasonFromIsoDate(rowCore.matchDate),
+        match_date: rowCore.matchDate,
+        home_team: rowCore.homeTeam,
+        away_team: rowCore.awayTeam,
+        home_score: rowCore.homeScore,
+        away_score: rowCore.awayScore,
+        actual_result: rowCore.resolvedResult.actualResult,
+        result_source: rowCore.resolvedResult.resultSource,
+        data_source: meta.sourceName,
+        data_version: meta.dataVersion,
+        odds_preview: rowCore.oddsPreview,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        odds_preview_only: true,
+        label_only_fields: ['FTHG', 'FTAG', 'FTR'],
+    };
+
+    return {
+        row_number: rowNumber,
+        status: 'candidate',
+        skip_reason: null,
+        normalized_row: normalizedRow,
+        warnings,
+        errors,
+        flags,
+        odds_preview: rowCore.oddsPreview,
+    };
+}
+
+function resolveSkipReason(flags) {
+    if (flags.invalid_date) {
+        return 'invalid_date';
+    }
+    if (flags.missing_team) {
+        return 'missing_team';
+    }
+    if (flags.missing_score) {
+        return 'missing_score';
+    }
+    if (flags.invalid_result) {
+        return 'invalid_result';
+    }
+    return 'skipped';
+}
+
+function classifyFootballDataRows(normalizedEntries = []) {
+    return normalizedEntries.reduce(
+        (summary, entry) => {
+            if (entry.normalized_row) {
+                summary.finished_rows += 1;
+                summary.trainable_label_rows += 1;
+                if (entry.flags.odds_preview_available) {
+                    summary.odds_preview_rows += 1;
+                }
+            } else {
+                summary.skipped_rows += 1;
+            }
+
+            if (entry.flags.invalid_date) {
+                summary.invalid_date_rows += 1;
+            }
+            if (entry.flags.missing_team) {
+                summary.missing_team_rows += 1;
+            }
+            if (entry.flags.missing_score) {
+                summary.missing_score_rows += 1;
+            }
+            if (entry.flags.invalid_result) {
+                summary.invalid_result_rows += 1;
+            }
+
+            return summary;
+        },
+        {
+            finished_rows: 0,
+            trainable_label_rows: 0,
+            skipped_rows: 0,
+            invalid_date_rows: 0,
+            missing_team_rows: 0,
+            missing_score_rows: 0,
+            invalid_result_rows: 0,
+            odds_preview_rows: 0,
+        }
+    );
+}
+
+function parseFootballDataCsv(csvTextOrRows, options = {}) {
+    const meta = buildBaseMeta(options);
+    const rows = normalizeRowsInput(csvTextOrRows);
+    const normalizedEntries = rows.map((row, index) =>
+        normalizeFootballDataRow(row, {
+            ...meta,
+            rowNumber: index + 1,
+        })
+    );
+    const candidateRows = normalizedEntries.map(entry => entry.normalized_row).filter(Boolean);
+    const warnings = normalizedEntries.flatMap(entry => entry.warnings);
+    const errors = normalizedEntries.flatMap(entry => entry.errors);
+
+    return {
+        parser_version: PARSER_VERSION,
+        source_name: meta.sourceName,
+        total_rows: rows.length,
+        parsed_rows: rows.length,
+        candidate_rows: candidateRows,
+        row_classification: classifyFootballDataRows(normalizedEntries),
+        warnings,
+        errors,
+        non_execution_confirmations: [...NON_EXECUTION_CONFIRMATIONS],
+    };
+}
+
+module.exports = {
+    parseFootballDataCsv,
+    normalizeFootballDataRow,
+    mapFtrToActualResult,
+    parseFootballDataDate,
+    detectOddsColumns,
+    classifyFootballDataRows,
+};

--- a/tests/fixtures/football_data/football_data_sample_phase462c.csv
+++ b/tests/fixtures/football_data/football_data_sample_phase462c.csv
@@ -1,0 +1,6 @@
+Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR,B365H,B365D,B365A,PSH,PSD,PSA
+SP2,17/08/2024,17:30,Synthetic Home Winners,Synthetic Away Losers,1,0,H,2.50,3.10,2.90,2.55,3.05,2.88
+SP2,18/08/2024,19:00,Example Home,Example Away,0,0,D,2.10,3.20,3.50,,,
+SP2,19/08/2024,20:00,Away Winners,Home Losers,1,2,A,,,,,,
+SP2,not-a-date,20:00,Bad Date FC,Other FC,1,1,D,2.00,3.00,4.00,,,
+SP2,20/08/2024,20:00,Missing Score FC,Other FC,,,D,2.00,3.00,4.00,,,

--- a/tests/unit/football_data_local_csv_parser.test.js
+++ b/tests/unit/football_data_local_csv_parser.test.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const PARSER_PATH = path.join(PROJECT_ROOT, 'scripts/lib/football_data_local_csv_parser.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const FIXTURE_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+const PARSER_OPTIONS = {
+    sourceName: 'football_data_local_fixture',
+    dataVersion: 'PHASE4.62C_LOCAL_PARSER',
+    defaultSeason: '2024/2025',
+    timezone: 'UTC',
+};
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_local_csv_parser`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'fs',
+            'node:fs',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        Module._load = originalLoad;
+    });
+}
+
+function loadParserFresh() {
+    delete require.cache[PARSER_PATH];
+    return require(PARSER_PATH);
+}
+
+function loadFixtureCsv() {
+    return fs.readFileSync(FIXTURE_PATH, 'utf8');
+}
+
+test('parser module 可以 import 且无 side effects', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+
+    assert.equal(typeof parser.parseFootballDataCsv, 'function');
+    assert.equal(typeof parser.normalizeFootballDataRow, 'function');
+    assert.equal(typeof parser.mapFtrToActualResult, 'function');
+    assert.equal(typeof parser.parseFootballDataDate, 'function');
+    assert.equal(typeof parser.detectOddsColumns, 'function');
+    assert.equal(typeof parser.classifyFootballDataRows, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('parser 可以成功解析本地 synthetic fixture CSV', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const parsed = parser.parseFootballDataCsv(loadFixtureCsv(), PARSER_OPTIONS);
+    const actualResults = parsed.candidate_rows.map(row => row.actual_result);
+    const warningCodes = parsed.warnings.map(item => item.code);
+
+    assert.equal(parsed.parser_version, 'PHASE4.62C_FOOTBALL_DATA_LOCAL_CSV_PARSER');
+    assert.equal(parsed.source_name, 'football_data_local_fixture');
+    assert.equal(parsed.total_rows, 5);
+    assert.equal(parsed.parsed_rows, 5);
+    assert.equal(parsed.candidate_rows.length, 3);
+    assert.deepEqual(actualResults, ['home_win', 'draw', 'away_win']);
+    assert.deepEqual(parsed.row_classification, {
+        finished_rows: 3,
+        trainable_label_rows: 3,
+        skipped_rows: 2,
+        invalid_date_rows: 1,
+        missing_team_rows: 0,
+        missing_score_rows: 1,
+        invalid_result_rows: 0,
+        odds_preview_rows: 3,
+    });
+    assert.ok(warningCodes.includes('invalid_date'));
+    assert.ok(warningCodes.includes('missing_score'));
+});
+
+test('candidate rows 应保持 preview only 且不产生任何写入意图', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const parsed = parser.parseFootballDataCsv(loadFixtureCsv(), PARSER_OPTIONS);
+    const firstCandidate = parsed.candidate_rows[0];
+    const thirdCandidate = parsed.candidate_rows[2];
+
+    for (const candidate of parsed.candidate_rows) {
+        assert.equal(candidate.would_insert_matches, false);
+        assert.equal(candidate.would_insert_odds, false);
+        assert.equal(candidate.odds_preview.odds_preview_only, true);
+        assert.equal(candidate.odds_preview.available, true);
+        assert.equal(candidate.data_source, 'football_data_local_fixture');
+        assert.equal(candidate.data_version, 'PHASE4.62C_LOCAL_PARSER');
+    }
+
+    assert.deepEqual(
+        firstCandidate.odds_preview.bookmakers.map(item => item.bookmaker),
+        ['Bet365', 'Pinnacle']
+    );
+    assert.equal(firstCandidate.odds_preview.bookmakers[0].complete_triplet, true);
+    assert.equal(thirdCandidate.odds_preview.bookmakers[0].has_any_value, false);
+});
+
+test('non_execution_confirmations 必须覆盖 no-network / no-db / no-file-write / no-legacy-runtime', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const parsed = parser.parseFootballDataCsv(loadFixtureCsv(), PARSER_OPTIONS);
+
+    assert.ok(parsed.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_db_reads'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_legacy_runtime'));
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('helper functions 支持 FTR label mapping 与日期解析', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+
+    assert.equal(parser.mapFtrToActualResult('H'), 'home_win');
+    assert.equal(parser.mapFtrToActualResult('D'), 'draw');
+    assert.equal(parser.mapFtrToActualResult('A'), 'away_win');
+    assert.equal(parser.mapFtrToActualResult('X'), null);
+    assert.equal(parser.parseFootballDataDate('17/08/2024', '17:30', { timezone: 'UTC' }), '2024-08-17T17:30:00.000Z');
+    assert.equal(parser.parseFootballDataDate('17/08/24', '07:05', { timezone: 'UTC' }), '2024-08-17T07:05:00.000Z');
+    assert.equal(parser.parseFootballDataDate('not-a-date', '17:30', { timezone: 'UTC' }), null);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.62C football-data local CSV pure parser.

Scope:
- Adds pure parser for local Football-Data style CSV text
- Adds synthetic parser fixture
- Adds unit tests
- Keeps legacy fetch_and_adapt_euro_leagues runtime blocked
- Supports label mapping and odds preview only
- Adds Phase 4.62C report

Safety:
- No DB writes
- No DB reads
- No file writes from parser
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- football_data_local_csv_parser tests passed
- football-data no-network tests passed
- acquisition gate tests passed
- acquisition gate remained blocked
- commit gate remained blocked
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed