### PR TITLE
feat(data): add football-data small write auth preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -572,9 +572,11 @@ Phase 4.57C football-data adapter rules：
 - `data-football-data-db-write-preflight` 不得触网、不得读 / 写 DB、不得执行 `pg_dump`、不得写文件、不得 import legacy downloader runtime；`make data-football-data-db-write-commit` 当前 blocked / not wired。
 - Phase 4.65C 的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是入库前 SELECT-only duplicate / existing match precheck；只能读取本地 manifest / CSV 并对 DB 执行 `BEGIN READ ONLY` + `SELECT` + `ROLLBACK`。
 - `data-football-data-duplicate-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-duplicate-precheck-commit` 当前 blocked / not wired。
+- Phase 4.67C 的 `make data-football-data-small-write-auth-preview SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 small DB write 授权预览；只能读取本地 manifest / CSV，复用 dry-run / preflight / duplicate / insert policy 结果，并执行 SELECT-only DB row count / schema inspection。
+- `data-football-data-small-write-auth-preview` 不得写 DB、不得执行 `pg_dump`、不得执行 `pg_restore`、不得写 backup 文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-small-write-commit` 当前 blocked / not wired。
 - Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。
 - `data-football-data-insert-policy-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-insert-policy-commit` 当前 blocked / not wired。
-- future DB write 必须单独阶段、单独授权、真实 `pg_dump`、small batch、post-write validation；DB write 前后 training / prediction 仍必须走单独 gate。
+- future real DB write 必须单独阶段、单独授权、真实 `pg_dump`、非空备份验证、small batch transaction、post-write validation；restore 也必须单独授权，不得自动执行；DB write 前后 training / prediction 仍必须走单独 gate。
 - 未来 football-data network dry-run 仍需单独授权；未来任何 DB write 仍需单独授权并先完成 `pg_dump`。
 - 未来 local CSV adapter 必须由 source manifest + 本地 CSV 驱动，不得下载 Football-Data CSV，不得写 staging / DB，不得训练或预测。
 - 任何 DB write 必须另行授权并先完成 `pg_dump`；不得把 legacy downloader 直接接到 training / prediction。

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
         data-football-data-duplicate-precheck data-football-data-duplicate-precheck-commit \
+        data-football-data-small-write-auth-preview data-football-data-small-write-commit \
         data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
@@ -267,6 +268,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-db-write-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-duplicate-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
+	@echo "  make data-football-data-small-write-auth-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
@@ -561,6 +563,24 @@ data-football-data-duplicate-precheck-commit: ## Blocked Football-Data duplicate
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data duplicate precheck commit is not wired in Phase 4.65C."
+	@exit 1
+
+data-football-data-small-write-auth-preview: ## Preview future Football-Data small DB write authorization checklist. Requires SOURCE_MANIFEST and LOCAL_CSV.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path> and LOCAL_CSV=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data small DB write authorization preview: SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_small_write_auth_preview.js --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)"
+
+data-football-data-small-write-commit: ## Blocked Football-Data small DB write commit gate. Requires CONFIRM_FOOTBALL_DATA_SMALL_WRITE=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_SMALL_WRITE)" != "1" ]; then \
+		echo "BLOCKED: football-data small DB write requires CONFIRM_FOOTBALL_DATA_SMALL_WRITE=1 and is not wired in Phase 4.67C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data small DB write commit is not wired in Phase 4.67C."
 	@exit 1
 
 data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.

--- a/docs/_reports/FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW_PHASE4_67C.md
+++ b/docs/_reports/FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW_PHASE4_67C.md
@@ -1,0 +1,290 @@
+# Football-Data Small Write Authorization Preview - Phase 4.67C
+
+## 当前状态
+
+- HEAD: `984066e26a3c540ccd3c37d890c54e4769fb4182`
+- 分支: `feat/football-data-small-write-auth-phase467c`
+- 主题: future small DB write authorization checklist + `pg_dump` command preview。
+
+本阶段适合做一个稍大的主题 PR，因为 future small DB write 不能只看单一 gate。授权条件、`pg_dump` 预案、post-write validation、rollback/restore preview、以及对 Phase 4.63C / 4.64C / 4.65C / 4.66C gate 的复用，必须一起固定下来，才能避免未来写库阶段临时拼 runbook。
+
+## 新增 / 修改文件
+
+新增:
+
+- `scripts/ops/football_data_small_write_auth_preview.js`
+- `tests/unit/football_data_small_write_auth_preview.test.js`
+- `docs/_reports/FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW_PHASE4_67C.md`
+
+修改:
+
+- `Makefile`
+- `AGENTS.md`
+
+## Small Write Authorization Preview 设计
+
+新增 gate:
+
+```bash
+make data-football-data-small-write-auth-preview \
+  SOURCE_MANIFEST=<path> \
+  LOCAL_CSV=<path>
+```
+
+它只做 preview，不写库。实现顺序:
+
+1. 读取本地 source manifest。
+2. 读取本地 CSV。
+3. 复用 Phase 4.63C local CSV dry-run。
+4. 复用 Phase 4.64C DB write preflight。
+5. 复用 Phase 4.65C duplicate precheck。
+6. 复用 Phase 4.66C insert policy precheck。
+7. 对 DB 做 SELECT-only row count / schema preview。
+8. 输出 future authorization checklist、`pg_dump` command preview、post-write validation checklist、rollback/restore preview。
+
+输出强制保持:
+
+- `db_write_allowed=false`
+- `small_write_authorized=false`
+- `would_execute_pg_dump=false`
+- `would_execute_pg_restore=false`
+- `would_insert_matches=false`
+- `would_insert_odds=false`
+- `would_write_db=false`
+- `commit_gate=blocked`
+
+## SELECT-only DB Inspection
+
+本阶段允许:
+
+- `BEGIN READ ONLY`
+- `SELECT`
+- `ROLLBACK`
+
+preview 只读取:
+
+- `matches`
+- `bookmaker_odds_history`
+- `raw_match_data`
+- `l3_features`
+- `match_features_training`
+- `predictions`
+
+并预览 `matches.match_id` 基本 schema 状态。没有 `INSERT` / `UPDATE` / `DELETE` / `CREATE` / `ALTER` / `DROP` / `TRUNCATE` / `COPY` / `\copy`。
+
+## pg_dump Command Preview
+
+本阶段输出 command preview string，但明确未执行:
+
+```text
+docker compose -f docker-compose.dev.yml exec -T db pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc > data/backups/<timestamp>_pre_football_data_small_write.dump
+```
+
+说明:
+
+- 只是 preview string。
+- 不执行 `pg_dump`。
+- 不创建 `data/backups`。
+- 不创建 backup 文件。
+- 不校验 backup 文件存在性，因为本阶段没有真实 backup。
+
+## pg_restore / Rollback Preview
+
+本阶段同样只输出 preview:
+
+- restore 不自动执行。
+- backup path 必须由人工确认。
+- restore 需要单独 restore authorization。
+- restore command 必须被文档化，但本阶段不执行。
+
+## Required Before Small DB Write
+
+future small DB write 前必须满足:
+
+- source manifest `approval_status` 必须为 `approved_for_db_write`
+- human approval note 必须指向 exact source 和 exact CSV
+- operator 必须在未来阶段提供 `CONFIRM_FOOTBALL_DATA_SMALL_WRITE=1`
+- deterministic `match_id` strategy 必须被接受
+- duplicate policy 必须被接受
+- exact existing matches 不得插入
+- manual review candidates 不得插入
+- max insert rows 必须显式给出
+- target tables 必须显式给出
+- `pg_dump` 必须在写入前立即执行
+- backup file 必须非空
+- write transaction 必须 small and auditable
+- post-write row counts 必须校验
+- inserted `match_id` 列表必须记录
+- downstream training / prediction 继续 blocked
+
+## Post-write Validation Checklist
+
+future post-write validation preview:
+
+- compare before/after row counts
+- verify inserted `match_id` only
+- verify no odds insert unless explicitly authorized
+- verify no raw / l3 / training / prediction writes
+- rerun dataset status
+- rerun duplicate precheck
+- record backup path
+- record commit hash / report path
+
+## 为什么本阶段仍不写 DB
+
+原因明确:
+
+- 目前只有 authorization preview，没有真实 small write phase 授权。
+- commit gate 仍 blocked。
+- 本阶段目标是固定 checklist、backup preview、rollback preview，不是执行写入。
+- 真实 write 仍需要单独阶段、单独授权、真实 `pg_dump`、small batch transaction 和 post-write validation。
+
+## 为什么本阶段仍不执行 pg_dump
+
+原因明确:
+
+- `pg_dump` 属于真实 backup 动作，不是 preview。
+- 本阶段只允许 command preview，不允许创建 backup 文件。
+- 没有真实 write authorization，就不应制造“像执行过备份一样”的假状态。
+
+## Commit Gate Blocked 结果
+
+新增 blocked gate:
+
+```bash
+make data-football-data-small-write-commit \
+  SOURCE_MANIFEST=<path> \
+  LOCAL_CSV=<path> \
+  CONFIRM_FOOTBALL_DATA_SMALL_WRITE=1
+```
+
+当前固定输出:
+
+```text
+BLOCKED: football-data small DB write commit is not wired in Phase 4.67C.
+```
+
+即使带确认变量也仍然 blocked。
+
+## 复验结果
+
+small write auth preview:
+
+- 缺参数按预期失败。
+- fixture preview 成功。
+- `db_write_allowed=false`
+- `small_write_authorized=false`
+- `would_execute_pg_dump=false`
+- `would_execute_pg_restore=false`
+- `would_write_db=false`
+- `no_external_network`
+- `select_only_db_reads`
+- `no_db_writes`
+- `no_file_writes`
+- `no_pg_dump_execution`
+- `no_pg_restore_execution`
+
+旧 gates 复验:
+
+- `make data-football-data-csv-dry-run ...`: 通过。
+- `make data-football-data-db-write-preflight ...`: 通过。
+- `make data-football-data-duplicate-precheck ...`: 通过。
+- `make data-football-data-insert-policy-precheck ...`: 通过。
+- `make data-football-data-csv-commit ... CONFIRM_FOOTBALL_DATA_CSV_COMMIT=1`: blocked。
+- `make data-football-data-db-write-commit ... CONFIRM_FOOTBALL_DATA_DB_WRITE=1`: blocked。
+- `make data-football-data-duplicate-precheck-commit ... CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1`: blocked。
+- `make data-football-data-insert-policy-commit ... CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1`: blocked。
+- `make data-acquisition-engine-audit`: 通过。
+- `make data-single-target-network-dry-run ...`: scaffold blocked，`would_access_network=false`、`would_write_db=false`、`would_execute_engine=false`。
+- `make data-single-target-network-commit ... CONFIRM_SINGLE_TARGET_NETWORK=1`: blocked。
+
+## Unit Tests
+
+新增 `tests/unit/football_data_small_write_auth_preview.test.js`，覆盖:
+
+- 缺 manifest 失败。
+- 缺 CSV 失败。
+- 正确 manifest + CSV + mock DB client 成功。
+- `pg_dump` preview string 存在但不执行。
+- required checklist 存在。
+- post-write validation checklist 存在。
+- rollback/restore preview 存在。
+- `dry_run_only` 时 `small_write_authorized=false`。
+- `approved_for_db_write` 时也仍然 `small_write_authorized=false`。
+- `--commit` blocked。
+- `sha256 mismatch` 时失败且不查 DB。
+- `row_count mismatch` 时失败且不查 DB。
+- SQL 只允许 `BEGIN READ ONLY` / `SELECT` / `ROLLBACK`。
+- 不 import legacy runtime。
+- 不触网。
+- 不写文件。
+- 不 spawn child process。
+- 不执行 `pg_dump`。
+- 不执行 `pg_restore`。
+
+## npm test / coverage
+
+本阶段要求:
+
+- `npm test` 通过。
+- `npm run test:coverage` 通过。
+- coverage threshold 保持不变:
+    - lines >= 80
+    - functions >= 80
+    - branches >= 80
+
+## DB 前后统计
+
+执行前预期:
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |    2 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+本阶段要求全部验证后仍保持:
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |    2 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+## 下一步建议
+
+- Phase 4.68C: prepare real small DB write runbook template + approval form，不写 DB，不执行 `pg_dump`。
+- 或 Phase 4.56A: 用户给齐真实 network dry-run 参数后再做 runbook。
+
+## 明确未执行
+
+- DB writes
+- non-SELECT DB SQL
+- `pg_dump` execution
+- `pg_restore` execution
+- backup file writes
+- preview runtime file writes
+- external download
+- `curl` / `wget` / `git clone`
+- 外部足球数据源访问
+- 外部赔率数据源访问
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- network dry-run 真执行
+- bulk harvest
+- adapted CSV / staging 数据写入
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume 清理
+- force push
+- `git fetch --all`
+- `git pull`
+- 删除文件

--- a/scripts/ops/football_data_small_write_auth_preview.js
+++ b/scripts/ops/football_data_small_write_auth_preview.js
@@ -1,0 +1,723 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+
+const { parseArgs: parseDryRunArgs, runDryRun } = require('./football_data_adapter_dry_run');
+const { runPreflight } = require('./football_data_db_write_preflight');
+const {
+    runDuplicatePrecheck,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    buildDbConfig,
+    assertSelectOnlySql,
+} = require('./football_data_duplicate_precheck');
+const { runInsertPolicyPrecheck } = require('./football_data_insert_policy_precheck');
+
+const SMALL_WRITE_AUTH_PHASE = 'PHASE4.67C_FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW';
+const APPROVED_FOR_DB_WRITE = 'approved_for_db_write';
+const APPROVED_FOR_DRY_RUN = 'approved_for_dry_run';
+const PG_DUMP_COMMAND_PREVIEW =
+    'docker compose -f docker-compose.dev.yml exec -T db pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc > data/backups/<timestamp>_pre_football_data_small_write.dump';
+const PG_RESTORE_COMMAND_PREVIEW =
+    'docker compose -f docker-compose.dev.yml exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists <backup_path>';
+const CURRENT_DB_TABLES = [
+    'matches',
+    'bookmaker_odds_history',
+    'raw_match_data',
+    'l3_features',
+    'match_features_training',
+    'predictions',
+];
+
+const CURRENT_DB_COUNTS_SQL = `
+SELECT table_name, rows
+FROM (
+    SELECT 'matches' AS table_name, COUNT(*)::bigint AS rows, 1 AS sort_order FROM matches
+    UNION ALL
+    SELECT 'bookmaker_odds_history', COUNT(*)::bigint, 2 FROM bookmaker_odds_history
+    UNION ALL
+    SELECT 'raw_match_data', COUNT(*)::bigint, 3 FROM raw_match_data
+    UNION ALL
+    SELECT 'l3_features', COUNT(*)::bigint, 4 FROM l3_features
+    UNION ALL
+    SELECT 'match_features_training', COUNT(*)::bigint, 5 FROM match_features_training
+    UNION ALL
+    SELECT 'predictions', COUNT(*)::bigint, 6 FROM predictions
+) counts
+ORDER BY sort_order
+`;
+
+const REQUIRED_TABLES_SQL = `
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_name IN (
+      'matches',
+      'bookmaker_odds_history',
+      'raw_match_data',
+      'l3_features',
+      'match_features_training',
+      'predictions'
+  )
+ORDER BY table_name
+`;
+
+const MATCH_ID_SCHEMA_SQL = `
+SELECT column_name, data_type, character_maximum_length, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'matches'
+  AND column_name = 'match_id'
+LIMIT 1
+`;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_small_write_auth_preview.js --source-manifest <path> --local-csv <path> [--json]',
+        '  node scripts/ops/football_data_small_write_auth_preview.js --source-manifest <path> --local-csv <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.67C is authorization preview only. No DB writes, no pg_dump execution, no pg_restore execution.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    return parseDryRunArgs(argv);
+}
+
+function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function createPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+async function withDbClient(dependencies, callback) {
+    if (dependencies.dbClient) {
+        return callback(dependencies.dbClient);
+    }
+
+    const pool = dependencies.pool || createPool();
+    const client = await pool.connect();
+    try {
+        return await callback(client);
+    } finally {
+        client.release();
+        if (!dependencies.pool && typeof pool.end === 'function') {
+            await pool.end();
+        }
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+function buildRequiredBeforeSmallDbWrite() {
+    return [
+        'source manifest approval_status must be approved_for_db_write',
+        'human approval note must identify exact source and exact CSV file',
+        'operator must provide CONFIRM_FOOTBALL_DATA_SMALL_WRITE=1 in future phase',
+        'deterministic match_id strategy must be accepted',
+        'duplicate policy must be accepted',
+        'exact existing matches must not be inserted',
+        'manual review candidates must not be inserted',
+        'max insert rows must be explicit',
+        'target tables must be explicit',
+        'pg_dump backup must run immediately before write',
+        'backup file must be non-empty',
+        'write transaction must be small and auditable',
+        'post-write row counts must be validated',
+        'target inserted match_ids must be listed',
+        'downstream training/prediction must remain blocked',
+    ];
+}
+
+function buildPostWriteValidationChecklist() {
+    return [
+        'compare before/after row counts',
+        'verify inserted match_ids only',
+        'verify no odds insert unless explicitly authorized',
+        'verify no raw/l3/training/prediction writes',
+        'rerun dataset status',
+        'rerun duplicate precheck',
+        'record backup path',
+        'record commit hash / report path',
+    ];
+}
+
+function buildRollbackRestorePreview() {
+    return [
+        'restore is not executed automatically',
+        'backup path must be reviewed by human',
+        'restore would require explicit restore authorization',
+        'restore command must be documented but not executed',
+    ];
+}
+
+function buildApprovalRequirements() {
+    return [
+        'approved_for_db_write source manifest',
+        'exact source + CSV human approval note',
+        'future CONFIRM_FOOTBALL_DATA_SMALL_WRITE=1 authorization',
+        'explicit max_rows and target_tables decision',
+    ];
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'select_only_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_legacy_runtime',
+        'no_pg_dump_execution',
+        'no_pg_restore_execution',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        select_only_db_reads: true,
+        db_write_allowed: false,
+        small_write_authorized: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_execute_legacy_runtime: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+        would_load_model_artifact: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: SMALL_WRITE_AUTH_PHASE,
+        mode: fields.mode || 'football-data-small-write-auth-preview',
+        ok: false,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        source_manifest_found: false,
+        local_csv_found: false,
+        csv_dry_run_passed: false,
+        db_write_preflight_passed: false,
+        duplicate_precheck_passed: false,
+        insert_policy_precheck_passed: false,
+        manifest_approval_status: null,
+        sha256_match: false,
+        row_count_match: false,
+        commit_gate: 'blocked',
+        current_db_counts: null,
+        current_db_schema_preview: null,
+        max_rows_preview: null,
+        target_tables_preview: ['matches', 'bookmaker_odds_history'],
+        approval_requirements: buildApprovalRequirements(),
+        pg_dump_command_preview: PG_DUMP_COMMAND_PREVIEW,
+        pg_restore_command_preview: PG_RESTORE_COMMAND_PREVIEW,
+        required_before_small_db_write: buildRequiredBeforeSmallDbWrite(),
+        post_write_validation: buildPostWriteValidationChecklist(),
+        rollback_restore_preview: buildRollbackRestorePreview(),
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: 'BLOCKED: football-data small DB write commit is not wired in Phase 4.67C.',
+        errors: ['BLOCKED: football-data small DB write commit is not wired in Phase 4.67C.'],
+    });
+}
+
+function buildManifestCompatibleDryRun(dependencies = {}) {
+    if (dependencies.runDryRun) {
+        return args => dependencies.runDryRun(args);
+    }
+
+    const dryRunDependencies = {
+        ...(dependencies.dryRunDependencies || {}),
+    };
+    const readManifest = dryRunDependencies.readManifest || readJsonFile;
+    let manifestApprovalStatus = null;
+
+    dryRunDependencies.readManifest = manifestPath => {
+        const manifest = readManifest(manifestPath);
+        manifestApprovalStatus = manifest.approval_status || null;
+        if (manifest.approval_status === APPROVED_FOR_DB_WRITE) {
+            return {
+                ...manifest,
+                approval_status: APPROVED_FOR_DRY_RUN,
+            };
+        }
+        return manifest;
+    };
+
+    return args => {
+        const payload = runDryRun(args, dryRunDependencies);
+        if (payload.ok && manifestApprovalStatus) {
+            return {
+                ...payload,
+                approval_status: manifestApprovalStatus,
+            };
+        }
+        return payload;
+    };
+}
+
+function mapCurrentDbCounts(rows) {
+    const mapped = {};
+    for (const tableName of CURRENT_DB_TABLES) {
+        mapped[tableName] = 0;
+    }
+    for (const row of rows || []) {
+        mapped[row.table_name] = Number.parseInt(row.rows, 10);
+    }
+    return mapped;
+}
+
+function buildSchemaPreview(requiredTables, matchIdRow) {
+    return {
+        required_tables_found: requiredTables,
+        required_tables_expected: CURRENT_DB_TABLES,
+        matches_match_id: matchIdRow
+            ? {
+                  column_name: matchIdRow.column_name,
+                  data_type: matchIdRow.data_type,
+                  character_maximum_length: matchIdRow.character_maximum_length,
+                  is_nullable: matchIdRow.is_nullable,
+              }
+            : null,
+    };
+}
+
+function valueOrNull(value) {
+    return value === undefined ? null : value;
+}
+
+function countOrZero(value) {
+    return value || 0;
+}
+
+function buildIdentityFields(dryRunPayload, insertPolicyPayload) {
+    return {
+        manifest_approval_status: insertPolicyPayload.manifest_approval_status || dryRunPayload.approval_status || null,
+        source_name: valueOrNull(dryRunPayload.source_name),
+        parser_version: valueOrNull(dryRunPayload.parser_version),
+        csv_dry_run_version: valueOrNull(dryRunPayload.dry_run_version),
+    };
+}
+
+function buildPhaseFields(preflightPayload, duplicatePayload, insertPolicyPayload) {
+    return {
+        db_write_preflight_phase: valueOrNull(preflightPayload.phase),
+        duplicate_precheck_phase: valueOrNull(duplicatePayload.phase),
+        insert_policy_precheck_phase: valueOrNull(insertPolicyPayload.phase),
+    };
+}
+
+function buildCandidateFields(dryRunPayload, duplicatePayload, insertPolicyPayload) {
+    return {
+        candidate_rows: dryRunPayload.candidate_rows.length,
+        trainable_label_rows: countOrZero((dryRunPayload.row_classification || {}).trainable_label_rows),
+        exact_existing_matches: countOrZero(duplicatePayload.exact_existing_matches),
+        reversed_team_matches: countOrZero(duplicatePayload.reversed_team_matches),
+        nearby_date_matches: countOrZero(duplicatePayload.nearby_date_matches),
+        invalid_candidates: countOrZero(insertPolicyPayload.invalid_candidates),
+        future_insert_candidates: countOrZero(insertPolicyPayload.future_insert_candidates),
+        blocked_by_manifest_policy: countOrZero(insertPolicyPayload.blocked_by_manifest_policy),
+        skip_existing_matches: countOrZero(insertPolicyPayload.skip_existing_matches),
+        manual_review_required: countOrZero(insertPolicyPayload.manual_review_required),
+        max_rows_preview: dryRunPayload.candidate_rows.length,
+    };
+}
+
+function buildNonExecutionEchoFields(dryRunPayload, duplicatePayload, insertPolicyPayload) {
+    return {
+        dry_run_non_execution_confirmations: dryRunPayload.non_execution_confirmations || [],
+        duplicate_precheck_non_execution_confirmations: duplicatePayload.non_execution_confirmations || [],
+        insert_policy_non_execution_confirmations: insertPolicyPayload.non_execution_confirmations || [],
+    };
+}
+
+function mergeWarnings(dryRunPayload, preflightPayload, duplicatePayload, insertPolicyPayload) {
+    return [
+        ...(dryRunPayload.warnings || []),
+        ...(preflightPayload.warnings || []),
+        ...(duplicatePayload.warnings || []),
+        ...(insertPolicyPayload.warnings || []),
+    ];
+}
+
+async function inspectCurrentDbState(dependencies = {}) {
+    if (dependencies.inspectCurrentDbState) {
+        return dependencies.inspectCurrentDbState();
+    }
+
+    return withDbClient(dependencies, async client => {
+        await querySelectOnly(client, READ_ONLY_BEGIN_SQL);
+        try {
+            const countsResult = await querySelectOnly(client, CURRENT_DB_COUNTS_SQL);
+            const requiredTablesResult = await querySelectOnly(client, REQUIRED_TABLES_SQL);
+            const matchIdSchemaResult = await querySelectOnly(client, MATCH_ID_SCHEMA_SQL);
+            return {
+                current_db_counts: mapCurrentDbCounts(countsResult.rows || []),
+                current_db_schema_preview: buildSchemaPreview(
+                    (requiredTablesResult.rows || []).map(row => row.table_name),
+                    (matchIdSchemaResult.rows || [])[0] || null
+                ),
+            };
+        } finally {
+            await querySelectOnly(client, READ_ONLY_ROLLBACK_SQL);
+        }
+    });
+}
+
+function buildSuccessPayload(args, dryRunPayload, preflightPayload, duplicatePayload, insertPolicyPayload, dbState) {
+    const identityFields = buildIdentityFields(dryRunPayload, insertPolicyPayload);
+    const phaseFields = buildPhaseFields(preflightPayload, duplicatePayload, insertPolicyPayload);
+    const candidateFields = buildCandidateFields(dryRunPayload, duplicatePayload, insertPolicyPayload);
+    const nonExecutionEchoFields = buildNonExecutionEchoFields(dryRunPayload, duplicatePayload, insertPolicyPayload);
+    return {
+        phase: SMALL_WRITE_AUTH_PHASE,
+        mode: 'football-data-small-write-auth-preview',
+        ok: true,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        csv_dry_run_passed: true,
+        db_write_preflight_passed: true,
+        duplicate_precheck_passed: true,
+        insert_policy_precheck_passed: true,
+        ...identityFields,
+        ...phaseFields,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        ...candidateFields,
+        commit_gate: 'blocked',
+        current_db_counts: dbState.current_db_counts,
+        current_db_schema_preview: dbState.current_db_schema_preview,
+        target_tables_preview: ['matches', 'bookmaker_odds_history'],
+        approval_requirements: buildApprovalRequirements(),
+        pg_dump_command_preview: PG_DUMP_COMMAND_PREVIEW,
+        pg_restore_command_preview: PG_RESTORE_COMMAND_PREVIEW,
+        required_before_small_db_write: buildRequiredBeforeSmallDbWrite(),
+        post_write_validation: buildPostWriteValidationChecklist(),
+        rollback_restore_preview: buildRollbackRestorePreview(),
+        small_write_authorized_reason:
+            'Phase 4.67C only previews future small DB write authorization requirements; real DB write remains blocked.',
+        db_write_allowed_reason:
+            'Phase 4.67C does not execute small DB writes, pg_dump, or pg_restore even when manifest approval_status is approved_for_db_write.',
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        ...nonExecutionEchoFields,
+        warnings: mergeWarnings(dryRunPayload, preflightPayload, duplicatePayload, insertPolicyPayload),
+        errors: [],
+    };
+}
+
+function buildDryRunFailurePayload(args, dryRunPayload) {
+    return buildFailurePayload(args, {
+        mode: 'csv-dry-run-failed',
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        manifest_approval_status: dryRunPayload.approval_status || null,
+        select_only_db_reads: false,
+        errors: dryRunPayload.errors || ['football-data CSV dry-run failed'],
+        warnings: dryRunPayload.warnings || [],
+    });
+}
+
+function buildPreflightFailurePayload(args, dryRunPayload, preflightPayload) {
+    return buildFailurePayload(args, {
+        mode: 'db-write-preflight-failed',
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        csv_dry_run_passed: true,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        manifest_approval_status: dryRunPayload.approval_status || null,
+        select_only_db_reads: false,
+        errors: preflightPayload.errors || ['football-data DB write preflight failed'],
+        warnings: preflightPayload.warnings || [],
+    });
+}
+
+function buildDuplicateFailurePayload(args, dryRunPayload, duplicatePayload) {
+    return buildFailurePayload(args, {
+        mode: 'duplicate-precheck-failed',
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        csv_dry_run_passed: true,
+        db_write_preflight_passed: true,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        manifest_approval_status: dryRunPayload.approval_status || null,
+        select_only_db_reads: false,
+        errors: duplicatePayload.errors || ['football-data duplicate precheck failed'],
+        warnings: duplicatePayload.warnings || [],
+    });
+}
+
+function buildInsertPolicyFailurePayload(args, dryRunPayload, insertPolicyPayload) {
+    return buildFailurePayload(args, {
+        mode: 'insert-policy-precheck-failed',
+        source_manifest_found: dryRunPayload.source_manifest_found,
+        local_csv_found: dryRunPayload.local_csv_found,
+        csv_dry_run_passed: true,
+        db_write_preflight_passed: true,
+        duplicate_precheck_passed: true,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+        manifest_approval_status: dryRunPayload.approval_status || null,
+        select_only_db_reads: false,
+        errors: insertPolicyPayload.errors || ['football-data insert policy precheck failed'],
+        warnings: insertPolicyPayload.warnings || [],
+    });
+}
+
+function buildDependencyRunArgs(args) {
+    return {
+        sourceManifest: args.sourceManifest,
+        localCsv: args.localCsv,
+    };
+}
+
+function buildPreflightDependencies(dependencies, dryRunPreview) {
+    return {
+        ...(dependencies.preflightDependencies || {}),
+        runDryRun: dryRunPreview,
+    };
+}
+
+function buildDbReadDependencies(dependencies, dryRunPreview, key) {
+    return {
+        ...(dependencies[key] || {}),
+        dbClient: dependencies.dbClient,
+        pool: dependencies.pool,
+        runDryRun: dryRunPreview,
+    };
+}
+
+async function runSmallWriteAuthPreview(args, dependencies = {}) {
+    if (!args.sourceManifest || !args.localCsv) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            select_only_db_reads: false,
+            errors: ['ERROR: provide --source-manifest=<path> and --local-csv=<path>'],
+        });
+    }
+
+    const dryRunPreview = buildManifestCompatibleDryRun(dependencies);
+    const dryRunArgs = buildDependencyRunArgs(args);
+
+    const dryRunPayload = dryRunPreview(dryRunArgs);
+    if (!dryRunPayload.ok) {
+        return buildDryRunFailurePayload(args, dryRunPayload);
+    }
+
+    const preflightRunner = dependencies.runPreflight || runPreflight;
+    const preflightPayload = await Promise.resolve(
+        preflightRunner(dryRunArgs, buildPreflightDependencies(dependencies, dryRunPreview))
+    );
+    if (!preflightPayload.ok) {
+        return buildPreflightFailurePayload(args, dryRunPayload, preflightPayload);
+    }
+
+    const duplicateRunner = dependencies.runDuplicatePrecheck || runDuplicatePrecheck;
+    const duplicatePayload = await duplicateRunner(
+        dryRunArgs,
+        buildDbReadDependencies(dependencies, dryRunPreview, 'duplicateDependencies')
+    );
+    if (!duplicatePayload.ok) {
+        return buildDuplicateFailurePayload(args, dryRunPayload, duplicatePayload);
+    }
+
+    const insertPolicyRunner = dependencies.runInsertPolicyPrecheck || runInsertPolicyPrecheck;
+    const insertPolicyPayload = await insertPolicyRunner(
+        dryRunArgs,
+        buildDbReadDependencies(dependencies, dryRunPreview, 'insertPolicyDependencies')
+    );
+    if (!insertPolicyPayload.ok) {
+        return buildInsertPolicyFailurePayload(args, dryRunPayload, insertPolicyPayload);
+    }
+
+    const dbState = await inspectCurrentDbState({
+        ...dependencies,
+        dbClient: dependencies.dbClient,
+        pool: dependencies.pool,
+    });
+
+    return buildSuccessPayload(args, dryRunPayload, preflightPayload, duplicatePayload, insertPolicyPayload, dbState);
+}
+
+function appendOptionalTextFields(lines, payload) {
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (payload.small_write_authorized_reason) {
+        lines.push(`small_write_authorized_reason=${payload.small_write_authorized_reason}`);
+    }
+    if (payload.db_write_allowed_reason) {
+        lines.push(`db_write_allowed_reason=${payload.db_write_allowed_reason}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+}
+
+function appendListSection(lines, title, values) {
+    lines.push(`${title}:`);
+    for (const value of values || []) {
+        lines.push(`- ${value}`);
+    }
+}
+
+function appendCurrentDbCounts(lines, counts) {
+    lines.push('current_db_counts:');
+    const values = counts || {};
+    for (const tableName of CURRENT_DB_TABLES) {
+        lines.push(`- ${tableName}=${values[tableName] ?? 'unknown'}`);
+    }
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `csv_dry_run_passed=${payload.csv_dry_run_passed}`,
+        `db_write_preflight_passed=${payload.db_write_preflight_passed}`,
+        `duplicate_precheck_passed=${payload.duplicate_precheck_passed}`,
+        `insert_policy_precheck_passed=${payload.insert_policy_precheck_passed}`,
+        `sha256_match=${payload.sha256_match}`,
+        `row_count_match=${payload.row_count_match}`,
+        `select_only_db_reads=${payload.select_only_db_reads}`,
+        `manifest_approval_status=${payload.manifest_approval_status}`,
+        `db_write_allowed=${payload.db_write_allowed}`,
+        `small_write_authorized=${payload.small_write_authorized}`,
+        `would_execute_pg_dump=${payload.would_execute_pg_dump}`,
+        `would_execute_pg_restore=${payload.would_execute_pg_restore}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+        `max_rows_preview=${payload.max_rows_preview}`,
+        `target_tables_preview=${JSON.stringify(payload.target_tables_preview || [])}`,
+        `pg_dump_command_preview=${JSON.stringify(payload.pg_dump_command_preview)}`,
+        `pg_restore_command_preview=${JSON.stringify(payload.pg_restore_command_preview)}`,
+        `commit_gate=${payload.commit_gate}`,
+    ];
+
+    if (payload.current_db_schema_preview) {
+        lines.push(`current_db_schema_preview=${JSON.stringify(payload.current_db_schema_preview)}`);
+    }
+
+    appendOptionalTextFields(lines, payload);
+    appendCurrentDbCounts(lines, payload.current_db_counts);
+    appendListSection(lines, 'approval_requirements', payload.approval_requirements);
+    appendListSection(lines, 'required_before_small_db_write', payload.required_before_small_db_write);
+    appendListSection(lines, 'post_write_validation', payload.post_write_validation);
+    appendListSection(lines, 'rollback_restore_preview', payload.rollback_restore_preview);
+    appendListSection(lines, 'non_execution_confirmations', payload.non_execution_confirmations);
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+async function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = await runSmallWriteAuthPreview(args, dependencies);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const json = argv.includes('--json');
+        const payload = buildFailurePayload(
+            {
+                sourceManifest: '',
+                localCsv: '',
+            },
+            {
+                mode: 'runtime-error',
+                select_only_db_reads: false,
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, json, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => {
+        process.exitCode = status;
+    });
+}
+
+module.exports = {
+    SMALL_WRITE_AUTH_PHASE,
+    CURRENT_DB_COUNTS_SQL,
+    REQUIRED_TABLES_SQL,
+    MATCH_ID_SCHEMA_SQL,
+    PG_DUMP_COMMAND_PREVIEW,
+    PG_RESTORE_COMMAND_PREVIEW,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    runSmallWriteAuthPreview,
+    inspectCurrentDbState,
+    buildRequiredBeforeSmallDbWrite,
+    buildPostWriteValidationChecklist,
+    buildRollbackRestorePreview,
+    buildNonExecutionConfirmations,
+    buildManifestCompatibleDryRun,
+    payloadToText,
+    assertSelectOnlySql,
+    main,
+};

--- a/tests/unit/football_data_small_write_auth_preview.test.js
+++ b/tests/unit/football_data_small_write_auth_preview.test.js
@@ -1,0 +1,912 @@
+'use strict';
+/* eslint-disable max-lines -- This file intentionally keeps the preview gate contract matrix in one place. */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const { spawnSync } = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_small_write_auth_preview.js');
+const DRY_RUN_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_adapter_dry_run.js');
+const PREFLIGHT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_db_write_preflight.js');
+const DUPLICATE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_duplicate_precheck.js');
+const INSERT_POLICY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_insert_policy_precheck.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+
+function installExecutionGuards(t, options = {}) {
+    const moduleOverrides = options.moduleOverrides || {};
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalWriteFile = fs.writeFile;
+    const originalAppendFileSync = fs.appendFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_small_write_auth_preview`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.writeFile = fail('fs.writeFile');
+    fs.appendFileSync = fail('fs.appendFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (Object.prototype.hasOwnProperty.call(moduleOverrides, request)) {
+            return moduleOverrides[request];
+        }
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.writeFile = originalWriteFile;
+        fs.appendFileSync = originalAppendFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        Module._load = originalLoad;
+    });
+}
+
+function loadPreviewFresh() {
+    delete require.cache[SCRIPT_PATH];
+    delete require.cache[DRY_RUN_PATH];
+    delete require.cache[PREFLIGHT_PATH];
+    delete require.cache[DUPLICATE_PATH];
+    delete require.cache[INSERT_POLICY_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function loadManifest() {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function createMockClient(queryHandler = () => ({ rows: [] })) {
+    const calls = [];
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+            return queryHandler(String(sql), params);
+        },
+    };
+}
+
+function buildDryRunPayload(overrides = {}) {
+    return {
+        ok: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        approval_status: 'dry_run_only',
+        source_name: 'unit_fixture',
+        parser_version: 'unit_parser',
+        dry_run_version: 'unit_dry_run',
+        sha256_match: true,
+        row_count_match: true,
+        candidate_rows: [
+            {
+                row_number: 1,
+                home_team: 'Synthetic Home Winners',
+                away_team: 'Synthetic Away Losers',
+                match_date: '2024-08-17T17:30:00.000Z',
+                actual_result: 'home_win',
+            },
+            {
+                row_number: 2,
+                home_team: 'Draw Home',
+                away_team: 'Draw Away',
+                match_date: '2024-08-18T17:30:00.000Z',
+                actual_result: 'draw',
+            },
+            {
+                row_number: 3,
+                home_team: 'Away Winners',
+                away_team: 'Home Losers',
+                match_date: '2024-08-19T17:30:00.000Z',
+                actual_result: 'away_win',
+            },
+        ],
+        row_classification: {
+            trainable_label_rows: 3,
+        },
+        non_execution_confirmations: ['no_external_network', 'no_db_writes'],
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildPreflightPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.64C_FOOTBALL_DATA_DB_WRITE_PREFLIGHT',
+        ok: true,
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildDuplicatePayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.65C_FOOTBALL_DATA_DUPLICATE_PRECHECK',
+        ok: true,
+        exact_existing_matches: 0,
+        reversed_team_matches: 0,
+        nearby_date_matches: 0,
+        non_execution_confirmations: ['select_only_db_reads', 'no_db_writes'],
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildInsertPolicyPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.66C_FOOTBALL_DATA_INSERT_POLICY',
+        ok: true,
+        manifest_approval_status: 'dry_run_only',
+        invalid_candidates: 0,
+        future_insert_candidates: 0,
+        blocked_by_manifest_policy: 3,
+        skip_existing_matches: 0,
+        manual_review_required: 0,
+        non_execution_confirmations: ['select_only_db_reads', 'no_db_writes'],
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildDbState() {
+    return {
+        current_db_counts: {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        current_db_schema_preview: {
+            required_tables_found: [
+                'bookmaker_odds_history',
+                'l3_features',
+                'match_features_training',
+                'matches',
+                'predictions',
+                'raw_match_data',
+            ],
+            required_tables_expected: [
+                'matches',
+                'bookmaker_odds_history',
+                'raw_match_data',
+                'l3_features',
+                'match_features_training',
+                'predictions',
+            ],
+            matches_match_id: {
+                column_name: 'match_id',
+                data_type: 'character varying',
+                character_maximum_length: 50,
+                is_nullable: 'NO',
+            },
+        },
+    };
+}
+
+async function runMain(gate, argv, dependencies = {}) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: JSON.parse(stdout),
+    };
+}
+
+async function runTextMain(gate, argv, dependencies = {}) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+
+    return {
+        status,
+        stdout,
+        stderr,
+    };
+}
+
+function assertSafetyPayload(payload) {
+    assert.equal(payload.select_only_db_reads, true);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.small_write_authorized, false);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+    assert.equal(payload.would_insert_matches, false);
+    assert.equal(payload.would_insert_odds, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.commit_gate, 'blocked');
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+    assert.ok(payload.non_execution_confirmations.includes('select_only_db_reads'));
+    assert.ok(payload.non_execution_confirmations.includes('no_db_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_legacy_runtime'));
+    assert.ok(payload.non_execution_confirmations.includes('no_pg_dump_execution'));
+    assert.ok(payload.non_execution_confirmations.includes('no_pg_restore_execution'));
+    assert.ok(payload.non_execution_confirmations.includes('no_training'));
+    assert.ok(payload.non_execution_confirmations.includes('no_prediction_execution'));
+}
+
+function assertSqlCallsAreReadOnly(gate, calls) {
+    assert.ok(calls.some(call => call.sql === gate.READ_ONLY_BEGIN_SQL));
+    assert.ok(calls.some(call => call.sql === gate.READ_ONLY_ROLLBACK_SQL));
+    for (const call of calls) {
+        gate.assertSelectOnlySql(call.sql);
+        const normalized = call.sql.replace(/\s+/g, ' ').trim().toUpperCase();
+        assert.ok(
+            normalized === 'BEGIN READ ONLY' || normalized === 'ROLLBACK' || normalized.startsWith('SELECT '),
+            `unexpected SQL: ${normalized}`
+        );
+        assert.doesNotMatch(
+            normalized,
+            /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|MERGE|GRANT|REVOKE|COMMIT)\b|\\COPY/
+        );
+    }
+}
+
+test('small write auth preview module 可以 import 且不加载 legacy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+
+    assert.equal(typeof gate.main, 'function');
+    assert.equal(typeof gate.runSmallWriteAuthPreview, 'function');
+    assert.equal(typeof gate.inspectCurrentDbState, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('缺 source manifest 参数必须失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for missing args');
+    });
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            localCsv: CSV_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /provide --source-manifest/);
+});
+
+test('缺 local CSV 参数必须失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for missing args');
+    });
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+        },
+        { dbClient: client }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /provide --source-manifest/);
+});
+
+test('正确 manifest + CSV + mock DB client auth preview 成功', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const client = createMockClient(sql => {
+        if (sql === gate.CURRENT_DB_COUNTS_SQL) {
+            return {
+                rows: [
+                    { table_name: 'matches', rows: '2' },
+                    { table_name: 'bookmaker_odds_history', rows: '2' },
+                    { table_name: 'raw_match_data', rows: '2' },
+                    { table_name: 'l3_features', rows: '2' },
+                    { table_name: 'match_features_training', rows: '2' },
+                    { table_name: 'predictions', rows: '2' },
+                ],
+            };
+        }
+        if (sql === gate.REQUIRED_TABLES_SQL) {
+            return {
+                rows: buildDbState().current_db_schema_preview.required_tables_found.map(table_name => ({
+                    table_name,
+                })),
+            };
+        }
+        if (sql === gate.MATCH_ID_SCHEMA_SQL) {
+            return {
+                rows: [buildDbState().current_db_schema_preview.matches_match_id],
+            };
+        }
+        return { rows: [] };
+    });
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload(),
+            runPreflight: () => buildPreflightPayload(),
+            runDuplicatePrecheck: async () => buildDuplicatePayload(),
+            runInsertPolicyPrecheck: async () => buildInsertPolicyPayload(),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.67C_FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW');
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+    assert.equal(payload.csv_dry_run_passed, true);
+    assert.equal(payload.db_write_preflight_passed, true);
+    assert.equal(payload.duplicate_precheck_passed, true);
+    assert.equal(payload.insert_policy_precheck_passed, true);
+    assert.equal(payload.select_only_db_reads, true);
+    assert.equal(payload.manifest_approval_status, 'dry_run_only');
+    assert.equal(payload.current_db_counts.matches, 2);
+    assert.equal(payload.current_db_counts.bookmaker_odds_history, 2);
+    assert.equal(payload.current_db_counts.raw_match_data, 2);
+    assert.equal(payload.current_db_counts.l3_features, 2);
+    assert.equal(payload.current_db_counts.match_features_training, 2);
+    assert.equal(payload.current_db_counts.predictions, 2);
+    assert.equal(payload.max_rows_preview, 3);
+    assert.deepEqual(payload.target_tables_preview, ['matches', 'bookmaker_odds_history']);
+    assertSafetyPayload(payload);
+    assertSqlCallsAreReadOnly(gate, client.calls);
+});
+
+test('pg_dump command preview、checklists 和 rollback preview 必须存在，但不执行', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            inspectCurrentDbState: async () => buildDbState(),
+            runDryRun: () => buildDryRunPayload(),
+            runPreflight: () => buildPreflightPayload(),
+            runDuplicatePrecheck: async () => buildDuplicatePayload(),
+            runInsertPolicyPrecheck: async () => buildInsertPolicyPayload(),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.match(payload.pg_dump_command_preview, /pg_dump/);
+    assert.match(payload.pg_restore_command_preview, /pg_restore/);
+    assert.ok(payload.required_before_small_db_write.includes('pg_dump backup must run immediately before write'));
+    assert.ok(payload.required_before_small_db_write.includes('backup file must be non-empty'));
+    assert.ok(payload.post_write_validation.includes('compare before/after row counts'));
+    assert.ok(payload.post_write_validation.includes('record backup path'));
+    assert.ok(payload.rollback_restore_preview.includes('restore is not executed automatically'));
+    assert.ok(payload.rollback_restore_preview.includes('restore command must be documented but not executed'));
+    assert.ok(payload.approval_requirements.includes('future CONFIRM_FOOTBALL_DATA_SMALL_WRITE=1 authorization'));
+    assertSafetyPayload(payload);
+});
+
+test('dry_run_only manifest 下 small_write_authorized=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            inspectCurrentDbState: async () => buildDbState(),
+            runDryRun: () => buildDryRunPayload({ approval_status: 'dry_run_only' }),
+            runPreflight: () => buildPreflightPayload(),
+            runDuplicatePrecheck: async () => buildDuplicatePayload(),
+            runInsertPolicyPrecheck: async () => buildInsertPolicyPayload({ manifest_approval_status: 'dry_run_only' }),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.manifest_approval_status, 'dry_run_only');
+    assert.equal(payload.small_write_authorized, false);
+    assert.equal(payload.db_write_allowed, false);
+});
+
+test('approved_for_db_write manifest 也仍然 small_write_authorized=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            inspectCurrentDbState: async () => buildDbState(),
+            runDryRun: () => buildDryRunPayload({ approval_status: 'approved_for_db_write' }),
+            runPreflight: () => buildPreflightPayload(),
+            runDuplicatePrecheck: async () => buildDuplicatePayload(),
+            runInsertPolicyPrecheck: async () =>
+                buildInsertPolicyPayload({ manifest_approval_status: 'approved_for_db_write' }),
+        }
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.manifest_approval_status, 'approved_for_db_write');
+    assert.equal(payload.small_write_authorized, false);
+    assert.equal(payload.db_write_allowed, false);
+    assert.match(payload.db_write_allowed_reason, /does not execute small DB writes/);
+});
+
+test('--commit 必须 blocked', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const result = await runMain(gate, [
+        '--source-manifest',
+        MANIFEST_PATH,
+        '--local-csv',
+        CSV_PATH,
+        '--commit',
+        '--json',
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'blocked-commit');
+    assert.equal(result.payload.blocked, true);
+    assert.match(result.payload.blocked_reason, /not wired in Phase 4\.67C/);
+    assert.equal(result.payload.would_execute_pg_dump, false);
+    assert.equal(result.payload.would_execute_pg_restore, false);
+    assert.equal(result.payload.would_write_db, false);
+});
+
+test('sha256 mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for sha256 mismatch');
+    });
+    const manifest = {
+        ...loadManifest(),
+        sha256: '0'.repeat(64),
+    };
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            dryRunDependencies: {
+                readManifest: () => manifest,
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'csv-dry-run-failed');
+    assert.equal(payload.sha256_match, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+});
+
+test('row_count mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for row_count mismatch');
+    });
+    const manifest = {
+        ...loadManifest(),
+        row_count: 999,
+    };
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            dryRunDependencies: {
+                readManifest: () => manifest,
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'csv-dry-run-failed');
+    assert.equal(payload.row_count_match, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+});
+
+test('text output 应包含所需 summary 字段', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const result = await runTextMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH], {
+        inspectCurrentDbState: async () => buildDbState(),
+        runDryRun: () => buildDryRunPayload(),
+        runPreflight: () => buildPreflightPayload(),
+        runDuplicatePrecheck: async () => buildDuplicatePayload(),
+        runInsertPolicyPrecheck: async () => buildInsertPolicyPayload(),
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /phase=PHASE4\.67C_FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW/);
+    assert.match(result.stdout, /csv_dry_run_passed=true/);
+    assert.match(result.stdout, /db_write_preflight_passed=true/);
+    assert.match(result.stdout, /duplicate_precheck_passed=true/);
+    assert.match(result.stdout, /insert_policy_precheck_passed=true/);
+    assert.match(result.stdout, /db_write_allowed=false/);
+    assert.match(result.stdout, /small_write_authorized=false/);
+    assert.match(result.stdout, /would_execute_pg_dump=false/);
+    assert.match(result.stdout, /would_execute_pg_restore=false/);
+    assert.match(result.stdout, /would_write_db=false/);
+    assert.match(result.stdout, /current_db_counts:/);
+    assert.match(result.stdout, /pg_dump_command_preview=/);
+    assert.match(result.stdout, /required_before_small_db_write:/);
+    assert.match(result.stdout, /post_write_validation:/);
+    assert.match(result.stdout, /rollback_restore_preview:/);
+    assert.match(result.stdout, /no_pg_dump_execution/);
+    assert.match(result.stdout, /no_pg_restore_execution/);
+});
+
+test('main --help 应输出 usage', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const result = await runTextMain(gate, ['--help']);
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /football_data_small_write_auth_preview\.js --source-manifest/);
+    assert.match(result.stdout, /No DB writes, no pg_dump execution, no pg_restore execution/);
+});
+
+test('blocked commit 的文本输出应包含 blocked_reason 与 errors', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const result = await runTextMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH, '--commit']);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /mode=blocked-commit/);
+    assert.match(
+        result.stdout,
+        /blocked_reason=BLOCKED: football-data small DB write commit is not wired in Phase 4\.67C\./
+    );
+    assert.match(result.stdout, /errors=BLOCKED: football-data small DB write commit is not wired in Phase 4\.67C\./);
+});
+
+test('文本输出应包含 warnings 行', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const result = await runTextMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH], {
+        inspectCurrentDbState: async () => buildDbState(),
+        runDryRun: () => buildDryRunPayload({ warnings: [{ code: 'warn_1', message: 'unit warning' }] }),
+        runPreflight: () => buildPreflightPayload({ warnings: [{ code: 'warn_2', message: 'preflight warning' }] }),
+        runDuplicatePrecheck: async () =>
+            buildDuplicatePayload({ warnings: [{ code: 'warn_3', message: 'duplicate warning' }] }),
+        runInsertPolicyPrecheck: async () =>
+            buildInsertPolicyPayload({ warnings: [{ code: 'warn_4', message: 'policy warning' }] }),
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /warnings=\[/);
+    assert.match(result.stdout, /unit warning/);
+    assert.match(result.stdout, /policy warning/);
+});
+
+test('preflight 失败时应返回 db-write-preflight-failed 且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for preflight failure');
+    });
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            dbClient: client,
+            runDryRun: () => buildDryRunPayload(),
+            runPreflight: () => buildPreflightPayload({ ok: false, errors: ['preflight failed'] }),
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'db-write-preflight-failed');
+    assert.equal(payload.csv_dry_run_passed, true);
+    assert.equal(payload.db_write_preflight_passed, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+    assert.match(payload.errors[0], /preflight failed/);
+});
+
+test('duplicate precheck 失败时应返回 duplicate-precheck-failed 且不继续查 DB state', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    let inspectCalled = false;
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            inspectCurrentDbState: async () => {
+                inspectCalled = true;
+                return buildDbState();
+            },
+            runDryRun: () => buildDryRunPayload(),
+            runPreflight: () => buildPreflightPayload(),
+            runDuplicatePrecheck: async () => buildDuplicatePayload({ ok: false, errors: ['duplicate failed'] }),
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'duplicate-precheck-failed');
+    assert.equal(payload.csv_dry_run_passed, true);
+    assert.equal(payload.db_write_preflight_passed, true);
+    assert.equal(payload.duplicate_precheck_passed, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(inspectCalled, false);
+    assert.match(payload.errors[0], /duplicate failed/);
+});
+
+test('insert policy 失败时应返回 insert-policy-precheck-failed 且不继续查 DB state', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    let inspectCalled = false;
+    const payload = await gate.runSmallWriteAuthPreview(
+        {
+            sourceManifest: MANIFEST_PATH,
+            localCsv: CSV_PATH,
+        },
+        {
+            inspectCurrentDbState: async () => {
+                inspectCalled = true;
+                return buildDbState();
+            },
+            runDryRun: () => buildDryRunPayload(),
+            runPreflight: () => buildPreflightPayload(),
+            runDuplicatePrecheck: async () => buildDuplicatePayload(),
+            runInsertPolicyPrecheck: async () => buildInsertPolicyPayload({ ok: false, errors: ['policy failed'] }),
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'insert-policy-precheck-failed');
+    assert.equal(payload.csv_dry_run_passed, true);
+    assert.equal(payload.db_write_preflight_passed, true);
+    assert.equal(payload.duplicate_precheck_passed, true);
+    assert.equal(payload.insert_policy_precheck_passed, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(inspectCalled, false);
+    assert.match(payload.errors[0], /policy failed/);
+});
+
+test('main runtime error 应返回 runtime-error payload', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const result = await runMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH, '--json'], {
+        runDryRun: () => {
+            throw new Error('boom');
+        },
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'runtime-error');
+    assert.equal(result.payload.select_only_db_reads, false);
+    assert.match(result.payload.errors[0], /boom/);
+});
+
+test('main runtime error 的文本输出应包含 errors', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const result = await runTextMain(gate, ['--source-manifest', MANIFEST_PATH, '--local-csv', CSV_PATH], {
+        runDryRun: () => {
+            throw new Error('text boom');
+        },
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /mode=runtime-error/);
+    assert.match(result.stdout, /errors=text boom/);
+});
+
+test('inspectCurrentDbState 应支持 injected pool 并在缺少 schema row 时返回 null', async t => {
+    installExecutionGuards(t, {
+        moduleOverrides: {
+            pg: {
+                Pool: class FakePool {
+                    constructor() {
+                        this.ended = false;
+                    }
+
+                    async connect() {
+                        const calls = [];
+                        return {
+                            calls,
+                            async query(sql) {
+                                calls.push(sql);
+                                if (sql === 'BEGIN READ ONLY' || sql === 'ROLLBACK') {
+                                    return { rows: [] };
+                                }
+                                if (sql.includes('FROM (')) {
+                                    return {
+                                        rows: [{ table_name: 'matches', rows: '2' }],
+                                    };
+                                }
+                                if (sql.includes('FROM information_schema.tables')) {
+                                    return {
+                                        rows: [{ table_name: 'matches' }],
+                                    };
+                                }
+                                if (sql.includes("table_name = 'matches'")) {
+                                    return {
+                                        rows: [],
+                                    };
+                                }
+                                return { rows: [] };
+                            },
+                            release() {},
+                        };
+                    }
+
+                    async end() {
+                        this.ended = true;
+                    }
+                },
+            },
+        },
+    });
+    const gate = loadPreviewFresh();
+    const state = await gate.inspectCurrentDbState({});
+
+    assert.equal(state.current_db_counts.matches, 2);
+    assert.equal(state.current_db_counts.bookmaker_odds_history, 0);
+    assert.deepEqual(state.current_db_schema_preview.required_tables_found, ['matches']);
+    assert.equal(state.current_db_schema_preview.matches_match_id, null);
+});
+
+test('script 作为真实入口执行 --help 应成功', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, '--help'], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /football_data_small_write_auth_preview\.js --source-manifest/);
+});
+
+test('buildManifestCompatibleDryRun 应支持 approved_for_db_write manifest 并在成功后还原 approval_status', t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const manifest = {
+        ...loadManifest(),
+        approval_status: 'approved_for_db_write',
+    };
+    const wrappedDryRun = gate.buildManifestCompatibleDryRun({
+        dryRunDependencies: {
+            readManifest: () => manifest,
+            parseFootballDataCsv: () => ({
+                parser_version: 'unit_parser',
+                total_rows: 5,
+                parsed_rows: 5,
+                candidate_rows: [],
+                row_classification: {
+                    trainable_label_rows: 0,
+                    skipped_rows: 0,
+                    invalid_date_rows: 0,
+                    missing_team_rows: 0,
+                    missing_score_rows: 0,
+                    invalid_result_rows: 0,
+                    odds_preview_rows: 0,
+                },
+                warnings: [],
+                errors: [],
+                non_execution_confirmations: ['no_external_network'],
+            }),
+        },
+    });
+
+    const payload = wrappedDryRun({
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+    });
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.approval_status, 'approved_for_db_write');
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+});
+
+test('buildManifestCompatibleDryRun 在底层 dry-run 失败时应原样返回失败 payload', t => {
+    installExecutionGuards(t);
+    const gate = loadPreviewFresh();
+    const manifest = loadManifest();
+    const wrappedDryRun = gate.buildManifestCompatibleDryRun({
+        dryRunDependencies: {
+            readManifest: () => manifest,
+        },
+    });
+
+    const payload = wrappedDryRun({
+        sourceManifest: MANIFEST_PATH,
+        localCsv: path.join(PROJECT_ROOT, 'tests/fixtures/football_data/missing.csv'),
+    });
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.local_csv_found, false);
+    assert.equal(payload.mode, 'csv-error');
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.67C football-data small DB write authorization preview.

Scope:
- Adds football_data_small_write_auth_preview
- Adds pg_dump command preview without execution
- Adds rollback/restore preview without execution
- Adds small write authorization checklist
- Adds post-write validation checklist
- Adds Makefile preview and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.67C report

Safety:
- No DB writes
- SELECT-only DB reads only
- No pg_dump execution
- No pg_restore execution
- No backup file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- small write auth preview passed
- small write commit gate remained blocked
- CSV dry-run still passed
- DB write preflight still passed
- duplicate precheck still passed
- insert policy precheck still passed
- legacy acquisition gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed