### PR TITLE
feat(data): add football-data CSV dry-run gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,7 @@ AI / Codex 默认只能执行：
 - 不访问外网、不写 DB 的 `make data-acquisition-engine-audit`
 - 用户明确授权且只读本地 source manifest、不写 DB、不训练、不预测的 `make data-real-source-audit SOURCE_MANIFEST=<local json>`
 - 用户明确授权且只读本地 source manifest + 本地 CSV、不写 DB、不训练、不预测的 `make data-real-finished-csv-dry-run SOURCE_MANIFEST=<local json> SAMPLE_CSV=<local csv>`
+- 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不训练、不预测、不写 staging 的 `make data-football-data-csv-dry-run SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 - 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
@@ -270,6 +271,8 @@ AI / Codex 不能直接执行：
 - `make data-real-finished-csv-commit`
 - `make data-real-finished-csv-commit CONFIRM_REAL_CSV_COMMIT=1`
 - `node scripts/ops/real_finished_csv_staging_dry_run.js --commit`
+- `make data-football-data-csv-commit`
+- `make data-football-data-csv-commit CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1`
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
@@ -553,6 +556,9 @@ Phase 4.57C football-data adapter rules：
 - 在用户明确授权下，Codex 可以运行 `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_local_csv_parser.test.js`。
 - `football_data_local_csv_parser` 不得访问外网、不得读 / 写 DB、不得写文件、不得 import `scripts/ops/fetch_and_adapt_euro_leagues.js` legacy runtime。
 - `FTHG` / `FTAG` / `FTR` 只能用于 finished label 映射，不得作为赛前 feature；`B365H/B365D/B365A`、`PSH/PSD/PSA` 等 odds columns 只能 preview，不得写 `odds` 或 `bookmaker_odds_history`。
+- Phase 4.63C 的 `make data-football-data-csv-dry-run SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是本地 source manifest + CSV dry-run gate；仅在用户提供本地路径并明确授权时运行。
+- `data-football-data-csv-dry-run` 只能读取本地 manifest / CSV，校验 sha256、row_count 和 approval_status，然后调用 pure parser；不得触网、不得读 / 写 DB、不得写 adapted CSV / staging 文件、不得 import `fetch_and_adapt_euro_leagues` legacy runtime。
+- `make data-football-data-csv-commit` 和 `make data-football-data-csv-commit CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1` 当前仍 blocked / not wired。
 - 未来 football-data network dry-run 仍需单独授权；未来任何 DB write 仍需单独授权并先完成 `pg_dump`。
 - 未来 local CSV adapter 必须由 source manifest + 本地 CSV 驱动，不得下载 Football-Data CSV，不得写 staging / DB，不得训练或预测。
 - 任何 DB write 必须另行授权并先完成 `pg_dump`；不得把 legacy downloader 直接接到 training / prediction。

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-single-target-network-dry-run data-single-target-network-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
+        data-football-data-csv-dry-run data-football-data-csv-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-fixture-dry-run data-raw-fixture-commit \
@@ -260,6 +261,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-acquisition-engine-audit"
 	@echo "  make data-real-source-audit SOURCE_MANIFEST=<path>"
 	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
+	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
@@ -277,6 +279,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-synthetic-prediction-commit MATCH_ID=<id> CONFIRM_SYNTHETIC_PREDICTION=1  # blocked in Phase 4.48"
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-real-finished-csv-commit SOURCE_MANIFEST=<path> SAMPLE_CSV=<path> CONFIRM_REAL_CSV_COMMIT=1  # blocked in Phase 4.52"
+	@echo "  make data-football-data-csv-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1  # blocked in Phase 4.63C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -495,6 +498,24 @@ data-real-finished-csv-commit: ## Blocked real finished CSV commit gate. Require
 		exit 1; \
 	fi
 	@echo "BLOCKED: real finished CSV commit is not wired in Phase 4.52."
+	@exit 1
+
+data-football-data-csv-dry-run: ## Run local Football-Data source manifest + CSV dry-run gate. Requires SOURCE_MANIFEST and LOCAL_CSV.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path> and LOCAL_CSV=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running safe Football-Data local CSV dry-run: SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_adapter_dry_run.js --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)"
+
+data-football-data-csv-commit: ## Blocked Football-Data CSV commit gate. Requires SOURCE_MANIFEST, LOCAL_CSV, CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_CSV_COMMIT)" != "1" ]; then \
+		echo "BLOCKED: football-data CSV commit requires CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1 and is not wired in Phase 4.63C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data CSV commit is not wired in Phase 4.63C."
 	@exit 1
 
 data-acquisition-engines: ## List acquisition engine registry entries. No network, no DB writes.

--- a/docs/_reports/FOOTBALL_DATA_ADAPTER_DRY_RUN_PHASE4_63C.md
+++ b/docs/_reports/FOOTBALL_DATA_ADAPTER_DRY_RUN_PHASE4_63C.md
@@ -1,0 +1,315 @@
+# Football-Data Adapter Dry-Run Gate Phase 4.63C
+
+## Current HEAD / Branch
+
+- Starting main HEAD: `b5afdee34be668100fe2943a1bc51ba0c4da744b`
+- Working branch: `feat/football-data-adapter-dry-run-phase463c`
+- Phase: `4.63C`
+
+## Why This PR Is One Cohesive Step
+
+Phase 4.62C delivered the pure Football-Data CSV parser and kept the legacy downloader runtime blocked. Phase 4.63C is the next local-only integration step: it connects the parser to a local source manifest and local CSV dry-run gate. Keeping the script, fixture, Makefile entry, tests, AGENTS update, and report together is reasonable because they define one governed operator surface.
+
+This phase still does not download external data, does not create staging files, does not read or write the database, and does not train or predict.
+
+## New Files
+
+- `scripts/ops/football_data_adapter_dry_run.js`
+- `tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json`
+- `tests/unit/football_data_adapter_dry_run.test.js`
+- `docs/_reports/FOOTBALL_DATA_ADAPTER_DRY_RUN_PHASE4_63C.md`
+
+Updated files:
+
+- `Makefile`
+- `AGENTS.md`
+
+## Dry-Run Gate Design
+
+The new gate is:
+
+```bash
+make data-football-data-csv-dry-run \
+  SOURCE_MANIFEST=<local json> \
+  LOCAL_CSV=<local csv>
+```
+
+The Makefile target runs inside the `dev` container:
+
+```bash
+node scripts/ops/football_data_adapter_dry_run.js \
+  --source-manifest <path> \
+  --local-csv <path>
+```
+
+The script only reads local files supplied by the caller and imports the pure parser:
+
+- no network modules
+- no `pg`
+- no DB reads
+- no DB writes
+- no file writes
+- no adapted CSV writes
+- no staging writes
+- no `child_process`
+- no legacy `fetch_and_adapt_euro_leagues.js` runtime import
+
+## Source Manifest Validation
+
+Required manifest fields:
+
+- `source_name`
+- `approval_status`
+- `sha256`
+- `row_count`
+- `local_csv_path`
+- `mapping_version`
+
+Allowed `approval_status` values:
+
+- `dry_run_only`
+- `approved_for_dry_run`
+
+The fixture manifest is synthetic local test data only:
+
+- `source_name=football_data_local_synthetic_fixture`
+- `source_type=local_csv_fixture`
+- `license_type=synthetic_test_fixture`
+- `allowed_use=engineering_tests_only`
+- `not_real_external_data=true`
+- `not_for_training=true`
+- `not_for_production=true`
+
+## Integrity Checks
+
+The gate computes the local CSV `sha256` and row count before parser execution.
+
+Fixture values:
+
+- CSV: `tests/fixtures/football_data/football_data_sample_phase462c.csv`
+- sha256: `d6681446dc08f44987aa50fec79e50091b12ff18a6808e2b4d4b703ed806605d`
+- row_count: `5`
+
+If `sha256` does not match, the gate fails and does not call the parser.
+
+If `row_count` does not match, the gate fails and does not call the parser.
+
+## Parser Integration
+
+The gate calls:
+
+```js
+parseFootballDataCsv(csvText, {
+    sourceName: manifest.source_name,
+    dataVersion: manifest.mapping_version,
+    defaultSeason: manifest.default_season || manifest.season || '2024/2025',
+    timezone: manifest.timezone || 'UTC',
+});
+```
+
+Parser output is surfaced as dry-run summary and preview only:
+
+- `total_rows`
+- `parsed_rows`
+- `row_classification`
+- `candidate_preview`
+- parser warnings
+- parser non-execution confirmations
+
+Odds columns remain preview only. `would_insert_matches=false` and `would_insert_odds=false` are emitted by both parser candidates and the dry-run gate summary.
+
+## Local Dry-Run Output Summary
+
+Command:
+
+```bash
+make data-football-data-csv-dry-run \
+  SOURCE_MANIFEST=tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json \
+  LOCAL_CSV=tests/fixtures/football_data/football_data_sample_phase462c.csv
+```
+
+Observed summary:
+
+- `source_manifest_found=true`
+- `local_csv_found=true`
+- `sha256_match=true`
+- `row_count_match=true`
+- `parser_version=PHASE4.62C_FOOTBALL_DATA_LOCAL_CSV_PARSER`
+- `total_rows=5`
+- `trainable_label_rows=3`
+- `skipped_rows=2`
+- `invalid_date_rows=1`
+- `missing_score_rows=1`
+- `odds_preview_rows=3`
+- `would_insert_matches=false`
+- `would_insert_odds=false`
+- `would_write_db=false`
+- `would_access_network=false`
+- `would_write_files=false`
+
+Non-execution confirmations:
+
+- `no_external_network`
+- `no_db_reads`
+- `no_db_writes`
+- `no_file_writes`
+- `no_legacy_runtime`
+- `no_training`
+- `no_prediction_execution`
+- `no_model_artifact_load`
+- `no_adapted_csv_writes`
+- `no_staging_writes`
+
+## Commit Gate
+
+New commit target:
+
+```bash
+make data-football-data-csv-commit \
+  SOURCE_MANIFEST=<path> \
+  LOCAL_CSV=<path> \
+  CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1
+```
+
+Phase 4.63C result:
+
+- blocked
+- not wired
+- no DB writes
+- no external network
+- no staging or adapted CSV writes
+
+Observed blocked output:
+
+```text
+BLOCKED: football-data CSV commit is not wired in Phase 4.63C.
+```
+
+## Unit Tests
+
+New test:
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_adapter_dry_run.test.js
+```
+
+Covered behavior:
+
+- missing source manifest argument fails
+- missing local CSV argument fails
+- valid manifest + CSV succeeds
+- CLI `--help`, `--source-manifest=<path>`, `--local-csv=<path>`, and text output work
+- output safety flags are false
+- `sha256` mismatch fails before parser execution
+- `row_count` mismatch fails before parser execution
+- disallowed `approval_status` fails
+- missing CSV path fails
+- malformed manifest JSON fails
+- invalid manifest `row_count` fails
+- unknown CLI argument fails
+- `--commit` is blocked
+- no legacy runtime import
+- no network calls
+- no DB imports
+- no child process calls
+- no file writes
+
+Result:
+
+- `pass 11`
+- `fail 0`
+
+## Validation Results
+
+Targeted validation:
+
+- `football_data_adapter_dry_run.test.js`: passed
+- `football_data_local_csv_parser.test.js`: passed
+- `fetch_and_adapt_euro_leagues_no_network.test.js`: passed
+- `acquisition_engine_gate.test.js`: passed
+
+Full validation:
+
+- `npm test`: passed
+- `npm run test:coverage`: passed
+- `eslint`: passed
+- `prettier`: passed
+- `git diff --check`: passed
+
+Coverage gate summary:
+
+- lines: `87.76`
+- statements: `87.76`
+- functions: `80.32`
+- branches: `80.06`
+
+## Old Acquisition Gate Verification
+
+Commands run:
+
+- `make data-acquisition-engine-audit`
+- `make data-single-target-network-dry-run ...`
+- `make data-single-target-network-commit ...`
+
+Observed safety posture remains:
+
+- `would_access_network=false`
+- `would_write_db=false`
+- `would_execute_engine=false`
+- `fetch_and_adapt_euro_leagues` scaffold gate blocked
+- commit gate blocked
+
+## DB Before / After Statistics
+
+Before Phase 4.63C implementation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After Phase 4.63C validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## Next Steps
+
+- Phase 4.64C: design a small DB write preflight / backup runbook, but still do not directly write DB.
+- Or Phase 4.56A: if the user provides the complete real network dry-run parameters, first write a runbook rather than touching the network directly.
+
+Without complete real network dry-run parameters and explicit authorization, Codex still must not access external football or odds data sources.
+
+## Explicitly Not Executed
+
+- DB writes
+- DB reads from parser or dry-run gate
+- parser / dry-run file writes
+- external downloads
+- `curl`
+- `wget`
+- `git clone`
+- external football data source access
+- external odds data source access
+- scraping
+- browser automation
+- harvest
+- ingest
+- batch backfill
+- real network dry-run execution
+- bulk harvest
+- adapted CSV / staging data writes
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/football_data_adapter_dry_run.js
+++ b/scripts/ops/football_data_adapter_dry_run.js
@@ -1,0 +1,474 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { parseFootballDataCsv } = require('../lib/football_data_local_csv_parser');
+
+const DRY_RUN_VERSION = 'PHASE4.63C_FOOTBALL_DATA_ADAPTER_DRY_RUN';
+const REQUIRED_MANIFEST_FIELDS = ['source_name', 'approval_status', 'sha256', 'row_count', 'mapping_version'];
+const ALLOWED_APPROVAL_STATUSES = new Set(['dry_run_only', 'approved_for_dry_run']);
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_adapter_dry_run.js --source-manifest <path> --local-csv <path> [--json]',
+        '  node scripts/ops/football_data_adapter_dry_run.js --source-manifest <path> --local-csv <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.63C is local dry-run only. No network, no DB, no adapted CSV, no staging writes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        sourceManifest: '',
+        localCsv: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token.startsWith('--source-manifest=')) {
+            args.sourceManifest = token.slice('--source-manifest='.length);
+        } else if (token === '--source-manifest') {
+            args.sourceManifest = String(argv[index + 1] || '');
+            index += 1;
+        } else if (token.startsWith('--local-csv=')) {
+            args.localCsv = token.slice('--local-csv='.length);
+        } else if (token === '--local-csv') {
+            args.localCsv = String(argv[index + 1] || '');
+            index += 1;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) {
+        return '';
+    }
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) {
+        return '';
+    }
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'no_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_legacy_runtime',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_adapted_csv_writes',
+        'no_staging_writes',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_execute_legacy_runtime: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+    };
+}
+
+function countCsvDataRows(csvText) {
+    const lines = String(csvText || '')
+        .replace(/^\uFEFF/, '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean);
+
+    return Math.max(0, lines.length - 1);
+}
+
+function sha256Text(text) {
+    return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function validateManifest(manifest) {
+    const errors = [];
+    const missingFields = REQUIRED_MANIFEST_FIELDS.filter(
+        field => manifest[field] === undefined || manifest[field] === null || manifest[field] === ''
+    );
+    const hasLocalCsvPath = typeof manifest.local_csv_path === 'string' && manifest.local_csv_path.trim() !== '';
+
+    if (missingFields.length > 0) {
+        errors.push(`manifest missing required fields: ${missingFields.join(',')}`);
+    }
+    if (!hasLocalCsvPath) {
+        errors.push('manifest missing required field: local_csv_path');
+    }
+    if (!ALLOWED_APPROVAL_STATUSES.has(String(manifest.approval_status || ''))) {
+        errors.push(`approval_status is not allowed for dry-run: ${manifest.approval_status || ''}`);
+    }
+    if (!Number.isInteger(manifest.row_count) || manifest.row_count < 0) {
+        errors.push('manifest row_count must be a non-negative integer');
+    }
+
+    return {
+        manifest_valid: errors.length === 0,
+        manifest_required_fields_present: missingFields.length === 0 && hasLocalCsvPath,
+        manifest_missing_fields: hasLocalCsvPath ? missingFields : [...missingFields, 'local_csv_path'],
+        approval_status_allowed: ALLOWED_APPROVAL_STATUSES.has(String(manifest.approval_status || '')),
+        errors,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        dry_run_version: DRY_RUN_VERSION,
+        mode: fields.mode || 'football-data-csv-dry-run',
+        ok: false,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        source_manifest_found: false,
+        local_csv_found: false,
+        sha256_match: false,
+        row_count_match: false,
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: 'BLOCKED: football-data CSV commit is not wired in Phase 4.63C.',
+        errors: ['BLOCKED: football-data CSV commit is not wired in Phase 4.63C.'],
+    });
+}
+
+function buildPathContext(args, cwd, existsSync) {
+    const sourceManifestPath = resolveLocalPath(args.sourceManifest, cwd);
+    const localCsvPath = resolveLocalPath(args.localCsv, cwd);
+    return {
+        sourceManifestPath,
+        localCsvPath,
+        sourceManifestFound: existsSync(sourceManifestPath),
+        localCsvFound: existsSync(localCsvPath),
+    };
+}
+
+function validateDryRunInputs(args, cwd, pathContext) {
+    if (!args.sourceManifest || !args.localCsv) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            errors: ['ERROR: provide --source-manifest=<path> and --local-csv=<path>'],
+        });
+    }
+
+    if (!pathContext.sourceManifestFound) {
+        return buildFailurePayload(args, {
+            mode: 'manifest-error',
+            source_manifest_found: false,
+            local_csv_found: pathContext.localCsvFound,
+            errors: [`source manifest not found: ${toRelativePath(pathContext.sourceManifestPath, cwd)}`],
+        });
+    }
+
+    if (!pathContext.localCsvFound) {
+        return buildFailurePayload(args, {
+            mode: 'csv-error',
+            source_manifest_found: true,
+            local_csv_found: false,
+            errors: [`local CSV not found: ${toRelativePath(pathContext.localCsvPath, cwd)}`],
+        });
+    }
+
+    return null;
+}
+
+function loadManifestPayload(args, pathContext, readManifest) {
+    try {
+        return {
+            manifest: readManifest(pathContext.sourceManifestPath),
+            errorPayload: null,
+        };
+    } catch (error) {
+        return {
+            manifest: null,
+            errorPayload: buildFailurePayload(args, {
+                mode: 'manifest-error',
+                source_manifest_found: true,
+                local_csv_found: true,
+                errors: [`unable to parse source manifest: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function buildManifestValidationPayload(args, manifestValidation) {
+    if (manifestValidation.manifest_valid) {
+        return null;
+    }
+
+    return buildFailurePayload(args, {
+        mode: 'manifest-error',
+        source_manifest_found: true,
+        local_csv_found: true,
+        manifest_valid: false,
+        manifest_required_fields_present: manifestValidation.manifest_required_fields_present,
+        manifest_missing_fields: manifestValidation.manifest_missing_fields,
+        approval_status_allowed: manifestValidation.approval_status_allowed,
+        errors: manifestValidation.errors,
+    });
+}
+
+function buildIntegrityFields(manifest, csvText) {
+    const actualSha256 = sha256Text(csvText);
+    const actualRowCount = countCsvDataRows(csvText);
+    return {
+        source_manifest_found: true,
+        local_csv_found: true,
+        manifest_valid: true,
+        manifest_required_fields_present: true,
+        approval_status_allowed: true,
+        expected_sha256: manifest.sha256,
+        actual_sha256: actualSha256,
+        sha256_match: actualSha256 === manifest.sha256,
+        expected_row_count: manifest.row_count,
+        actual_row_count: actualRowCount,
+        row_count_match: actualRowCount === manifest.row_count,
+    };
+}
+
+function buildIntegrityFailurePayload(args, integrityFields) {
+    if (!integrityFields.sha256_match) {
+        return buildFailurePayload(args, {
+            mode: 'integrity-error',
+            ...integrityFields,
+            errors: ['sha256 mismatch; parser was not executed'],
+        });
+    }
+
+    if (!integrityFields.row_count_match) {
+        return buildFailurePayload(args, {
+            mode: 'integrity-error',
+            ...integrityFields,
+            errors: ['row_count mismatch; parser was not executed'],
+        });
+    }
+
+    return null;
+}
+
+function buildParserOptions(manifest) {
+    return {
+        sourceName: manifest.source_name,
+        dataVersion: manifest.mapping_version,
+        defaultSeason: manifest.default_season || manifest.season || '2024/2025',
+        timezone: manifest.timezone || 'UTC',
+    };
+}
+
+function buildSuccessPayload(args, manifest, parserResult, integrityFields) {
+    const classification = parserResult.row_classification || {};
+    return {
+        dry_run_version: DRY_RUN_VERSION,
+        mode: 'football-data-csv-dry-run',
+        ok: true,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        source_name: manifest.source_name,
+        source_type: manifest.source_type || null,
+        approval_status: manifest.approval_status,
+        mapping_version: manifest.mapping_version,
+        parser_version: parserResult.parser_version,
+        ...integrityFields,
+        total_rows: parserResult.total_rows,
+        parsed_rows: parserResult.parsed_rows,
+        candidate_rows: parserResult.candidate_rows,
+        candidate_preview: parserResult.candidate_rows.slice(0, 5),
+        row_classification: classification,
+        trainable_label_rows: classification.trainable_label_rows || 0,
+        skipped_rows: classification.skipped_rows || 0,
+        invalid_date_rows: classification.invalid_date_rows || 0,
+        missing_team_rows: classification.missing_team_rows || 0,
+        missing_score_rows: classification.missing_score_rows || 0,
+        invalid_result_rows: classification.invalid_result_rows || 0,
+        odds_preview_rows: classification.odds_preview_rows || 0,
+        warnings: parserResult.warnings,
+        errors: parserResult.errors,
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        parser_non_execution_confirmations: parserResult.non_execution_confirmations,
+    };
+}
+
+function runDryRun(args, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readManifest = dependencies.readManifest || readJsonFile;
+    const parseCsv = dependencies.parseFootballDataCsv || parseFootballDataCsv;
+    const pathContext = buildPathContext(args, cwd, existsSync);
+    const inputFailure = validateDryRunInputs(args, cwd, pathContext);
+    if (inputFailure) {
+        return inputFailure;
+    }
+
+    const manifestPayload = loadManifestPayload(args, pathContext, readManifest);
+    if (manifestPayload.errorPayload) {
+        return manifestPayload.errorPayload;
+    }
+
+    const manifest = manifestPayload.manifest;
+    const manifestValidation = validateManifest(manifest);
+    const manifestFailure = buildManifestValidationPayload(args, manifestValidation);
+    if (manifestFailure) {
+        return manifestFailure;
+    }
+
+    const csvText = readFileSync(pathContext.localCsvPath, 'utf8');
+    const integrityFields = buildIntegrityFields(manifest, csvText);
+    const integrityFailure = buildIntegrityFailurePayload(args, integrityFields);
+    if (integrityFailure) {
+        return integrityFailure;
+    }
+
+    const parserResult = parseCsv(csvText, buildParserOptions(manifest));
+    return buildSuccessPayload(args, manifest, parserResult, integrityFields);
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `sha256_match=${payload.sha256_match}`,
+        `row_count_match=${payload.row_count_match}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+    ];
+
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (payload.parser_version) {
+        lines.push(`parser_version=${payload.parser_version}`);
+    }
+    if (payload.total_rows !== undefined) {
+        lines.push(`total_rows=${payload.total_rows}`);
+        lines.push(`trainable_label_rows=${payload.trainable_label_rows}`);
+        lines.push(`skipped_rows=${payload.skipped_rows}`);
+        lines.push(`invalid_date_rows=${payload.invalid_date_rows}`);
+        lines.push(`missing_score_rows=${payload.missing_score_rows}`);
+        lines.push(`odds_preview_rows=${payload.odds_preview_rows}`);
+    }
+    if (payload.row_classification) {
+        lines.push(`row_classification=${JSON.stringify(payload.row_classification)}`);
+    }
+    if (payload.candidate_preview) {
+        lines.push(`candidate_preview=${JSON.stringify(payload.candidate_preview)}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+    lines.push('non_execution_confirmations=');
+    for (const confirmation of payload.non_execution_confirmations || []) {
+        lines.push(`  ${confirmation}`);
+    }
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = runDryRun(args);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            {
+                sourceManifest: '',
+                localCsv: '',
+            },
+            {
+                mode: 'argument-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, argv.includes('--json'), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    DRY_RUN_VERSION,
+    parseArgs,
+    runDryRun,
+    validateManifest,
+    countCsvDataRows,
+    sha256Text,
+    buildNonExecutionConfirmations,
+    main,
+};

--- a/tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json
+++ b/tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json
@@ -1,0 +1,22 @@
+{
+    "source_name": "football_data_local_synthetic_fixture",
+    "source_type": "local_csv_fixture",
+    "source_url": "local://tests/fixtures/football_data/football_data_sample_phase462c.csv",
+    "license_url": "local://synthetic-fixture",
+    "terms_url": "local://synthetic-fixture",
+    "license_type": "synthetic_test_fixture",
+    "allowed_use": "engineering_tests_only",
+    "approval_status": "dry_run_only",
+    "human_approval_note": "Synthetic local parser fixture for Phase 4.63C dry-run gate tests. Not real external football data.",
+    "original_filename": "football_data_sample_phase462c.csv",
+    "local_csv_path": "tests/fixtures/football_data/football_data_sample_phase462c.csv",
+    "sha256": "d6681446dc08f44987aa50fec79e50091b12ff18a6808e2b4d4b703ed806605d",
+    "row_count": 5,
+    "mapping_version": "PHASE4.63C_FOOTBALL_DATA_DRY_RUN",
+    "parser_version": "PHASE4.62C_FOOTBALL_DATA_LOCAL_CSV_PARSER",
+    "downloaded_by": "not_downloaded_synthetic_fixture",
+    "downloaded_at": null,
+    "not_real_external_data": true,
+    "not_for_training": true,
+    "not_for_production": true
+}

--- a/tests/unit/football_data_adapter_dry_run.test.js
+++ b/tests/unit/football_data_adapter_dry_run.test.js
@@ -1,0 +1,403 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_adapter_dry_run.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalWriteFile = fs.writeFile;
+    const originalAppendFileSync = fs.appendFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_adapter_dry_run`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.writeFile = fail('fs.writeFile');
+    fs.appendFileSync = fail('fs.appendFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.writeFile = originalWriteFile;
+        fs.appendFileSync = originalAppendFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        Module._load = originalLoad;
+    });
+}
+
+function loadGateFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function loadManifest() {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function runMain(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: JSON.parse(stdout),
+    };
+}
+
+function runTextMain(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    return {
+        status,
+        stdout,
+        stderr,
+    };
+}
+
+function assertSafetyPayload(payload) {
+    assert.equal(payload.would_insert_matches, false);
+    assert.equal(payload.would_insert_odds, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_reads'));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_legacy_runtime'));
+}
+
+test('adapter module 可以 import 且不加载 legacy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+
+    assert.equal(typeof gate.main, 'function');
+    assert.equal(typeof gate.runDryRun, 'function');
+    assert.equal(typeof gate.validateManifest, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('缺 source manifest 或 local CSV 参数必须失败', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const missingManifest = runMain(gate, ['--local-csv', CSV_PATH, '--json']);
+    const missingCsv = runMain(gate, ['--source-manifest', MANIFEST_PATH, '--json']);
+
+    assert.equal(missingManifest.status, 1);
+    assert.equal(missingCsv.status, 1);
+    assert.equal(missingManifest.payload.mode, 'argument-error');
+    assert.equal(missingCsv.payload.mode, 'argument-error');
+    assert.match(missingManifest.payload.errors[0], /provide --source-manifest/);
+    assert.match(missingCsv.payload.errors[0], /provide --source-manifest/);
+    assertSafetyPayload(missingManifest.payload);
+    assertSafetyPayload(missingCsv.payload);
+});
+
+test('正确 manifest + CSV dry-run 成功并输出 parser summary', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const result = runMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH, '--json']);
+    const payload = result.payload;
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(payload.parser_version, 'PHASE4.62C_FOOTBALL_DATA_LOCAL_CSV_PARSER');
+    assert.equal(payload.total_rows, 5);
+    assert.equal(payload.trainable_label_rows, 3);
+    assert.equal(payload.skipped_rows, 2);
+    assert.equal(payload.invalid_date_rows, 1);
+    assert.equal(payload.missing_score_rows, 1);
+    assert.equal(payload.odds_preview_rows, 3);
+    assert.equal(payload.candidate_preview.length, 3);
+    assert.equal(payload.candidate_preview[0].would_insert_matches, false);
+    assert.equal(payload.candidate_preview[0].would_insert_odds, false);
+    assert.equal(payload.candidate_preview[0].odds_preview.odds_preview_only, true);
+    assertSafetyPayload(payload);
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('CLI help、等号参数和文本输出应可用', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const help = runTextMain(gate, ['--help']);
+    const result = runTextMain(gate, [`--source-manifest=${MANIFEST_PATH}`, `--local-csv=${CSV_PATH}`]);
+
+    assert.equal(help.status, 0);
+    assert.match(help.stdout, /football_data_adapter_dry_run\.js --source-manifest/);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /mode=football-data-csv-dry-run/);
+    assert.match(result.stdout, /source_manifest_found=true/);
+    assert.match(result.stdout, /local_csv_found=true/);
+    assert.match(result.stdout, /sha256_match=true/);
+    assert.match(result.stdout, /row_count_match=true/);
+    assert.match(result.stdout, /parser_version=PHASE4\.62C_FOOTBALL_DATA_LOCAL_CSV_PARSER/);
+    assert.match(result.stdout, /candidate_preview=/);
+    assert.match(result.stdout, /warnings=/);
+    assert.match(result.stdout, /no_external_network/);
+    assert.match(result.stdout, /no_db_writes/);
+});
+
+test('sha256 mismatch 必须失败且不调用 parser', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const manifest = {
+        ...loadManifest(),
+        sha256: '0'.repeat(64),
+    };
+    let parserCalled = false;
+    const payload = gate.runDryRun(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            readManifest: () => manifest,
+            parseFootballDataCsv: () => {
+                parserCalled = true;
+                return {};
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'integrity-error');
+    assert.equal(payload.sha256_match, false);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(parserCalled, false);
+    assert.match(payload.errors[0], /sha256 mismatch/);
+    assertSafetyPayload(payload);
+});
+
+test('row_count mismatch 必须失败且不调用 parser', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const manifest = {
+        ...loadManifest(),
+        row_count: 99,
+    };
+    let parserCalled = false;
+    const payload = gate.runDryRun(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            readManifest: () => manifest,
+            parseFootballDataCsv: () => {
+                parserCalled = true;
+                return {};
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'integrity-error');
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, false);
+    assert.equal(parserCalled, false);
+    assert.match(payload.errors[0], /row_count mismatch/);
+    assertSafetyPayload(payload);
+});
+
+test('approval_status 不允许 dry-run 时必须失败', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const manifest = {
+        ...loadManifest(),
+        approval_status: 'not_approved',
+    };
+    const payload = gate.runDryRun(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            readManifest: () => manifest,
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'manifest-error');
+    assert.equal(payload.approval_status_allowed, false);
+    assert.match(payload.errors.join('\n'), /approval_status is not allowed/);
+    assertSafetyPayload(payload);
+});
+
+test('local CSV 缺失和 manifest JSON 解析失败必须失败且不执行 parser', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const missingCsv = gate.runDryRun({
+        sourceManifest: MANIFEST_PATH,
+        localCsv: path.join(PROJECT_ROOT, 'tests/fixtures/football_data/missing.csv'),
+    });
+    const invalidJson = gate.runDryRun(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            readManifest: () => {
+                throw new Error('synthetic invalid json');
+            },
+        }
+    );
+
+    assert.equal(missingCsv.ok, false);
+    assert.equal(missingCsv.mode, 'csv-error');
+    assert.equal(missingCsv.source_manifest_found, true);
+    assert.equal(missingCsv.local_csv_found, false);
+    assert.match(missingCsv.errors[0], /local CSV not found/);
+    assert.equal(invalidJson.ok, false);
+    assert.equal(invalidJson.mode, 'manifest-error');
+    assert.equal(invalidJson.source_manifest_found, true);
+    assert.equal(invalidJson.local_csv_found, true);
+    assert.match(invalidJson.errors[0], /unable to parse source manifest/);
+    assertSafetyPayload(missingCsv);
+    assertSafetyPayload(invalidJson);
+});
+
+test('manifest row_count 类型非法和未知参数必须失败', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const manifest = {
+        ...loadManifest(),
+        row_count: '5',
+    };
+    const invalidRowCount = gate.runDryRun(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            readManifest: () => manifest,
+        }
+    );
+    const unknownArg = runMain(gate, ['--unknown-option', '--json']);
+
+    assert.equal(invalidRowCount.ok, false);
+    assert.equal(invalidRowCount.mode, 'manifest-error');
+    assert.match(invalidRowCount.errors.join('\n'), /row_count must be a non-negative integer/);
+    assert.equal(unknownArg.status, 1);
+    assert.equal(unknownArg.payload.mode, 'argument-error');
+    assert.match(unknownArg.payload.errors[0], /Unknown argument/);
+    assertSafetyPayload(invalidRowCount);
+    assertSafetyPayload(unknownArg.payload);
+});
+
+test('--commit 必须 blocked，即使提供确认参数语义也不写入', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const result = runMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH, '--commit', '--json']);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'blocked-commit');
+    assert.equal(result.payload.blocked, true);
+    assert.match(result.payload.blocked_reason, /not wired in Phase 4\.63C/);
+    assertSafetyPayload(result.payload);
+});
+
+test('missing files 和 manifest required fields 失败时也保持 non-execution flags', t => {
+    installExecutionGuards(t);
+    const gate = loadGateFresh();
+    const missingFile = gate.runDryRun({
+        sourceManifest: path.join(PROJECT_ROOT, 'tests/fixtures/football_data/source_manifests/missing.json'),
+        localCsv: CSV_PATH,
+    });
+    const invalidManifest = gate.runDryRun(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            readManifest: () => ({
+                source_name: 'football_data_local_synthetic_fixture',
+                approval_status: 'dry_run_only',
+                sha256: loadManifest().sha256,
+                row_count: 5,
+            }),
+        }
+    );
+
+    assert.equal(missingFile.ok, false);
+    assert.equal(missingFile.source_manifest_found, false);
+    assert.match(missingFile.errors[0], /source manifest not found/);
+    assert.equal(invalidManifest.ok, false);
+    assert.equal(invalidManifest.manifest_required_fields_present, false);
+    assert.ok(invalidManifest.manifest_missing_fields.includes('local_csv_path'));
+    assert.ok(invalidManifest.manifest_missing_fields.includes('mapping_version'));
+    assertSafetyPayload(missingFile);
+    assertSafetyPayload(invalidManifest);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.63C football-data local CSV dry-run gate.

Scope:
- Adds football_data_adapter_dry_run
- Adds local source manifest fixture
- Connects source manifest + local CSV + pure parser
- Adds dry-run and blocked commit Makefile targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.63C report

Safety:
- No DB writes
- No DB reads
- No file writes from parser or dry-run gate
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- football_data_adapter_dry_run tests passed
- football_data_local_csv_parser tests passed
- fetch_and_adapt_euro_leagues no-network tests passed
- acquisition gate tests passed
- npm test passed
- npm run test:coverage passed
- football-data CSV dry-run succeeded locally
- football-data CSV commit gate remained blocked
- legacy acquisition gate remained blocked
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed