### PR TITLE
feat(data): add football-data duplicate precheck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 source manifest + 本地 CSV、不写 DB、不训练、不预测的 `make data-real-finished-csv-dry-run SOURCE_MANIFEST=<local json> SAMPLE_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不训练、不预测、不写 staging 的 `make data-football-data-csv-dry-run SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不执行 pg_dump、不训练、不预测的 `make data-football-data-db-write-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
+- 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB 查重、不写 DB、不训练、不预测的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 - 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
@@ -276,6 +277,8 @@ AI / Codex 不能直接执行：
 - `make data-football-data-csv-commit CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1`
 - `make data-football-data-db-write-commit`
 - `make data-football-data-db-write-commit CONFIRM_FOOTBALL_DATA_DB_WRITE=1`
+- `make data-football-data-duplicate-precheck-commit`
+- `make data-football-data-duplicate-precheck-commit CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1`
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
@@ -564,6 +567,8 @@ Phase 4.57C football-data adapter rules：
 - `make data-football-data-csv-commit` 和 `make data-football-data-csv-commit CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1` 当前仍 blocked / not wired。
 - Phase 4.64C 的 `make data-football-data-db-write-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 DB write 前置 runbook preview，不是真写库；只能读取本地 manifest / CSV 并复用 dry-run 结果。
 - `data-football-data-db-write-preflight` 不得触网、不得读 / 写 DB、不得执行 `pg_dump`、不得写文件、不得 import legacy downloader runtime；`make data-football-data-db-write-commit` 当前 blocked / not wired。
+- Phase 4.65C 的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是入库前 SELECT-only duplicate / existing match precheck；只能读取本地 manifest / CSV 并对 DB 执行 `BEGIN READ ONLY` + `SELECT` + `ROLLBACK`。
+- `data-football-data-duplicate-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-duplicate-precheck-commit` 当前 blocked / not wired。
 - future DB write 必须单独阶段、单独授权、真实 `pg_dump`、small batch、post-write validation；DB write 前后 training / prediction 仍必须走单独 gate。
 - 未来 football-data network dry-run 仍需单独授权；未来任何 DB write 仍需单独授权并先完成 `pg_dump`。
 - 未来 local CSV adapter 必须由 source manifest + 本地 CSV 驱动，不得下载 Football-Data CSV，不得写 staging / DB，不得训练或预测。

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
+        data-football-data-duplicate-precheck data-football-data-duplicate-precheck-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-fixture-dry-run data-raw-fixture-commit \
@@ -264,6 +265,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-db-write-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
+	@echo "  make data-football-data-duplicate-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
@@ -283,6 +285,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-real-finished-csv-commit SOURCE_MANIFEST=<path> SAMPLE_CSV=<path> CONFIRM_REAL_CSV_COMMIT=1  # blocked in Phase 4.52"
 	@echo "  make data-football-data-csv-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1  # blocked in Phase 4.63C"
 	@echo "  make data-football-data-db-write-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DB_WRITE=1  # blocked in Phase 4.64C"
+	@echo "  make data-football-data-duplicate-precheck-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1  # blocked in Phase 4.65C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -537,6 +540,24 @@ data-football-data-db-write-commit: ## Blocked Football-Data DB write gate. Requ
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data DB write commit is not wired in Phase 4.64C."
+	@exit 1
+
+data-football-data-duplicate-precheck: ## Run SELECT-only Football-Data duplicate/existing match precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path> and LOCAL_CSV=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data SELECT-only duplicate precheck: SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_duplicate_precheck.js --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)"
+
+data-football-data-duplicate-precheck-commit: ## Blocked Football-Data duplicate precheck commit gate. Requires CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK)" != "1" ]; then \
+		echo "BLOCKED: football-data duplicate precheck requires CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1 and is not wired in Phase 4.65C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data duplicate precheck commit is not wired in Phase 4.65C."
 	@exit 1
 
 data-acquisition-engines: ## List acquisition engine registry entries. No network, no DB writes.

--- a/docs/_reports/FOOTBALL_DATA_DUPLICATE_PRECHECK_PHASE4_65C.md
+++ b/docs/_reports/FOOTBALL_DATA_DUPLICATE_PRECHECK_PHASE4_65C.md
@@ -1,0 +1,185 @@
+# Football-Data Duplicate Precheck Phase 4.65C
+
+## Current State
+
+- Branch: `feat/football-data-duplicate-precheck-phase465c`
+- HEAD at report time: `16f78451ab08976e1106836f5854729c982a3b21`
+- Base phase: Phase 4.64C DB write preflight merged on `main`
+
+## PR Scope
+
+This is a slightly larger theme PR because the changes belong to one safety
+boundary: preparing Football-Data local CSV candidates for a future small DB
+write without writing anything yet. The script, Makefile gate, tests,
+AGENTS.md rules, and report all document the same SELECT-only duplicate /
+existing match precheck behavior.
+
+## Added Files
+
+- `scripts/ops/football_data_duplicate_precheck.js`
+- `tests/unit/football_data_duplicate_precheck.test.js`
+- `docs/_reports/FOOTBALL_DATA_DUPLICATE_PRECHECK_PHASE4_65C.md`
+
+## Design
+
+`football_data_duplicate_precheck.js` reuses the Phase 4.63C local CSV dry-run
+gate, so source manifest approval, `sha256`, `row_count`, and parser candidate
+rows are validated before any DB precheck begins.
+
+The precheck then opens a read-only DB transaction and checks each candidate
+with SELECT-only queries:
+
+- exact home / away / match date match
+- reversed home / away / match date match
+- same teams or reversed teams within plus/minus 2 days
+
+Each candidate receives a preview with:
+
+- `duplicate_risk`
+- `existing_match_ids`
+- `nearby_match_ids`
+- `candidate_identity_key`
+- `proposed_match_id_strategy=not_finalized`
+- `match_id_write_allowed=false`
+- `would_insert_match=false`
+- `would_insert_odds=false`
+
+## SELECT-Only DB Safety
+
+The script uses `BEGIN READ ONLY`, SELECT statements, and `ROLLBACK`. It also
+guards every SQL string and rejects write keywords including `INSERT`,
+`UPDATE`, `DELETE`, `CREATE`, `ALTER`, `DROP`, `TRUNCATE`, `COPY`, `MERGE`,
+`GRANT`, `REVOKE`, `COMMIT`, and `\\copy`.
+
+The script does not execute DB writes, `pg_dump`, child processes, training, or
+prediction. It does not import the legacy Football-Data downloader runtime.
+
+## Duplicate Checks
+
+The fixture precheck completed with:
+
+- `candidate_rows=3`
+- `trainable_label_rows=3`
+- `exact_existing_matches=0`
+- `reversed_team_matches=0`
+- `nearby_date_matches=0`
+- `invalid_candidates=0`
+- all candidates had `duplicate_risk=none`
+
+## Identity Preview
+
+The current preview key is:
+
+```text
+league_name + season + match_date + normalized_home_team + normalized_away_team
+```
+
+This is not a final write ID. The report and gate keep
+`proposed_match_id_strategy=not_finalized` and `match_id_write_allowed=false`.
+
+## Required Before DB Write
+
+- deterministic match_id strategy must be finalized
+- duplicate policy must be approved
+- exact_existing_match rows must not be inserted
+- nearby_date_possible_duplicate rows require manual review
+- pg_dump backup must run immediately before write
+- max rows must be explicit
+- target table list must be explicit
+- post-write validation must compare row counts and target rows
+- training/prediction must remain blocked
+
+## Gate Results
+
+- `make data-football-data-duplicate-precheck` without args failed as expected.
+- `make data-football-data-duplicate-precheck SOURCE_MANIFEST=... LOCAL_CSV=...`
+  passed with `select_only_db_reads=true`, `no_db_writes=true`, and
+  `would_write_db=false`.
+- `make data-football-data-duplicate-precheck-commit` remained blocked.
+- `make data-football-data-duplicate-precheck-commit ... CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1`
+  remained blocked.
+
+## Existing Gate Recheck
+
+- Football-Data CSV dry-run passed.
+- Football-Data DB write preflight passed.
+- Football-Data CSV commit remained blocked.
+- Football-Data DB write commit remained blocked.
+- Acquisition engine audit passed with `no_db_writes` and `no_external_network`.
+- Single-target acquisition network scaffold remained blocked with
+  `would_access_network=false`, `would_write_db=false`, and
+  `would_execute_engine=false`.
+- Acquisition network commit remained blocked.
+
+## Test Results
+
+- `node --test tests/unit/football_data_duplicate_precheck.test.js`: passed,
+  20 tests.
+- `node --test tests/unit/football_data_db_write_preflight.test.js`: passed,
+  11 tests.
+- `node --test tests/unit/football_data_adapter_dry_run.test.js`: passed,
+  11 tests.
+- `node --test tests/unit/football_data_local_csv_parser.test.js`: passed,
+  10 tests.
+- `node --test tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js`:
+  passed, 4 tests.
+- `node --test tests/unit/acquisition_engine_gate.test.js`: passed, 8 tests.
+- `npm test`: passed.
+- `npm run test:coverage`: passed with `lines=87.90`, `branches=80.06`,
+  `functions=80.44`.
+
+## DB Counts
+
+Before this phase:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+After validation:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## Why No DB Write
+
+Phase 4.65C only answers whether future candidate rows look duplicative against
+existing matches. It intentionally stops before deterministic match ID policy,
+insert policy, backup execution, and authorized small-batch write.
+
+## Next Steps
+
+- Phase 4.66C: design deterministic match_id strategy and insert candidate
+  policy without writing DB.
+- Or Phase 4.56A: continue the real network dry-run runbook only after the user
+  provides the complete authorized parameters.
+
+## Not Executed
+
+- DB writes
+- non-SELECT DB SQL
+- `pg_dump` or `pg_restore`
+- file writes from the precheck script
+- external downloads
+- `curl`, `wget`, or `git clone`
+- external football data source access
+- external odds data source access
+- scraping or browser automation
+- harvest, ingest, batch backfill, or bulk harvest
+- real network dry-run execution
+- adapted CSV or staging writes
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/football_data_duplicate_precheck.js
+++ b/scripts/ops/football_data_duplicate_precheck.js
@@ -1,0 +1,593 @@
+#!/usr/bin/env node
+'use strict';
+
+const { runDryRun, parseArgs: parseDryRunArgs } = require('./football_data_adapter_dry_run');
+
+const DUPLICATE_PRECHECK_PHASE = 'PHASE4.65C_FOOTBALL_DATA_DUPLICATE_PRECHECK';
+
+const MATCH_SELECT_COLUMNS = [
+    'match_id',
+    'league_name',
+    'season',
+    'match_date',
+    'home_team',
+    'away_team',
+    'home_score',
+    'away_score',
+    'actual_result',
+    'status',
+    'is_finished',
+    'data_source',
+].join(', ');
+
+const EXACT_MATCH_SQL = `
+SELECT ${MATCH_SELECT_COLUMNS}
+FROM matches
+WHERE lower(home_team) = lower($1)
+  AND lower(away_team) = lower($2)
+  AND match_date::date = $3::date
+LIMIT 10
+`;
+
+const REVERSED_MATCH_SQL = `
+SELECT ${MATCH_SELECT_COLUMNS}
+FROM matches
+WHERE lower(home_team) = lower($1)
+  AND lower(away_team) = lower($2)
+  AND match_date::date = $3::date
+LIMIT 10
+`;
+
+const NEARBY_MATCH_SQL = `
+SELECT ${MATCH_SELECT_COLUMNS}
+FROM matches
+WHERE (
+    (lower(home_team) = lower($1) AND lower(away_team) = lower($2))
+    OR
+    (lower(home_team) = lower($2) AND lower(away_team) = lower($1))
+)
+AND match_date::date BETWEEN $3::date - interval '2 days' AND $3::date + interval '2 days'
+LIMIT 20
+`;
+
+const READ_ONLY_BEGIN_SQL = 'BEGIN READ ONLY';
+const READ_ONLY_ROLLBACK_SQL = 'ROLLBACK';
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_duplicate_precheck.js --source-manifest <path> --local-csv <path> [--json]',
+        '  node scripts/ops/football_data_duplicate_precheck.js --source-manifest <path> --local-csv <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.65C is SELECT-only duplicate precheck. No DB writes, no pg_dump execution, no network harvest.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    return parseDryRunArgs(argv);
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+function createPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+function buildRequiredBeforeDbWrite() {
+    return [
+        'deterministic match_id strategy must be finalized',
+        'duplicate policy must be approved',
+        'exact_existing_match rows must not be inserted',
+        'nearby_date_possible_duplicate rows require manual review',
+        'pg_dump backup must run immediately before write',
+        'max rows must be explicit',
+        'target table list must be explicit',
+        'post-write validation must compare row counts and target rows',
+        'training/prediction must remain blocked',
+    ];
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'select_only_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_legacy_runtime',
+        'no_pg_dump_execution',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_adapted_csv_writes',
+        'no_staging_writes',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        select_only_db_reads: true,
+        no_db_writes: true,
+        db_write_allowed: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_execute_pg_dump: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_execute_legacy_runtime: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: DUPLICATE_PRECHECK_PHASE,
+        mode: fields.mode || 'football-data-duplicate-precheck',
+        ok: false,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        source_manifest_found: false,
+        local_csv_found: false,
+        dry_run_passed: false,
+        sha256_match: false,
+        row_count_match: false,
+        candidate_rows: 0,
+        trainable_label_rows: 0,
+        exact_existing_matches: 0,
+        reversed_team_matches: 0,
+        nearby_date_matches: 0,
+        invalid_candidates: 0,
+        candidate_previews: [],
+        commit_gate: 'blocked',
+        required_before_db_write: buildRequiredBeforeDbWrite(),
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: 'BLOCKED: football-data duplicate precheck commit is not wired in Phase 4.65C.',
+        errors: ['BLOCKED: football-data duplicate precheck commit is not wired in Phase 4.65C.'],
+    });
+}
+
+function normalizeTeamName(value) {
+    return String(value || '')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .trim()
+        .replace(/\s+/g, ' ')
+        .toLowerCase();
+}
+
+function toDateOnly(value) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+    return date.toISOString().slice(0, 10);
+}
+
+function buildCandidateIdentityKey(candidate) {
+    return [
+        String(candidate.league_name || '').trim(),
+        String(candidate.season || '').trim(),
+        toDateOnly(candidate.match_date),
+        normalizeTeamName(candidate.home_team),
+        normalizeTeamName(candidate.away_team),
+    ].join('|');
+}
+
+function isCandidateValid(candidate) {
+    return (
+        Boolean(String(candidate.home_team || '').trim()) &&
+        Boolean(String(candidate.away_team || '').trim()) &&
+        Boolean(toDateOnly(candidate.match_date)) &&
+        Boolean(String(candidate.actual_result || '').trim())
+    );
+}
+
+function mapMatchRows(rows) {
+    return rows.map(row => ({
+        match_id: row.match_id,
+        league_name: row.league_name,
+        season: row.season,
+        match_date: row.match_date,
+        home_team: row.home_team,
+        away_team: row.away_team,
+        home_score: row.home_score,
+        away_score: row.away_score,
+        actual_result: row.actual_result,
+        status: row.status,
+        is_finished: row.is_finished,
+        data_source: row.data_source,
+    }));
+}
+
+function uniqueIds(rows) {
+    return [...new Set(rows.map(row => row.match_id).filter(Boolean))];
+}
+
+function assertSelectOnlySql(sql) {
+    const normalized = String(sql || '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toUpperCase();
+    const allowed =
+        normalized === READ_ONLY_BEGIN_SQL || normalized === READ_ONLY_ROLLBACK_SQL || normalized.startsWith('SELECT ');
+    const forbidden =
+        /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|MERGE|GRANT|REVOKE|COMMIT)\b|\\COPY/.test(normalized);
+
+    if (!allowed || forbidden) {
+        throw new Error(`Unsafe SQL rejected by duplicate precheck: ${normalized.slice(0, 80)}`);
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+function classifyDuplicateRisk(exactRows, reversedRows, nearbyRows, valid) {
+    if (!valid) {
+        return 'invalid_candidate';
+    }
+    if (exactRows.length > 0) {
+        return 'exact_existing_match';
+    }
+    if (reversedRows.length > 0) {
+        return 'reversed_teams_possible_duplicate';
+    }
+    if (nearbyRows.length > 0) {
+        return 'nearby_date_possible_duplicate';
+    }
+    return 'none';
+}
+
+async function precheckCandidate(client, candidate) {
+    const valid = isCandidateValid(candidate);
+    const dateOnly = toDateOnly(candidate.match_date);
+    const basePreview = {
+        row_number: candidate.row_number || null,
+        home_team: candidate.home_team || null,
+        away_team: candidate.away_team || null,
+        match_date: dateOnly || candidate.match_date || null,
+        actual_result: candidate.actual_result || null,
+        duplicate_risk: 'invalid_candidate',
+        existing_match_ids: [],
+        nearby_match_ids: [],
+        candidate_identity_key: buildCandidateIdentityKey(candidate),
+        proposed_match_id_strategy: 'not_finalized',
+        match_id_write_allowed: false,
+        would_insert_match: false,
+        would_insert_odds: false,
+        exact_matches: [],
+        reversed_matches: [],
+        nearby_matches: [],
+    };
+
+    if (!valid) {
+        return basePreview;
+    }
+
+    const exactResult = await querySelectOnly(client, EXACT_MATCH_SQL, [
+        candidate.home_team,
+        candidate.away_team,
+        dateOnly,
+    ]);
+    const reversedResult = await querySelectOnly(client, REVERSED_MATCH_SQL, [
+        candidate.away_team,
+        candidate.home_team,
+        dateOnly,
+    ]);
+    const nearbyResult = await querySelectOnly(client, NEARBY_MATCH_SQL, [
+        candidate.home_team,
+        candidate.away_team,
+        dateOnly,
+    ]);
+    const exactRows = mapMatchRows(exactResult.rows || []);
+    const reversedRows = mapMatchRows(reversedResult.rows || []);
+    const nearbyRows = mapMatchRows(nearbyResult.rows || []);
+    const risk = classifyDuplicateRisk(exactRows, reversedRows, nearbyRows, valid);
+
+    return {
+        ...basePreview,
+        duplicate_risk: risk,
+        existing_match_ids: uniqueIds([...exactRows, ...reversedRows]),
+        nearby_match_ids: uniqueIds(nearbyRows),
+        exact_matches: exactRows,
+        reversed_matches: reversedRows,
+        nearby_matches: nearbyRows,
+    };
+}
+
+async function runCandidatePrechecks(client, candidates) {
+    const previews = [];
+    let began = false;
+
+    await querySelectOnly(client, READ_ONLY_BEGIN_SQL);
+    began = true;
+    try {
+        for (const candidate of candidates) {
+            previews.push(await precheckCandidate(client, candidate));
+        }
+    } finally {
+        if (began) {
+            await querySelectOnly(client, READ_ONLY_ROLLBACK_SQL);
+        }
+    }
+
+    return previews;
+}
+
+async function withDbClient(dependencies, callback) {
+    if (dependencies.dbClient) {
+        return callback(dependencies.dbClient);
+    }
+
+    const pool = dependencies.pool || createPool();
+    const client = await pool.connect();
+    try {
+        return await callback(client);
+    } finally {
+        client.release();
+        if (!dependencies.pool && typeof pool.end === 'function') {
+            await pool.end();
+        }
+    }
+}
+
+function countRisk(previews, risk) {
+    return previews.filter(preview => preview.duplicate_risk === risk).length;
+}
+
+function sumMatchRows(previews, field) {
+    return previews.reduce((total, preview) => total + (preview[field] || []).length, 0);
+}
+
+function buildInsertRiskSummary(candidatePreviews) {
+    return {
+        duplicate_free_candidates: countRisk(candidatePreviews, 'none'),
+        exact_existing_match_candidates: countRisk(candidatePreviews, 'exact_existing_match'),
+        reversed_team_possible_duplicate_candidates: countRisk(candidatePreviews, 'reversed_teams_possible_duplicate'),
+        nearby_date_possible_duplicate_candidates: countRisk(candidatePreviews, 'nearby_date_possible_duplicate'),
+        invalid_candidates: countRisk(candidatePreviews, 'invalid_candidate'),
+        policy: 'future_insert_blocked_until_duplicate_policy_and_match_id_strategy_are_approved',
+    };
+}
+
+function buildSuccessPayload(args, dryRunPayload, candidatePreviews) {
+    const rowClassification = dryRunPayload.row_classification || {};
+    return {
+        phase: DUPLICATE_PRECHECK_PHASE,
+        mode: 'football-data-duplicate-precheck',
+        ok: true,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        dry_run_passed: true,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        approval_status: dryRunPayload.approval_status,
+        source_name: dryRunPayload.source_name,
+        parser_version: dryRunPayload.parser_version,
+        dry_run_version: dryRunPayload.dry_run_version,
+        candidate_rows: dryRunPayload.candidate_rows.length,
+        trainable_label_rows: rowClassification.trainable_label_rows || 0,
+        exact_existing_matches: sumMatchRows(candidatePreviews, 'exact_matches'),
+        reversed_team_matches: sumMatchRows(candidatePreviews, 'reversed_matches'),
+        nearby_date_matches: sumMatchRows(candidatePreviews, 'nearby_matches'),
+        invalid_candidates: countRisk(candidatePreviews, 'invalid_candidate'),
+        candidate_previews: candidatePreviews,
+        insert_risk_summary: buildInsertRiskSummary(candidatePreviews),
+        identity_strategy: {
+            candidate_identity_key_fields: [
+                'league_name',
+                'season',
+                'match_date',
+                'normalized_home_team',
+                'normalized_away_team',
+            ],
+            proposed_match_id_strategy: 'not_finalized',
+            match_id_write_allowed: false,
+        },
+        commit_gate: 'blocked',
+        required_before_db_write: buildRequiredBeforeDbWrite(),
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        dry_run_non_execution_confirmations: dryRunPayload.non_execution_confirmations,
+        warnings: dryRunPayload.warnings || [],
+        errors: [],
+    };
+}
+
+async function runDuplicatePrecheck(args, dependencies = {}) {
+    if (!args.sourceManifest || !args.localCsv) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            select_only_db_reads: false,
+            errors: ['ERROR: provide --source-manifest=<path> and --local-csv=<path>'],
+        });
+    }
+
+    const dryRun = dependencies.runDryRun || runDryRun;
+    const dryRunPayload = dryRun(
+        {
+            sourceManifest: args.sourceManifest,
+            localCsv: args.localCsv,
+        },
+        dependencies.dryRunDependencies || {}
+    );
+
+    if (!dryRunPayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'dry-run-failed',
+            source_manifest_found: dryRunPayload.source_manifest_found,
+            local_csv_found: dryRunPayload.local_csv_found,
+            sha256_match: dryRunPayload.sha256_match,
+            row_count_match: dryRunPayload.row_count_match,
+            dry_run_passed: false,
+            dry_run_failure_mode: dryRunPayload.mode,
+            select_only_db_reads: false,
+            errors: dryRunPayload.errors || ['football-data CSV dry-run failed'],
+            warnings: dryRunPayload.warnings || [],
+        });
+    }
+
+    const candidatePreviews = await withDbClient(dependencies, client =>
+        runCandidatePrechecks(client, dryRunPayload.candidate_rows || [])
+    );
+    return buildSuccessPayload(args, dryRunPayload, candidatePreviews);
+}
+
+function appendOptionalTextFields(lines, payload) {
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+}
+
+function appendListSection(lines, title, values) {
+    lines.push(`${title}:`);
+    for (const value of values || []) {
+        lines.push(`- ${value}`);
+    }
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `dry_run_passed=${payload.dry_run_passed}`,
+        `sha256_match=${payload.sha256_match}`,
+        `row_count_match=${payload.row_count_match}`,
+        `select_only_db_reads=${payload.select_only_db_reads}`,
+        `no_db_writes=${payload.no_db_writes}`,
+        `candidate_rows=${payload.candidate_rows || 0}`,
+        `trainable_label_rows=${payload.trainable_label_rows || 0}`,
+        `exact_existing_matches=${payload.exact_existing_matches || 0}`,
+        `reversed_team_matches=${payload.reversed_team_matches || 0}`,
+        `nearby_date_matches=${payload.nearby_date_matches || 0}`,
+        `invalid_candidates=${payload.invalid_candidates || 0}`,
+        `db_write_allowed=${payload.db_write_allowed}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+        `commit_gate=${payload.commit_gate}`,
+    ];
+
+    if (Array.isArray(payload.candidate_previews) && payload.candidate_previews.length > 0) {
+        lines.push(`candidate_previews=${JSON.stringify(payload.candidate_previews)}`);
+    }
+    if (payload.insert_risk_summary) {
+        lines.push(`insert_risk_summary=${JSON.stringify(payload.insert_risk_summary)}`);
+    }
+    if (payload.identity_strategy) {
+        lines.push(`identity_strategy=${JSON.stringify(payload.identity_strategy)}`);
+    }
+
+    appendOptionalTextFields(lines, payload);
+    appendListSection(lines, 'required_before_db_write', payload.required_before_db_write);
+    appendListSection(lines, 'non_execution_confirmations', payload.non_execution_confirmations);
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+async function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = await runDuplicatePrecheck(args);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const json = argv.includes('--json');
+        const payload = buildFailurePayload(
+            {
+                sourceManifest: '',
+                localCsv: '',
+            },
+            {
+                mode: 'runtime-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, json, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => {
+        process.exitCode = status;
+    });
+}
+
+module.exports = {
+    DUPLICATE_PRECHECK_PHASE,
+    EXACT_MATCH_SQL,
+    REVERSED_MATCH_SQL,
+    NEARBY_MATCH_SQL,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    runDuplicatePrecheck,
+    runCandidatePrechecks,
+    buildRequiredBeforeDbWrite,
+    buildNonExecutionConfirmations,
+    buildDbConfig,
+    assertSelectOnlySql,
+    buildCandidateIdentityKey,
+    payloadToText,
+    main,
+};

--- a/tests/unit/football_data_duplicate_precheck.test.js
+++ b/tests/unit/football_data_duplicate_precheck.test.js
@@ -1,0 +1,853 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_duplicate_precheck.js');
+const DRY_RUN_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_adapter_dry_run.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+
+function installExecutionGuards(t, options = {}) {
+    const moduleOverrides = options.moduleOverrides || {};
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalWriteFile = fs.writeFile;
+    const originalAppendFileSync = fs.appendFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_duplicate_precheck`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.writeFile = fail('fs.writeFile');
+    fs.appendFileSync = fail('fs.appendFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (Object.prototype.hasOwnProperty.call(moduleOverrides, request)) {
+            return moduleOverrides[request];
+        }
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.writeFile = originalWriteFile;
+        fs.appendFileSync = originalAppendFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        Module._load = originalLoad;
+    });
+}
+
+function loadPrecheckFresh() {
+    delete require.cache[SCRIPT_PATH];
+    delete require.cache[DRY_RUN_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function loadManifest() {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function createMockClient(queryHandler = () => ({ rows: [] })) {
+    const calls = [];
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+            return queryHandler(String(sql), params);
+        },
+    };
+}
+
+async function runMain(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: JSON.parse(stdout),
+    };
+}
+
+async function runTextMain(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    return {
+        status,
+        stdout,
+        stderr,
+    };
+}
+
+function assertSafetyPayload(payload) {
+    assert.equal(payload.select_only_db_reads, true);
+    assert.equal(payload.no_db_writes, true);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.would_insert_matches, false);
+    assert.equal(payload.would_insert_odds, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.commit_gate, 'blocked');
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('select_only_db_reads'));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_legacy_runtime'));
+    assert.ok(payload.non_execution_confirmations.includes('no_pg_dump_execution'));
+    assert.ok(payload.non_execution_confirmations.includes('no_training'));
+    assert.ok(payload.non_execution_confirmations.includes('no_prediction_execution'));
+}
+
+function assertSqlCallsAreReadOnly(gate, calls) {
+    assert.ok(calls.some(call => call.sql === gate.READ_ONLY_BEGIN_SQL));
+    assert.ok(calls.some(call => call.sql === gate.READ_ONLY_ROLLBACK_SQL));
+    for (const call of calls) {
+        gate.assertSelectOnlySql(call.sql);
+        const normalized = call.sql.replace(/\s+/g, ' ').trim().toUpperCase();
+        assert.ok(
+            normalized === 'BEGIN READ ONLY' || normalized === 'ROLLBACK' || normalized.startsWith('SELECT '),
+            `unexpected SQL: ${normalized}`
+        );
+        assert.doesNotMatch(normalized, /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|MERGE|COMMIT)\b/);
+    }
+}
+
+function buildDryRunPayload(candidates) {
+    return {
+        ok: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        sha256_match: true,
+        row_count_match: true,
+        approval_status: 'dry_run_only',
+        source_name: 'unit_fixture',
+        parser_version: 'unit_parser',
+        dry_run_version: 'unit_dry_run',
+        candidate_rows: candidates,
+        row_classification: {
+            trainable_label_rows: candidates.length,
+        },
+        non_execution_confirmations: ['no_external_network', 'no_db_writes'],
+        warnings: [],
+        errors: [],
+    };
+}
+
+function snapshotDbEnv() {
+    return {
+        DB_HOST: process.env.DB_HOST,
+        POSTGRES_HOST: process.env.POSTGRES_HOST,
+        DB_PORT: process.env.DB_PORT,
+        POSTGRES_PORT: process.env.POSTGRES_PORT,
+        DB_NAME: process.env.DB_NAME,
+        POSTGRES_DB: process.env.POSTGRES_DB,
+        DB_USER: process.env.DB_USER,
+        POSTGRES_USER: process.env.POSTGRES_USER,
+        DB_PASSWORD: process.env.DB_PASSWORD,
+        POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD,
+    };
+}
+
+function restoreDbEnv(snapshot) {
+    for (const [key, value] of Object.entries(snapshot)) {
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
+    }
+}
+
+test('duplicate precheck module 可以 import 且不加载 legacy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+
+    assert.equal(typeof gate.main, 'function');
+    assert.equal(typeof gate.runDuplicatePrecheck, 'function');
+    assert.equal(typeof gate.assertSelectOnlySql, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('缺 source manifest 参数必须失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for missing args');
+    });
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /provide --source-manifest/);
+    assert.equal(payload.no_db_writes, true);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('缺 local CSV 参数必须失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for missing args');
+    });
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /provide --source-manifest/);
+    assert.equal(payload.no_db_writes, true);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('正确 manifest + CSV + mock DB client precheck 成功', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const client = createMockClient(() => ({ rows: [] }));
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.65C_FOOTBALL_DATA_DUPLICATE_PRECHECK');
+    assert.equal(payload.dry_run_passed, true);
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+    assert.equal(payload.candidate_rows, 3);
+    assert.equal(payload.trainable_label_rows, 3);
+    assert.equal(payload.exact_existing_matches, 0);
+    assert.equal(payload.reversed_team_matches, 0);
+    assert.equal(payload.nearby_date_matches, 0);
+    assert.equal(payload.invalid_candidates, 0);
+    assert.equal(payload.candidate_previews.length, 3);
+    assert.ok(payload.candidate_previews.every(preview => preview.duplicate_risk === 'none'));
+    assertSafetyPayload(payload);
+    assertSqlCallsAreReadOnly(gate, client.calls);
+});
+
+test('exact / reversed / nearby duplicate risks 应被识别，invalid candidate 不进入查询计划', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const candidates = [
+        {
+            row_number: 1,
+            league_name: 'League',
+            season: '2024/2025',
+            match_date: '2024-01-01T12:00:00.000Z',
+            home_team: 'Exact Home',
+            away_team: 'Exact Away',
+            actual_result: 'home_win',
+        },
+        {
+            row_number: 2,
+            league_name: 'League',
+            season: '2024/2025',
+            match_date: '2024-01-02T12:00:00.000Z',
+            home_team: 'Reverse Home',
+            away_team: 'Reverse Away',
+            actual_result: 'draw',
+        },
+        {
+            row_number: 3,
+            league_name: 'League',
+            season: '2024/2025',
+            match_date: '2024-01-03T12:00:00.000Z',
+            home_team: 'Nearby Home',
+            away_team: 'Nearby Away',
+            actual_result: 'away_win',
+        },
+        {
+            row_number: 4,
+            league_name: 'League',
+            season: '2024/2025',
+            match_date: '',
+            home_team: '',
+            away_team: 'Invalid Away',
+            actual_result: 'home_win',
+        },
+    ];
+    const client = createMockClient((sql, params) => {
+        if (sql === gate.EXACT_MATCH_SQL && params[0] === 'Exact Home') {
+            return { rows: [{ match_id: 'exact_1', home_team: 'Exact Home', away_team: 'Exact Away' }] };
+        }
+        if (sql === gate.REVERSED_MATCH_SQL && params[0] === 'Reverse Away') {
+            return { rows: [{ match_id: 'reversed_1', home_team: 'Reverse Away', away_team: 'Reverse Home' }] };
+        }
+        if (sql === gate.NEARBY_MATCH_SQL && params[0] === 'Nearby Home') {
+            return { rows: [{ match_id: 'nearby_1', home_team: 'Nearby Home', away_team: 'Nearby Away' }] };
+        }
+        return { rows: [] };
+    });
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload(candidates),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.exact_existing_matches, 1);
+    assert.equal(payload.reversed_team_matches, 1);
+    assert.equal(payload.nearby_date_matches, 1);
+    assert.equal(payload.invalid_candidates, 1);
+    assert.equal(payload.candidate_previews[0].duplicate_risk, 'exact_existing_match');
+    assert.deepEqual(payload.candidate_previews[0].existing_match_ids, ['exact_1']);
+    assert.equal(payload.candidate_previews[1].duplicate_risk, 'reversed_teams_possible_duplicate');
+    assert.deepEqual(payload.candidate_previews[1].existing_match_ids, ['reversed_1']);
+    assert.equal(payload.candidate_previews[2].duplicate_risk, 'nearby_date_possible_duplicate');
+    assert.deepEqual(payload.candidate_previews[2].nearby_match_ids, ['nearby_1']);
+    assert.equal(payload.candidate_previews[3].duplicate_risk, 'invalid_candidate');
+    assert.equal(payload.candidate_previews[3].would_insert_match, false);
+    assert.equal(payload.candidate_previews[3].would_insert_odds, false);
+    assert.ok(payload.candidate_previews[0].candidate_identity_key.includes('exact home'));
+    assert.equal(payload.identity_strategy.proposed_match_id_strategy, 'not_finalized');
+    assert.equal(payload.identity_strategy.match_id_write_allowed, false);
+    assert.equal(client.calls.filter(call => call.params.includes('Invalid Away')).length, 0);
+    assertSafetyPayload(payload);
+    assertSqlCallsAreReadOnly(gate, client.calls);
+});
+
+test('existing_match_ids 应去重并过滤空 match_id', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const candidates = [
+        {
+            row_number: 1,
+            league_name: 'League',
+            season: '2024/2025',
+            match_date: '2024-02-01T12:00:00.000Z',
+            home_team: 'Duplicate Home',
+            away_team: 'Duplicate Away',
+            actual_result: 'home_win',
+        },
+    ];
+    const client = createMockClient((sql, params) => {
+        if (sql === gate.EXACT_MATCH_SQL && params[0] === 'Duplicate Home') {
+            return {
+                rows: [
+                    { match_id: 'duplicate_1', home_team: 'Duplicate Home', away_team: 'Duplicate Away' },
+                    { match_id: 'duplicate_1', home_team: 'Duplicate Home', away_team: 'Duplicate Away' },
+                    { match_id: '', home_team: 'Duplicate Home', away_team: 'Duplicate Away' },
+                ],
+            };
+        }
+        return { rows: [] };
+    });
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload(candidates),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.exact_existing_matches, 3);
+    assert.equal(payload.candidate_previews[0].duplicate_risk, 'exact_existing_match');
+    assert.deepEqual(payload.candidate_previews[0].existing_match_ids, ['duplicate_1']);
+    assertSqlCallsAreReadOnly(gate, client.calls);
+});
+
+test('缺 actual_result 的 candidate 应标记 invalid 且不执行 match SELECT', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const candidates = [
+        {
+            row_number: 1,
+            league_name: 'League',
+            season: '2024/2025',
+            match_date: '2024-03-01T12:00:00.000Z',
+            home_team: 'No Label Home',
+            away_team: 'No Label Away',
+            actual_result: '',
+        },
+    ];
+    const client = createMockClient(sql => {
+        if (sql === gate.EXACT_MATCH_SQL || sql === gate.REVERSED_MATCH_SQL || sql === gate.NEARBY_MATCH_SQL) {
+            throw new Error('invalid candidate should not query duplicate SELECTs');
+        }
+        return { rows: [] };
+    });
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload(candidates),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.invalid_candidates, 1);
+    assert.equal(payload.candidate_previews[0].duplicate_risk, 'invalid_candidate');
+    assert.deepEqual(
+        client.calls.map(call => call.sql),
+        [gate.READ_ONLY_BEGIN_SQL, gate.READ_ONLY_ROLLBACK_SQL]
+    );
+});
+
+test('--commit 必须 blocked，即使提供 manifest 和 CSV', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const result = await runMain(gate, [
+        '--source-manifest',
+        MANIFEST_PATH,
+        '--local-csv',
+        CSV_PATH,
+        '--commit',
+        '--json',
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'blocked-commit');
+    assert.equal(result.payload.blocked, true);
+    assert.match(result.payload.blocked_reason, /not wired in Phase 4\.65C/);
+    assertSafetyPayload(result.payload);
+});
+
+test('sha256 mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const manifest = {
+        ...loadManifest(),
+        sha256: '0'.repeat(64),
+    };
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for sha256 mismatch');
+    });
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            dryRunDependencies: {
+                readManifest: () => manifest,
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'dry-run-failed');
+    assert.equal(payload.dry_run_passed, false);
+    assert.equal(payload.sha256_match, false);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /sha256 mismatch/);
+    assert.equal(payload.no_db_writes, true);
+});
+
+test('row_count mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const manifest = {
+        ...loadManifest(),
+        row_count: 99,
+    };
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for row_count mismatch');
+    });
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            dryRunDependencies: {
+                readManifest: () => manifest,
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'dry-run-failed');
+    assert.equal(payload.dry_run_passed, false);
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /row_count mismatch/);
+    assert.equal(payload.no_db_writes, true);
+});
+
+test('文本输出包含 duplicate summary、future checklist 和 non-execution confirmations', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const client = createMockClient(() => ({ rows: [] }));
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+    const text = gate.payloadToText(payload);
+
+    assert.match(text, /phase=PHASE4\.65C_FOOTBALL_DATA_DUPLICATE_PRECHECK/);
+    assert.match(text, /dry_run_passed=true/);
+    assert.match(text, /sha256_match=true/);
+    assert.match(text, /row_count_match=true/);
+    assert.match(text, /select_only_db_reads=true/);
+    assert.match(text, /no_db_writes=true/);
+    assert.match(text, /would_insert_matches=false/);
+    assert.match(text, /would_insert_odds=false/);
+    assert.match(text, /would_write_db=false/);
+    assert.match(text, /would_access_network=false/);
+    assert.match(text, /would_write_files=false/);
+    assert.match(text, /candidate_previews=/);
+    assert.match(text, /candidate_identity_key/);
+    assert.match(text, /required_before_db_write:/);
+    assert.match(text, /deterministic match_id strategy must be finalized/);
+    assert.match(text, /no_external_network/);
+    assert.match(text, /no_file_writes/);
+    assert.match(text, /no_pg_dump_execution/);
+});
+
+test('SQL guard 只允许 SELECT / BEGIN READ ONLY / ROLLBACK', t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.READ_ONLY_BEGIN_SQL));
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.EXACT_MATCH_SQL));
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.REVERSED_MATCH_SQL));
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.NEARBY_MATCH_SQL));
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.READ_ONLY_ROLLBACK_SQL));
+    assert.throws(() => gate.assertSelectOnlySql('INSERT INTO matches VALUES ($1)'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('UPDATE matches SET status = $1'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('DELETE FROM matches'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('CREATE TABLE unsafe_table(id int)'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('COMMIT'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('SELECT 1; DROP TABLE matches'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('WITH unsafe AS (SELECT 1) SELECT * FROM unsafe'), /Unsafe SQL/);
+});
+
+test('candidate identity key helper 应覆盖缺失字段和球队名标准化分支', t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+
+    assert.equal(gate.buildCandidateIdentityKey({}), '||||');
+    assert.equal(
+        gate.buildCandidateIdentityKey({
+            league_name: ' League ',
+            season: ' 2024/2025 ',
+            match_date: '2024-01-01T00:00:00.000Z',
+            home_team: '  Málaga   CF ',
+            away_team: 'Away   Team',
+        }),
+        'League|2024/2025|2024-01-01|malaga cf|away team'
+    );
+});
+
+test('DB config helper 应覆盖默认值、POSTGRES fallback 和 DB_* 优先级', t => {
+    installExecutionGuards(t);
+    const snapshot = snapshotDbEnv();
+    t.after(() => restoreDbEnv(snapshot));
+    const gate = loadPrecheckFresh();
+
+    for (const key of Object.keys(snapshot)) {
+        delete process.env[key];
+    }
+    assert.deepEqual(gate.buildDbConfig(), {
+        host: 'db',
+        port: 5432,
+        database: 'football_db',
+        user: 'football_user',
+        password: undefined,
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    });
+
+    process.env.POSTGRES_HOST = 'postgres-host';
+    process.env.POSTGRES_PORT = '15432';
+    process.env.POSTGRES_DB = 'postgres-db';
+    process.env.POSTGRES_USER = 'postgres-user';
+    process.env.POSTGRES_PASSWORD = 'postgres-password';
+    assert.deepEqual(gate.buildDbConfig(), {
+        host: 'postgres-host',
+        port: 15432,
+        database: 'postgres-db',
+        user: 'postgres-user',
+        password: 'postgres-password',
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    });
+
+    process.env.DB_HOST = 'db-host';
+    process.env.DB_PORT = '25432';
+    process.env.DB_NAME = 'db-name';
+    process.env.DB_USER = 'db-user';
+    process.env.DB_PASSWORD = 'db-password';
+    assert.deepEqual(gate.buildDbConfig(), {
+        host: 'db-host',
+        port: 25432,
+        database: 'db-name',
+        user: 'db-user',
+        password: 'db-password',
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    });
+});
+
+test('CLI help 和未知参数错误分支应可用且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const help = await runTextMain(gate, ['--help']);
+    const unknown = await runMain(gate, ['--unknown-option', '--json']);
+    const unknownText = await runTextMain(gate, ['--unknown-option']);
+
+    assert.equal(help.status, 0);
+    assert.match(help.stdout, /football_data_duplicate_precheck\.js --source-manifest/);
+    assert.equal(unknown.status, 1);
+    assert.equal(unknown.payload.mode, 'runtime-error');
+    assert.match(unknown.payload.errors[0], /Unknown argument/);
+    assert.equal(unknown.payload.no_db_writes, true);
+    assert.equal(unknown.payload.would_write_db, false);
+    assert.equal(unknownText.status, 1);
+    assert.match(unknownText.stdout, /mode=runtime-error/);
+    assert.match(unknownText.stdout, /errors=Unknown argument/);
+    assert.match(unknownText.stdout, /required_before_db_write:/);
+});
+
+test('pool dependency 分支应 release client 且不 end injected pool', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    let released = false;
+    let poolEnded = false;
+    const client = createMockClient(() => ({ rows: [] }));
+    client.release = () => {
+        released = true;
+    };
+    const pool = {
+        async connect() {
+            return client;
+        },
+        async end() {
+            poolEnded = true;
+        },
+    };
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        { pool }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(released, true);
+    assert.equal(poolEnded, false);
+    assertSqlCallsAreReadOnly(gate, client.calls);
+});
+
+test('未注入 pool 时应创建 pg Pool、release client 并 end pool', async t => {
+    let released = false;
+    let poolEnded = false;
+    let receivedConfig = null;
+    const client = createMockClient(() => ({ rows: [] }));
+    client.release = () => {
+        released = true;
+    };
+    class FakePool {
+        constructor(config) {
+            receivedConfig = config;
+        }
+
+        async connect() {
+            return client;
+        }
+
+        async end() {
+            poolEnded = true;
+        }
+    }
+
+    installExecutionGuards(t, {
+        moduleOverrides: {
+            pg: { Pool: FakePool },
+        },
+    });
+    const snapshot = snapshotDbEnv();
+    t.after(() => restoreDbEnv(snapshot));
+    process.env.DB_HOST = 'fake-db-host';
+    process.env.DB_PORT = '45432';
+    process.env.DB_NAME = 'fake-db-name';
+    process.env.DB_USER = 'fake-db-user';
+    process.env.DB_PASSWORD = 'fake-db-password';
+    const gate = loadPrecheckFresh();
+    const payload = await gate.runDuplicatePrecheck({
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+    });
+
+    assert.equal(payload.ok, true);
+    assert.equal(released, true);
+    assert.equal(poolEnded, true);
+    assert.equal(receivedConfig.host, 'fake-db-host');
+    assert.equal(receivedConfig.port, 45432);
+    assert.equal(receivedConfig.database, 'fake-db-name');
+    assert.equal(receivedConfig.user, 'fake-db-user');
+    assert.equal(receivedConfig.password, 'fake-db-password');
+    assertSqlCallsAreReadOnly(gate, client.calls);
+});
+
+test('空 candidate 集合仍应使用 read-only transaction 并返回 0 风险', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const client = createMockClient(() => ({ rows: [] }));
+    const payload = await gate.runDuplicatePrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => ({
+                ...buildDryRunPayload([]),
+                row_classification: undefined,
+                warnings: undefined,
+                non_execution_confirmations: undefined,
+            }),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.candidate_rows, 0);
+    assert.equal(payload.trainable_label_rows, 0);
+    assert.equal(payload.insert_risk_summary.duplicate_free_candidates, 0);
+    assert.deepEqual(payload.candidate_previews, []);
+    assert.deepEqual(
+        client.calls.map(call => call.sql),
+        [gate.READ_ONLY_BEGIN_SQL, gate.READ_ONLY_ROLLBACK_SQL]
+    );
+});
+
+test('read-only transaction 查询失败时仍应 ROLLBACK', async t => {
+    installExecutionGuards(t);
+    const gate = loadPrecheckFresh();
+    const candidate = {
+        row_number: 1,
+        league_name: 'League',
+        season: '2024/2025',
+        match_date: '2024-01-01T12:00:00.000Z',
+        home_team: 'Boom Home',
+        away_team: 'Boom Away',
+        actual_result: 'home_win',
+    };
+    const client = createMockClient(sql => {
+        if (sql === gate.EXACT_MATCH_SQL) {
+            throw new Error('synthetic select failure');
+        }
+        return { rows: [] };
+    });
+
+    await assert.rejects(() => gate.runCandidatePrechecks(client, [candidate]), /synthetic select failure/);
+    assert.deepEqual(
+        client.calls.map(call => call.sql),
+        [gate.READ_ONLY_BEGIN_SQL, gate.EXACT_MATCH_SQL, gate.READ_ONLY_ROLLBACK_SQL]
+    );
+});
+
+test('source 文本不引用 legacy downloader、child_process 或文件写入 API', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+    assert.doesNotMatch(source, /fetch_and_adapt_euro_leagues/);
+    assert.doesNotMatch(source, /child_process/);
+    assert.doesNotMatch(source, /spawn\(/);
+    assert.doesNotMatch(source, /execFile\(/);
+    assert.doesNotMatch(source, /writeFile/);
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.65C football-data SELECT-only duplicate / existing match precheck.

Scope:
- Adds football_data_duplicate_precheck
- Adds Makefile precheck and blocked commit targets
- Adds SELECT-only duplicate/existing match checks
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.65C report

Safety:
- No DB writes
- SELECT-only DB reads only
- No pg_dump execution
- No file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- duplicate precheck passed
- duplicate precheck commit gate remained blocked
- football-data CSV dry-run still passed
- football-data DB write preflight still passed
- legacy acquisition gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed