### PR TITLE
feat(data): add football-data insert policy precheck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不训练、不预测、不写 staging 的 `make data-football-data-csv-dry-run SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不执行 pg_dump、不训练、不预测的 `make data-football-data-db-write-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB 查重、不写 DB、不训练、不预测的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
+- 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB schema / duplicate 查询、不写 DB、不训练、不预测的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 - 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
@@ -279,6 +280,8 @@ AI / Codex 不能直接执行：
 - `make data-football-data-db-write-commit CONFIRM_FOOTBALL_DATA_DB_WRITE=1`
 - `make data-football-data-duplicate-precheck-commit`
 - `make data-football-data-duplicate-precheck-commit CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1`
+- `make data-football-data-insert-policy-commit`
+- `make data-football-data-insert-policy-commit CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1`
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
@@ -569,6 +572,8 @@ Phase 4.57C football-data adapter rules：
 - `data-football-data-db-write-preflight` 不得触网、不得读 / 写 DB、不得执行 `pg_dump`、不得写文件、不得 import legacy downloader runtime；`make data-football-data-db-write-commit` 当前 blocked / not wired。
 - Phase 4.65C 的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是入库前 SELECT-only duplicate / existing match precheck；只能读取本地 manifest / CSV 并对 DB 执行 `BEGIN READ ONLY` + `SELECT` + `ROLLBACK`。
 - `data-football-data-duplicate-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-duplicate-precheck-commit` 当前 blocked / not wired。
+- Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。
+- `data-football-data-insert-policy-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-insert-policy-commit` 当前 blocked / not wired。
 - future DB write 必须单独阶段、单独授权、真实 `pg_dump`、small batch、post-write validation；DB write 前后 training / prediction 仍必须走单独 gate。
 - 未来 football-data network dry-run 仍需单独授权；未来任何 DB write 仍需单独授权并先完成 `pg_dump`。
 - 未来 local CSV adapter 必须由 source manifest + 本地 CSV 驱动，不得下载 Football-Data CSV，不得写 staging / DB，不得训练或预测。

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
         data-football-data-duplicate-precheck data-football-data-duplicate-precheck-commit \
+        data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
         data-raw-fixture-dry-run data-raw-fixture-commit \
@@ -266,6 +267,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-db-write-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-duplicate-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
+	@echo "  make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id> FIXTURE=<path>"
@@ -286,6 +288,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-csv-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1  # blocked in Phase 4.63C"
 	@echo "  make data-football-data-db-write-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DB_WRITE=1  # blocked in Phase 4.64C"
 	@echo "  make data-football-data-duplicate-precheck-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1  # blocked in Phase 4.65C"
+	@echo "  make data-football-data-insert-policy-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1  # blocked in Phase 4.66C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -558,6 +561,24 @@ data-football-data-duplicate-precheck-commit: ## Blocked Football-Data duplicate
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data duplicate precheck commit is not wired in Phase 4.65C."
+	@exit 1
+
+data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path> and LOCAL_CSV=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data insert policy precheck: SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_insert_policy_precheck.js --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)"
+
+data-football-data-insert-policy-commit: ## Blocked Football-Data insert policy commit gate. Requires CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_INSERT_POLICY)" != "1" ]; then \
+		echo "BLOCKED: football-data insert policy requires CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1 and is not wired in Phase 4.66C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data insert policy commit is not wired in Phase 4.66C."
 	@exit 1
 
 data-acquisition-engines: ## List acquisition engine registry entries. No network, no DB writes.

--- a/docs/_reports/FOOTBALL_DATA_INSERT_POLICY_PHASE4_66C.md
+++ b/docs/_reports/FOOTBALL_DATA_INSERT_POLICY_PHASE4_66C.md
@@ -1,0 +1,208 @@
+# Football-Data Insert Policy Precheck - Phase 4.66C
+
+## 当前状态
+
+- HEAD: `c2dfa6932030f942f59155b571df45e0b30f9f45`
+- 分支: `feat/football-data-insert-policy-phase466c`
+- 主题: deterministic `match_id` strategy + future insert candidate policy。
+
+本阶段适合做一个稍大的主题 PR，因为 `match_id` 稳定生成和 insert eligibility 必须一起审查。只有 deterministic ID 但没有 duplicate policy 不安全；只有 duplicate policy 但没有稳定 proposed ID，也不足以进入未来写库授权。
+
+## 新增 / 修改文件
+
+新增:
+
+- `scripts/ops/football_data_insert_policy_precheck.js`
+- `tests/unit/football_data_insert_policy_precheck.test.js`
+- `docs/_reports/FOOTBALL_DATA_INSERT_POLICY_PHASE4_66C.md`
+
+修改:
+
+- `Makefile`
+- `AGENTS.md`
+
+## Deterministic Match ID Strategy
+
+预览策略:
+
+```text
+fd_<league>_<season>_<date>_<home>_<away>_<hash8>
+```
+
+规则:
+
+- prefix 固定为 `fd`。
+- `league_slug` 从 `league_name` / `Div` 派生，小写、去重音，仅保留 `[a-z0-9]`。
+- `season_slug` 将 `2024/2025` 转成 `20242025`。
+- `date_slug` 使用 `YYYYMMDD`。
+- 主客队 slug 小写、去重音、空白转 `_`，仅保留 `[a-z0-9_]`，必要时 deterministic truncation。
+- `hash8 = sha256(candidate_identity_key).slice(0, 8)`。
+- 不使用随机数、当前时间、DB sequence、行顺序、比分、结果、赔率、parser version、训练或预测输出。
+- 如果 proposed ID 无法适配 schema 最大长度，precheck 失败，不输出非法 ID。
+- `match_id_strategy_finalized=false`: 本阶段只做策略预览，不授权写库。
+
+## Candidate Identity Key
+
+```text
+football_data|<source_name>|<league_name>|<season>|<match_date_date>|<normalized_home_team>|<normalized_away_team>
+```
+
+identity key 明确不包含 score、`actual_result`、odds、`row_number`、parser version 和当前时间，避免同一场比赛因为标签、赔率或 CSV 行号变化而改变身份。
+
+## Schema / Constraint 只读检查
+
+对 `matches` 的 SELECT-only inspection 结果:
+
+- `matches.match_id`: `character varying(50)`
+- `is_nullable`: `NO`
+- constraint: `matches_pkey`
+- `match_id_primary_key=true`
+- `match_id_unique=true`
+- proposed ID 有效最大长度: `50`
+
+precheck 只通过 `information_schema` 读取，并使用 read-only transaction 语义包裹 DB 查询。
+
+## Insert Candidate Policy
+
+每行 candidate 输出 `insert_policy`:
+
+- `blocked_by_manifest_policy`: manifest `approval_status` 不是 `approved_for_db_write`。
+- `skip_existing_match`: duplicate precheck 发现 `exact_existing_match`。
+- `manual_review_required`: duplicate precheck 发现 reversed teams 或 nearby date possible duplicate。
+- `invalid_candidate`: 必需 identity / label 字段无效，或 proposed ID 无法适配 schema 长度。
+- `future_insert_candidate`: candidate 有效、无 duplicate risk、manifest 为 `approved_for_db_write`、proposed ID 合法。
+
+即使是 `future_insert_candidate`，Phase 4.66C 仍然只是 preview:
+
+- `would_insert_match=false`
+- `would_insert_odds=false`
+- `would_write_db=false`
+- `db_write_allowed=false`
+
+当前 fixture manifest 是 `dry_run_only`，真实本地 precheck 输出:
+
+- `candidate_rows=3`
+- `future_insert_candidates=0`
+- `blocked_by_manifest_policy=3`
+- `skip_existing_matches=0`
+- `manual_review_required=0`
+- `invalid_candidates=0`
+
+## 安全机制
+
+新 precheck:
+
+- 读取本地 source manifest 和本地 CSV。
+- 复用 football-data dry-run / parser 链路。
+- 复用 SELECT-only duplicate precheck。
+- 执行 SELECT-only `matches` schema / constraint inspection。
+- 不 import `fetch_and_adapt_euro_leagues.js`。
+- 不 spawn child process。
+- 不执行 `pg_dump`。
+- 不访问外网。
+- 不写 DB。
+- 不写业务数据文件。
+- 不训练、不预测、不加载 model artifact。
+
+commit target 继续 blocked:
+
+```text
+BLOCKED: football-data insert policy commit is not wired in Phase 4.66C.
+```
+
+## 验证结果
+
+precheck 验证:
+
+- 缺参数 precheck 按预期失败。
+- 本地 fixture precheck 通过。
+- `select_only_db_reads=true`
+- `no_db_writes=true`
+- `would_write_db=false`
+- `match_id_strategy_finalized=false`
+- `db_write_allowed=false`
+
+旧 gate 复验:
+
+- `make data-football-data-csv-dry-run ...`: 通过。
+- `make data-football-data-db-write-preflight ...`: 通过。
+- `make data-football-data-duplicate-precheck ...`: 通过。
+- `make data-football-data-csv-commit ... CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1`: blocked。
+- `make data-football-data-db-write-commit ... CONFIRM_FOOTBALL_DATA_DB_WRITE=1`: blocked。
+- `make data-football-data-duplicate-precheck-commit ... CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1`: blocked。
+- `make data-acquisition-engine-audit`: 通过，no DB writes / no external network。
+- `make data-single-target-network-dry-run ...`: scaffold blocked，`would_access_network=false`、`would_write_db=false`、`would_execute_engine=false`。
+- `make data-single-target-network-commit ... CONFIRM_SINGLE_TARGET_NETWORK=1`: blocked。
+
+测试:
+
+- `node --test tests/unit/football_data_insert_policy_precheck.test.js`: 通过，23 tests。
+- `node --test tests/unit/football_data_duplicate_precheck.test.js`: 通过。
+- `node --test tests/unit/football_data_db_write_preflight.test.js`: 通过。
+- `node --test tests/unit/football_data_adapter_dry_run.test.js`: 通过。
+- `node --test tests/unit/football_data_local_csv_parser.test.js`: 通过。
+- `node --test tests/unit/fetch_and_adapt_euro_leagues_no_network.test.js`: 通过。
+- `node --test tests/unit/acquisition_engine_gate.test.js`: 通过。
+- `npm test`: 通过。
+- `npm run test:coverage`: 通过。
+
+coverage:
+
+- lines: `87.99`
+- functions: `80.54`
+- branches: `80.01`
+
+第一次 coverage 运行报告 `branches=79.96 < 80`；随后只补了 Phase 4.66C 相关分支测试，最终 coverage gate 通过，没有修改 coverage 阈值。
+
+## DB 前后统计
+
+实施前:
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |    2 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+全部验证后:
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |    2 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+## 下一步建议
+
+- Phase 4.67C: small DB write authorization checklist + `pg_dump` command preview；仍不执行 `pg_dump`，不写 DB。
+- 或 Phase 4.56A: 用户给齐真实 network dry-run 参数并单独授权后，再做 runbook。
+
+## 明确未执行
+
+- DB writes。
+- non-SELECT DB SQL。
+- `pg_dump` / `pg_restore`。
+- external download。
+- `curl` / `wget` / `git clone`。
+- 外部足球数据源访问。
+- 外部赔率数据源访问。
+- scraping / browser automation。
+- harvest / ingest / batch backfill / bulk harvest。
+- network dry-run 真执行。
+- adapted CSV 或 staging 数据写入。
+- model training。
+- real prediction execution。
+- model artifact loading。
+- Docker volume 清理。
+- force push。
+- `git fetch --all`。
+- `git pull`。
+- 删除文件。
+
+除允许的代码、测试、Makefile、AGENTS 和本报告文件修改外，未执行任何业务数据文件写入。

--- a/scripts/ops/football_data_insert_policy_precheck.js
+++ b/scripts/ops/football_data_insert_policy_precheck.js
@@ -1,0 +1,668 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+
+const { runDryRun, parseArgs: parseDryRunArgs } = require('./football_data_adapter_dry_run');
+const {
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    runCandidatePrechecks,
+    buildDbConfig,
+    assertSelectOnlySql,
+} = require('./football_data_duplicate_precheck');
+
+const INSERT_POLICY_PHASE = 'PHASE4.66C_FOOTBALL_DATA_INSERT_POLICY';
+const MATCH_ID_STRATEGY = 'fd_<league>_<season>_<date>_<home>_<away>_<hash8>';
+const DEFAULT_MATCH_ID_MAX_LENGTH = 64;
+const APPROVED_FOR_DB_WRITE = 'approved_for_db_write';
+
+const MATCH_ID_COLUMN_SQL = `
+SELECT column_name, data_type, character_maximum_length, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'matches'
+  AND column_name = 'match_id'
+LIMIT 1
+`;
+
+const MATCHES_CONSTRAINT_SQL = `
+SELECT
+  tc.constraint_name,
+  tc.constraint_type,
+  kcu.column_name
+FROM information_schema.table_constraints tc
+LEFT JOIN information_schema.key_column_usage kcu
+  ON tc.constraint_name = kcu.constraint_name
+  AND tc.table_schema = kcu.table_schema
+WHERE tc.table_schema = 'public'
+  AND tc.table_name = 'matches'
+ORDER BY tc.constraint_type, tc.constraint_name, kcu.ordinal_position
+`;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_insert_policy_precheck.js --source-manifest <path> --local-csv <path> [--json]',
+        '  node scripts/ops/football_data_insert_policy_precheck.js --source-manifest <path> --local-csv <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.66C is SELECT-only insert policy preview. No DB writes, no pg_dump execution, no network harvest.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    return parseDryRunArgs(argv);
+}
+
+function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function createPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+async function withDbClient(dependencies, callback) {
+    if (dependencies.dbClient) {
+        return callback(dependencies.dbClient);
+    }
+
+    const pool = dependencies.pool || createPool();
+    const client = await pool.connect();
+    try {
+        return await callback(client);
+    } finally {
+        client.release();
+        if (!dependencies.pool && typeof pool.end === 'function') {
+            await pool.end();
+        }
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'select_only_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_legacy_runtime',
+        'no_pg_dump_execution',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+        'no_adapted_csv_writes',
+        'no_staging_writes',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        select_only_db_reads: true,
+        no_db_writes: true,
+        db_write_allowed: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_execute_pg_dump: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_execute_legacy_runtime: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: INSERT_POLICY_PHASE,
+        mode: fields.mode || 'football-data-insert-policy-precheck',
+        ok: false,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        source_manifest_found: false,
+        local_csv_found: false,
+        dry_run_passed: false,
+        duplicate_precheck_passed: false,
+        sha256_match: false,
+        row_count_match: false,
+        match_id_strategy: MATCH_ID_STRATEGY,
+        match_id_strategy_finalized: false,
+        manifest_approval_status: null,
+        candidate_rows: 0,
+        future_insert_candidates: 0,
+        blocked_by_manifest_policy: 0,
+        skip_existing_matches: 0,
+        manual_review_required: 0,
+        invalid_candidates: 0,
+        candidate_previews: [],
+        commit_gate: 'blocked',
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: 'BLOCKED: football-data insert policy commit is not wired in Phase 4.66C.',
+        errors: ['BLOCKED: football-data insert policy commit is not wired in Phase 4.66C.'],
+    });
+}
+
+function normalizeIdentityText(value) {
+    return String(value || '')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .trim()
+        .replace(/\s+/g, ' ')
+        .toLowerCase();
+}
+
+function toDateOnly(value) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+    return date.toISOString().slice(0, 10);
+}
+
+function toDateSlug(value) {
+    return toDateOnly(value).replace(/-/g, '');
+}
+
+function slugToken(value, options = {}) {
+    const separator = options.separator === undefined ? '_' : options.separator;
+    const fallback = options.fallback || 'x';
+    const normalized = String(value || '')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim();
+    const spaced = separator ? normalized.replace(/\s+/g, separator) : normalized.replace(/\s+/g, '');
+    const pattern = separator ? /[^a-z0-9_]/g : /[^a-z0-9]/g;
+    const collapsed = spaced
+        .replace(pattern, '')
+        .replace(/_+/g, '_')
+        .replace(/^_+|_+$/g, '');
+    return collapsed || fallback;
+}
+
+function truncateSlug(value, maxLength) {
+    const truncated = String(value || '')
+        .slice(0, Math.max(1, maxLength))
+        .replace(/^_+|_+$/g, '');
+    return truncated || 'x';
+}
+
+function buildCandidateIdentityKey(candidate, sourceName = '') {
+    return [
+        'football_data',
+        normalizeIdentityText(sourceName),
+        normalizeIdentityText(candidate.league_name || candidate.league_code || ''),
+        normalizeIdentityText(candidate.season || ''),
+        toDateOnly(candidate.match_date),
+        normalizeIdentityText(candidate.home_team),
+        normalizeIdentityText(candidate.away_team),
+    ].join('|');
+}
+
+function sha256Prefix(text, length = 8) {
+    return crypto.createHash('sha256').update(text).digest('hex').slice(0, length);
+}
+
+function buildProposedMatchId(candidate, options = {}) {
+    const maxLength =
+        Number.isInteger(options.maxLength) && options.maxLength > 0 ? options.maxLength : DEFAULT_MATCH_ID_MAX_LENGTH;
+    const sourceName = options.sourceName || '';
+    const candidateIdentityKey = options.candidateIdentityKey || buildCandidateIdentityKey(candidate, sourceName);
+    const hash8 = sha256Prefix(candidateIdentityKey);
+    let leagueSlug = truncateSlug(
+        slugToken(candidate.league_name || candidate.league_code || 'league', {
+            separator: '',
+            fallback: 'league',
+        }),
+        10
+    );
+    let seasonSlug = truncateSlug(slugToken(candidate.season || 'season', { separator: '', fallback: 'season' }), 12);
+    const dateSlug = truncateSlug(toDateSlug(candidate.match_date) || 'date', 8);
+    let homeSlug = slugToken(candidate.home_team, { separator: '_', fallback: 'home' });
+    let awaySlug = slugToken(candidate.away_team, { separator: '_', fallback: 'away' });
+    const joinParts = () => ['fd', leagueSlug, seasonSlug, dateSlug, homeSlug, awaySlug, hash8].join('_');
+
+    if (joinParts().length > maxLength) {
+        let overhead = ['fd', leagueSlug, seasonSlug, dateSlug, '', '', hash8].join('_').length;
+        let availableTeamLength = maxLength - overhead;
+        if (availableTeamLength < 2) {
+            leagueSlug = truncateSlug(leagueSlug, 4);
+            seasonSlug = truncateSlug(seasonSlug, 8);
+            overhead = ['fd', leagueSlug, seasonSlug, dateSlug, '', '', hash8].join('_').length;
+            availableTeamLength = maxLength - overhead;
+        }
+        if (availableTeamLength < 2) {
+            throw new Error(`proposed_match_id cannot fit match_id max length: ${maxLength}`);
+        }
+        const homeBudget = Math.max(1, Math.floor(availableTeamLength / 2));
+        const awayBudget = Math.max(1, availableTeamLength - homeBudget);
+        homeSlug = truncateSlug(homeSlug, homeBudget);
+        awaySlug = truncateSlug(awaySlug, awayBudget);
+    }
+
+    const proposedMatchId = joinParts();
+    if (proposedMatchId.length > maxLength) {
+        throw new Error(`proposed_match_id exceeds match_id max length: ${proposedMatchId.length} > ${maxLength}`);
+    }
+
+    return {
+        proposed_match_id: proposedMatchId,
+        proposed_match_id_length: proposedMatchId.length,
+        proposed_match_id_valid_length: proposedMatchId.length <= maxLength,
+        candidate_identity_key: candidateIdentityKey,
+        hash8,
+        max_length: maxLength,
+    };
+}
+
+function deriveMatchIdSchema(columnRows, constraintRows) {
+    const matchIdColumn = columnRows[0] || null;
+    const rawMaxLength = Number.parseInt(matchIdColumn?.character_maximum_length, 10);
+    const matchIdMaxLength =
+        Number.isInteger(rawMaxLength) && rawMaxLength > 0 ? rawMaxLength : DEFAULT_MATCH_ID_MAX_LENGTH;
+    const matchIdConstraintRows = constraintRows.filter(row => row.column_name === 'match_id');
+    const primaryKey = matchIdConstraintRows.some(row => row.constraint_type === 'PRIMARY KEY');
+    const explicitUnique = matchIdConstraintRows.some(row => row.constraint_type === 'UNIQUE');
+
+    return {
+        table_name: 'matches',
+        match_id_column_found: Boolean(matchIdColumn),
+        match_id_data_type: matchIdColumn?.data_type || null,
+        match_id_character_maximum_length: matchIdColumn?.character_maximum_length || null,
+        match_id_max_length: matchIdMaxLength,
+        match_id_max_length_source: matchIdColumn?.character_maximum_length ? 'information_schema' : 'default_64',
+        match_id_is_nullable: matchIdColumn?.is_nullable || null,
+        match_id_column_default: matchIdColumn?.column_default || null,
+        match_id_primary_key: primaryKey,
+        match_id_unique: primaryKey || explicitUnique,
+        constraints: constraintRows.map(row => ({
+            constraint_name: row.constraint_name,
+            constraint_type: row.constraint_type,
+            column_name: row.column_name,
+        })),
+    };
+}
+
+async function inspectMatchesSchema(client) {
+    await querySelectOnly(client, READ_ONLY_BEGIN_SQL);
+    try {
+        const columnResult = await querySelectOnly(client, MATCH_ID_COLUMN_SQL);
+        const constraintResult = await querySelectOnly(client, MATCHES_CONSTRAINT_SQL);
+        return deriveMatchIdSchema(columnResult.rows || [], constraintResult.rows || []);
+    } finally {
+        await querySelectOnly(client, READ_ONLY_ROLLBACK_SQL);
+    }
+}
+
+function decideInsertPolicy(duplicatePreview, manifestApprovalStatus, proposedMatchId) {
+    if (duplicatePreview.duplicate_risk === 'invalid_candidate') {
+        return {
+            insert_policy: 'invalid_candidate',
+            policy_reason: 'candidate is missing required identity or finished-label fields',
+            skip_reason: 'invalid_candidate',
+            review_reason: null,
+        };
+    }
+    if (duplicatePreview.duplicate_risk === 'exact_existing_match') {
+        return {
+            insert_policy: 'skip_existing_match',
+            policy_reason: 'exact existing match already exists in DB',
+            skip_reason: 'exact_existing_match',
+            review_reason: null,
+        };
+    }
+    if (
+        duplicatePreview.duplicate_risk === 'reversed_teams_possible_duplicate' ||
+        duplicatePreview.duplicate_risk === 'nearby_date_possible_duplicate'
+    ) {
+        return {
+            insert_policy: 'manual_review_required',
+            policy_reason: `${duplicatePreview.duplicate_risk} requires manual review before any future insert`,
+            skip_reason: null,
+            review_reason: duplicatePreview.duplicate_risk,
+        };
+    }
+    if (!proposedMatchId.proposed_match_id_valid_length) {
+        return {
+            insert_policy: 'invalid_candidate',
+            policy_reason: 'proposed_match_id does not fit matches.match_id length limit',
+            skip_reason: 'invalid_match_id_length',
+            review_reason: null,
+        };
+    }
+    if (manifestApprovalStatus !== APPROVED_FOR_DB_WRITE) {
+        return {
+            insert_policy: 'blocked_by_manifest_policy',
+            policy_reason: 'source manifest approval_status is not approved_for_db_write',
+            skip_reason: 'manifest_not_approved_for_db_write',
+            review_reason: null,
+        };
+    }
+
+    return {
+        insert_policy: 'future_insert_candidate',
+        policy_reason: 'clean candidate under approved_for_db_write manifest; Phase 4.66C still does not write DB',
+        skip_reason: null,
+        review_reason: null,
+    };
+}
+
+function countPolicy(previews, policy) {
+    return previews.filter(preview => preview.insert_policy === policy).length;
+}
+
+function buildPolicyPreview(candidate, duplicatePreview, dryRunPayload, matchIdSchema) {
+    const sourceName = dryRunPayload.source_name || '';
+    const candidateIdentityKey = buildCandidateIdentityKey(candidate, sourceName);
+    const proposedMatchId = buildProposedMatchId(candidate, {
+        sourceName,
+        candidateIdentityKey,
+        maxLength: matchIdSchema.match_id_max_length,
+    });
+    const policy = decideInsertPolicy(duplicatePreview, dryRunPayload.approval_status, proposedMatchId);
+
+    return {
+        row_number: candidate.row_number || duplicatePreview.row_number || null,
+        home_team: candidate.home_team || duplicatePreview.home_team || null,
+        away_team: candidate.away_team || duplicatePreview.away_team || null,
+        match_date: toDateOnly(candidate.match_date) || duplicatePreview.match_date || null,
+        actual_result: candidate.actual_result || duplicatePreview.actual_result || null,
+        candidate_identity_key: proposedMatchId.candidate_identity_key,
+        proposed_match_id: proposedMatchId.proposed_match_id,
+        proposed_match_id_length: proposedMatchId.proposed_match_id_length,
+        proposed_match_id_valid_length: proposedMatchId.proposed_match_id_valid_length,
+        duplicate_risk: duplicatePreview.duplicate_risk,
+        insert_policy: policy.insert_policy,
+        policy_reason: policy.policy_reason,
+        skip_reason: policy.skip_reason,
+        review_reason: policy.review_reason,
+        existing_match_ids: duplicatePreview.existing_match_ids || [],
+        nearby_match_ids: duplicatePreview.nearby_match_ids || [],
+        would_insert_match: false,
+        would_insert_odds: false,
+    };
+}
+
+function buildPolicyPreviews(dryRunPayload, duplicatePreviews, matchIdSchema) {
+    const candidates = dryRunPayload.candidate_rows || [];
+    return candidates.map((candidate, index) =>
+        buildPolicyPreview(
+            candidate,
+            duplicatePreviews[index] || { duplicate_risk: 'invalid_candidate' },
+            dryRunPayload,
+            matchIdSchema
+        )
+    );
+}
+
+function buildSuccessPayload(args, dryRunPayload, duplicatePreviews, matchIdSchema, policyPreviews) {
+    return {
+        phase: INSERT_POLICY_PHASE,
+        mode: 'football-data-insert-policy-precheck',
+        ok: true,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        dry_run_passed: true,
+        duplicate_precheck_passed: true,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        select_only_db_reads: true,
+        match_id_strategy: MATCH_ID_STRATEGY,
+        match_id_strategy_finalized: false,
+        match_id_schema: matchIdSchema,
+        manifest_approval_status: dryRunPayload.approval_status,
+        source_name: dryRunPayload.source_name,
+        candidate_rows: (dryRunPayload.candidate_rows || []).length,
+        future_insert_candidates: countPolicy(policyPreviews, 'future_insert_candidate'),
+        blocked_by_manifest_policy: countPolicy(policyPreviews, 'blocked_by_manifest_policy'),
+        skip_existing_matches: countPolicy(policyPreviews, 'skip_existing_match'),
+        manual_review_required: countPolicy(policyPreviews, 'manual_review_required'),
+        invalid_candidates: countPolicy(policyPreviews, 'invalid_candidate'),
+        candidate_previews: policyPreviews,
+        duplicate_precheck_summary: {
+            exact_existing_matches: duplicatePreviews.filter(
+                preview => preview.duplicate_risk === 'exact_existing_match'
+            ).length,
+            reversed_team_matches: duplicatePreviews.filter(
+                preview => preview.duplicate_risk === 'reversed_teams_possible_duplicate'
+            ).length,
+            nearby_date_matches: duplicatePreviews.filter(
+                preview => preview.duplicate_risk === 'nearby_date_possible_duplicate'
+            ).length,
+            invalid_candidates: duplicatePreviews.filter(preview => preview.duplicate_risk === 'invalid_candidate')
+                .length,
+        },
+        commit_gate: 'blocked',
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        warnings: dryRunPayload.warnings || [],
+        errors: [],
+    };
+}
+
+function runPolicyDryRun(args, dependencies = {}) {
+    if (dependencies.runDryRun) {
+        return dependencies.runDryRun(args);
+    }
+
+    const dryRunDependencies = {
+        ...(dependencies.dryRunDependencies || {}),
+    };
+    const readManifest = dryRunDependencies.readManifest || readJsonFile;
+    let originalApprovalStatus = null;
+
+    dryRunDependencies.readManifest = manifestPath => {
+        const manifest = readManifest(manifestPath);
+        originalApprovalStatus = manifest.approval_status || null;
+        if (manifest.approval_status === APPROVED_FOR_DB_WRITE) {
+            return {
+                ...manifest,
+                approval_status: 'approved_for_dry_run',
+            };
+        }
+        return manifest;
+    };
+
+    const dryRunPayload = runDryRun(args, dryRunDependencies);
+    if (dryRunPayload.ok && originalApprovalStatus) {
+        return {
+            ...dryRunPayload,
+            approval_status: originalApprovalStatus,
+        };
+    }
+    return dryRunPayload;
+}
+
+async function runInsertPolicyPrecheck(args, dependencies = {}) {
+    if (!args.sourceManifest || !args.localCsv) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            select_only_db_reads: false,
+            errors: ['ERROR: provide --source-manifest=<path> and --local-csv=<path>'],
+        });
+    }
+
+    const dryRunPayload = runPolicyDryRun(
+        {
+            sourceManifest: args.sourceManifest,
+            localCsv: args.localCsv,
+        },
+        dependencies
+    );
+
+    if (!dryRunPayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'dry-run-failed',
+            source_manifest_found: dryRunPayload.source_manifest_found,
+            local_csv_found: dryRunPayload.local_csv_found,
+            sha256_match: dryRunPayload.sha256_match,
+            row_count_match: dryRunPayload.row_count_match,
+            dry_run_passed: false,
+            select_only_db_reads: false,
+            dry_run_failure_mode: dryRunPayload.mode,
+            errors: dryRunPayload.errors || ['football-data CSV dry-run failed'],
+            warnings: dryRunPayload.warnings || [],
+        });
+    }
+
+    return withDbClient(dependencies, async client => {
+        const matchIdSchema = dependencies.matchIdSchema || (await inspectMatchesSchema(client));
+        const duplicatePreviews =
+            dependencies.duplicatePreviews || (await runCandidatePrechecks(client, dryRunPayload.candidate_rows || []));
+        const policyPreviews = buildPolicyPreviews(dryRunPayload, duplicatePreviews, matchIdSchema);
+        return buildSuccessPayload(args, dryRunPayload, duplicatePreviews, matchIdSchema, policyPreviews);
+    });
+}
+
+function appendOptionalTextFields(lines, payload) {
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+}
+
+function appendListSection(lines, title, values) {
+    lines.push(`${title}:`);
+    for (const value of values || []) {
+        lines.push(`- ${value}`);
+    }
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `dry_run_passed=${payload.dry_run_passed}`,
+        `duplicate_precheck_passed=${payload.duplicate_precheck_passed}`,
+        `sha256_match=${payload.sha256_match}`,
+        `row_count_match=${payload.row_count_match}`,
+        `select_only_db_reads=${payload.select_only_db_reads}`,
+        `match_id_strategy=${payload.match_id_strategy}`,
+        `match_id_strategy_finalized=${payload.match_id_strategy_finalized}`,
+        `manifest_approval_status=${payload.manifest_approval_status}`,
+        `db_write_allowed=${payload.db_write_allowed}`,
+        `candidate_rows=${payload.candidate_rows || 0}`,
+        `future_insert_candidates=${payload.future_insert_candidates || 0}`,
+        `blocked_by_manifest_policy=${payload.blocked_by_manifest_policy || 0}`,
+        `skip_existing_matches=${payload.skip_existing_matches || 0}`,
+        `manual_review_required=${payload.manual_review_required || 0}`,
+        `invalid_candidates=${payload.invalid_candidates || 0}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+        `commit_gate=${payload.commit_gate}`,
+    ];
+
+    if (payload.match_id_schema) {
+        lines.push(`match_id_schema=${JSON.stringify(payload.match_id_schema)}`);
+    }
+    if (Array.isArray(payload.candidate_previews) && payload.candidate_previews.length > 0) {
+        lines.push(`candidate_previews=${JSON.stringify(payload.candidate_previews)}`);
+    }
+    if (payload.duplicate_precheck_summary) {
+        lines.push(`duplicate_precheck_summary=${JSON.stringify(payload.duplicate_precheck_summary)}`);
+    }
+
+    appendOptionalTextFields(lines, payload);
+    appendListSection(lines, 'non_execution_confirmations', payload.non_execution_confirmations);
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+async function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = await runInsertPolicyPrecheck(args);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const json = argv.includes('--json');
+        const payload = buildFailurePayload(
+            {
+                sourceManifest: '',
+                localCsv: '',
+            },
+            {
+                mode: 'runtime-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, json, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => {
+        process.exitCode = status;
+    });
+}
+
+module.exports = {
+    INSERT_POLICY_PHASE,
+    MATCH_ID_STRATEGY,
+    MATCH_ID_COLUMN_SQL,
+    MATCHES_CONSTRAINT_SQL,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    runInsertPolicyPrecheck,
+    inspectMatchesSchema,
+    deriveMatchIdSchema,
+    buildCandidateIdentityKey,
+    buildProposedMatchId,
+    decideInsertPolicy,
+    assertSelectOnlySql,
+    payloadToText,
+    main,
+};

--- a/tests/unit/football_data_insert_policy_precheck.test.js
+++ b/tests/unit/football_data_insert_policy_precheck.test.js
@@ -1,0 +1,773 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_insert_policy_precheck.js');
+const DRY_RUN_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_adapter_dry_run.js');
+const DUPLICATE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_duplicate_precheck.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+
+function installExecutionGuards(t, options = {}) {
+    const moduleOverrides = options.moduleOverrides || {};
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalWriteFile = fs.writeFile;
+    const originalAppendFileSync = fs.appendFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_insert_policy_precheck`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.writeFile = fail('fs.writeFile');
+    fs.appendFileSync = fail('fs.appendFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (Object.prototype.hasOwnProperty.call(moduleOverrides, request)) {
+            return moduleOverrides[request];
+        }
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.writeFile = originalWriteFile;
+        fs.appendFileSync = originalAppendFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        Module._load = originalLoad;
+    });
+}
+
+function loadPolicyFresh() {
+    delete require.cache[SCRIPT_PATH];
+    delete require.cache[DRY_RUN_PATH];
+    delete require.cache[DUPLICATE_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function loadManifest() {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function baseCandidate(overrides = {}) {
+    return {
+        row_number: 1,
+        league_code: 'SP2',
+        league_name: 'Segunda Division',
+        season: '2024/2025',
+        match_date: '2024-08-17T17:30:00.000Z',
+        home_team: 'Synthetic Home Winners',
+        away_team: 'Synthetic Away Losers',
+        home_score: 1,
+        away_score: 0,
+        actual_result: 'home_win',
+        odds_preview: {
+            available: true,
+            values: {
+                home: 2.5,
+                draw: 3.1,
+                away: 2.9,
+            },
+        },
+        ...overrides,
+    };
+}
+
+function buildDryRunPayload(candidates, approvalStatus = 'dry_run_only') {
+    return {
+        ok: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        sha256_match: true,
+        row_count_match: true,
+        approval_status: approvalStatus,
+        source_name: 'unit_fixture',
+        parser_version: 'unit_parser',
+        dry_run_version: 'unit_dry_run',
+        candidate_rows: candidates,
+        row_classification: {
+            trainable_label_rows: candidates.length,
+        },
+        warnings: [],
+        errors: [],
+    };
+}
+
+function createMockClient(queryHandler = () => ({ rows: [] })) {
+    const calls = [];
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+            return queryHandler(String(sql), params);
+        },
+    };
+}
+
+function createDefaultQueryHandler(gate, options = {}) {
+    const maxLength = options.maxLength || 50;
+    return (sql, params = []) => {
+        if (sql === gate.MATCH_ID_COLUMN_SQL) {
+            return {
+                rows: [
+                    {
+                        column_name: 'match_id',
+                        data_type: 'character varying',
+                        character_maximum_length: maxLength,
+                        is_nullable: 'NO',
+                        column_default: null,
+                    },
+                ],
+            };
+        }
+        if (sql === gate.MATCHES_CONSTRAINT_SQL) {
+            return {
+                rows: [
+                    {
+                        constraint_name: 'matches_pkey',
+                        constraint_type: 'PRIMARY KEY',
+                        column_name: 'match_id',
+                    },
+                ],
+            };
+        }
+        if (params[0] === 'Exact Home' && params[1] === 'Exact Away') {
+            return { rows: [{ match_id: 'exact_1', home_team: 'Exact Home', away_team: 'Exact Away' }] };
+        }
+        if (params[0] === 'Reverse Away' && params[1] === 'Reverse Home') {
+            return { rows: [{ match_id: 'reversed_1', home_team: 'Reverse Away', away_team: 'Reverse Home' }] };
+        }
+        if (params[0] === 'Nearby Home' && String(sql).includes('BETWEEN')) {
+            return { rows: [{ match_id: 'nearby_1', home_team: 'Nearby Home', away_team: 'Nearby Away' }] };
+        }
+        return { rows: [] };
+    };
+}
+
+async function runMain(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: JSON.parse(stdout),
+    };
+}
+
+function assertSafetyPayload(payload) {
+    assert.equal(payload.select_only_db_reads, true);
+    assert.equal(payload.no_db_writes, true);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.would_insert_matches, false);
+    assert.equal(payload.would_insert_odds, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.commit_gate, 'blocked');
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('select_only_db_reads'));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_legacy_runtime'));
+    assert.ok(payload.non_execution_confirmations.includes('no_pg_dump_execution'));
+    assert.ok(payload.non_execution_confirmations.includes('no_training'));
+    assert.ok(payload.non_execution_confirmations.includes('no_prediction_execution'));
+}
+
+function assertSqlCallsAreReadOnly(gate, calls) {
+    assert.ok(calls.some(call => call.sql === gate.READ_ONLY_BEGIN_SQL));
+    assert.ok(calls.some(call => call.sql === gate.READ_ONLY_ROLLBACK_SQL));
+    for (const call of calls) {
+        gate.assertSelectOnlySql(call.sql);
+        const normalized = call.sql.replace(/\s+/g, ' ').trim().toUpperCase();
+        assert.ok(
+            normalized === 'BEGIN READ ONLY' || normalized === 'ROLLBACK' || normalized.startsWith('SELECT '),
+            `unexpected SQL: ${normalized}`
+        );
+        assert.doesNotMatch(
+            normalized,
+            /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|MERGE|GRANT|REVOKE|COMMIT)\b/
+        );
+    }
+}
+
+test('insert policy module 可以 import 且不加载 legacy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+
+    assert.equal(typeof gate.main, 'function');
+    assert.equal(typeof gate.runInsertPolicyPrecheck, 'function');
+    assert.equal(typeof gate.buildProposedMatchId, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('缺 source manifest 参数必须失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for missing args');
+    });
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /provide --source-manifest/);
+    assert.equal(payload.no_db_writes, true);
+});
+
+test('缺 local CSV 参数必须失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for missing args');
+    });
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /provide --source-manifest/);
+    assert.equal(payload.no_db_writes, true);
+});
+
+test('正确 manifest + CSV + mock DB client insert policy precheck 成功', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.66C_FOOTBALL_DATA_INSERT_POLICY');
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+    assert.equal(payload.dry_run_passed, true);
+    assert.equal(payload.duplicate_precheck_passed, true);
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(payload.manifest_approval_status, 'dry_run_only');
+    assert.equal(payload.match_id_strategy, 'fd_<league>_<season>_<date>_<home>_<away>_<hash8>');
+    assert.equal(payload.match_id_strategy_finalized, false);
+    assert.equal(payload.match_id_schema.match_id_max_length, 50);
+    assert.equal(payload.match_id_schema.match_id_primary_key, true);
+    assert.equal(payload.match_id_schema.match_id_unique, true);
+    assert.equal(payload.candidate_rows, 3);
+    assert.equal(payload.future_insert_candidates, 0);
+    assert.equal(payload.blocked_by_manifest_policy, 3);
+    assert.equal(payload.skip_existing_matches, 0);
+    assert.equal(payload.manual_review_required, 0);
+    assert.equal(payload.invalid_candidates, 0);
+    assert.ok(payload.candidate_previews.every(preview => preview.insert_policy === 'blocked_by_manifest_policy'));
+    assert.ok(payload.candidate_previews.every(preview => preview.proposed_match_id_length <= 50));
+    assertSafetyPayload(payload);
+    assertSqlCallsAreReadOnly(gate, client.calls);
+});
+
+test('deterministic match_id 对同一 candidate_identity_key 稳定', t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const candidate = baseCandidate();
+    const identityKey = gate.buildCandidateIdentityKey(candidate, 'unit_fixture');
+    const first = gate.buildProposedMatchId(candidate, {
+        sourceName: 'unit_fixture',
+        candidateIdentityKey: identityKey,
+        maxLength: 50,
+    });
+    const second = gate.buildProposedMatchId(candidate, {
+        sourceName: 'unit_fixture',
+        candidateIdentityKey: identityKey,
+        maxLength: 50,
+    });
+
+    assert.equal(first.proposed_match_id, second.proposed_match_id);
+    assert.equal(first.hash8, second.hash8);
+    assert.equal(first.proposed_match_id_valid_length, true);
+    assert.match(first.proposed_match_id, /^fd_[a-z0-9]+_[a-z0-9]+_[0-9]{8}_[a-z0-9_]+_[a-z0-9_]+_[a-f0-9]{8}$/);
+});
+
+test('match_id identity 不包含 score / actual_result / odds / row_number', t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const candidateA = baseCandidate({
+        row_number: 1,
+        home_score: 1,
+        away_score: 0,
+        actual_result: 'home_win',
+        odds_preview: { available: true, values: { home: 2.5 } },
+    });
+    const candidateB = baseCandidate({
+        row_number: 99,
+        home_score: 9,
+        away_score: 9,
+        actual_result: 'away_win',
+        odds_preview: { available: true, values: { home: 99.9 } },
+    });
+
+    const identityA = gate.buildCandidateIdentityKey(candidateA, 'unit_fixture');
+    const identityB = gate.buildCandidateIdentityKey(candidateB, 'unit_fixture');
+    const idA = gate.buildProposedMatchId(candidateA, {
+        sourceName: 'unit_fixture',
+        candidateIdentityKey: identityA,
+        maxLength: 50,
+    });
+    const idB = gate.buildProposedMatchId(candidateB, {
+        sourceName: 'unit_fixture',
+        candidateIdentityKey: identityB,
+        maxLength: 50,
+    });
+
+    assert.equal(identityA, identityB);
+    assert.equal(idA.proposed_match_id, idB.proposed_match_id);
+    assert.doesNotMatch(identityA, /home_win|away_win|99\.9|row_number/);
+    assert.doesNotMatch(idA.proposed_match_id, /home_win|away_win|99/);
+});
+
+test('proposed_match_id 不超过模拟 schema 最大长度', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const client = createMockClient(createDefaultQueryHandler(gate, { maxLength: 50 }));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.ok(payload.candidate_previews.every(preview => preview.proposed_match_id_length <= 50));
+    assert.ok(payload.candidate_previews.every(preview => preview.proposed_match_id_valid_length));
+});
+
+test('schema 缺少 match_id 长度时默认使用 64 并保留 unique 约束信息', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const schema = gate.deriveMatchIdSchema(
+        [],
+        [
+            {
+                constraint_name: 'matches_match_id_key',
+                constraint_type: 'UNIQUE',
+                column_name: 'match_id',
+            },
+        ]
+    );
+
+    assert.equal(schema.match_id_column_found, false);
+    assert.equal(schema.match_id_max_length, 64);
+    assert.equal(schema.match_id_max_length_source, 'default_64');
+    assert.equal(schema.match_id_primary_key, false);
+    assert.equal(schema.match_id_unique, true);
+});
+
+test('过短 match_id 长度限制必须失败而不是输出非法 proposed_match_id', t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+
+    assert.throws(
+        () =>
+            gate.buildProposedMatchId(baseCandidate(), {
+                sourceName: 'unit_fixture',
+                maxLength: 10,
+            }),
+        /cannot fit match_id max length/
+    );
+});
+
+test('dry_run_only manifest 下 policy 必须 blocked_by_manifest_policy', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const candidate = baseCandidate();
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload([candidate], 'dry_run_only'),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.future_insert_candidates, 0);
+    assert.equal(payload.blocked_by_manifest_policy, 1);
+    assert.equal(payload.candidate_previews[0].insert_policy, 'blocked_by_manifest_policy');
+    assert.equal(payload.candidate_previews[0].would_insert_match, false);
+});
+
+test('缺少 duplicate preview 时 candidate 必须按 invalid_candidate 处理', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const candidate = baseCandidate();
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload([candidate], 'approved_for_db_write'),
+            duplicatePreviews: [],
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.invalid_candidates, 1);
+    assert.equal(payload.candidate_previews[0].duplicate_risk, 'invalid_candidate');
+    assert.equal(payload.candidate_previews[0].insert_policy, 'invalid_candidate');
+});
+
+test('approved_for_db_write manifest + clean candidate 只能成为 future_insert_candidate preview', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const approvedManifest = {
+        ...loadManifest(),
+        approval_status: 'approved_for_db_write',
+    };
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            dryRunDependencies: {
+                readManifest: () => approvedManifest,
+            },
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.manifest_approval_status, 'approved_for_db_write');
+    assert.equal(payload.future_insert_candidates, 3);
+    assert.ok(payload.candidate_previews.every(preview => preview.insert_policy === 'future_insert_candidate'));
+    assert.ok(payload.candidate_previews.every(preview => preview.would_insert_match === false));
+    assert.equal(payload.would_write_db, false);
+});
+
+test('exact existing match 必须 skip_existing_match', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const candidate = baseCandidate({
+        home_team: 'Exact Home',
+        away_team: 'Exact Away',
+    });
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload([candidate], 'approved_for_db_write'),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.skip_existing_matches, 1);
+    assert.equal(payload.candidate_previews[0].duplicate_risk, 'exact_existing_match');
+    assert.equal(payload.candidate_previews[0].insert_policy, 'skip_existing_match');
+    assert.equal(payload.candidate_previews[0].skip_reason, 'exact_existing_match');
+});
+
+test('reversed / nearby duplicate 必须 manual_review_required', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const candidates = [
+        baseCandidate({
+            row_number: 1,
+            home_team: 'Reverse Home',
+            away_team: 'Reverse Away',
+        }),
+        baseCandidate({
+            row_number: 2,
+            home_team: 'Nearby Home',
+            away_team: 'Nearby Away',
+        }),
+    ];
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload(candidates, 'approved_for_db_write'),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.manual_review_required, 2);
+    assert.equal(payload.candidate_previews[0].duplicate_risk, 'reversed_teams_possible_duplicate');
+    assert.equal(payload.candidate_previews[0].insert_policy, 'manual_review_required');
+    assert.equal(payload.candidate_previews[1].duplicate_risk, 'nearby_date_possible_duplicate');
+    assert.equal(payload.candidate_previews[1].insert_policy, 'manual_review_required');
+});
+
+test('invalid candidate 必须 invalid_candidate 且不进入 future insert', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const candidate = baseCandidate({
+        match_date: '',
+        actual_result: '',
+    });
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload([candidate], 'approved_for_db_write'),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.invalid_candidates, 1);
+    assert.equal(payload.future_insert_candidates, 0);
+    assert.equal(payload.candidate_previews[0].duplicate_risk, 'invalid_candidate');
+    assert.equal(payload.candidate_previews[0].insert_policy, 'invalid_candidate');
+    assert.equal(payload.candidate_previews[0].would_insert_match, false);
+});
+
+test('--commit 必须 blocked，即使提供 manifest 和 CSV', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const result = await runMain(gate, [
+        '--source-manifest',
+        MANIFEST_PATH,
+        '--local-csv',
+        CSV_PATH,
+        '--commit',
+        '--json',
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'blocked-commit');
+    assert.equal(result.payload.blocked, true);
+    assert.match(result.payload.blocked_reason, /not wired in Phase 4\.66C/);
+    assertSafetyPayload(result.payload);
+});
+
+test('main --help 输出 usage 且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    let stdout = '';
+    const status = await gate.main(['--help'], {
+        stdout: text => {
+            stdout += text;
+        },
+    });
+
+    assert.equal(status, 0);
+    assert.match(stdout, /football_data_insert_policy_precheck\.js/);
+    assert.match(stdout, /Phase 4\.66C is SELECT-only insert policy preview/);
+});
+
+test('main runtime error 返回 runtime-error payload', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const result = await runMain(gate, ['--unknown-option', '--json']);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.ok, false);
+    assert.equal(result.payload.mode, 'runtime-error');
+    assert.match(result.payload.errors[0], /Unknown argument/);
+});
+
+test('sha256 mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const manifest = {
+        ...loadManifest(),
+        sha256: '0'.repeat(64),
+    };
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for sha256 mismatch');
+    });
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            dryRunDependencies: {
+                readManifest: () => manifest,
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'dry-run-failed');
+    assert.equal(payload.dry_run_passed, false);
+    assert.equal(payload.sha256_match, false);
+    assert.equal(payload.row_count_match, true);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /sha256 mismatch/);
+});
+
+test('row_count mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const manifest = {
+        ...loadManifest(),
+        row_count: 99,
+    };
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for row_count mismatch');
+    });
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            dryRunDependencies: {
+                readManifest: () => manifest,
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'dry-run-failed');
+    assert.equal(payload.dry_run_passed, false);
+    assert.equal(payload.sha256_match, true);
+    assert.equal(payload.row_count_match, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /row_count mismatch/);
+});
+
+test('SQL guard 只允许 SELECT / BEGIN READ ONLY / ROLLBACK', t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.READ_ONLY_BEGIN_SQL));
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.MATCH_ID_COLUMN_SQL));
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.MATCHES_CONSTRAINT_SQL));
+    assert.doesNotThrow(() => gate.assertSelectOnlySql(gate.READ_ONLY_ROLLBACK_SQL));
+    assert.throws(() => gate.assertSelectOnlySql('INSERT INTO matches VALUES ($1)'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('UPDATE matches SET status = $1'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('DELETE FROM matches'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('CREATE TABLE unsafe_table(id int)'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('COMMIT'), /Unsafe SQL/);
+    assert.throws(() => gate.assertSelectOnlySql('SELECT 1; DROP TABLE matches'), /Unsafe SQL/);
+});
+
+test('文本输出包含策略摘要、candidate preview 和 non-execution confirmations', async t => {
+    installExecutionGuards(t);
+    const gate = loadPolicyFresh();
+    const client = createMockClient(createDefaultQueryHandler(gate));
+    const payload = await gate.runInsertPolicyPrecheck(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+    const text = gate.payloadToText(payload);
+
+    assert.match(text, /phase=PHASE4\.66C_FOOTBALL_DATA_INSERT_POLICY/);
+    assert.match(text, /duplicate_precheck_passed=true/);
+    assert.match(text, /match_id_strategy=fd_<league>_<season>_<date>_<home>_<away>_<hash8>/);
+    assert.match(text, /match_id_strategy_finalized=false/);
+    assert.match(text, /blocked_by_manifest_policy=3/);
+    assert.match(text, /candidate_previews=/);
+    assert.match(text, /proposed_match_id/);
+    assert.match(text, /no_external_network/);
+    assert.match(text, /no_db_writes/);
+    assert.match(text, /no_file_writes/);
+    assert.match(text, /no_pg_dump_execution/);
+});
+
+test('source 文本不引用 legacy downloader、child_process 或文件写入 API', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+    assert.doesNotMatch(source, /fetch_and_adapt_euro_leagues/);
+    assert.doesNotMatch(source, /child_process/);
+    assert.doesNotMatch(source, /spawn\(/);
+    assert.doesNotMatch(source, /execFile\(/);
+    assert.doesNotMatch(source, /writeFile/);
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.66C football-data deterministic match_id strategy and insert candidate policy precheck.

Scope:
- Adds football_data_insert_policy_precheck
- Adds deterministic proposed match_id preview
- Adds insert candidate policy decisions
- Adds Makefile precheck and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.66C report

Safety:
- No DB writes
- SELECT-only DB reads only
- No pg_dump execution
- No file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- insert policy precheck passed
- insert policy commit gate remained blocked
- CSV dry-run still passed
- DB write preflight still passed
- duplicate precheck still passed
- legacy acquisition gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed