### PR TITLE
docs(data): add football-data small write runbook template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不执行 pg_dump、不训练、不预测的 `make data-football-data-db-write-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB 查重、不写 DB、不训练、不预测的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB schema / duplicate 查询、不写 DB、不训练、不预测的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
+- 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 - 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
@@ -282,6 +283,8 @@ AI / Codex 不能直接执行：
 - `make data-football-data-duplicate-precheck-commit CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1`
 - `make data-football-data-insert-policy-commit`
 - `make data-football-data-insert-policy-commit CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1`
+- `make data-football-data-small-write-runbook-commit`
+- `make data-football-data-small-write-runbook-commit CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1`
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
@@ -574,6 +577,11 @@ Phase 4.57C football-data adapter rules：
 - `data-football-data-duplicate-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-duplicate-precheck-commit` 当前 blocked / not wired。
 - Phase 4.67C 的 `make data-football-data-small-write-auth-preview SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 small DB write 授权预览；只能读取本地 manifest / CSV，复用 dry-run / preflight / duplicate / insert policy 结果，并执行 SELECT-only DB row count / schema inspection。
 - `data-football-data-small-write-auth-preview` 不得写 DB、不得执行 `pg_dump`、不得执行 `pg_restore`、不得写 backup 文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-small-write-commit` 当前 blocked / not wired。
+- Phase 4.68C 的 `docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md` 是未来真实写库 runbook 模板，不是执行授权。
+- Phase 4.68C 的 `docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md` 默认 `approval_status=not_approved`，Codex 不得把模板当作真实 approval，不得自行改成 `approved_for_db_write`，不得自行填写 `final_human_confirmation=true`。
+- `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>` 只验证本地模板；不得读 DB、写 DB、执行 `pg_dump` / `pg_restore`、写 backup、触网、训练或预测。
+- `make data-football-data-small-write-runbook-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1` 也不得执行真实写库。
+- 真实 small DB write 必须在单独阶段进行，且必须有用户明确授权、真实 `pg_dump`、非空备份验证、小批量 transaction 和 post-write validation。
 - Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。
 - `data-football-data-insert-policy-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-insert-policy-commit` 当前 blocked / not wired。
 - future real DB write 必须单独阶段、单独授权、真实 `pg_dump`、非空备份验证、small batch transaction、post-write validation；restore 也必须单独授权，不得自动执行；DB write 前后 training / prediction 仍必须走单独 gate。

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
         data-football-data-db-write-preflight data-football-data-db-write-commit \
         data-football-data-duplicate-precheck data-football-data-duplicate-precheck-commit \
         data-football-data-small-write-auth-preview data-football-data-small-write-commit \
+        data-football-data-small-write-runbook-validate data-football-data-small-write-runbook-commit \
         data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
@@ -269,6 +270,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-db-write-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-duplicate-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-small-write-auth-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
+	@echo "  make data-football-data-small-write-runbook-validate APPROVAL_FORM=<path>"
 	@echo "  make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
@@ -291,6 +293,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-db-write-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DB_WRITE=1  # blocked in Phase 4.64C"
 	@echo "  make data-football-data-duplicate-precheck-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1  # blocked in Phase 4.65C"
 	@echo "  make data-football-data-insert-policy-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1  # blocked in Phase 4.66C"
+	@echo "  make data-football-data-small-write-runbook-commit APPROVAL_FORM=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1  # blocked in Phase 4.68C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -581,6 +584,23 @@ data-football-data-small-write-commit: ## Blocked Football-Data small DB write c
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data small DB write commit is not wired in Phase 4.67C."
+	@exit 1
+
+data-football-data-small-write-runbook-validate: ## Validate Football-Data small DB write approval form template. Requires APPROVAL_FORM.
+	@if [ -z "$(APPROVAL_FORM)" ]; then \
+		echo "ERROR: provide APPROVAL_FORM=<path>"; \
+		exit 1; \
+	fi
+	@echo "Validating Football-Data small DB write runbook approval form: APPROVAL_FORM=$(APPROVAL_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(APPROVAL_FORM)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_small_write_runbook_validate.js --approval-form "$(APPROVAL_FORM)"
+
+data-football-data-small-write-runbook-commit: ## Blocked Football-Data small DB write runbook commit gate. Requires CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK)" != "1" ]; then \
+		echo "BLOCKED: football-data small write runbook commit requires CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1 and is not wired in Phase 4.68C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data small write runbook commit is not wired in Phase 4.68C."
 	@exit 1
 
 data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.

--- a/docs/_reports/FOOTBALL_DATA_SMALL_WRITE_RUNBOOK_TEMPLATE_PHASE4_68C.md
+++ b/docs/_reports/FOOTBALL_DATA_SMALL_WRITE_RUNBOOK_TEMPLATE_PHASE4_68C.md
@@ -1,0 +1,206 @@
+# Football-Data Small Write Runbook Template Phase 4.68C
+
+## 1. Current HEAD / branch
+
+- Branch: `docs/football-data-small-write-runbook-phase468c`
+- Start HEAD: `72e1db0976d7c9b14b42201a9bce95e9a51a5eff`
+- Start commit: `72e1db0 feat(data): add football-data small write auth preview`
+
+## 2. Why a slightly larger PR is reasonable
+
+Phase 4.68C fixes the human-facing control surface before any real small DB write.
+The runbook template, approval form, validator, Makefile gates, tests, AGENTS rules,
+and report are tightly coupled: each one defines or verifies the same approval
+boundary. Splitting them would leave a template without enforcement, or a gate
+without the documented approval contract.
+
+## 3. New / changed files
+
+- `docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md`
+- `docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md`
+- `scripts/ops/football_data_small_write_runbook_validate.js`
+- `tests/unit/football_data_small_write_runbook_validate.test.js`
+- `docs/_reports/FOOTBALL_DATA_SMALL_WRITE_RUNBOOK_TEMPLATE_PHASE4_68C.md`
+- `Makefile`
+- `AGENTS.md`
+
+## 4. Runbook template summary
+
+The runbook template records the future real small DB write procedure. It includes
+scope, required preconditions, pre-write command previews, `pg_dump` preview,
+candidate insert and forbidden candidate tables, a blocked future write placeholder,
+post-write validation, rollback / restore preview, and final sign-off.
+
+Every command preview is marked as preview-only for Phase 4.68C. The template is
+not an execution authorization.
+
+## 5. Approval form template summary
+
+The approval form template contains a machine-readable YAML block with:
+
+- `approval_status: not_approved`
+- explicit source / license / terms / operator / reviewer fields
+- `target_tables: [matches]`
+- all write expansion flags set to `false`
+- `allow_training: false`
+- `allow_prediction: false`
+- `require_pg_dump: true`
+- before / after count placeholders
+- `rollback_plan_reviewed: false`
+- `post_write_validation_required: true`
+- `final_human_confirmation: false`
+
+## 6. Why the form defaults to not approved
+
+Phase 4.68C prepares templates only. It does not approve real writes, does not
+prove a real source license, does not validate a real backup file, and does not
+grant final human confirmation. Keeping `approval_status=not_approved` prevents
+the template from being mistaken for a completed approval record.
+
+## 7. Validator design
+
+`scripts/ops/football_data_small_write_runbook_validate.js` reads a local markdown
+approval form, extracts the YAML fenced block, parses the supported local template
+shape, and validates required safety fields.
+
+The validator confirms:
+
+- required fields exist
+- template approval status remains `not_approved`
+- `target_tables` contains only `matches`
+- odds/raw/L3/training/prediction write flags remain `false`
+- training and prediction remain disabled
+- `require_pg_dump=true`
+- `final_human_confirmation=false`
+
+The validator does not access the network, read DB, write DB, write files, execute
+`pg_dump`, execute `pg_restore`, or spawn child processes.
+
+## 8. Makefile entries
+
+- `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<path>`
+- `make data-football-data-small-write-runbook-commit APPROVAL_FORM=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1`
+
+The commit target remains blocked in Phase 4.68C, even with confirmation.
+
+## 9. Commit gate blocked result
+
+Validated commands:
+
+- `make data-football-data-small-write-runbook-validate || true`
+    - Result: failed with `ERROR: provide APPROVAL_FORM=<path>`
+- `make data-football-data-small-write-runbook-validate APPROVAL_FORM=docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md`
+    - Result: passed
+- `make data-football-data-small-write-runbook-commit || true`
+    - Result: blocked
+- `make data-football-data-small-write-runbook-commit APPROVAL_FORM=docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1 || true`
+    - Result: blocked
+
+## 10. Existing gates recheck
+
+All existing Football-Data gates passed with the local fixture manifest and CSV:
+
+- `make data-football-data-csv-dry-run`
+- `make data-football-data-db-write-preflight`
+- `make data-football-data-duplicate-precheck`
+- `make data-football-data-insert-policy-precheck`
+- `make data-football-data-small-write-auth-preview`
+
+No DB writes, `pg_dump`, or `pg_restore` were executed by these gates.
+
+## 11. Unit tests
+
+Passed:
+
+- `node --test tests/unit/football_data_small_write_runbook_validate.test.js`
+    - 31 tests passed
+- `node --test tests/unit/football_data_small_write_auth_preview.test.js`
+    - 23 tests passed
+- `node --test tests/unit/football_data_insert_policy_precheck.test.js`
+    - 23 tests passed
+- `node --test tests/unit/football_data_duplicate_precheck.test.js`
+    - 20 tests passed
+- `node --test tests/unit/football_data_db_write_preflight.test.js`
+    - 11 tests passed
+- `node --test tests/unit/football_data_adapter_dry_run.test.js`
+    - 11 tests passed
+- `node --test tests/unit/football_data_local_csv_parser.test.js`
+    - 10 tests passed
+- `node --test tests/unit/acquisition_engine_gate.test.js`
+    - 8 tests passed
+
+## 12. npm test / coverage
+
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`
+    - Result: passed
+- First `npm run test:coverage`
+    - Result: failed only on coverage threshold
+    - Cause: `branches=79.97 < 80`
+    - Action: added validator branch coverage tests; coverage threshold was not changed
+- Final `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`
+    - Result: passed
+    - Coverage summary:
+        - lines: `88.19`
+        - functions: `80.74`
+        - branches: `80.07`
+
+## 13. DB row counts
+
+Before changes:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    2 |
+| predictions             |    2 |
+
+After validation:
+
+| table                   | rows |
+| ----------------------- | ---: |
+| matches                 |    2 |
+| bookmaker_odds_history  |    2 |
+| raw_match_data          |    2 |
+| l3_features             |    2 |
+| match_features_training |    2 |
+| predictions             |    2 |
+
+## 14. Next steps
+
+- Phase 4.69C: prepare real small write dry-run packet assembly, still no DB writes
+  and no `pg_dump` execution.
+- Or Phase 4.56A: only after the user provides complete real network dry-run
+  parameters should a network-source runbook be prepared.
+
+## 15. Explicitly not executed
+
+- DB writes
+- non-SELECT DB SQL
+- `INSERT` / `UPDATE` / `DELETE` / `CREATE` / `ALTER` / `DROP` / `TRUNCATE` / `COPY`
+- DB reads from the new validator
+- `pg_dump`
+- `pg_restore`
+- backup file writes
+- file writes from validator runtime
+- approval status changes to `approved_for_db_write`
+- `final_human_confirmation=true`
+- external downloads
+- external football data source access
+- external odds data source access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- network dry-run execution
+- bulk harvest
+- adapted CSV / staging data writes
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md
+++ b/docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md
@@ -1,0 +1,62 @@
+# Football-Data Small DB Write Approval Form Template
+
+> TEMPLATE ONLY / NOT APPROVED.
+>
+> This form is a machine-readable template for a future real small DB write
+> approval. It does not authorize any write in Phase 4.68C.
+
+```yaml
+phase: PHASE4_REAL_SMALL_DB_WRITE_APPROVAL
+approval_status: not_approved
+operator:
+reviewer:
+source_manifest:
+local_csv:
+source_name:
+source_url:
+license_url:
+terms_url:
+human_approval_note:
+max_insert_rows:
+target_tables:
+    - matches
+allow_odds_insert: false
+allow_raw_insert: false
+allow_l3_insert: false
+allow_training_features_insert: false
+allow_predictions_insert: false
+allow_training: false
+allow_prediction: false
+require_pg_dump: true
+pg_dump_command_preview:
+backup_path:
+approved_candidate_match_ids: []
+excluded_candidate_match_ids: []
+manual_review_candidate_match_ids: []
+expected_before_counts:
+    matches:
+    bookmaker_odds_history:
+    raw_match_data:
+    l3_features:
+    match_features_training:
+    predictions:
+expected_after_counts:
+    matches:
+    bookmaker_odds_history:
+    raw_match_data:
+    l3_features:
+    match_features_training:
+    predictions:
+rollback_plan_reviewed: false
+post_write_validation_required: true
+final_human_confirmation: false
+```
+
+## Notes
+
+- `approval_status` defaults to `not_approved`.
+- All actual write permissions default to disabled.
+- Only a future real DB write phase may change `approval_status` to `approved_for_db_write`.
+- This form must not be used to execute a DB write in Phase 4.68C.
+- This file is a template, not an approval record.
+- Codex must not set `final_human_confirmation` to `true`.

--- a/docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md
+++ b/docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md
@@ -1,0 +1,144 @@
+# Football-Data Small DB Write Runbook Template
+
+> PREVIEW ONLY / DO NOT RUN IN PHASE 4.68C.
+>
+> This template records the human runbook required before any future real small
+> DB write. It is not an execution authorization.
+
+## 1. Scope
+
+- Phase:
+- Operator:
+- Reviewer:
+- Date:
+- Target environment:
+- Source manifest:
+- Local CSV:
+- Max rows:
+- Target tables:
+- Allowed operation:
+- Explicitly forbidden operations:
+
+## 2. Required preconditions
+
+- Source manifest exists
+- Source manifest approval_status=approved_for_db_write
+- Human approval note present
+- Local CSV exists
+- sha256 matches
+- row_count matches
+- CSV dry-run passed
+- DB write preflight passed
+- duplicate precheck passed
+- insert policy precheck passed
+- small write auth preview passed
+- exact existing matches excluded
+- manual review candidates excluded
+- invalid candidates excluded
+- deterministic match_id strategy accepted
+- max insert rows explicitly approved
+- target inserted match_ids listed
+- downstream training/prediction remains blocked
+
+## 3. Pre-write commands preview
+
+PREVIEW ONLY / DO NOT RUN IN PHASE 4.68C.
+
+```bash
+make data-football-data-csv-dry-run \
+  SOURCE_MANIFEST=<local source manifest> \
+  LOCAL_CSV=<local csv>
+```
+
+PREVIEW ONLY / DO NOT RUN IN PHASE 4.68C.
+
+```bash
+make data-football-data-db-write-preflight \
+  SOURCE_MANIFEST=<local source manifest> \
+  LOCAL_CSV=<local csv>
+```
+
+PREVIEW ONLY / DO NOT RUN IN PHASE 4.68C.
+
+```bash
+make data-football-data-duplicate-precheck \
+  SOURCE_MANIFEST=<local source manifest> \
+  LOCAL_CSV=<local csv>
+```
+
+PREVIEW ONLY / DO NOT RUN IN PHASE 4.68C.
+
+```bash
+make data-football-data-insert-policy-precheck \
+  SOURCE_MANIFEST=<local source manifest> \
+  LOCAL_CSV=<local csv>
+```
+
+PREVIEW ONLY / DO NOT RUN IN PHASE 4.68C.
+
+```bash
+make data-football-data-small-write-auth-preview \
+  SOURCE_MANIFEST=<local source manifest> \
+  LOCAL_CSV=<local csv>
+```
+
+## 4. pg_dump backup command preview
+
+DO NOT RUN IN PHASE 4.68C.
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T db pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc > data/backups/<timestamp>_pre_football_data_small_write.dump
+```
+
+## 5. Candidate insert list
+
+| row_number | proposed_match_id | home_team | away_team | match_date | insert_policy | approved_to_insert |
+| ---------- | ----------------- | --------- | --------- | ---------- | ------------- | ------------------ |
+|            |                   |           |           |            |               |                    |
+
+## 6. Forbidden candidate list
+
+| row_number | reason | duplicate_risk | required_action |
+| ---------- | ------ | -------------- | --------------- |
+|            |        |                |                 |
+
+## 7. Future write command placeholder
+
+The future write command remains blocked / not wired in Phase 4.68C.
+
+```bash
+make data-football-data-small-write-runbook-commit \
+  APPROVAL_FORM=<completed approval form> \
+  CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1
+```
+
+## 8. Post-write validation checklist
+
+- before/after row counts
+- inserted match_ids only
+- no odds insert unless separately authorized
+- no raw/l3/training/prediction writes
+- rerun dataset status
+- rerun duplicate precheck
+- record backup path
+- record commit hash
+- record report path
+
+## 9. Rollback / restore preview
+
+- restore not automatic
+- restore requires separate human authorization
+- restore command preview only
+- backup file must be reviewed before restore
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists <backup_path>
+```
+
+## 10. Final sign-off
+
+- Operator signature:
+- Reviewer signature:
+- Timestamp:
+- Approval scope:
+- Explicit exclusions:

--- a/scripts/ops/football_data_small_write_runbook_validate.js
+++ b/scripts/ops/football_data_small_write_runbook_validate.js
@@ -1,0 +1,510 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const RUNBOOK_VALIDATE_PHASE = 'PHASE4.68C_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK_VALIDATE';
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: football-data small write runbook commit is not wired in Phase 4.68C.';
+const REQUIRED_FIELDS = [
+    'phase',
+    'approval_status',
+    'operator',
+    'reviewer',
+    'source_manifest',
+    'local_csv',
+    'source_name',
+    'source_url',
+    'license_url',
+    'terms_url',
+    'human_approval_note',
+    'max_insert_rows',
+    'target_tables',
+    'allow_odds_insert',
+    'allow_raw_insert',
+    'allow_l3_insert',
+    'allow_training_features_insert',
+    'allow_predictions_insert',
+    'allow_training',
+    'allow_prediction',
+    'require_pg_dump',
+    'pg_dump_command_preview',
+    'backup_path',
+    'approved_candidate_match_ids',
+    'excluded_candidate_match_ids',
+    'manual_review_candidate_match_ids',
+    'expected_before_counts',
+    'expected_after_counts',
+    'rollback_plan_reviewed',
+    'post_write_validation_required',
+    'final_human_confirmation',
+];
+const REQUIRED_COUNT_FIELDS = [
+    'matches',
+    'bookmaker_odds_history',
+    'raw_match_data',
+    'l3_features',
+    'match_features_training',
+    'predictions',
+];
+const REQUIRED_FALSE_FIELDS = [
+    'allow_odds_insert',
+    'allow_raw_insert',
+    'allow_l3_insert',
+    'allow_training_features_insert',
+    'allow_predictions_insert',
+    'allow_training',
+    'allow_prediction',
+    'final_human_confirmation',
+];
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_small_write_runbook_validate.js --approval-form <path> [--json]',
+        '  node scripts/ops/football_data_small_write_runbook_validate.js --approval-form <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.68C validates a local approval form template only.',
+        '  No DB reads, no DB writes, no pg_dump, no pg_restore, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        approvalForm: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token.startsWith('--approval-form=')) {
+            args.approvalForm = token.slice('--approval-form='.length);
+        } else if (token === '--approval-form') {
+            args.approvalForm = String(argv[index + 1] || '');
+            index += 1;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) {
+        return '';
+    }
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) {
+        return '';
+    }
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'no_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_pg_dump_execution',
+        'no_pg_restore_execution',
+        'no_child_process_spawn',
+        'no_training',
+        'no_prediction_execution',
+        'no_model_artifact_load',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        would_read_db: false,
+        would_write_db: false,
+        would_write_files: false,
+        would_access_network: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_spawn_child_process: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+        would_load_model_artifact: false,
+        approval_granted: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: RUNBOOK_VALIDATE_PHASE,
+        mode: fields.mode || 'football-data-small-write-runbook-validate',
+        ok: false,
+        approval_form: args.approvalForm || null,
+        approval_form_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        approval_status: null,
+        target_tables: null,
+        commit_gate: 'blocked',
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function extractYamlBlock(markdownText) {
+    const match = String(markdownText || '').match(/```ya?ml\s*\n([\s\S]*?)\n```/i);
+    return match ? match[1] : '';
+}
+
+function stripInlineComment(value) {
+    const hashIndex = value.indexOf(' #');
+    if (hashIndex === -1) {
+        return value;
+    }
+    return value.slice(0, hashIndex);
+}
+
+function parseScalar(rawValue) {
+    const value = stripInlineComment(String(rawValue || '')).trim();
+    if (value === '') {
+        return null;
+    }
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+        return false;
+    }
+    if (value === '[]') {
+        return [];
+    }
+    if (value.startsWith('[') && value.endsWith(']')) {
+        const inner = value.slice(1, -1).trim();
+        if (!inner) {
+            return [];
+        }
+        return inner.split(',').map(item => parseScalar(item.trim()));
+    }
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    if (/^-?\d+$/.test(value)) {
+        return Number(value);
+    }
+    return value;
+}
+
+function parseTopLevelYamlLine(root, trimmed) {
+    const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+    if (!match) {
+        throw new Error(`unsupported YAML line: ${trimmed}`);
+    }
+
+    const key = match[1];
+    const value = match[2].trim();
+    root[key] = value === '' ? null : parseScalar(value);
+    return key;
+}
+
+function parseNestedYamlLine(root, currentKey, trimmed) {
+    if (trimmed.startsWith('- ')) {
+        if (!Array.isArray(root[currentKey])) {
+            root[currentKey] = [];
+        }
+        root[currentKey].push(parseScalar(trimmed.slice(2)));
+        return;
+    }
+
+    const nestedMatch = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+    if (!nestedMatch) {
+        throw new Error(`unsupported YAML line: ${trimmed}`);
+    }
+    if (!root[currentKey] || Array.isArray(root[currentKey]) || typeof root[currentKey] !== 'object') {
+        root[currentKey] = {};
+    }
+    root[currentKey][nestedMatch[1]] = nestedMatch[2].trim() === '' ? null : parseScalar(nestedMatch[2]);
+}
+
+function parseYamlBlock(yamlText) {
+    const root = {};
+    let currentKey = '';
+
+    for (const rawLine of String(yamlText || '').split(/\r?\n/)) {
+        if (!rawLine.trim() || rawLine.trim().startsWith('#')) {
+            continue;
+        }
+
+        const indent = rawLine.match(/^ */)[0].length;
+        const trimmed = rawLine.trim();
+
+        if (indent === 0) {
+            currentKey = parseTopLevelYamlLine(root, trimmed);
+            continue;
+        }
+
+        if (indent >= 2 && currentKey) {
+            parseNestedYamlLine(root, currentKey, trimmed);
+            continue;
+        }
+
+        throw new Error(`unsupported YAML indentation: ${trimmed}`);
+    }
+
+    return root;
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_FIELDS.filter(field => !Object.prototype.hasOwnProperty.call(parsedYaml, field));
+
+    for (const parent of ['expected_before_counts', 'expected_after_counts']) {
+        if (!parsedYaml[parent] || typeof parsedYaml[parent] !== 'object' || Array.isArray(parsedYaml[parent])) {
+            continue;
+        }
+        for (const field of REQUIRED_COUNT_FIELDS) {
+            if (!Object.prototype.hasOwnProperty.call(parsedYaml[parent], field)) {
+                missingFields.push(`${parent}.${field}`);
+            }
+        }
+    }
+
+    return missingFields;
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+
+    if (missingFields.length > 0) {
+        errors.push(`missing required fields: ${missingFields.join(',')}`);
+    }
+    if (parsedYaml.approval_status !== 'not_approved') {
+        errors.push('approval_status must remain not_approved in the Phase 4.68C template');
+    }
+    if (
+        !Array.isArray(parsedYaml.target_tables) ||
+        parsedYaml.target_tables.length !== 1 ||
+        parsedYaml.target_tables[0] !== 'matches'
+    ) {
+        errors.push('target_tables must contain only matches in Phase 4.68C');
+    }
+    for (const field of REQUIRED_FALSE_FIELDS) {
+        if (parsedYaml[field] !== false) {
+            errors.push(`${field} must be false in the Phase 4.68C template`);
+        }
+    }
+    if (parsedYaml.require_pg_dump !== true) {
+        errors.push('require_pg_dump must be true');
+    }
+    if (parsedYaml.post_write_validation_required !== true) {
+        errors.push('post_write_validation_required must be true');
+    }
+
+    return {
+        ok: errors.length === 0,
+        missingFields,
+        errors,
+    };
+}
+
+function buildSuccessPayload(args, parsedYaml, approvalFormFound) {
+    return {
+        phase: RUNBOOK_VALIDATE_PHASE,
+        mode: 'football-data-small-write-runbook-validate',
+        ok: true,
+        approval_form: args.approvalForm,
+        approval_form_found: approvalFormFound,
+        yaml_block_found: true,
+        required_fields_present: true,
+        missing_fields: [],
+        approval_status: parsedYaml.approval_status,
+        target_tables: parsedYaml.target_tables,
+        commit_gate: 'blocked',
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+    const approvalFormPath = resolveLocalPath(args.approvalForm, cwd);
+
+    if (!args.approvalForm) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            errors: ['ERROR: provide --approval-form=<path>'],
+        });
+    }
+
+    if (!existsSync(approvalFormPath)) {
+        return buildFailurePayload(args, {
+            mode: 'approval-form-error',
+            approval_form_found: false,
+            errors: [`approval form not found: ${toRelativePath(approvalFormPath, cwd)}`],
+        });
+    }
+
+    const markdownText = readFileSync(approvalFormPath, 'utf8');
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        return buildFailurePayload(args, {
+            mode: 'approval-form-error',
+            approval_form_found: true,
+            yaml_block_found: false,
+            errors: ['YAML fenced block not found'],
+        });
+    }
+
+    let parsedYaml;
+    try {
+        parsedYaml = parseYamlBlock(yamlText);
+    } catch (error) {
+        return buildFailurePayload(args, {
+            mode: 'approval-form-error',
+            approval_form_found: true,
+            yaml_block_found: true,
+            errors: [`unable to parse YAML block: ${error.message}`],
+        });
+    }
+
+    const validation = validateParsedYaml(parsedYaml);
+    if (!validation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'approval-form-error',
+            approval_form_found: true,
+            yaml_block_found: true,
+            required_fields_present: validation.missingFields.length === 0,
+            missing_fields: validation.missingFields,
+            approval_status: parsedYaml.approval_status || null,
+            target_tables: parsedYaml.target_tables || null,
+            errors: validation.errors,
+        });
+    }
+
+    return buildSuccessPayload(args, parsedYaml, true);
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `approval_form_found=${payload.approval_form_found}`,
+        `yaml_block_found=${payload.yaml_block_found}`,
+        `required_fields_present=${payload.required_fields_present}`,
+        `approval_status=${payload.approval_status}`,
+        `target_tables=${JSON.stringify(payload.target_tables)}`,
+        `commit_gate=${payload.commit_gate}`,
+        `would_read_db=${payload.would_read_db}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_write_files=${payload.would_write_files}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_execute_pg_dump=${payload.would_execute_pg_dump}`,
+        `would_execute_pg_restore=${payload.would_execute_pg_restore}`,
+        `would_spawn_child_process=${payload.would_spawn_child_process}`,
+        `approval_granted=${payload.approval_granted}`,
+    ];
+
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.missing_fields) && payload.missing_fields.length > 0) {
+        lines.push(`missing_fields=${payload.missing_fields.join(',')}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+    lines.push('non_execution_confirmations=');
+    for (const confirmation of payload.non_execution_confirmations || []) {
+        lines.push(`  ${confirmation}`);
+    }
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            {
+                approvalForm: '',
+            },
+            {
+                mode: 'argument-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, argv.includes('--json'), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    RUNBOOK_VALIDATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    REQUIRED_FIELDS,
+    REQUIRED_COUNT_FIELDS,
+    parseArgs,
+    extractYamlBlock,
+    parseYamlBlock,
+    validateParsedYaml,
+    runValidation,
+    buildNonExecutionConfirmations,
+    main,
+};

--- a/tests/unit/football_data_small_write_runbook_validate.test.js
+++ b/tests/unit/football_data_small_write_runbook_validate.test.js
@@ -1,0 +1,436 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_small_write_runbook_validate.js');
+const TEMPLATE_PATH = path.join(PROJECT_ROOT, 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md');
+const TEMPLATE_TEXT = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_small_write_runbook_validate`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        Module._load = originalLoad;
+    });
+}
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildDependencies(markdownText = TEMPLATE_TEXT) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: () => true,
+        readFileSync: () => markdownText,
+    };
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(TEMPLATE_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return TEMPLATE_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return TEMPLATE_TEXT.replace(`${line}\n`, '');
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+
+    return {
+        status,
+        stdout,
+        stderr,
+    };
+}
+
+test('缺 approval form 参数时失败', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, [], buildDependencies());
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /ERROR: provide --approval-form=<path>/);
+});
+
+test('正确 approval form template validation 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { approvalForm: 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md' },
+        buildDependencies()
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.approval_status, 'not_approved');
+    assert.deepEqual(payload.target_tables, ['matches']);
+    assert.equal(payload.would_read_db, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+});
+
+test('CLI --help 输出 usage', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--help'], buildDependencies());
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Usage:/);
+    assert.match(result.stdout, /No DB reads, no DB writes/);
+});
+
+test('CLI 支持等号参数和 JSON 输出', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--approval-form=approval.md', '--json'], buildDependencies());
+    const payload = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.approval_status, 'not_approved');
+});
+
+test('未知参数失败且保持 non-execution flags', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--unknown', '--json'], buildDependencies());
+    const payload = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.would_read_db, false);
+    assert.equal(payload.would_write_db, false);
+    assert.match(payload.errors.join('\n'), /Unknown argument: --unknown/);
+});
+
+test('approval form 文件不存在时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { approvalForm: 'missing/approval.md' },
+        {
+            cwd: PROJECT_ROOT,
+            existsSync: () => false,
+            readFileSync: () => {
+                throw new Error('readFileSync should not run for missing approval form');
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.approval_form_found, false);
+    assert.match(payload.errors.join('\n'), /approval form not found: missing\/approval.md/);
+});
+
+test('YAML block 缺失时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies('# missing yaml\n'));
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.yaml_block_found, false);
+    assert.match(payload.errors.join('\n'), /YAML fenced block not found/);
+});
+
+test('YAML 顶层格式不支持时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies('```yaml\nnot yaml\n```\n'));
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.yaml_block_found, true);
+    assert.match(payload.errors.join('\n'), /unable to parse YAML block: unsupported YAML line/);
+});
+
+test('YAML nested 格式不支持时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { approvalForm: 'approval.md' },
+        buildDependencies('```yaml\nexpected_before_counts:\n  not yaml\n```\n')
+    );
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unable to parse YAML block: unsupported YAML line/);
+});
+
+test('YAML indentation 不支持时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { approvalForm: 'approval.md' },
+        buildDependencies('```yaml\n  matches:\n```\n')
+    );
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unable to parse YAML block: unsupported YAML indentation/);
+});
+
+test('YAML scalar parser 支持注释、数组、引号、数字和 nested overwrite', () => {
+    const gate = loadValidatorFresh();
+    const parsed = gate.parseYamlBlock(
+        [
+            'phase: PHASE # inline comment',
+            'empty_value:',
+            'empty_array: []',
+            'inline_array: [matches, 2, true]',
+            'quoted: "hello"',
+            "single_quoted: 'world'",
+            'number_value: 7',
+            'parent: scalar',
+            '  child:',
+        ].join('\n')
+    );
+
+    assert.equal(parsed.phase, 'PHASE');
+    assert.equal(parsed.empty_value, null);
+    assert.deepEqual(parsed.empty_array, []);
+    assert.deepEqual(parsed.inline_array, ['matches', 2, true]);
+    assert.equal(parsed.quoted, 'hello');
+    assert.equal(parsed.single_quoted, 'world');
+    assert.equal(parsed.number_value, 7);
+    assert.deepEqual(parsed.parent, { child: null });
+});
+
+test('required field 缺失时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = removeLineFromTemplate('operator:');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.deepEqual(payload.missing_fields, ['operator']);
+    assert.match(payload.errors.join('\n'), /missing required fields: operator/);
+});
+
+test('nested required count field 缺失时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = removeLineFromTemplate('  bookmaker_odds_history:');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.deepEqual(payload.missing_fields, ['expected_before_counts.bookmaker_odds_history']);
+    assert.match(payload.errors.join('\n'), /expected_before_counts\.bookmaker_odds_history/);
+});
+
+test('approval_status 不是 not_approved 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('approval_status: not_approved', 'approval_status: approved_for_db_write');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /approval_status must remain not_approved/);
+});
+
+test('target_tables 包含非 matches 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('  - matches', '  - matches\n  - bookmaker_odds_history');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /target_tables must contain only matches/);
+});
+
+test('allow_odds_insert=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_odds_insert: false', 'allow_odds_insert: true');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_odds_insert must be false/);
+});
+
+test('allow_raw_insert=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_raw_insert: false', 'allow_raw_insert: true');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_raw_insert must be false/);
+});
+
+test('allow_l3_insert=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_l3_insert: false', 'allow_l3_insert: true');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_l3_insert must be false/);
+});
+
+test('allow_training=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_training: false', 'allow_training: true');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_training must be false/);
+});
+
+test('allow_prediction=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_prediction: false', 'allow_prediction: true');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_prediction must be false/);
+});
+
+test('require_pg_dump=false 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('require_pg_dump: true', 'require_pg_dump: false');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /require_pg_dump must be true/);
+});
+
+test('post_write_validation_required=false 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate(
+        'post_write_validation_required: true',
+        'post_write_validation_required: false'
+    );
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /post_write_validation_required must be true/);
+});
+
+test('final_human_confirmation=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('final_human_confirmation: false', 'final_human_confirmation: true');
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /final_human_confirmation must be false/);
+});
+
+test('--commit 始终 blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--approval-form', 'approval.md', '--commit'], buildDependencies());
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /BLOCKED: football-data small write runbook commit is not wired in Phase 4.68C/);
+});
+
+test('validator 不访问外网', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_access_network, false);
+});
+
+test('validator 不读 DB', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_read_db, false);
+});
+
+test('validator 不写 DB', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('validator 不写文件', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_files, false);
+});
+
+test('validator 不执行 pg_dump', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_pg_dump, false);
+});
+
+test('validator 不执行 pg_restore', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_pg_restore, false);
+});
+
+test('validator 不 spawn child process', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ approvalForm: 'approval.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_spawn_child_process, false);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.68C football-data real small DB write runbook template and approval form.

Scope:
- Adds small DB write runbook template
- Adds approval form template
- Adds approval form validator
- Adds Makefile validation and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.68C report

Safety:
- No DB writes
- No DB reads from validator
- No pg_dump execution
- No pg_restore execution
- No backup file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- runbook approval form validation passed
- runbook commit gate remained blocked
- existing football-data gates still passed
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed