### PR TITLE
test(data): restore football-data parser coverage gate

### DIFF
--- a/docs/_reports/FOOTBALL_DATA_LOCAL_CSV_PARSER_COVERAGE_HOTFIX_PHASE4_62C.md
+++ b/docs/_reports/FOOTBALL_DATA_LOCAL_CSV_PARSER_COVERAGE_HOTFIX_PHASE4_62C.md
@@ -1,0 +1,237 @@
+# Phase 4.62C Hotfix Football-Data Parser Coverage Gate
+
+Date: 2026-05-07
+
+## 1. Current Head / Branch
+
+- Starting main HEAD: `747c3bb6ad0f6b288b830d1157cfb18f15d64461`
+- Working branch: `test/football-data-parser-coverage-hotfix-phase462c`
+- Base branch: `main`
+
+## 2. Main Red Gate Reason
+
+The merge commit from PR #1170 reached `main`, then the `Production Gate` push workflow failed.
+
+Failure context:
+
+- run id: `25424427867`
+- event: `push`
+- branch: `main`
+- headSha: `747c3bb6ad0f6b288b830d1157cfb18f15d64461`
+- failed step: `Run Gatekeeper`
+- failed command: `npm run test:coverage`
+
+Key failure:
+
+```text
+[TEST-GATE] 覆盖率门禁已启用: lines>=80, functions>=80, branches>=80
+[TEST-GATE] 覆盖率未达标: branches=79.96 < 80
+[TEST-GATE] 覆盖率测试已完成，但覆盖率门禁失败。
+[Gatekeeper] GATEKEEPER_FAILURE_REASON=npm run test:coverage failed
+```
+
+Local reproduction before the hotfix also failed with:
+
+```text
+branches=79.98 < 80
+```
+
+## 3. Fix Strategy
+
+This hotfix does not change the coverage threshold.
+
+This hotfix does not bypass Gatekeeper.
+
+The fix is intentionally narrow:
+
+- add parser branch coverage tests
+- keep the parser pure
+- keep legacy runtime blocked
+- keep external network / DB / file-write boundaries unchanged
+
+One parser behavior bug was corrected:
+
+- before: invalid non-empty `FTR` could fall back to score-derived result when the score was complete
+- after: non-empty unsupported `FTR` is `invalid_result`
+
+This matches the Phase 4.62C rule that score-derived fallback is only allowed when `FTR` is missing.
+
+## 4. Test Changes Summary
+
+Updated:
+
+- `tests/unit/football_data_local_csv_parser.test.js`
+- `scripts/lib/football_data_local_csv_parser.js`
+
+Added parser branch coverage for:
+
+- `FTR` missing with score-derived fallback
+- invalid non-empty `FTR`
+- `FTR` / score mismatch
+- missing `HomeTeam`
+- no odds columns
+- partial odds columns
+- rows input instead of CSV text
+- default parser options
+- `dd/mm/yy` date parsing
+- missing `Time`
+- empty CSV text
+
+## 5. Coverage Gate Result
+
+After the hotfix:
+
+```text
+lines=87.69
+statements=87.69
+functions=80.28
+branches=80.02
+```
+
+`npm run test:coverage` exited `0`.
+
+## 6. Parser Safety Constraints
+
+The parser safety constraints remain in place:
+
+- no network
+- no DB read
+- no DB write
+- no file write from parser
+- no legacy runtime import
+- no training
+- no prediction execution
+
+The unit test still monkey-patches / blocks:
+
+- `http.request`
+- `https.request`
+- `global.fetch`
+- `child_process.spawn`
+- `child_process.exec`
+- `child_process.execFile`
+- parser-time imports of `pg`, `fs`, `http`, `https`, `child_process`, and `fetch_and_adapt_euro_leagues`
+
+## 7. Gate Blocked Verification
+
+Validated:
+
+```bash
+make data-acquisition-engine-audit
+```
+
+Result:
+
+- `registry_found=true`
+- `registry_valid=true`
+- `fetch_and_adapt_euro_leagues` remains an `adapter_candidate`
+- `no_db_writes`
+- `no_external_network`
+
+Validated:
+
+```bash
+make data-single-target-network-dry-run \
+  ENGINE=fetch_and_adapt_euro_leagues \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json || true
+```
+
+Result:
+
+- `engine_found=true`
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+- blocked with `Phase 4.54 is scaffold-only`
+
+Validated:
+
+```bash
+make data-single-target-network-commit \
+  ENGINE=fetch_and_adapt_euro_leagues \
+  TARGET_MATCH_ID=47_20242025_900002 \
+  SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json \
+  CONFIRM_SINGLE_TARGET_NETWORK=1 || true
+```
+
+Result:
+
+- blocked with `acquisition network commit is not wired in Phase 4.54`
+
+## 8. DB Before / After
+
+Before hotfix validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After hotfix validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 9. Validation Summary
+
+Validated commands:
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_local_csv_parser.test.js
+docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js
+docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/acquisition_engine_gate.test.js
+docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage
+docker compose -f docker-compose.dev.yml exec -T dev npm test
+docker compose -f docker-compose.dev.yml exec -T dev npx eslint scripts/lib/football_data_local_csv_parser.js tests/unit/football_data_local_csv_parser.test.js --no-cache
+docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check AGENTS.md scripts/lib/football_data_local_csv_parser.js tests/unit/football_data_local_csv_parser.test.js docs/_reports/FOOTBALL_DATA_LOCAL_CSV_PARSER_PHASE4_62C.md
+```
+
+Results:
+
+- parser unit tests: 10/10 passed
+- football-data legacy no-network tests: 4/4 passed
+- acquisition gate tests: 8/8 passed
+- `npm run test:coverage`: passed
+- `npm test`: passed
+- eslint: passed
+- prettier: passed
+
+## 10. Next Step
+
+Recommended next step:
+
+- Phase 4.63C: implement `football_data_adapter_dry_run`, connect the parser to local source manifest + local CSV dry-run, and still avoid DB writes.
+
+## 11. Explicit Non-Execution
+
+Not executed in this hotfix:
+
+- coverage threshold changes
+- Gatekeeper bypass
+- DB writes
+- parser DB reads
+- parser file writes
+- external download
+- `curl` / `wget` / `git clone`
+- external football data source access
+- external odds data source access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- network dry-run execution
+- bulk harvest
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/lib/football_data_local_csv_parser.js
+++ b/scripts/lib/football_data_local_csv_parser.js
@@ -297,8 +297,18 @@ function buildBaseMeta(context = {}) {
 }
 
 function resolveResult(homeScore, awayScore, ftrValue) {
+    const hasFtrValue = normalizeText(ftrValue) !== '';
     const resultFromFtr = mapFtrToActualResult(ftrValue);
     const resultFromScore = deriveActualResultFromScores(homeScore, awayScore);
+
+    if (hasFtrValue && !resultFromFtr) {
+        return {
+            actualResult: null,
+            resultSource: null,
+            invalidResult: true,
+            mismatch: false,
+        };
+    }
 
     if (resultFromFtr && resultFromScore && resultFromFtr !== resultFromScore) {
         return {

--- a/tests/unit/football_data_local_csv_parser.test.js
+++ b/tests/unit/football_data_local_csv_parser.test.js
@@ -165,3 +165,129 @@ test('helper functions 支持 FTR label mapping 与日期解析', t => {
     assert.equal(parser.parseFootballDataDate('17/08/24', '07:05', { timezone: 'UTC' }), '2024-08-17T07:05:00.000Z');
     assert.equal(parser.parseFootballDataDate('not-a-date', '17:30', { timezone: 'UTC' }), null);
 });
+
+test('FTR 缺失但比分完整时应使用 score-derived fallback', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const parsed = parser.parseFootballDataCsv(
+        'Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR\nSP2,21/08/2024,20:00,Fallback Home,Fallback Away,2,1,',
+        PARSER_OPTIONS
+    );
+    const candidate = parsed.candidate_rows[0];
+
+    assert.equal(parsed.total_rows, 1);
+    assert.equal(parsed.row_classification.trainable_label_rows, 1);
+    assert.equal(candidate.actual_result, 'home_win');
+    assert.equal(candidate.result_source, 'score_derived');
+    assert.equal(candidate.would_insert_matches, false);
+    assert.equal(candidate.would_insert_odds, false);
+    assert.ok(parsed.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_db_reads'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(parsed.non_execution_confirmations.includes('no_legacy_runtime'));
+});
+
+test('非法 FTR 和 FTR/比分冲突必须标记 invalid_result', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const parsed = parser.parseFootballDataCsv(
+        [
+            {
+                Div: 'SP2',
+                Date: '22/08/2024',
+                Time: '20:00',
+                HomeTeam: 'Bad FTR FC',
+                AwayTeam: 'Other FC',
+                FTHG: '1',
+                FTAG: '1',
+                FTR: 'Z',
+            },
+            {
+                Div: 'SP2',
+                Date: '22/08/2024',
+                Time: '20:00',
+                HomeTeam: 'Mismatch FC',
+                AwayTeam: 'Other FC',
+                FTHG: '2',
+                FTAG: '0',
+                FTR: 'A',
+            },
+        ],
+        PARSER_OPTIONS
+    );
+
+    assert.equal(parsed.total_rows, 2);
+    assert.equal(parsed.candidate_rows.length, 0);
+    assert.equal(parsed.row_classification.invalid_result_rows, 2);
+    assert.equal(parsed.row_classification.skipped_rows, 2);
+    assert.deepEqual(
+        parsed.warnings.map(item => item.code),
+        ['invalid_result', 'result_score_mismatch']
+    );
+});
+
+test('missing team 行应跳过并记录 warning', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const parsed = parser.parseFootballDataCsv(
+        'Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR\nSP2,23/08/2024,20:00,,Away FC,1,0,H',
+        PARSER_OPTIONS
+    );
+
+    assert.equal(parsed.candidate_rows.length, 0);
+    assert.equal(parsed.row_classification.missing_team_rows, 1);
+    assert.equal(parsed.row_classification.skipped_rows, 1);
+    assert.equal(parsed.warnings[0].code, 'missing_team');
+});
+
+test('无 odds columns 与 partial odds columns 都只能 preview，不写 odds', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const noOdds = parser.parseFootballDataCsv(
+        'Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR\nSP2,24/08/2024,20:00,No Odds Home,No Odds Away,0,0,D',
+        PARSER_OPTIONS
+    );
+    const partialOdds = parser.parseFootballDataCsv(
+        'Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR,B365H\nSP2,24/08/2024,20:00,Partial Odds Home,Partial Odds Away,0,0,D,2.10',
+        PARSER_OPTIONS
+    );
+    const partialBookmaker = partialOdds.candidate_rows[0].odds_preview.bookmakers[0];
+
+    assert.equal(noOdds.candidate_rows[0].odds_preview.available, false);
+    assert.equal(noOdds.candidate_rows[0].would_insert_odds, false);
+    assert.equal(noOdds.row_classification.odds_preview_rows, 0);
+    assert.equal(partialOdds.candidate_rows[0].odds_preview.available, true);
+    assert.equal(partialBookmaker.supported_columns_present, false);
+    assert.equal(partialBookmaker.has_any_value, true);
+    assert.equal(partialBookmaker.complete_triplet, false);
+    assert.equal(partialOdds.candidate_rows[0].odds_preview_only, true);
+    assert.equal(partialOdds.candidate_rows[0].would_insert_odds, false);
+});
+
+test('rows 输入、默认 options、短年份、缺失 Time 和空 CSV 分支应稳定', t => {
+    installExecutionGuards(t);
+    const parser = loadParserFresh();
+    const parsed = parser.parseFootballDataCsv([
+        {
+            Div: 'SP2',
+            Date: '25/08/24',
+            Time: '',
+            HomeTeam: 'Short Year Home',
+            AwayTeam: 'Short Year Away',
+            FTHG: '0',
+            FTAG: '1',
+            FTR: 'A',
+        },
+    ]);
+    const empty = parser.parseFootballDataCsv('\n\n');
+    const candidate = parsed.candidate_rows[0];
+
+    assert.equal(parsed.source_name, 'football_data_local_csv');
+    assert.equal(candidate.match_date, '2024-08-25T00:00:00.000Z');
+    assert.equal(candidate.season, '2024/2025');
+    assert.equal(candidate.actual_result, 'away_win');
+    assert.equal(empty.total_rows, 0);
+    assert.equal(empty.parsed_rows, 0);
+    assert.equal(empty.row_classification.finished_rows, 0);
+});


### PR DESCRIPTION
## Summary

Adds a minimal Phase 4.62C hotfix to restore the main coverage gate after the football-data parser merge.

Scope:
- Does not change coverage thresholds
- Does not bypass gatekeeper
- Adds parser branch coverage tests
- Preserves pure parser safety constraints
- Adds hotfix report

Safety:
- No DB writes
- No DB reads from parser
- No parser file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- targeted parser tests passed
- fetch_and_adapt_euro_leagues no-network tests passed
- acquisition gate tests passed
- npm test passed
- npm run test:coverage passed
- acquisition gate remained blocked
- commit gate remained blocked
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed