### PR TITLE
feat(data): add football-data DB write preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 source manifest、不写 DB、不训练、不预测的 `make data-real-source-audit SOURCE_MANIFEST=<local json>`
 - 用户明确授权且只读本地 source manifest + 本地 CSV、不写 DB、不训练、不预测的 `make data-real-finished-csv-dry-run SOURCE_MANIFEST=<local json> SAMPLE_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不训练、不预测、不写 staging 的 `make data-football-data-csv-dry-run SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
+- 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不执行 pg_dump、不训练、不预测的 `make data-football-data-db-write-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 - 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
@@ -273,6 +274,8 @@ AI / Codex 不能直接执行：
 - `node scripts/ops/real_finished_csv_staging_dry_run.js --commit`
 - `make data-football-data-csv-commit`
 - `make data-football-data-csv-commit CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1`
+- `make data-football-data-db-write-commit`
+- `make data-football-data-db-write-commit CONFIRM_FOOTBALL_DATA_DB_WRITE=1`
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
@@ -559,6 +562,9 @@ Phase 4.57C football-data adapter rules：
 - Phase 4.63C 的 `make data-football-data-csv-dry-run SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是本地 source manifest + CSV dry-run gate；仅在用户提供本地路径并明确授权时运行。
 - `data-football-data-csv-dry-run` 只能读取本地 manifest / CSV，校验 sha256、row_count 和 approval_status，然后调用 pure parser；不得触网、不得读 / 写 DB、不得写 adapted CSV / staging 文件、不得 import `fetch_and_adapt_euro_leagues` legacy runtime。
 - `make data-football-data-csv-commit` 和 `make data-football-data-csv-commit CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1` 当前仍 blocked / not wired。
+- Phase 4.64C 的 `make data-football-data-db-write-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 DB write 前置 runbook preview，不是真写库；只能读取本地 manifest / CSV 并复用 dry-run 结果。
+- `data-football-data-db-write-preflight` 不得触网、不得读 / 写 DB、不得执行 `pg_dump`、不得写文件、不得 import legacy downloader runtime；`make data-football-data-db-write-commit` 当前 blocked / not wired。
+- future DB write 必须单独阶段、单独授权、真实 `pg_dump`、small batch、post-write validation；DB write 前后 training / prediction 仍必须走单独 gate。
 - 未来 football-data network dry-run 仍需单独授权；未来任何 DB write 仍需单独授权并先完成 `pg_dump`。
 - 未来 local CSV adapter 必须由 source manifest + 本地 CSV 驱动，不得下载 Football-Data CSV，不得写 staging / DB，不得训练或预测。
 - 任何 DB write 必须另行授权并先完成 `pg_dump`；不得把 legacy downloader 直接接到 training / prediction。

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
         data-single-target-network-dry-run data-single-target-network-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
+        data-football-data-db-write-preflight data-football-data-db-write-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-fixture-dry-run data-raw-fixture-commit \
@@ -262,6 +263,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-real-source-audit SOURCE_MANIFEST=<path>"
 	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
+	@echo "  make data-football-data-db-write-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
@@ -280,6 +282,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-finished-csv-commit SAMPLE_CSV=<path> CONFIRM_FINISHED_CSV_COMMIT=1  # blocked in Phase 4.38"
 	@echo "  make data-real-finished-csv-commit SOURCE_MANIFEST=<path> SAMPLE_CSV=<path> CONFIRM_REAL_CSV_COMMIT=1  # blocked in Phase 4.52"
 	@echo "  make data-football-data-csv-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1  # blocked in Phase 4.63C"
+	@echo "  make data-football-data-db-write-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DB_WRITE=1  # blocked in Phase 4.64C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -516,6 +519,24 @@ data-football-data-csv-commit: ## Blocked Football-Data CSV commit gate. Require
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data CSV commit is not wired in Phase 4.63C."
+	@exit 1
+
+data-football-data-db-write-preflight: ## Preview future Football-Data small DB write runbook. Requires SOURCE_MANIFEST and LOCAL_CSV.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path> and LOCAL_CSV=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data DB write preflight preview: SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_db_write_preflight.js --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)"
+
+data-football-data-db-write-commit: ## Blocked Football-Data DB write gate. Requires SOURCE_MANIFEST, LOCAL_CSV, CONFIRM_FOOTBALL_DATA_DB_WRITE=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_DB_WRITE)" != "1" ]; then \
+		echo "BLOCKED: football-data DB write requires CONFIRM_FOOTBALL_DATA_DB_WRITE=1 and is not wired in Phase 4.64C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data DB write commit is not wired in Phase 4.64C."
 	@exit 1
 
 data-acquisition-engines: ## List acquisition engine registry entries. No network, no DB writes.

--- a/docs/_reports/FOOTBALL_DATA_DB_WRITE_PREFLIGHT_PHASE4_64C.md
+++ b/docs/_reports/FOOTBALL_DATA_DB_WRITE_PREFLIGHT_PHASE4_64C.md
@@ -1,0 +1,188 @@
+# Phase 4.64C Football-Data DB Write Preflight
+
+## 当前状态
+
+- 日期: 2026-05-07
+- 起始 HEAD: `09dada71d9bf6422aa2b0ad15fba4210239c22b6`
+- 起始提交: `09dada7 feat(data): add football-data CSV dry-run gate`
+- 工作分支: `feat/football-data-db-write-preflight-phase464c`
+- 主题: football-data 本地 CSV 从 dry-run 走向未来小批量 DB write 的前置安全机制
+
+## PR 粒度说明
+
+本阶段把 preflight script、Makefile gate、unit tests、AGENTS 规则和 runbook 报告放入同一个主题 PR 是合理的，因为它们共同定义同一个安全边界: 只预览未来小批量 DB write 的必备条件，不执行真实 DB write、`pg_dump`、network dry-run、staging write、training 或 prediction。
+
+本 PR 没有引入真实写库实现，也没有接入 legacy downloader runtime。
+
+## 新增和修改文件
+
+- `scripts/ops/football_data_db_write_preflight.js`
+- `tests/unit/football_data_db_write_preflight.test.js`
+- `docs/_reports/FOOTBALL_DATA_DB_WRITE_PREFLIGHT_PHASE4_64C.md`
+- `Makefile`
+- `AGENTS.md`
+
+## DB Write Preflight 设计
+
+新增命令:
+
+```bash
+make data-football-data-db-write-preflight \
+  SOURCE_MANIFEST=<path> \
+  LOCAL_CSV=<path>
+```
+
+preflight 行为:
+
+- 读取本地 source manifest。
+- 读取本地 local CSV。
+- 复用 Phase 4.63C `football_data_adapter_dry_run` 的 manifest、sha256、row_count 和 parser dry-run 结果。
+- 输出 future DB write plan preview。
+- 固定 `db_write_allowed=false`。
+- 固定 `would_insert_matches=false`。
+- 固定 `would_insert_odds=false`。
+- 固定 `would_write_db=false`。
+- 固定 `would_execute_pg_dump=false`。
+- 固定 `would_access_network=false`。
+- 固定 `would_write_files=false`。
+- 固定 `commit_gate=blocked`。
+
+preflight 不 import `fetch_and_adapt_euro_leagues.js`，不 import `pg`，不 spawn child process，不连接 DB，不写文件，不执行 `pg_dump`。
+
+## Future Backup / Pg Dump Runbook
+
+未来真实 DB write 前必须另开阶段并获得单独授权:
+
+1. 确认 source manifest 已升级为 `approved_for_db_write`。
+2. 确认 manifest 包含人工 approval note、license、terms、provenance。
+3. 先完成 SELECT-only duplicate / existing match precheck。
+4. 在写库前立即创建真实 `pg_dump` 备份。
+5. 记录 backup path、sha256、timestamp、DB name 和 operator。
+6. 仅写入显式批准的小批量 rows。
+7. 写后用 SELECT-only row counts 和 inserted match IDs 验证。
+8. training / prediction 继续保持 blocked，必须单独 gate 授权。
+
+本阶段不执行 `pg_dump`，因为 Phase 4.64C 只允许 runbook preview。提前执行真实备份会越过“DB write 前立即备份”的时间点要求，也会把 preflight 从只读预览扩大成真实运维动作。
+
+## Required Before DB Write
+
+- approval_status must be approved_for_db_write
+- source manifest must include human approval note
+- deterministic match_id strategy must be finalized
+- duplicate detection against DB must be SELECT-only prechecked
+- pg_dump backup must be created immediately before write
+- max rows must be small and explicit
+- target tables must be declared
+- rollback/restore plan must be written
+- post-write row counts must be validated
+- training/prediction must remain blocked
+
+## 为什么本阶段不写 DB
+
+本阶段的目标是把未来写库前的安全条件、备份要求、验证清单和 blocked commit gate 固化下来。真实 `INSERT` / odds write / staging write / DB duplicate check 都需要单独阶段、单独授权和新的验证证据。
+
+preflight 自身不连接 DB，DB duplicate detection 仅进入 future checklist。真正 SELECT-only duplicate precheck 留到 Phase 4.65C。
+
+## 验证结果
+
+### New DB Write Gate
+
+- `make data-football-data-db-write-preflight || true`: 缺参数失败。
+- `make data-football-data-db-write-preflight SOURCE_MANIFEST=tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json LOCAL_CSV=tests/fixtures/football_data/football_data_sample_phase462c.csv`: 通过。
+- 成功输出包含:
+    - `dry_run_passed=true`
+    - `sha256_match=true`
+    - `row_count_match=true`
+    - `candidate_rows=3`
+    - `trainable_label_rows=3`
+    - `odds_preview_rows=3`
+    - `db_write_allowed=false`
+    - `would_write_db=false`
+    - `would_execute_pg_dump=false`
+    - `no_external_network`
+    - `no_db_writes`
+    - `no_file_writes`
+    - `no_pg_dump_execution`
+
+### Commit Gate
+
+- `make data-football-data-db-write-commit || true`: blocked。
+- `make data-football-data-db-write-commit SOURCE_MANIFEST=tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json LOCAL_CSV=tests/fixtures/football_data/football_data_sample_phase462c.csv CONFIRM_FOOTBALL_DATA_DB_WRITE=1 || true`: blocked。
+
+即使提供 `CONFIRM_FOOTBALL_DATA_DB_WRITE=1`，Phase 4.64C 仍保持 not wired。
+
+### Old Gates
+
+- `make data-football-data-csv-dry-run SOURCE_MANIFEST=tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json LOCAL_CSV=tests/fixtures/football_data/football_data_sample_phase462c.csv`: 通过。
+- `make data-football-data-csv-commit ... CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1 || true`: blocked。
+- `make data-acquisition-engine-audit`: 通过，`no_db_writes` / `no_external_network`。
+- `make data-single-target-network-dry-run ENGINE=fetch_and_adapt_euro_leagues TARGET_MATCH_ID=47_20242025_900002 SOURCE_MANIFEST=tests/fixtures/real_source_manifests/local_sample_history_phase452.json || true`: scaffold-only blocked，`would_access_network=false` / `would_write_db=false` / `would_execute_engine=false`。
+- `make data-single-target-network-commit ... CONFIRM_SINGLE_TARGET_NETWORK=1 || true`: blocked。
+
+### Tests
+
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_db_write_preflight.test.js`: 通过，11 tests。
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_adapter_dry_run.test.js`: 通过，11 tests。
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/football_data_local_csv_parser.test.js`: 通过，10 tests。
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js`: 通过，4 tests。
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/acquisition_engine_gate.test.js`: 通过，8 tests。
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`: 通过。
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`: 通过。
+
+Coverage summary:
+
+- lines: 87.79
+- functions: 80.33
+- branches: 80.00
+
+## DB 前后统计
+
+变更前基线:
+
+- matches: 2
+- bookmaker_odds_history: 2
+- raw_match_data: 2
+- l3_features: 2
+- match_features_training: 2
+- predictions: 2
+
+变更后只读复核:
+
+- matches: 2
+- bookmaker_odds_history: 2
+- raw_match_data: 2
+- l3_features: 2
+- match_features_training: 2
+- predictions: 2
+
+DB 行数未变化。
+
+## 下一步建议
+
+- Phase 4.65C: 实现 SELECT-only duplicate / existing match precheck，不写 DB。
+- 或 Phase 4.56A: 用户给齐真实 network dry-run 参数后，仅做 runbook / manifest / target scope 预检。
+
+## 未执行事项
+
+- 未执行 DB writes。
+- 未从 preflight 读取 DB。
+- 未执行 `pg_dump`。
+- 未写文件或 staging 数据。
+- 未写 adapted CSV。
+- 未执行 external download。
+- 未执行 `curl` / `wget` / `git clone`。
+- 未访问外部足球数据源。
+- 未访问外部赔率数据源。
+- 未执行 scraping / browser automation。
+- 未执行 harvest / ingest。
+- 未执行 batch backfill。
+- 未执行 network dry-run 真执行。
+- 未执行 bulk harvest。
+- 未执行 model training。
+- 未执行 real prediction execution。
+- 未加载 model artifact。
+- 未清理 Docker volume。
+- 未 force push。
+- 未执行 `git fetch --all`。
+- 未执行 `git pull`。
+- 未删除文件、旧引擎、报告或备份。

--- a/scripts/ops/football_data_db_write_preflight.js
+++ b/scripts/ops/football_data_db_write_preflight.js
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+'use strict';
+
+const { runDryRun, parseArgs: parseDryRunArgs } = require('./football_data_adapter_dry_run');
+
+const PREFLIGHT_PHASE = 'PHASE4.64C_FOOTBALL_DATA_DB_WRITE_PREFLIGHT';
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_db_write_preflight.js --source-manifest <path> --local-csv <path> [--json]',
+        '  node scripts/ops/football_data_db_write_preflight.js --source-manifest <path> --local-csv <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.64C is preflight/runbook preview only. No DB writes, no DB reads, no pg_dump execution.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    return parseDryRunArgs(argv);
+}
+
+function buildRequiredBeforeDbWrite() {
+    return [
+        'approval_status must be approved_for_db_write',
+        'source manifest must include human approval note',
+        'deterministic match_id strategy must be finalized',
+        'duplicate detection against DB must be SELECT-only prechecked',
+        'pg_dump backup must be created immediately before write',
+        'max rows must be small and explicit',
+        'target tables must be declared',
+        'rollback/restore plan must be written',
+        'post-write row counts must be validated',
+        'training/prediction must remain blocked',
+    ];
+}
+
+function buildFuturePgDumpRunbook() {
+    return [
+        'Stop before write and request explicit DB write authorization.',
+        'Confirm source manifest is approved_for_db_write and includes license/provenance approval.',
+        'Run SELECT-only duplicate/existing match precheck in a separate authorized phase.',
+        'Create pg_dump backup immediately before any future write.',
+        'Record backup path, sha256, timestamp, DB name, and operator in the write report.',
+        'Write only an explicit small batch after backup verification.',
+        'Validate post-write row counts and inserted match IDs.',
+        'Keep training and prediction gates blocked until separately authorized.',
+    ];
+}
+
+function buildFutureValidationChecklist() {
+    return [
+        'source manifest sha256 and row_count still match local CSV',
+        'candidate rows reviewed and max row count explicitly approved',
+        'target tables limited to matches and optional future odds history',
+        'odds remain preview-only until odds write policy is separately approved',
+        'rollback restore command documented but not executed by this preflight',
+        'post-write SELECT-only counts compared against pre-write counts',
+        'no training or prediction command is chained after write',
+    ];
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'no_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_legacy_runtime',
+        'no_pg_dump_execution',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_adapted_csv_writes',
+        'no_staging_writes',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        db_write_allowed: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_execute_pg_dump: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_execute_legacy_runtime: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: PREFLIGHT_PHASE,
+        mode: fields.mode || 'football-data-db-write-preflight',
+        ok: false,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        source_manifest_found: false,
+        local_csv_found: false,
+        dry_run_passed: false,
+        sha256_match: false,
+        row_count_match: false,
+        commit_gate: 'blocked',
+        required_before_db_write: buildRequiredBeforeDbWrite(),
+        future_pg_dump_runbook: buildFuturePgDumpRunbook(),
+        future_validation_checklist: buildFutureValidationChecklist(),
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: 'BLOCKED: football-data DB write commit is not wired in Phase 4.64C.',
+        errors: ['BLOCKED: football-data DB write commit is not wired in Phase 4.64C.'],
+    });
+}
+
+function buildPreflightPlan(dryRunPayload) {
+    const rowClassification = dryRunPayload.row_classification || {};
+    return {
+        target_tables_preview: ['matches', 'bookmaker_odds_history_preview_only'],
+        max_rows_preview: dryRunPayload.candidate_rows.length,
+        candidate_rows: dryRunPayload.candidate_rows.length,
+        trainable_label_rows: rowClassification.trainable_label_rows || 0,
+        odds_preview_rows: rowClassification.odds_preview_rows || 0,
+        match_write_policy: 'future_small_batch_only_after_backup_and_authorization',
+        odds_write_policy: 'blocked_preview_only_in_phase_4_64c',
+        deterministic_match_id_strategy: 'future_required_not_finalized_in_phase_4_64c',
+        duplicate_detection_policy: 'future_select_only_precheck_required_not_executed_here',
+        rollback_policy: 'future_pg_restore_runbook_required_not_executed_here',
+    };
+}
+
+function buildSuccessPayload(args, dryRunPayload) {
+    const rowClassification = dryRunPayload.row_classification || {};
+    const preflightPlan = buildPreflightPlan(dryRunPayload);
+    return {
+        phase: PREFLIGHT_PHASE,
+        mode: 'football-data-db-write-preflight',
+        ok: true,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        dry_run_passed: true,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        approval_status: dryRunPayload.approval_status,
+        source_name: dryRunPayload.source_name,
+        parser_version: dryRunPayload.parser_version,
+        dry_run_version: dryRunPayload.dry_run_version,
+        total_rows: dryRunPayload.total_rows,
+        candidate_rows: dryRunPayload.candidate_rows.length,
+        trainable_label_rows: rowClassification.trainable_label_rows || 0,
+        odds_preview_rows: rowClassification.odds_preview_rows || 0,
+        skipped_rows: rowClassification.skipped_rows || 0,
+        row_classification: rowClassification,
+        candidate_preview: dryRunPayload.candidate_preview,
+        db_write_allowed_reason:
+            'Phase 4.64C only previews future DB write requirements; approval_status=dry_run_only is not DB write approval.',
+        commit_gate: 'blocked',
+        preflight_plan: preflightPlan,
+        required_before_db_write: buildRequiredBeforeDbWrite(),
+        future_pg_dump_runbook: buildFuturePgDumpRunbook(),
+        future_validation_checklist: buildFutureValidationChecklist(),
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        dry_run_non_execution_confirmations: dryRunPayload.non_execution_confirmations,
+        warnings: dryRunPayload.warnings || [],
+        errors: [],
+    };
+}
+
+function runPreflight(args, dependencies = {}) {
+    if (!args.sourceManifest || !args.localCsv) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            errors: ['ERROR: provide --source-manifest=<path> and --local-csv=<path>'],
+        });
+    }
+
+    const dryRun = dependencies.runDryRun || runDryRun;
+    const dryRunPayload = dryRun(
+        {
+            sourceManifest: args.sourceManifest,
+            localCsv: args.localCsv,
+        },
+        dependencies.dryRunDependencies || {}
+    );
+
+    if (!dryRunPayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'dry-run-failed',
+            source_manifest_found: dryRunPayload.source_manifest_found,
+            local_csv_found: dryRunPayload.local_csv_found,
+            sha256_match: dryRunPayload.sha256_match,
+            row_count_match: dryRunPayload.row_count_match,
+            dry_run_passed: false,
+            dry_run_failure_mode: dryRunPayload.mode,
+            errors: dryRunPayload.errors || ['football-data CSV dry-run failed'],
+            warnings: dryRunPayload.warnings || [],
+        });
+    }
+
+    return buildSuccessPayload(args, dryRunPayload);
+}
+
+function appendOptionalTextFields(lines, payload) {
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+}
+
+function appendListSection(lines, title, values) {
+    lines.push(`${title}:`);
+    for (const value of values || []) {
+        lines.push(`- ${value}`);
+    }
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `dry_run_passed=${payload.dry_run_passed}`,
+        `sha256_match=${payload.sha256_match}`,
+        `row_count_match=${payload.row_count_match}`,
+        `candidate_rows=${payload.candidate_rows || 0}`,
+        `trainable_label_rows=${payload.trainable_label_rows || 0}`,
+        `odds_preview_rows=${payload.odds_preview_rows || 0}`,
+        `db_write_allowed=${payload.db_write_allowed}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_execute_pg_dump=${payload.would_execute_pg_dump}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+        `commit_gate=${payload.commit_gate}`,
+    ];
+
+    appendOptionalTextFields(lines, payload);
+    appendListSection(lines, 'required_before_db_write', payload.required_before_db_write);
+    appendListSection(lines, 'future_pg_dump_runbook', payload.future_pg_dump_runbook);
+    appendListSection(lines, 'future_validation_checklist', payload.future_validation_checklist);
+    appendListSection(lines, 'non_execution_confirmations', payload.non_execution_confirmations);
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = runPreflight(args);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const json = argv.includes('--json');
+        const payload = buildFailurePayload(
+            {
+                sourceManifest: '',
+                localCsv: '',
+            },
+            {
+                mode: 'argument-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, json, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    PREFLIGHT_PHASE,
+    parseArgs,
+    runPreflight,
+    buildRequiredBeforeDbWrite,
+    buildFuturePgDumpRunbook,
+    buildFutureValidationChecklist,
+    buildNonExecutionConfirmations,
+    main,
+};

--- a/tests/unit/football_data_db_write_preflight.test.js
+++ b/tests/unit/football_data_db_write_preflight.test.js
@@ -1,0 +1,351 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_db_write_preflight.js');
+const DRY_RUN_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_adapter_dry_run.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalWriteFile = fs.writeFile;
+    const originalAppendFileSync = fs.appendFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_db_write_preflight`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.writeFile = fail('fs.writeFile');
+    fs.appendFileSync = fail('fs.appendFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'pg-native',
+            'net',
+            'node:net',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.writeFile = originalWriteFile;
+        fs.appendFileSync = originalAppendFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        Module._load = originalLoad;
+    });
+}
+
+function loadPreflightFresh() {
+    delete require.cache[SCRIPT_PATH];
+    delete require.cache[DRY_RUN_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function loadManifest() {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function runMain(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: JSON.parse(stdout),
+    };
+}
+
+function runTextMain(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    return {
+        status,
+        stdout,
+        stderr,
+    };
+}
+
+function assertSafetyPayload(payload) {
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.would_insert_matches, false);
+    assert.equal(payload.would_insert_odds, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.commit_gate, 'blocked');
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_reads'));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_legacy_runtime'));
+    assert.ok(payload.non_execution_confirmations.includes('no_pg_dump_execution'));
+    assert.ok(payload.non_execution_confirmations.includes('no_training'));
+    assert.ok(payload.non_execution_confirmations.includes('no_prediction_execution'));
+}
+
+test('preflight module 可以 import 且不加载 legacy runtime / pg / child_process', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+
+    assert.equal(typeof gate.main, 'function');
+    assert.equal(typeof gate.runPreflight, 'function');
+    assert.equal(typeof gate.buildRequiredBeforeDbWrite, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('缺 source manifest 参数必须失败', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const result = runMain(gate, ['--local-csv', CSV_PATH, '--json']);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'argument-error');
+    assert.match(result.payload.errors[0], /provide --source-manifest/);
+    assertSafetyPayload(result.payload);
+});
+
+test('缺 local CSV 参数必须失败', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const result = runMain(gate, ['--source-manifest', MANIFEST_PATH, '--json']);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'argument-error');
+    assert.match(result.payload.errors[0], /provide --source-manifest/);
+    assertSafetyPayload(result.payload);
+});
+
+test('正确 manifest + CSV preflight 成功并输出 future DB write preview', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const result = runMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH, '--json']);
+    const payload = result.payload;
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.phase, 'PHASE4.64C_FOOTBALL_DATA_DB_WRITE_PREFLIGHT');
+    assert.equal(payload.ok, true);
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+    assert.equal(payload.dry_run_passed, true);
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(payload.approval_status, 'dry_run_only');
+    assert.equal(payload.candidate_rows, 3);
+    assert.equal(payload.trainable_label_rows, 3);
+    assert.equal(payload.odds_preview_rows, 3);
+    assert.equal(payload.preflight_plan.max_rows_preview, 3);
+    assert.equal(payload.preflight_plan.match_write_policy, 'future_small_batch_only_after_backup_and_authorization');
+    assertSafetyPayload(payload);
+});
+
+test('required_before_db_write checklist 和 runbook preview 必须存在', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = gate.runPreflight({
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+    });
+
+    assert.equal(payload.ok, true);
+    assert.ok(payload.required_before_db_write.includes('approval_status must be approved_for_db_write'));
+    assert.ok(payload.required_before_db_write.includes('pg_dump backup must be created immediately before write'));
+    assert.ok(payload.required_before_db_write.includes('training/prediction must remain blocked'));
+    assert.ok(payload.future_pg_dump_runbook.some(item => item.includes('Create pg_dump backup')));
+    assert.ok(payload.future_validation_checklist.some(item => item.includes('post-write SELECT-only counts')));
+    assertSafetyPayload(payload);
+});
+
+test('approval_status=dry_run_only 时 db_write_allowed=false', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = gate.runPreflight({
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+    });
+
+    assert.equal(payload.approval_status, 'dry_run_only');
+    assert.equal(payload.db_write_allowed, false);
+    assert.match(payload.db_write_allowed_reason, /not DB write approval/);
+    assertSafetyPayload(payload);
+});
+
+test('--commit 必须 blocked，即使提供 manifest 和 CSV', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const result = runMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH, '--commit', '--json']);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'blocked-commit');
+    assert.equal(result.payload.blocked, true);
+    assert.match(result.payload.blocked_reason, /not wired in Phase 4\.64C/);
+    assertSafetyPayload(result.payload);
+});
+
+test('sha256 mismatch 时 preflight 失败且 parser 不执行', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const manifest = {
+        ...loadManifest(),
+        sha256: '0'.repeat(64),
+    };
+    let parserCalled = false;
+    const payload = gate.runPreflight(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dryRunDependencies: {
+                readManifest: () => manifest,
+                parseFootballDataCsv: () => {
+                    parserCalled = true;
+                    return {};
+                },
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'dry-run-failed');
+    assert.equal(payload.dry_run_passed, false);
+    assert.equal(payload.sha256_match, false);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(parserCalled, false);
+    assert.match(payload.errors[0], /sha256 mismatch/);
+    assertSafetyPayload(payload);
+});
+
+test('row_count mismatch 时 preflight 失败且 parser 不执行', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const manifest = {
+        ...loadManifest(),
+        row_count: 99,
+    };
+    let parserCalled = false;
+    const payload = gate.runPreflight(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dryRunDependencies: {
+                readManifest: () => manifest,
+                parseFootballDataCsv: () => {
+                    parserCalled = true;
+                    return {};
+                },
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'dry-run-failed');
+    assert.equal(payload.dry_run_passed, false);
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, false);
+    assert.equal(parserCalled, false);
+    assert.match(payload.errors[0], /row_count mismatch/);
+    assertSafetyPayload(payload);
+});
+
+test('文本输出包含安全确认和 blocked commit gate', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const result = runTextMain(gate, [`--source-manifest=${MANIFEST_PATH}`, `--local-csv=${CSV_PATH}`]);
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /phase=PHASE4\.64C_FOOTBALL_DATA_DB_WRITE_PREFLIGHT/);
+    assert.match(result.stdout, /dry_run_passed=true/);
+    assert.match(result.stdout, /sha256_match=true/);
+    assert.match(result.stdout, /row_count_match=true/);
+    assert.match(result.stdout, /db_write_allowed=false/);
+    assert.match(result.stdout, /would_insert_matches=false/);
+    assert.match(result.stdout, /would_insert_odds=false/);
+    assert.match(result.stdout, /would_write_db=false/);
+    assert.match(result.stdout, /would_execute_pg_dump=false/);
+    assert.match(result.stdout, /would_access_network=false/);
+    assert.match(result.stdout, /would_write_files=false/);
+    assert.match(result.stdout, /commit_gate=blocked/);
+    assert.match(result.stdout, /required_before_db_write:/);
+    assert.match(result.stdout, /approval_status must be approved_for_db_write/);
+    assert.match(result.stdout, /no_external_network/);
+    assert.match(result.stdout, /no_db_writes/);
+    assert.match(result.stdout, /no_file_writes/);
+    assert.match(result.stdout, /no_pg_dump_execution/);
+});
+
+test('source 文本不引用 legacy downloader、pg 或 child_process runtime', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+    assert.doesNotMatch(source, /fetch_and_adapt_euro_leagues/);
+    assert.doesNotMatch(source, /require\(['"]pg['"]\)/);
+    assert.doesNotMatch(source, /require\(['"]node:pg['"]\)/);
+    assert.doesNotMatch(source, /child_process/);
+    assert.doesNotMatch(source, /spawn\(/);
+    assert.doesNotMatch(source, /execFile\(/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.64C football-data small DB write preflight and backup runbook preview.

Scope:
- Adds football_data_db_write_preflight
- Adds Makefile preflight and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.64C report

Safety:
- No DB writes
- No DB reads from preflight
- No file writes
- No pg_dump execution
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- DB write preflight passed
- DB write commit gate remained blocked
- football-data CSV dry-run still passed
- football-data CSV commit gate remained blocked
- acquisition gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed