### PR TITLE
feat(data): add football-data small write packet preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -582,6 +582,10 @@ Phase 4.57C football-data adapter rules：
 - `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>` 只验证本地模板；不得读 DB、写 DB、执行 `pg_dump` / `pg_restore`、写 backup、触网、训练或预测。
 - `make data-football-data-small-write-runbook-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1` 也不得执行真实写库。
 - 真实 small DB write 必须在单独阶段进行，且必须有用户明确授权、真实 `pg_dump`、非空备份验证、小批量 transaction 和 post-write validation。
+- Phase 4.69C 的 `make data-football-data-small-write-packet-preview SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv> APPROVAL_FORM=<local md> RUNBOOK_TEMPLATE=<local md>` 只组装 stdout dry-run packet preview，不创建 packet 文件。
+- `data-football-data-small-write-packet-preview` 不得写 DB、不得执行 `pg_dump` / `pg_restore`、不得把 approval form 变成真实授权、不得把 `approval_status` 改成 `approved_for_db_write`、不得把 `final_human_confirmation` 改成 `true`。
+- `make data-football-data-small-write-packet-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1` 也不得执行真实 packet 写入或 DB write。
+- 真实 packet 文件创建、真实 `pg_dump` 和真实 small DB write 必须在单独阶段进行，并需要用户明确授权。
 - Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。
 - `data-football-data-insert-policy-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-insert-policy-commit` 当前 blocked / not wired。
 - future real DB write 必须单独阶段、单独授权、真实 `pg_dump`、非空备份验证、small batch transaction、post-write validation；restore 也必须单独授权，不得自动执行；DB write 前后 training / prediction 仍必须走单独 gate。

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@
         data-football-data-duplicate-precheck data-football-data-duplicate-precheck-commit \
         data-football-data-small-write-auth-preview data-football-data-small-write-commit \
         data-football-data-small-write-runbook-validate data-football-data-small-write-runbook-commit \
+        data-football-data-small-write-packet-preview data-football-data-small-write-packet-commit \
         data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
@@ -271,6 +272,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-duplicate-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-small-write-auth-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-small-write-runbook-validate APPROVAL_FORM=<path>"
+	@echo "  make data-football-data-small-write-packet-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
@@ -294,6 +296,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-duplicate-precheck-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_DUPLICATE_PRECHECK=1  # blocked in Phase 4.65C"
 	@echo "  make data-football-data-insert-policy-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1  # blocked in Phase 4.66C"
 	@echo "  make data-football-data-small-write-runbook-commit APPROVAL_FORM=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1  # blocked in Phase 4.68C"
+	@echo "  make data-football-data-small-write-packet-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1  # blocked in Phase 4.69C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -601,6 +604,26 @@ data-football-data-small-write-runbook-commit: ## Blocked Football-Data small DB
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data small write runbook commit is not wired in Phase 4.68C."
+	@exit 1
+
+data-football-data-small-write-packet-preview: ## Assemble Football-Data small write dry-run packet preview to stdout only. Requires SOURCE_MANIFEST, LOCAL_CSV, APPROVAL_FORM, RUNBOOK_TEMPLATE.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ] || [ -z "$(APPROVAL_FORM)" ] || [ -z "$(RUNBOOK_TEMPLATE)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path>, LOCAL_CSV=<path>, APPROVAL_FORM=<path>, and RUNBOOK_TEMPLATE=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data small write packet preview: SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV), APPROVAL_FORM=$(APPROVAL_FORM), RUNBOOK_TEMPLATE=$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(APPROVAL_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_small_write_packet_assembly.js --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)" --approval-form "$(APPROVAL_FORM)" --runbook-template "$(RUNBOOK_TEMPLATE)"
+
+data-football-data-small-write-packet-commit: ## Blocked Football-Data small write packet commit gate. Requires CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET)" != "1" ]; then \
+		echo "BLOCKED: football-data small write packet commit requires CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1 and is not wired in Phase 4.69C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data small write packet commit is not wired in Phase 4.69C."
 	@exit 1
 
 data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.

--- a/docs/_reports/FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY_PHASE4_69C.md
+++ b/docs/_reports/FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY_PHASE4_69C.md
@@ -1,0 +1,214 @@
+# Football-Data Small Write Packet Assembly - Phase 4.69C
+
+## 1. Current HEAD / branch
+
+- Starting HEAD: `e67d40407ba4bae5ba02121ad17ed332ee341bfa`
+- Branch: `feat/football-data-small-write-packet-phase469c`
+- Base: Phase 4.68C merged on remote `main`
+
+## 2. Why one larger themed PR is reasonable
+
+Phase 4.69C adds one coherent safety layer: a stdout-only dry-run packet preview for future human review before any real small DB write. The script, Makefile targets, unit tests, AGENTS rules, and this report all describe the same non-write contract, so keeping them in one PR makes the gate auditable end to end.
+
+## 3. Added / changed files
+
+- `scripts/ops/football_data_small_write_packet_assembly.js`
+- `tests/unit/football_data_small_write_packet_assembly.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY_PHASE4_69C.md`
+
+## 4. Dry-run packet assembly design
+
+The new packet assembly script accepts:
+
+```bash
+node scripts/ops/football_data_small_write_packet_assembly.js \
+  --source-manifest <path> \
+  --local-csv <path> \
+  --approval-form docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md \
+  --runbook-template docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md
+```
+
+It assembles a preview to stdout only. It reads local files, validates the approval form template, reuses the existing Football-Data dry-run / precheck gates, and permits only SELECT-only DB reads through the existing duplicate / insert policy / small write auth preview path.
+
+The script does not spawn child processes, write files, execute `pg_dump`, execute `pg_restore`, train, predict, or import the legacy downloader runtime.
+
+## 5. Packet sections
+
+The preview includes these sections:
+
+- `source_manifest_summary`
+- `local_csv_summary`
+- `csv_dry_run_summary`
+- `db_write_preflight_summary`
+- `duplicate_precheck_summary`
+- `insert_policy_summary`
+- `small_write_auth_preview_summary`
+- `runbook_template_summary`
+- `approval_form_summary`
+- `proposed_match_ids`
+- `insert_candidate_table`
+- `blocked_candidate_table`
+- `manual_review_table`
+- `pg_dump_command_preview`
+- `post_write_validation_checklist`
+- `rollback_restore_preview`
+- `final_human_approval_required`
+
+## 6. Approval form / runbook template integration
+
+- Approval form: `docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md`
+- Runbook template: `docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md`
+- The approval form remains a template with `approval_status=not_approved`.
+- The packet preview reports `final_human_confirmation=false`.
+- The packet preview reports `approval_granted=false`.
+
+The template is never converted into a real approval during Phase 4.69C.
+
+## 7. Why no packet file is written
+
+This phase is only packet assembly preview. Writing a real packet file would create a durable review artifact and must be separately authorized in a later phase. The script reports:
+
+- `packet_write_allowed=false`
+- `would_write_packet_file=false`
+- `would_write_files=false`
+- `no_packet_file_write`
+
+## 8. Why no DB write is performed
+
+The packet is an audit preview, not an insert operation. DB access remains limited to existing SELECT-only inspection paths. The script reports:
+
+- `select_only_db_reads=true`
+- `db_write_allowed=false`
+- `small_write_authorized=false`
+- `would_insert_matches=false`
+- `would_insert_odds=false`
+- `would_write_db=false`
+- `no_db_writes`
+
+## 9. Why no pg_dump is executed
+
+This phase previews the future backup command string only. Real `pg_dump` must occur in a separately authorized future write phase, immediately before a real small write. The script reports:
+
+- `would_execute_pg_dump=false`
+- `would_execute_pg_restore=false`
+- `no_pg_dump_execution`
+- `no_pg_restore_execution`
+
+## 10. Commit gate result
+
+Both packet commit target checks remained blocked:
+
+- `make data-football-data-small-write-packet-commit || true`
+- `make data-football-data-small-write-packet-commit ... CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1 || true`
+
+Observed blocked message:
+
+```text
+BLOCKED: football-data small write packet commit is not wired in Phase 4.69C.
+```
+
+## 11. Existing gates revalidated
+
+All existing Football-Data gates passed:
+
+- `make data-football-data-csv-dry-run`: passed
+- `make data-football-data-db-write-preflight`: passed
+- `make data-football-data-duplicate-precheck`: passed
+- `make data-football-data-insert-policy-precheck`: passed
+- `make data-football-data-small-write-auth-preview`: passed
+- `make data-football-data-small-write-runbook-validate`: passed
+
+No DB writes or `pg_dump` execution occurred.
+
+## 12. Unit tests
+
+All requested unit tests passed:
+
+- `tests/unit/football_data_small_write_packet_assembly.test.js`
+- `tests/unit/football_data_small_write_runbook_validate.test.js`
+- `tests/unit/football_data_small_write_auth_preview.test.js`
+- `tests/unit/football_data_insert_policy_precheck.test.js`
+- `tests/unit/football_data_duplicate_precheck.test.js`
+- `tests/unit/football_data_db_write_preflight.test.js`
+- `tests/unit/football_data_adapter_dry_run.test.js`
+- `tests/unit/football_data_local_csv_parser.test.js`
+- `tests/unit/acquisition_engine_gate.test.js`
+
+The new packet assembly test covers missing arguments, missing files, successful mock assembly, packet sections, approval defaults, blocked commit, sha256 / row_count mismatch without DB reads, invalid approval form, no legacy import, no network, no file writes, no packet file write, no `pg_dump`, no `pg_restore`, no child process spawn, no training, no prediction, and SELECT-only SQL guard behavior.
+
+## 13. npm test / coverage
+
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`: passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`: passed
+- Coverage thresholds were not modified.
+
+Final coverage:
+
+```text
+lines=88.33
+branches=80.01
+functions=80.80
+```
+
+## 14. DB before / after statistics
+
+Expected before counts:
+
+```text
+matches=2
+bookmaker_odds_history=2
+raw_match_data=2
+l3_features=2
+match_features_training=2
+predictions=2
+```
+
+Observed after counts:
+
+```text
+matches=2
+bookmaker_odds_history=2
+raw_match_data=2
+l3_features=2
+match_features_training=2
+predictions=2
+```
+
+DB row counts were unchanged.
+
+## 15. Next steps
+
+- Phase 4.70C: real packet file generation preflight, still no DB write and no `pg_dump`; whether to create a packet file requires separate user authorization.
+- Or Phase 4.56A: prepare runbook only after the user provides complete real network dry-run parameters.
+
+## 16. Explicitly not executed
+
+- DB writes
+- non-SELECT DB SQL
+- `pg_dump`
+- `pg_restore`
+- backup file writes
+- packet file writes
+- file writes from packet runtime
+- changing `approval_status` to `approved_for_db_write`
+- changing `final_human_confirmation` to `true`
+- external download
+- `curl` / `wget` / `git clone`
+- external football data source access
+- external odds source access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- network dry-run execution
+- bulk harvest
+- adapted CSV / staging data writes
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/football_data_small_write_packet_assembly.js
+++ b/scripts/ops/football_data_small_write_packet_assembly.js
@@ -1,0 +1,1033 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable max-lines -- This packet preview keeps the full non-write contract in one file for auditability. */
+
+const fs = require('fs');
+const path = require('path');
+
+const { runPreflight } = require('./football_data_db_write_preflight');
+const { runDuplicatePrecheck, assertSelectOnlySql } = require('./football_data_duplicate_precheck');
+const { runInsertPolicyPrecheck } = require('./football_data_insert_policy_precheck');
+const {
+    PG_DUMP_COMMAND_PREVIEW,
+    PG_RESTORE_COMMAND_PREVIEW,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    buildManifestCompatibleDryRun,
+    buildPostWriteValidationChecklist,
+    buildRollbackRestorePreview,
+    runSmallWriteAuthPreview,
+} = require('./football_data_small_write_auth_preview');
+const { extractYamlBlock, parseYamlBlock, runValidation } = require('./football_data_small_write_runbook_validate');
+
+const PACKET_ASSEMBLY_PHASE = 'PHASE4.69C_FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY';
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: football-data small write packet commit is not wired in Phase 4.69C.';
+const MISSING_ARGS_MESSAGE =
+    'ERROR: provide --source-manifest=<path>, --local-csv=<path>, --approval-form=<path>, and --runbook-template=<path>';
+const CURRENT_DB_TABLES = [
+    'matches',
+    'bookmaker_odds_history',
+    'raw_match_data',
+    'l3_features',
+    'match_features_training',
+    'predictions',
+];
+const PACKET_SECTIONS = [
+    'source_manifest_summary',
+    'local_csv_summary',
+    'csv_dry_run_summary',
+    'db_write_preflight_summary',
+    'duplicate_precheck_summary',
+    'insert_policy_summary',
+    'small_write_auth_preview_summary',
+    'runbook_template_summary',
+    'approval_form_summary',
+    'proposed_match_ids',
+    'insert_candidate_table',
+    'blocked_candidate_table',
+    'manual_review_table',
+    'pg_dump_command_preview',
+    'post_write_validation_checklist',
+    'rollback_restore_preview',
+    'final_human_approval_required',
+];
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_small_write_packet_assembly.js --source-manifest <path> --local-csv <path> --approval-form <path> --runbook-template <path> [--json]',
+        '  node scripts/ops/football_data_small_write_packet_assembly.js --source-manifest <path> --local-csv <path> --approval-form <path> --runbook-template <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.69C assembles a stdout-only dry-run packet preview.',
+        '  No packet file writes, no DB writes, no pg_dump, no pg_restore, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const valueOptions = new Map([
+        ['--source-manifest', 'sourceManifest'],
+        ['--local-csv', 'localCsv'],
+        ['--approval-form', 'approvalForm'],
+        ['--runbook-template', 'runbookTemplate'],
+    ]);
+    const flagOptions = new Map([
+        ['--commit', 'commit'],
+        ['--json', 'json'],
+        ['--help', 'help'],
+        ['-h', 'help'],
+    ]);
+    const args = {
+        sourceManifest: '',
+        localCsv: '',
+        approvalForm: '',
+        runbookTemplate: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        const matchedValueOption = [...valueOptions.keys()].find(
+            option => token === option || token.startsWith(`${option}=`)
+        );
+        if (matchedValueOption) {
+            const key = valueOptions.get(matchedValueOption);
+            const usesSeparateValue = token === matchedValueOption;
+            args[key] = usesSeparateValue
+                ? String(argv[index + 1] || '')
+                : token.slice(`${matchedValueOption}=`.length);
+            if (usesSeparateValue) {
+                index += 1;
+            }
+            continue;
+        }
+        if (flagOptions.has(token)) {
+            args[flagOptions.get(token)] = true;
+            continue;
+        }
+        throw new Error(`Unknown argument: ${token}`);
+    }
+
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) {
+        return '';
+    }
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) {
+        return '';
+    }
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'select_only_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_packet_file_write',
+        'no_legacy_runtime',
+        'no_pg_dump_execution',
+        'no_pg_restore_execution',
+        'no_training',
+        'no_prediction_execution',
+    ];
+}
+
+function buildFutureRealPacketRequirements() {
+    return [
+        'approval form must be copied from template into a real reviewed file',
+        'approval_status must be changed only by human',
+        'final_human_confirmation must be set only by human',
+        'packet must list exact proposed_match_ids',
+        'packet must exclude manual_review and invalid candidates',
+        'pg_dump must be executed only in future authorized write phase',
+        'backup file must be non-empty before write',
+        'write must be small and auditable',
+        'post-write validation must be recorded',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        select_only_db_reads: true,
+        packet_write_allowed: false,
+        db_write_allowed: false,
+        small_write_authorized: false,
+        would_write_packet_file: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_execute_legacy_runtime: false,
+        would_spawn_child_process: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+        would_load_model_artifact: false,
+        approval_form_is_template: true,
+        approval_granted: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: PACKET_ASSEMBLY_PHASE,
+        mode: fields.mode || 'football-data-small-write-packet-assembly',
+        ok: false,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        approval_form: args.approvalForm || null,
+        runbook_template: args.runbookTemplate || null,
+        source_manifest_found: false,
+        local_csv_found: false,
+        approval_form_found: false,
+        runbook_template_found: false,
+        csv_dry_run_passed: false,
+        db_write_preflight_passed: false,
+        duplicate_precheck_passed: false,
+        insert_policy_precheck_passed: false,
+        small_write_auth_preview_passed: false,
+        approval_form_validation_passed: false,
+        approval_status: null,
+        final_human_confirmation: null,
+        commit_gate: 'blocked',
+        packet_sections: PACKET_SECTIONS,
+        pg_dump_command_preview: PG_DUMP_COMMAND_PREVIEW,
+        pg_restore_command_preview: PG_RESTORE_COMMAND_PREVIEW,
+        post_write_validation_checklist: buildPostWriteValidationChecklist(),
+        rollback_restore_preview: buildRollbackRestorePreview(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        future_real_packet_requirements: buildFutureRealPacketRequirements(),
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        select_only_db_reads: false,
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function buildPathContext(args, cwd, existsSync) {
+    const sourceManifestPath = resolveLocalPath(args.sourceManifest, cwd);
+    const localCsvPath = resolveLocalPath(args.localCsv, cwd);
+    const approvalFormPath = resolveLocalPath(args.approvalForm, cwd);
+    const runbookTemplatePath = resolveLocalPath(args.runbookTemplate, cwd);
+    return {
+        sourceManifestPath,
+        localCsvPath,
+        approvalFormPath,
+        runbookTemplatePath,
+        sourceManifestFound: existsSync(sourceManifestPath),
+        localCsvFound: existsSync(localCsvPath),
+        approvalFormFound: existsSync(approvalFormPath),
+        runbookTemplateFound: existsSync(runbookTemplatePath),
+    };
+}
+
+function validateRequiredArgs(args) {
+    return Boolean(args.sourceManifest && args.localCsv && args.approvalForm && args.runbookTemplate);
+}
+
+function buildMissingPathPayload(args, cwd, pathContext) {
+    const baseFields = {
+        source_manifest_found: pathContext.sourceManifestFound,
+        local_csv_found: pathContext.localCsvFound,
+        approval_form_found: pathContext.approvalFormFound,
+        runbook_template_found: pathContext.runbookTemplateFound,
+    };
+
+    if (!pathContext.sourceManifestFound) {
+        return buildFailurePayload(args, {
+            mode: 'manifest-error',
+            ...baseFields,
+            errors: [`source manifest not found: ${toRelativePath(pathContext.sourceManifestPath, cwd)}`],
+        });
+    }
+    if (!pathContext.localCsvFound) {
+        return buildFailurePayload(args, {
+            mode: 'csv-error',
+            ...baseFields,
+            errors: [`local CSV not found: ${toRelativePath(pathContext.localCsvPath, cwd)}`],
+        });
+    }
+    if (!pathContext.approvalFormFound) {
+        return buildFailurePayload(args, {
+            mode: 'approval-form-error',
+            ...baseFields,
+            errors: [`approval form not found: ${toRelativePath(pathContext.approvalFormPath, cwd)}`],
+        });
+    }
+    if (!pathContext.runbookTemplateFound) {
+        return buildFailurePayload(args, {
+            mode: 'runbook-template-error',
+            ...baseFields,
+            errors: [`runbook template not found: ${toRelativePath(pathContext.runbookTemplatePath, cwd)}`],
+        });
+    }
+    return null;
+}
+
+function readJsonSafely(readFileSync, filePath) {
+    try {
+        return JSON.parse(readFileSync(filePath, 'utf8'));
+    } catch (error) {
+        return {
+            parse_error: error.message,
+        };
+    }
+}
+
+function parseApprovalTemplate(markdownText) {
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        return {};
+    }
+    try {
+        return parseYamlBlock(yamlText);
+    } catch (error) {
+        return {
+            parse_error: error.message,
+        };
+    }
+}
+
+function pickFields(source, mapping) {
+    const picked = {};
+    for (const [targetKey, sourceKey] of Object.entries(mapping)) {
+        picked[targetKey] = source?.[sourceKey] ?? null;
+    }
+    return picked;
+}
+
+function summarizeSourceManifest(manifest, manifestPath, cwd) {
+    return {
+        path: toRelativePath(manifestPath, cwd),
+        source_name: manifest.source_name || null,
+        source_type: manifest.source_type || null,
+        source_url: manifest.source_url || null,
+        license_url: manifest.license_url || null,
+        terms_url: manifest.terms_url || null,
+        approval_status: manifest.approval_status || null,
+        human_approval_note_present: Boolean(String(manifest.human_approval_note || '').trim()),
+        local_csv_path: manifest.local_csv_path || null,
+        sha256: manifest.sha256 || null,
+        row_count: manifest.row_count ?? null,
+        mapping_version: manifest.mapping_version || null,
+        parser_version: manifest.parser_version || null,
+    };
+}
+
+function summarizeLocalCsv(localCsvPath, dryRunPayload, cwd) {
+    return {
+        path: toRelativePath(localCsvPath, cwd),
+        expected_sha256: dryRunPayload.expected_sha256 || null,
+        actual_sha256: dryRunPayload.actual_sha256 || null,
+        sha256_match: dryRunPayload.sha256_match,
+        expected_row_count: dryRunPayload.expected_row_count ?? null,
+        actual_row_count: dryRunPayload.actual_row_count ?? null,
+        row_count_match: dryRunPayload.row_count_match,
+        total_rows: dryRunPayload.total_rows ?? null,
+        parsed_rows: dryRunPayload.parsed_rows ?? null,
+        candidate_rows: (dryRunPayload.candidate_rows || []).length,
+        trainable_label_rows: dryRunPayload.trainable_label_rows || 0,
+        skipped_rows: dryRunPayload.skipped_rows || 0,
+        odds_preview_rows: dryRunPayload.odds_preview_rows || 0,
+    };
+}
+
+function summarizeRunbookTemplate(runbookTemplatePath, markdownText, cwd) {
+    return {
+        path: toRelativePath(runbookTemplatePath, cwd),
+        template_only: true,
+        preview_only: /PREVIEW ONLY/i.test(markdownText),
+        do_not_run_marker_present: /DO NOT RUN/i.test(markdownText),
+        headings: String(markdownText || '')
+            .split(/\r?\n/)
+            .filter(line => /^#{1,3} /.test(line))
+            .map(line => line.replace(/^#+\s*/, '').trim()),
+    };
+}
+
+function summarizeApprovalForm(approvalFormPath, parsedApproval, validationPayload, cwd) {
+    return {
+        path: toRelativePath(approvalFormPath, cwd),
+        template_only: true,
+        validation_passed: validationPayload.ok,
+        approval_status: parsedApproval.approval_status || validationPayload.approval_status || null,
+        final_human_confirmation: parsedApproval.final_human_confirmation ?? null,
+        target_tables: parsedApproval.target_tables || validationPayload.target_tables || null,
+        allow_odds_insert: parsedApproval.allow_odds_insert ?? null,
+        allow_raw_insert: parsedApproval.allow_raw_insert ?? null,
+        allow_l3_insert: parsedApproval.allow_l3_insert ?? null,
+        allow_training: parsedApproval.allow_training ?? null,
+        allow_prediction: parsedApproval.allow_prediction ?? null,
+        require_pg_dump: parsedApproval.require_pg_dump ?? null,
+    };
+}
+
+function summarizeCsvDryRun(dryRunPayload) {
+    return {
+        ...pickFields(dryRunPayload, {
+            phase: 'dry_run_version',
+            ok: 'ok',
+            source_name: 'source_name',
+            approval_status: 'approval_status',
+            total_rows: 'total_rows',
+            parsed_rows: 'parsed_rows',
+        }),
+        candidate_rows: (dryRunPayload.candidate_rows || []).length,
+        row_classification: dryRunPayload.row_classification || null,
+        warnings: dryRunPayload.warnings || [],
+    };
+}
+
+function summarizePreflight(preflightPayload) {
+    return {
+        ...pickFields(preflightPayload, {
+            phase: 'phase',
+            ok: 'ok',
+            commit_gate: 'commit_gate',
+        }),
+        target_tables_preview: preflightPayload.preflight_plan?.target_tables_preview || null,
+        max_rows_preview: preflightPayload.preflight_plan?.max_rows_preview ?? null,
+        match_write_policy: preflightPayload.preflight_plan?.match_write_policy || null,
+        odds_write_policy: preflightPayload.preflight_plan?.odds_write_policy || null,
+    };
+}
+
+function summarizeDuplicatePrecheck(duplicatePayload) {
+    return {
+        ...pickFields(duplicatePayload, {
+            phase: 'phase',
+            ok: 'ok',
+            candidate_rows: 'candidate_rows',
+            exact_existing_matches: 'exact_existing_matches',
+            reversed_team_matches: 'reversed_team_matches',
+            nearby_date_matches: 'nearby_date_matches',
+            invalid_candidates: 'invalid_candidates',
+            commit_gate: 'commit_gate',
+        }),
+        insert_risk_summary: duplicatePayload.insert_risk_summary || null,
+    };
+}
+
+function summarizeInsertPolicy(insertPolicyPayload) {
+    return {
+        ...pickFields(insertPolicyPayload, {
+            phase: 'phase',
+            ok: 'ok',
+            match_id_strategy: 'match_id_strategy',
+            match_id_strategy_finalized: 'match_id_strategy_finalized',
+            manifest_approval_status: 'manifest_approval_status',
+            candidate_rows: 'candidate_rows',
+            future_insert_candidates: 'future_insert_candidates',
+            blocked_by_manifest_policy: 'blocked_by_manifest_policy',
+            skip_existing_matches: 'skip_existing_matches',
+            manual_review_required: 'manual_review_required',
+            invalid_candidates: 'invalid_candidates',
+            commit_gate: 'commit_gate',
+        }),
+    };
+}
+
+function summarizeAuthPreview(authPayload) {
+    return {
+        ...pickFields(authPayload, {
+            phase: 'phase',
+            ok: 'ok',
+            current_db_counts: 'current_db_counts',
+            current_db_schema_preview: 'current_db_schema_preview',
+            max_rows_preview: 'max_rows_preview',
+            target_tables_preview: 'target_tables_preview',
+            small_write_authorized: 'small_write_authorized',
+            db_write_allowed: 'db_write_allowed',
+            commit_gate: 'commit_gate',
+        }),
+    };
+}
+
+function mapCandidatePreview(preview) {
+    return {
+        row_number: preview.row_number || null,
+        proposed_match_id: preview.proposed_match_id || null,
+        home_team: preview.home_team || null,
+        away_team: preview.away_team || null,
+        match_date: preview.match_date || null,
+        insert_policy: preview.insert_policy || null,
+        duplicate_risk: preview.duplicate_risk || null,
+        policy_reason: preview.policy_reason || null,
+        required_action: preview.review_reason || preview.skip_reason || preview.policy_reason || null,
+    };
+}
+
+function buildCandidateTables(insertPolicyPayload) {
+    const previews = insertPolicyPayload.candidate_previews || [];
+    const insertCandidateTable = previews
+        .filter(preview => preview.insert_policy === 'future_insert_candidate')
+        .map(preview => ({
+            ...mapCandidatePreview(preview),
+            approved_to_insert: false,
+        }));
+    const manualReviewTable = previews
+        .filter(preview => preview.insert_policy === 'manual_review_required')
+        .map(mapCandidatePreview);
+    const blockedCandidateTable = previews
+        .filter(preview => preview.insert_policy !== 'future_insert_candidate')
+        .filter(preview => preview.insert_policy !== 'manual_review_required')
+        .map(mapCandidatePreview);
+
+    return {
+        proposed_match_ids: previews.map(preview => preview.proposed_match_id).filter(Boolean),
+        insert_candidate_table: insertCandidateTable,
+        blocked_candidate_table: blockedCandidateTable,
+        manual_review_table: manualReviewTable,
+    };
+}
+
+function mergeWarnings(...payloads) {
+    return payloads.flatMap(payload => payload?.warnings || []);
+}
+
+function buildBaseDependencyArgs(args) {
+    return {
+        sourceManifest: args.sourceManifest,
+        localCsv: args.localCsv,
+    };
+}
+
+function buildDbReadDependencies(dependencies, dryRunPreview, key) {
+    return {
+        ...(dependencies[key] || {}),
+        dbClient: dependencies.dbClient,
+        pool: dependencies.pool,
+        runDryRun: dryRunPreview,
+    };
+}
+
+function buildApprovalValidationDependencies(dependencies, pathContext, approvalMarkdown) {
+    const cwd = dependencies.cwd || process.cwd();
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+    return {
+        ...(dependencies.approvalValidationDependencies || {}),
+        cwd,
+        existsSync,
+        readFileSync: filePath => {
+            const resolved = resolveLocalPath(filePath, cwd);
+            if (resolved === pathContext.approvalFormPath) {
+                return approvalMarkdown;
+            }
+            return readFileSync(filePath, 'utf8');
+        },
+    };
+}
+
+function buildProgressState(pathContext, parsedApproval, fields = {}) {
+    return {
+        source_manifest_found: Boolean(pathContext.sourceManifestFound),
+        local_csv_found: Boolean(pathContext.localCsvFound),
+        approval_form_found: Boolean(pathContext.approvalFormFound),
+        runbook_template_found: Boolean(pathContext.runbookTemplateFound),
+        approval_status: parsedApproval.approval_status ?? null,
+        final_human_confirmation: parsedApproval.final_human_confirmation ?? null,
+        ...fields,
+    };
+}
+
+function buildStageFailurePayload(args, progressState, mode, payload, fields = {}) {
+    return buildFailurePayload(args, {
+        mode,
+        ...progressState,
+        ...fields,
+        errors: payload.errors || [`${mode} failed`],
+        warnings: payload.warnings || [],
+    });
+}
+
+function buildSuccessPacketPayload(args, context) {
+    const candidateTables = buildCandidateTables(context.insertPolicyPayload);
+    return {
+        phase: PACKET_ASSEMBLY_PHASE,
+        mode: 'football-data-small-write-packet-assembly',
+        ok: true,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        approval_form: args.approvalForm,
+        runbook_template: args.runbookTemplate,
+        ...buildProgressState(context.pathContext, context.parsedApproval, {
+            csv_dry_run_passed: true,
+            db_write_preflight_passed: true,
+            duplicate_precheck_passed: true,
+            insert_policy_precheck_passed: true,
+            small_write_auth_preview_passed: true,
+            approval_form_validation_passed: true,
+        }),
+        commit_gate: 'blocked',
+        packet_sections: PACKET_SECTIONS,
+        source_manifest_summary: summarizeSourceManifest(
+            context.manifest,
+            context.pathContext.sourceManifestPath,
+            context.cwd
+        ),
+        local_csv_summary: summarizeLocalCsv(context.pathContext.localCsvPath, context.dryRunPayload, context.cwd),
+        csv_dry_run_summary: summarizeCsvDryRun(context.dryRunPayload),
+        db_write_preflight_summary: summarizePreflight(context.preflightPayload),
+        duplicate_precheck_summary: summarizeDuplicatePrecheck(context.duplicatePayload),
+        insert_policy_summary: summarizeInsertPolicy(context.insertPolicyPayload),
+        small_write_auth_preview_summary: summarizeAuthPreview(context.authPayload),
+        runbook_template_summary: summarizeRunbookTemplate(
+            context.pathContext.runbookTemplatePath,
+            context.runbookMarkdown,
+            context.cwd
+        ),
+        approval_form_summary: summarizeApprovalForm(
+            context.pathContext.approvalFormPath,
+            context.parsedApproval,
+            context.approvalValidationPayload,
+            context.cwd
+        ),
+        ...candidateTables,
+        pg_dump_command_preview: context.authPayload.pg_dump_command_preview || PG_DUMP_COMMAND_PREVIEW,
+        pg_restore_command_preview: context.authPayload.pg_restore_command_preview || PG_RESTORE_COMMAND_PREVIEW,
+        post_write_validation_checklist:
+            context.authPayload.post_write_validation || buildPostWriteValidationChecklist(),
+        rollback_restore_preview: context.authPayload.rollback_restore_preview || buildRollbackRestorePreview(),
+        final_human_approval_required: {
+            required: true,
+            approval_granted: false,
+            approval_status: context.parsedApproval.approval_status,
+            final_human_confirmation: context.parsedApproval.final_human_confirmation,
+        },
+        future_real_packet_requirements: buildFutureRealPacketRequirements(),
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        current_db_counts: context.authPayload.current_db_counts || null,
+        current_db_schema_preview: context.authPayload.current_db_schema_preview || null,
+        warnings: mergeWarnings(
+            context.dryRunPayload,
+            context.preflightPayload,
+            context.duplicatePayload,
+            context.insertPolicyPayload,
+            context.authPayload
+        ),
+        errors: [],
+    };
+}
+
+function buildPacketContext(args, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+
+    if (!validateRequiredArgs(args)) {
+        return {
+            failurePayload: buildFailurePayload(args, { mode: 'argument-error', errors: [MISSING_ARGS_MESSAGE] }),
+        };
+    }
+
+    const pathContext = buildPathContext(args, cwd, existsSync);
+    const missingPathPayload = buildMissingPathPayload(args, cwd, pathContext);
+    if (missingPathPayload) {
+        return { failurePayload: missingPathPayload };
+    }
+
+    const approvalMarkdown = readFileSync(pathContext.approvalFormPath, 'utf8');
+    const runbookMarkdown = readFileSync(pathContext.runbookTemplatePath, 'utf8');
+    const parsedApproval = parseApprovalTemplate(approvalMarkdown);
+    return {
+        context: {
+            cwd,
+            readFileSync,
+            pathContext,
+            approvalMarkdown,
+            runbookMarkdown,
+            parsedApproval,
+            baseProgress: buildProgressState(pathContext, parsedApproval),
+            runArgs: buildBaseDependencyArgs(args),
+        },
+    };
+}
+
+function runApprovalValidationStage(args, context, dependencies) {
+    const approvalValidationPayload = (dependencies.runApprovalValidation || runValidation)(
+        { approvalForm: args.approvalForm },
+        buildApprovalValidationDependencies(dependencies, context.pathContext, context.approvalMarkdown)
+    );
+    if (!approvalValidationPayload.ok) {
+        return {
+            failurePayload: buildStageFailurePayload(
+                args,
+                context.baseProgress,
+                'approval-form-validation-failed',
+                approvalValidationPayload
+            ),
+        };
+    }
+    context.approvalValidationPayload = approvalValidationPayload;
+    return {};
+}
+
+function runDryRunStage(args, context, dependencies) {
+    context.manifest = readJsonSafely(context.readFileSync, context.pathContext.sourceManifestPath);
+    const runArgs = buildBaseDependencyArgs(args);
+    context.dryRunPreview = dependencies.runDryRun || buildManifestCompatibleDryRun(dependencies);
+    const dryRunPayload = context.dryRunPreview(runArgs);
+    const dryRunProgress = buildProgressState(context.pathContext, context.parsedApproval, {
+        approval_form_validation_passed: true,
+        sha256_match: dryRunPayload.sha256_match,
+        row_count_match: dryRunPayload.row_count_match,
+    });
+    if (!dryRunPayload.ok) {
+        return {
+            failurePayload: buildStageFailurePayload(args, dryRunProgress, 'csv-dry-run-failed', dryRunPayload),
+        };
+    }
+    context.dryRunPayload = dryRunPayload;
+    context.dryRunProgress = dryRunProgress;
+    return {};
+}
+
+async function runPreflightStage(args, context, dependencies) {
+    const preflightPayload = await Promise.resolve(
+        (dependencies.runPreflight || runPreflight)(context.runArgs, {
+            ...(dependencies.preflightDependencies || {}),
+            runDryRun: context.dryRunPreview,
+        })
+    );
+    const preflightProgress = { ...context.dryRunProgress, csv_dry_run_passed: true };
+    if (!preflightPayload.ok) {
+        return {
+            failurePayload: buildStageFailurePayload(
+                args,
+                preflightProgress,
+                'db-write-preflight-failed',
+                preflightPayload,
+                { warnings: mergeWarnings(context.dryRunPayload, preflightPayload) }
+            ),
+        };
+    }
+    context.preflightPayload = preflightPayload;
+    context.preflightProgress = preflightProgress;
+    return {};
+}
+
+async function runDuplicateStage(args, context, dependencies) {
+    const duplicatePayload = await (dependencies.runDuplicatePrecheck || runDuplicatePrecheck)(
+        context.runArgs,
+        buildDbReadDependencies(dependencies, context.dryRunPreview, 'duplicateDependencies')
+    );
+    const duplicateProgress = { ...context.preflightProgress, db_write_preflight_passed: true };
+    if (!duplicatePayload.ok) {
+        return {
+            failurePayload: buildStageFailurePayload(
+                args,
+                duplicateProgress,
+                'duplicate-precheck-failed',
+                duplicatePayload,
+                { warnings: mergeWarnings(context.dryRunPayload, context.preflightPayload, duplicatePayload) }
+            ),
+        };
+    }
+    context.duplicatePayload = duplicatePayload;
+    context.duplicateProgress = duplicateProgress;
+    return {};
+}
+
+async function runInsertPolicyStage(args, context, dependencies) {
+    const insertPolicyPayload = await (dependencies.runInsertPolicyPrecheck || runInsertPolicyPrecheck)(
+        context.runArgs,
+        buildDbReadDependencies(dependencies, context.dryRunPreview, 'insertPolicyDependencies')
+    );
+    const insertProgress = { ...context.duplicateProgress, duplicate_precheck_passed: true };
+    if (!insertPolicyPayload.ok) {
+        return {
+            failurePayload: buildStageFailurePayload(
+                args,
+                insertProgress,
+                'insert-policy-precheck-failed',
+                insertPolicyPayload,
+                {
+                    warnings: mergeWarnings(
+                        context.dryRunPayload,
+                        context.preflightPayload,
+                        context.duplicatePayload,
+                        insertPolicyPayload
+                    ),
+                }
+            ),
+        };
+    }
+    context.insertPolicyPayload = insertPolicyPayload;
+    context.insertProgress = insertProgress;
+    return {};
+}
+
+async function runAuthStage(args, context, dependencies) {
+    const authPayload = await (dependencies.runSmallWriteAuthPreview || runSmallWriteAuthPreview)(context.runArgs, {
+        ...(dependencies.authPreviewDependencies || {}),
+        dbClient: dependencies.dbClient,
+        pool: dependencies.pool,
+        runDryRun: () => context.dryRunPayload,
+        runPreflight: () => context.preflightPayload,
+        runDuplicatePrecheck: async () => context.duplicatePayload,
+        runInsertPolicyPrecheck: async () => context.insertPolicyPayload,
+        inspectCurrentDbState: dependencies.inspectCurrentDbState,
+    });
+    if (!authPayload.ok) {
+        return {
+            failurePayload: buildStageFailurePayload(
+                args,
+                { ...context.insertProgress, insert_policy_precheck_passed: true },
+                'small-write-auth-preview-failed',
+                authPayload,
+                {
+                    warnings: mergeWarnings(
+                        context.dryRunPayload,
+                        context.preflightPayload,
+                        context.duplicatePayload,
+                        context.insertPolicyPayload,
+                        authPayload
+                    ),
+                }
+            ),
+        };
+    }
+    context.authPayload = authPayload;
+    return {};
+}
+
+async function runPacketStages(args, context, dependencies) {
+    const stageRunners = [
+        runApprovalValidationStage,
+        runDryRunStage,
+        runPreflightStage,
+        runDuplicateStage,
+        runInsertPolicyStage,
+        runAuthStage,
+    ];
+
+    for (const runStage of stageRunners) {
+        const stageResult = await runStage(args, context, dependencies);
+        if (stageResult.failurePayload) {
+            return stageResult;
+        }
+    }
+    return {};
+}
+
+async function runPacketAssembly(args, dependencies = {}) {
+    const prepared = buildPacketContext(args, dependencies);
+    if (prepared.failurePayload) {
+        return prepared.failurePayload;
+    }
+
+    const context = prepared.context;
+    const stageResult = await runPacketStages(args, context, dependencies);
+    if (stageResult.failurePayload) {
+        return stageResult.failurePayload;
+    }
+    return buildSuccessPacketPayload(args, context);
+}
+
+function appendListSection(lines, title, values) {
+    lines.push(`${title}:`);
+    for (const value of values || []) {
+        lines.push(`- ${value}`);
+    }
+}
+
+function appendOptionalTextFields(lines, payload) {
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+}
+
+function appendCurrentDbCounts(lines, counts) {
+    if (!counts) {
+        return;
+    }
+    lines.push('current_db_counts:');
+    for (const tableName of CURRENT_DB_TABLES) {
+        lines.push(`- ${tableName}=${counts[tableName] ?? 'unknown'}`);
+    }
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `approval_form_found=${payload.approval_form_found}`,
+        `runbook_template_found=${payload.runbook_template_found}`,
+        `csv_dry_run_passed=${payload.csv_dry_run_passed}`,
+        `db_write_preflight_passed=${payload.db_write_preflight_passed}`,
+        `duplicate_precheck_passed=${payload.duplicate_precheck_passed}`,
+        `insert_policy_precheck_passed=${payload.insert_policy_precheck_passed}`,
+        `small_write_auth_preview_passed=${payload.small_write_auth_preview_passed}`,
+        `approval_form_validation_passed=${payload.approval_form_validation_passed}`,
+        `select_only_db_reads=${payload.select_only_db_reads}`,
+        `packet_write_allowed=${payload.packet_write_allowed}`,
+        `db_write_allowed=${payload.db_write_allowed}`,
+        `small_write_authorized=${payload.small_write_authorized}`,
+        `would_write_packet_file=${payload.would_write_packet_file}`,
+        `would_execute_pg_dump=${payload.would_execute_pg_dump}`,
+        `would_execute_pg_restore=${payload.would_execute_pg_restore}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+        `commit_gate=${payload.commit_gate}`,
+        `approval_status=${payload.approval_status}`,
+        `final_human_confirmation=${payload.final_human_confirmation}`,
+        `approval_form_is_template=${payload.approval_form_is_template}`,
+        `approval_granted=${payload.approval_granted}`,
+        `pg_dump_command_preview=${JSON.stringify(payload.pg_dump_command_preview)}`,
+        `pg_restore_command_preview=${JSON.stringify(payload.pg_restore_command_preview)}`,
+    ];
+
+    appendOptionalTextFields(lines, payload);
+    appendCurrentDbCounts(lines, payload.current_db_counts);
+    appendListSection(lines, 'packet_sections', payload.packet_sections);
+    appendListSection(lines, 'non_execution_confirmations', payload.non_execution_confirmations);
+    appendListSection(lines, 'future_real_packet_requirements', payload.future_real_packet_requirements);
+
+    if (payload.source_manifest_summary) {
+        lines.push(`source_manifest_summary=${JSON.stringify(payload.source_manifest_summary)}`);
+    }
+    if (payload.local_csv_summary) {
+        lines.push(`local_csv_summary=${JSON.stringify(payload.local_csv_summary)}`);
+    }
+    if (payload.csv_dry_run_summary) {
+        lines.push(`csv_dry_run_summary=${JSON.stringify(payload.csv_dry_run_summary)}`);
+    }
+    if (payload.db_write_preflight_summary) {
+        lines.push(`db_write_preflight_summary=${JSON.stringify(payload.db_write_preflight_summary)}`);
+    }
+    if (payload.duplicate_precheck_summary) {
+        lines.push(`duplicate_precheck_summary=${JSON.stringify(payload.duplicate_precheck_summary)}`);
+    }
+    if (payload.insert_policy_summary) {
+        lines.push(`insert_policy_summary=${JSON.stringify(payload.insert_policy_summary)}`);
+    }
+    if (payload.small_write_auth_preview_summary) {
+        lines.push(`small_write_auth_preview_summary=${JSON.stringify(payload.small_write_auth_preview_summary)}`);
+    }
+    if (payload.runbook_template_summary) {
+        lines.push(`runbook_template_summary=${JSON.stringify(payload.runbook_template_summary)}`);
+    }
+    if (payload.approval_form_summary) {
+        lines.push(`approval_form_summary=${JSON.stringify(payload.approval_form_summary)}`);
+    }
+    if (payload.proposed_match_ids) {
+        lines.push(`proposed_match_ids=${JSON.stringify(payload.proposed_match_ids)}`);
+    }
+    if (payload.insert_candidate_table) {
+        lines.push(`insert_candidate_table=${JSON.stringify(payload.insert_candidate_table)}`);
+    }
+    if (payload.blocked_candidate_table) {
+        lines.push(`blocked_candidate_table=${JSON.stringify(payload.blocked_candidate_table)}`);
+    }
+    if (payload.manual_review_table) {
+        lines.push(`manual_review_table=${JSON.stringify(payload.manual_review_table)}`);
+    }
+    if (payload.final_human_approval_required) {
+        lines.push(`final_human_approval_required=${JSON.stringify(payload.final_human_approval_required)}`);
+    }
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+async function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = await runPacketAssembly(args, dependencies);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            {
+                sourceManifest: '',
+                localCsv: '',
+                approvalForm: '',
+                runbookTemplate: '',
+            },
+            {
+                mode: 'runtime-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, argv.includes('--json'), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => {
+        process.exitCode = status;
+    });
+}
+
+module.exports = {
+    PACKET_ASSEMBLY_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    MISSING_ARGS_MESSAGE,
+    PACKET_SECTIONS,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    runPacketAssembly,
+    buildNonExecutionConfirmations,
+    buildFutureRealPacketRequirements,
+    buildCandidateTables,
+    assertSelectOnlySql,
+    payloadToText,
+    main,
+};

--- a/tests/unit/football_data_small_write_packet_assembly.test.js
+++ b/tests/unit/football_data_small_write_packet_assembly.test.js
@@ -1,0 +1,966 @@
+'use strict';
+/* eslint-disable max-lines -- Phase 4.69C keeps the packet assembly safety contract in one test file. */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_small_write_packet_assembly.js');
+const DRY_RUN_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_adapter_dry_run.js');
+const PREFLIGHT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_db_write_preflight.js');
+const DUPLICATE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_duplicate_precheck.js');
+const INSERT_POLICY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_insert_policy_precheck.js');
+const AUTH_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_small_write_auth_preview.js');
+const RUNBOOK_VALIDATE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_small_write_runbook_validate.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+const APPROVAL_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md'
+);
+const RUNBOOK_TEMPLATE_PATH = path.join(PROJECT_ROOT, 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md');
+
+const APPROVAL_FORM_TEXT = fs.readFileSync(APPROVAL_FORM_PATH, 'utf8');
+const RUNBOOK_TEMPLATE_TEXT = fs.readFileSync(RUNBOOK_TEMPLATE_PATH, 'utf8');
+const MANIFEST_TEXT = fs.readFileSync(MANIFEST_PATH, 'utf8');
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_small_write_packet_assembly`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        Module._load = originalLoad;
+    });
+}
+
+function loadPacketFresh() {
+    for (const modulePath of [
+        SCRIPT_PATH,
+        DRY_RUN_PATH,
+        PREFLIGHT_PATH,
+        DUPLICATE_PATH,
+        INSERT_POLICY_PATH,
+        AUTH_PATH,
+        RUNBOOK_VALIDATE_PATH,
+    ]) {
+        delete require.cache[modulePath];
+    }
+    return require(SCRIPT_PATH);
+}
+
+function baseArgs(overrides = {}) {
+    return {
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+        approvalForm: APPROVAL_FORM_PATH,
+        runbookTemplate: RUNBOOK_TEMPLATE_PATH,
+        ...overrides,
+    };
+}
+
+function createReadFileSync(overrides = {}) {
+    return filePath => {
+        const normalized = path.resolve(String(filePath));
+        if (Object.prototype.hasOwnProperty.call(overrides, normalized)) {
+            return overrides[normalized];
+        }
+        if (normalized === APPROVAL_FORM_PATH) {
+            return APPROVAL_FORM_TEXT;
+        }
+        if (normalized === RUNBOOK_TEMPLATE_PATH) {
+            return RUNBOOK_TEMPLATE_TEXT;
+        }
+        if (normalized === MANIFEST_PATH) {
+            return MANIFEST_TEXT;
+        }
+        return fs.readFileSync(normalized, 'utf8');
+    };
+}
+
+function createMockClient(queryHandler = () => ({ rows: [] })) {
+    const calls = [];
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+            return queryHandler(String(sql), params);
+        },
+    };
+}
+
+function buildDryRunPayload(overrides = {}) {
+    return {
+        ok: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        source_name: 'football_data_local_synthetic_fixture',
+        source_type: 'local_csv_fixture',
+        approval_status: 'dry_run_only',
+        dry_run_version: 'PHASE4.63C_FOOTBALL_DATA_ADAPTER_DRY_RUN',
+        parser_version: 'PHASE4.62C_FOOTBALL_DATA_LOCAL_CSV_PARSER',
+        expected_sha256: 'expected-sha',
+        actual_sha256: 'expected-sha',
+        sha256_match: true,
+        expected_row_count: 3,
+        actual_row_count: 3,
+        row_count_match: true,
+        total_rows: 3,
+        parsed_rows: 3,
+        candidate_rows: [
+            {
+                row_number: 1,
+                home_team: 'Alpha Home',
+                away_team: 'Beta Away',
+                match_date: '2024-08-17',
+                actual_result: 'home_win',
+            },
+            {
+                row_number: 2,
+                home_team: 'Gamma Home',
+                away_team: 'Delta Away',
+                match_date: '2024-08-18',
+                actual_result: 'draw',
+            },
+            {
+                row_number: 3,
+                home_team: 'Manual Home',
+                away_team: 'Manual Away',
+                match_date: '2024-08-19',
+                actual_result: 'away_win',
+            },
+        ],
+        row_classification: {
+            trainable_label_rows: 3,
+            odds_preview_rows: 1,
+            skipped_rows: 0,
+        },
+        trainable_label_rows: 3,
+        skipped_rows: 0,
+        odds_preview_rows: 1,
+        non_execution_confirmations: ['no_external_network', 'no_db_writes'],
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildPreflightPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.64C_FOOTBALL_DATA_DB_WRITE_PREFLIGHT',
+        ok: true,
+        preflight_plan: {
+            target_tables_preview: ['matches', 'bookmaker_odds_history_preview_only'],
+            max_rows_preview: 3,
+            match_write_policy: 'future_small_batch_only_after_backup_and_authorization',
+            odds_write_policy: 'blocked_preview_only_in_phase_4_64c',
+        },
+        commit_gate: 'blocked',
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildDuplicatePayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.65C_FOOTBALL_DATA_DUPLICATE_PRECHECK',
+        ok: true,
+        candidate_rows: 3,
+        exact_existing_matches: 0,
+        reversed_team_matches: 0,
+        nearby_date_matches: 0,
+        invalid_candidates: 0,
+        insert_risk_summary: {
+            duplicate_free_candidates: 3,
+        },
+        commit_gate: 'blocked',
+        non_execution_confirmations: ['select_only_db_reads', 'no_db_writes'],
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildInsertPolicyPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.66C_FOOTBALL_DATA_INSERT_POLICY',
+        ok: true,
+        match_id_strategy: 'fd_<league>_<season>_<date>_<home>_<away>_<hash8>',
+        match_id_strategy_finalized: false,
+        manifest_approval_status: 'dry_run_only',
+        candidate_rows: 3,
+        future_insert_candidates: 1,
+        blocked_by_manifest_policy: 1,
+        skip_existing_matches: 0,
+        manual_review_required: 1,
+        invalid_candidates: 0,
+        candidate_previews: [
+            {
+                row_number: 1,
+                proposed_match_id: 'fd_sp2_2024_20240817_alpha_beta_11111111',
+                home_team: 'Alpha Home',
+                away_team: 'Beta Away',
+                match_date: '2024-08-17',
+                insert_policy: 'future_insert_candidate',
+                duplicate_risk: 'none',
+                policy_reason: 'clean candidate',
+            },
+            {
+                row_number: 2,
+                proposed_match_id: 'fd_sp2_2024_20240818_gamma_delta_22222222',
+                home_team: 'Gamma Home',
+                away_team: 'Delta Away',
+                match_date: '2024-08-18',
+                insert_policy: 'blocked_by_manifest_policy',
+                duplicate_risk: 'none',
+                policy_reason: 'manifest not approved',
+                skip_reason: 'manifest_not_approved_for_db_write',
+            },
+            {
+                row_number: 3,
+                proposed_match_id: 'fd_sp2_2024_20240819_manual_33333333',
+                home_team: 'Manual Home',
+                away_team: 'Manual Away',
+                match_date: '2024-08-19',
+                insert_policy: 'manual_review_required',
+                duplicate_risk: 'nearby_date_possible_duplicate',
+                policy_reason: 'nearby date requires review',
+                review_reason: 'nearby_date_possible_duplicate',
+            },
+        ],
+        commit_gate: 'blocked',
+        non_execution_confirmations: ['select_only_db_reads', 'no_db_writes'],
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildAuthPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.67C_FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW',
+        ok: true,
+        current_db_counts: {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        current_db_schema_preview: {
+            required_tables_found: [
+                'bookmaker_odds_history',
+                'l3_features',
+                'match_features_training',
+                'matches',
+                'predictions',
+                'raw_match_data',
+            ],
+        },
+        max_rows_preview: 3,
+        target_tables_preview: ['matches', 'bookmaker_odds_history'],
+        pg_dump_command_preview: 'docker compose -f docker-compose.dev.yml exec -T db pg_dump ...',
+        pg_restore_command_preview: 'docker compose -f docker-compose.dev.yml exec -T db pg_restore ...',
+        post_write_validation: ['compare before/after row counts', 'record backup path'],
+        rollback_restore_preview: ['restore is not executed automatically'],
+        small_write_authorized: false,
+        db_write_allowed: false,
+        commit_gate: 'blocked',
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: filePath => Boolean(filePath) && !String(filePath).includes('/missing/'),
+        readFileSync: createReadFileSync(),
+        runDryRun: () => buildDryRunPayload(),
+        runPreflight: () => buildPreflightPayload(),
+        runDuplicatePrecheck: async () => buildDuplicatePayload(),
+        runInsertPolicyPrecheck: async () => buildInsertPolicyPayload(),
+        runSmallWriteAuthPreview: async () => buildAuthPayload(),
+        ...overrides,
+    };
+}
+
+async function runJsonMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(
+        [...argv, '--json'],
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: JSON.parse(stdout),
+    };
+}
+
+function assertSafetyPayload(payload) {
+    assert.equal(payload.packet_write_allowed, false);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.small_write_authorized, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+    assert.equal(payload.would_insert_matches, false);
+    assert.equal(payload.would_insert_odds, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.approval_granted, false);
+}
+
+test('packet assembly module 可以 import 且不加载 legacy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+
+    assert.equal(typeof gate.runPacketAssembly, 'function');
+    assert.equal(typeof gate.main, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('缺 source manifest 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs({ sourceManifest: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /provide --source-manifest/);
+});
+
+test('缺 local CSV 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs({ localCsv: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /provide --source-manifest/);
+});
+
+test('缺 approval form 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs({ approvalForm: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /approval-form/);
+});
+
+test('缺 runbook template 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs({ runbookTemplate: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /runbook-template/);
+});
+
+test('路径不存在时返回对应错误且不进入 gate', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    let dryRunCalled = false;
+    const payload = await gate.runPacketAssembly(
+        baseArgs({ sourceManifest: path.join(PROJECT_ROOT, 'missing/source.json') }),
+        buildDependencies({
+            runDryRun: () => {
+                dryRunCalled = true;
+                return buildDryRunPayload();
+            },
+        })
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.source_manifest_found, false);
+    assert.equal(dryRunCalled, false);
+    assert.match(payload.errors.join('\n'), /source manifest not found/);
+});
+
+test('local CSV / approval form / runbook template 路径不存在时分别失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const missingCsv = await gate.runPacketAssembly(
+        baseArgs({ localCsv: path.join(PROJECT_ROOT, 'missing/local.csv') }),
+        buildDependencies()
+    );
+    const missingApproval = await gate.runPacketAssembly(
+        baseArgs({ approvalForm: path.join(PROJECT_ROOT, 'missing/approval.md') }),
+        buildDependencies()
+    );
+    const missingRunbook = await gate.runPacketAssembly(
+        baseArgs({ runbookTemplate: path.join(PROJECT_ROOT, 'missing/runbook.md') }),
+        buildDependencies()
+    );
+
+    assert.equal(missingCsv.mode, 'csv-error');
+    assert.equal(missingCsv.local_csv_found, false);
+    assert.match(missingCsv.errors.join('\n'), /local CSV not found/);
+    assert.equal(missingApproval.mode, 'approval-form-error');
+    assert.equal(missingApproval.approval_form_found, false);
+    assert.match(missingApproval.errors.join('\n'), /approval form not found/);
+    assert.equal(missingRunbook.mode, 'runbook-template-error');
+    assert.equal(missingRunbook.runbook_template_found, false);
+    assert.match(missingRunbook.errors.join('\n'), /runbook template not found/);
+});
+
+test('正确输入 + mock gate 成功', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.69C_FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY');
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+    assert.equal(payload.approval_form_found, true);
+    assert.equal(payload.runbook_template_found, true);
+    assert.equal(payload.csv_dry_run_passed, true);
+    assert.equal(payload.db_write_preflight_passed, true);
+    assert.equal(payload.duplicate_precheck_passed, true);
+    assert.equal(payload.insert_policy_precheck_passed, true);
+    assert.equal(payload.small_write_auth_preview_passed, true);
+    assert.equal(payload.approval_form_validation_passed, true);
+    assert.equal(payload.select_only_db_reads, true);
+    assertSafetyPayload(payload);
+});
+
+test('输出 safety flags 全部保持 false/blocked', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const result = await runJsonMain(gate, [
+        '--source-manifest',
+        MANIFEST_PATH,
+        '--local-csv',
+        CSV_PATH,
+        '--approval-form',
+        APPROVAL_FORM_PATH,
+        '--runbook-template',
+        RUNBOOK_TEMPLATE_PATH,
+    ]);
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.csv_dry_run_passed, true);
+    assert.equal(result.payload.db_write_preflight_passed, true);
+    assert.equal(result.payload.duplicate_precheck_passed, true);
+    assert.equal(result.payload.insert_policy_precheck_passed, true);
+    assert.equal(result.payload.small_write_auth_preview_passed, true);
+    assert.equal(result.payload.approval_form_validation_passed, true);
+    assert.equal(result.payload.commit_gate, 'blocked');
+    assertSafetyPayload(result.payload);
+});
+
+test('packet_sections 完整', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.deepEqual(payload.packet_sections, gate.PACKET_SECTIONS);
+    assert.ok(payload.packet_sections.includes('source_manifest_summary'));
+    assert.ok(payload.packet_sections.includes('final_human_approval_required'));
+});
+
+test('approval form 默认 not_approved 且 final_human_confirmation=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.equal(payload.approval_status, 'not_approved');
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.approval_form_is_template, true);
+    assert.equal(payload.approval_granted, false);
+    assert.deepEqual(payload.approval_form_summary.target_tables, ['matches']);
+});
+
+test('candidate tables 包含 proposed、blocked 和 manual review 列表', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.deepEqual(payload.proposed_match_ids, [
+        'fd_sp2_2024_20240817_alpha_beta_11111111',
+        'fd_sp2_2024_20240818_gamma_delta_22222222',
+        'fd_sp2_2024_20240819_manual_33333333',
+    ]);
+    assert.equal(payload.insert_candidate_table.length, 1);
+    assert.equal(payload.insert_candidate_table[0].approved_to_insert, false);
+    assert.equal(payload.blocked_candidate_table.length, 1);
+    assert.equal(payload.manual_review_table.length, 1);
+});
+
+test('--commit blocked', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const result = await runJsonMain(gate, [
+        '--source-manifest',
+        MANIFEST_PATH,
+        '--local-csv',
+        CSV_PATH,
+        '--approval-form',
+        APPROVAL_FORM_PATH,
+        '--runbook-template',
+        RUNBOOK_TEMPLATE_PATH,
+        '--commit',
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'blocked-commit');
+    assert.equal(result.payload.blocked, true);
+    assert.match(result.payload.blocked_reason, /not wired in Phase 4\.69C/);
+    assertSafetyPayload(result.payload);
+});
+
+test('sha256 mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for sha256 mismatch');
+    });
+    const payload = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            dbClient: client,
+            runDryRun: () =>
+                buildDryRunPayload({
+                    ok: false,
+                    sha256_match: false,
+                    row_count_match: true,
+                    errors: ['sha256 mismatch; parser was not executed'],
+                }),
+            runDuplicatePrecheck: async () => {
+                throw new Error('duplicate precheck should not run');
+            },
+        })
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'csv-dry-run-failed');
+    assert.equal(payload.sha256_match, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+});
+
+test('row_count mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const client = createMockClient(() => {
+        throw new Error('DB should not be queried for row_count mismatch');
+    });
+    const payload = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            dbClient: client,
+            runDryRun: () =>
+                buildDryRunPayload({
+                    ok: false,
+                    sha256_match: true,
+                    row_count_match: false,
+                    errors: ['row_count mismatch; parser was not executed'],
+                }),
+            runDuplicatePrecheck: async () => {
+                throw new Error('duplicate precheck should not run');
+            },
+        })
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'csv-dry-run-failed');
+    assert.equal(payload.row_count_match, false);
+    assert.equal(payload.select_only_db_reads, false);
+    assert.equal(client.calls.length, 0);
+});
+
+test('approval form invalid 时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    let dryRunCalled = false;
+    const invalidApproval = APPROVAL_FORM_TEXT.replace('approval_status: not_approved', 'approval_status: approved');
+    const payload = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            readFileSync: createReadFileSync({
+                [APPROVAL_FORM_PATH]: invalidApproval,
+            }),
+            runDryRun: () => {
+                dryRunCalled = true;
+                return buildDryRunPayload();
+            },
+        })
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'approval-form-validation-failed');
+    assert.equal(payload.approval_form_validation_passed, false);
+    assert.equal(dryRunCalled, false);
+    assert.match(payload.errors.join('\n'), /approval_status must remain not_approved/);
+});
+
+test('approval YAML 缺失或解析失败时不会授予 approval', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const noYaml = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            readFileSync: createReadFileSync({
+                [APPROVAL_FORM_PATH]: '# no yaml block\n',
+            }),
+            runApprovalValidation: () => ({ ok: true, target_tables: ['matches'], warnings: [], errors: [] }),
+        })
+    );
+    const malformedYaml = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            readFileSync: createReadFileSync({
+                [APPROVAL_FORM_PATH]: '```yaml\nnot yaml\n```\n',
+            }),
+            runApprovalValidation: () => ({ ok: true, target_tables: ['matches'], warnings: [], errors: [] }),
+        })
+    );
+
+    assert.equal(noYaml.ok, true);
+    assert.equal(noYaml.approval_status, null);
+    assert.equal(noYaml.approval_granted, false);
+    assert.equal(malformedYaml.ok, true);
+    assert.equal(malformedYaml.approval_status, null);
+    assert.equal(malformedYaml.approval_granted, false);
+});
+
+test('manifest JSON 解析失败只进入 summary，不触发写入', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            readFileSync: createReadFileSync({
+                [MANIFEST_PATH]: '{not json',
+            }),
+        })
+    );
+
+    assert.equal(payload.ok, true);
+    assert.match(payload.source_manifest_summary.path, /football_data_sample_phase463c_manifest\.json/);
+    assert.equal(payload.source_manifest_summary.source_name, null);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('preflight / duplicate / insert policy / auth preview 失败时短路', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const preflightFailed = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            runPreflight: () => ({ ok: false, errors: ['preflight failed'], warnings: ['preflight warning'] }),
+        })
+    );
+    const duplicateFailed = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            runDuplicatePrecheck: async () => ({ ok: false, errors: ['duplicate failed'], warnings: [] }),
+        })
+    );
+    const insertFailed = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            runInsertPolicyPrecheck: async () => ({ ok: false, errors: ['insert policy failed'], warnings: [] }),
+        })
+    );
+    const authFailed = await gate.runPacketAssembly(
+        baseArgs(),
+        buildDependencies({
+            runSmallWriteAuthPreview: async () => ({ ok: false, errors: ['auth failed'], warnings: [] }),
+        })
+    );
+
+    assert.equal(preflightFailed.mode, 'db-write-preflight-failed');
+    assert.equal(preflightFailed.csv_dry_run_passed, true);
+    assert.match(preflightFailed.errors.join('\n'), /preflight failed/);
+    assert.deepEqual(preflightFailed.warnings, ['preflight warning']);
+    assert.equal(duplicateFailed.mode, 'duplicate-precheck-failed');
+    assert.equal(duplicateFailed.db_write_preflight_passed, true);
+    assert.match(duplicateFailed.errors.join('\n'), /duplicate failed/);
+    assert.equal(insertFailed.mode, 'insert-policy-precheck-failed');
+    assert.equal(insertFailed.duplicate_precheck_passed, true);
+    assert.match(insertFailed.errors.join('\n'), /insert policy failed/);
+    assert.equal(authFailed.mode, 'small-write-auth-preview-failed');
+    assert.equal(authFailed.insert_policy_precheck_passed, true);
+    assert.match(authFailed.errors.join('\n'), /auth failed/);
+});
+
+test('packet assembly 不访问外网', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_access_network, false);
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+});
+
+test('packet assembly 不写文件或 packet 文件', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.ok(payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_packet_file_write'));
+});
+
+test('packet assembly 不执行 pg_dump / pg_restore', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+    assert.match(payload.pg_dump_command_preview, /pg_dump/);
+    assert.match(payload.pg_restore_command_preview, /pg_restore/);
+});
+
+test('packet assembly 不 spawn child process', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_spawn_child_process, false);
+});
+
+test('packet assembly 不训练和不预测', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const payload = await gate.runPacketAssembly(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_train_model, false);
+    assert.equal(payload.would_execute_prediction, false);
+    assert.ok(payload.non_execution_confirmations.includes('no_training'));
+    assert.ok(payload.non_execution_confirmations.includes('no_prediction_execution'));
+});
+
+test('SQL 只允许 SELECT / BEGIN READ ONLY / ROLLBACK', t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    const allowedSql = [
+        gate.READ_ONLY_BEGIN_SQL,
+        gate.READ_ONLY_ROLLBACK_SQL,
+        'SELECT table_name FROM information_schema.tables',
+    ];
+
+    for (const sql of allowedSql) {
+        assert.doesNotThrow(() => gate.assertSelectOnlySql(sql));
+    }
+    for (const sql of [
+        'INSERT INTO matches(match_id) VALUES ($1)',
+        'UPDATE matches SET status=$1',
+        'DELETE FROM matches',
+        'CREATE TABLE unsafe(id int)',
+        'ALTER TABLE matches ADD COLUMN unsafe text',
+        'DROP TABLE matches',
+        'TRUNCATE matches',
+        'COPY matches TO STDOUT',
+        '\\copy matches to file',
+        'COMMIT',
+    ]) {
+        assert.throws(() => gate.assertSelectOnlySql(sql), /Unsafe SQL rejected/);
+    }
+});
+
+test('CLI --help、等号参数、未知参数和 runtime error 分支可用', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    let helpStdout = '';
+    const helpStatus = await gate.main(['--help'], {
+        stdout: text => {
+            helpStdout += text;
+        },
+        stderr: () => {},
+    });
+    const equalsResult = await runJsonMain(gate, [
+        `--source-manifest=${MANIFEST_PATH}`,
+        `--local-csv=${CSV_PATH}`,
+        `--approval-form=${APPROVAL_FORM_PATH}`,
+        `--runbook-template=${RUNBOOK_TEMPLATE_PATH}`,
+    ]);
+    const unknownResult = await runJsonMain(gate, ['--unknown']);
+    const runtimeResult = await runJsonMain(
+        gate,
+        [
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        {
+            ...buildDependencies(),
+            existsSync: () => {
+                throw new Error('synthetic exists failure');
+            },
+        }
+    );
+
+    assert.equal(helpStatus, 0);
+    assert.match(helpStdout, /Usage:/);
+    assert.equal(equalsResult.status, 0);
+    assert.equal(equalsResult.payload.ok, true);
+    assert.equal(unknownResult.status, 1);
+    assert.equal(unknownResult.payload.mode, 'runtime-error');
+    assert.match(unknownResult.payload.errors.join('\n'), /Unknown argument: --unknown/);
+    assert.equal(runtimeResult.status, 1);
+    assert.equal(runtimeResult.payload.mode, 'runtime-error');
+    assert.match(runtimeResult.payload.errors.join('\n'), /synthetic exists failure/);
+});
+
+test('failure text output 包含 errors 和 warnings', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    let stdout = '';
+    const status = await gate.main(
+        [
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: () => {},
+        },
+        buildDependencies({
+            runPreflight: () => ({ ok: false, errors: ['preflight failed'], warnings: ['preview warning'] }),
+        })
+    );
+
+    assert.equal(status, 1);
+    assert.match(stdout, /mode=db-write-preflight-failed/);
+    assert.match(stdout, /errors=preflight failed/);
+    assert.match(stdout, /warnings=\["preview warning"\]/);
+});
+
+test('text output 包含 required summary 字段', async t => {
+    installExecutionGuards(t);
+    const gate = loadPacketFresh();
+    let stdout = '';
+    const status = await gate.main(
+        [
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: () => {},
+        },
+        buildDependencies()
+    );
+
+    assert.equal(status, 0);
+    assert.match(stdout, /phase=PHASE4\.69C_FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY/);
+    assert.match(stdout, /csv_dry_run_passed=true/);
+    assert.match(stdout, /db_write_preflight_passed=true/);
+    assert.match(stdout, /duplicate_precheck_passed=true/);
+    assert.match(stdout, /insert_policy_precheck_passed=true/);
+    assert.match(stdout, /small_write_auth_preview_passed=true/);
+    assert.match(stdout, /approval_form_validation_passed=true/);
+    assert.match(stdout, /packet_write_allowed=false/);
+    assert.match(stdout, /db_write_allowed=false/);
+    assert.match(stdout, /small_write_authorized=false/);
+    assert.match(stdout, /would_write_packet_file=false/);
+    assert.match(stdout, /would_execute_pg_dump=false/);
+    assert.match(stdout, /would_execute_pg_restore=false/);
+    assert.match(stdout, /would_write_db=false/);
+    assert.match(stdout, /approval_status=not_approved/);
+    assert.match(stdout, /final_human_confirmation=false/);
+    assert.match(stdout, /future_real_packet_requirements:/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.69C football-data real small write dry-run packet assembly preview.

Scope:
- Adds small write packet assembly preview
- Connects source manifest, local CSV, runbook template, approval form template, and existing dry-run/precheck gates
- Adds Makefile preview and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.69C report

Safety:
- No DB writes
- SELECT-only DB reads only
- No pg_dump execution
- No pg_restore execution
- No backup file writes
- No packet file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- small write packet preview passed
- small write packet commit gate remained blocked
- existing football-data gates still passed
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed