### PR TITLE
feat(data): add football-data packet file preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,6 +586,10 @@ Phase 4.57C football-data adapter rules：
 - `data-football-data-small-write-packet-preview` 不得写 DB、不得执行 `pg_dump` / `pg_restore`、不得把 approval form 变成真实授权、不得把 `approval_status` 改成 `approved_for_db_write`、不得把 `final_human_confirmation` 改成 `true`。
 - `make data-football-data-small-write-packet-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1` 也不得执行真实 packet 写入或 DB write。
 - 真实 packet 文件创建、真实 `pg_dump` 和真实 small DB write 必须在单独阶段进行，并需要用户明确授权。
+- Phase 4.70C 的 `make data-football-data-packet-file-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv> APPROVAL_FORM=<local md> RUNBOOK_TEMPLATE=<local md>` 只预览未来 packet 文件路径和 metadata，不创建目录，也不写 packet 文件。
+- `data-football-data-packet-file-preflight` 不得创建目录、不得写 packet 文件、不得写 DB、不得执行 `pg_dump` / `pg_restore`、不得把 approval form 变成真实授权、不得把 `approval_status` 改成 `approved_for_db_write`、不得把 `final_human_confirmation` 改成 `true`。
+- `make data-football-data-packet-file-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_PACKET_FILE=1` 也不得创建真实 packet 文件、执行真实 `pg_dump` 或执行真实 DB write。
+- 真实 packet 文件创建、真实 `pg_dump` 和真实 DB write 必须分别在单独阶段进行，并需要用户明确授权。
 - Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。
 - `data-football-data-insert-policy-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-insert-policy-commit` 当前 blocked / not wired。
 - future real DB write 必须单独阶段、单独授权、真实 `pg_dump`、非空备份验证、small batch transaction、post-write validation；restore 也必须单独授权，不得自动执行；DB write 前后 training / prediction 仍必须走单独 gate。

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@
         data-football-data-small-write-auth-preview data-football-data-small-write-commit \
         data-football-data-small-write-runbook-validate data-football-data-small-write-runbook-commit \
         data-football-data-small-write-packet-preview data-football-data-small-write-packet-commit \
+        data-football-data-packet-file-preflight data-football-data-packet-file-commit \
         data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
@@ -273,6 +274,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-small-write-auth-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-football-data-small-write-runbook-validate APPROVAL_FORM=<path>"
 	@echo "  make data-football-data-small-write-packet-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
+	@echo "  make data-football-data-packet-file-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
@@ -297,6 +299,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-insert-policy-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1  # blocked in Phase 4.66C"
 	@echo "  make data-football-data-small-write-runbook-commit APPROVAL_FORM=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1  # blocked in Phase 4.68C"
 	@echo "  make data-football-data-small-write-packet-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1  # blocked in Phase 4.69C"
+	@echo "  make data-football-data-packet-file-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE=1  # blocked in Phase 4.70C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -624,6 +627,26 @@ data-football-data-small-write-packet-commit: ## Blocked Football-Data small wri
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data small write packet commit is not wired in Phase 4.69C."
+	@exit 1
+
+data-football-data-packet-file-preflight: ## Preview future Football-Data packet file generation metadata/path only. Requires SOURCE_MANIFEST, LOCAL_CSV, APPROVAL_FORM, RUNBOOK_TEMPLATE.
+	@if [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ] || [ -z "$(APPROVAL_FORM)" ] || [ -z "$(RUNBOOK_TEMPLATE)" ]; then \
+		echo "ERROR: provide SOURCE_MANIFEST=<path>, LOCAL_CSV=<path>, APPROVAL_FORM=<path>, and RUNBOOK_TEMPLATE=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data packet file preflight: SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV), APPROVAL_FORM=$(APPROVAL_FORM), RUNBOOK_TEMPLATE=$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(APPROVAL_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_packet_file_preflight.js --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)" --approval-form "$(APPROVAL_FORM)" --runbook-template "$(RUNBOOK_TEMPLATE)"
+
+data-football-data-packet-file-commit: ## Blocked Football-Data packet file generation gate. Requires CONFIRM_FOOTBALL_DATA_PACKET_FILE=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_PACKET_FILE)" != "1" ]; then \
+		echo "BLOCKED: football-data packet file generation requires CONFIRM_FOOTBALL_DATA_PACKET_FILE=1 and is not wired in Phase 4.70C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data packet file generation is not wired in Phase 4.70C."
 	@exit 1
 
 data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.

--- a/docs/_reports/FOOTBALL_DATA_PACKET_FILE_PREFLIGHT_PHASE4_70C.md
+++ b/docs/_reports/FOOTBALL_DATA_PACKET_FILE_PREFLIGHT_PHASE4_70C.md
@@ -1,0 +1,201 @@
+# Football-Data Packet File Preflight - Phase 4.70C
+
+## 1. Current HEAD / branch
+
+- Starting HEAD: `da30a4a7ff86907861b3f29cd20c16c98cc1ae1a`
+- Branch: `feat/football-data-packet-file-preflight-phase470c`
+- Base: Phase 4.69C merged on remote `main`
+
+## 2. Why one larger themed PR is reasonable
+
+Phase 4.70C adds one coherent safety layer: a preflight gate for future packet file generation. The script, Makefile targets, unit tests, AGENTS rules, and this report all describe the same non-write contract around future packet path and metadata preview, so keeping them in one PR keeps the behavior auditable end to end.
+
+## 3. Added / changed files
+
+- `scripts/ops/football_data_packet_file_preflight.js`
+- `tests/unit/football_data_packet_file_preflight.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/FOOTBALL_DATA_PACKET_FILE_PREFLIGHT_PHASE4_70C.md`
+
+## 4. Packet file preflight design
+
+The new preflight script accepts:
+
+```bash
+node scripts/ops/football_data_packet_file_preflight.js \
+  --source-manifest <path> \
+  --local-csv <path> \
+  --approval-form docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md \
+  --runbook-template docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md
+```
+
+It reads only local files, reuses the Phase 4.69C packet preview, preserves SELECT-only DB inspection through the reused gate path, validates that the packet sections are complete, and previews only the future packet directory, future packet filename, future packet manifest filename, and future metadata.
+
+The script does not create directories, does not write packet files, does not write DB state, does not execute `pg_dump`, does not execute `pg_restore`, does not spawn child processes, and does not import the legacy downloader runtime.
+
+## 5. Future packet directory / filename / manifest preview
+
+The preflight outputs these preview strings:
+
+```text
+future_packet_directory_preview=docs/_packets/football_data/small_write/<timestamp>_<source_slug>/
+future_packet_file_preview=football_data_small_write_packet_<source_slug>_<hash8>.json
+future_packet_manifest_preview=football_data_small_write_packet_manifest_<source_slug>_<hash8>.json
+```
+
+These are preview-only strings. The script does not create `docs/_packets`, does not create the preview directory, and does not create either JSON file.
+
+## 6. Why no packet file is created
+
+Phase 4.70C is still a preview-only gate. A real packet file would become a durable review artifact and therefore requires a separately authorized later phase. The preflight reports:
+
+- `packet_file_generation_allowed=false`
+- `packet_write_allowed=false`
+- `would_write_packet_file=false`
+- `would_write_packet_manifest=false`
+
+## 7. Why no directory is created
+
+The future directory path is previewed only so reviewers can verify where a real packet file would belong. Directory creation would be an actual filesystem mutation and is therefore out of scope for this phase. The preflight reports:
+
+- `would_create_packet_directory=false`
+- `no_packet_directory_create`
+
+## 8. Why no DB write is performed
+
+This phase only previews future packet file generation prerequisites. DB access remains SELECT-only through the reused packet preview chain. The preflight reports:
+
+- `select_only_db_reads=true`
+- `would_write_db=false`
+- `would_insert_matches=false`
+- `would_insert_odds=false`
+
+## 9. Why no pg_dump is executed
+
+This phase only previews the future packet metadata and keeps backup activity blocked. A real `pg_dump` remains a separate authorization step before any future DB write. The preflight reports:
+
+- `would_execute_pg_dump=false`
+- `would_execute_pg_restore=false`
+- `no_pg_dump_execution`
+- `no_pg_restore_execution`
+
+## 10. Commit gate result
+
+Both packet file commit gate checks remained blocked:
+
+- `make data-football-data-packet-file-commit || true`
+- `make data-football-data-packet-file-commit ... CONFIRM_FOOTBALL_DATA_PACKET_FILE=1 || true`
+
+Observed blocked message:
+
+```text
+BLOCKED: football-data packet file generation is not wired in Phase 4.70C.
+```
+
+## 11. Existing gates revalidated
+
+All reused Football-Data gates passed:
+
+- `make data-football-data-small-write-packet-preview`: passed
+- `make data-football-data-csv-dry-run`: passed
+- `make data-football-data-db-write-preflight`: passed
+- `make data-football-data-duplicate-precheck`: passed
+- `make data-football-data-insert-policy-precheck`: passed
+- `make data-football-data-small-write-auth-preview`: passed
+- `make data-football-data-small-write-runbook-validate`: passed
+
+No DB writes, no `pg_dump`, no directory creation, and no packet file writes occurred.
+
+## 12. Unit tests
+
+All requested unit tests passed:
+
+- `tests/unit/football_data_packet_file_preflight.test.js`
+- `tests/unit/football_data_small_write_packet_assembly.test.js`
+- `tests/unit/football_data_small_write_runbook_validate.test.js`
+- `tests/unit/football_data_small_write_auth_preview.test.js`
+- `tests/unit/football_data_insert_policy_precheck.test.js`
+- `tests/unit/football_data_duplicate_precheck.test.js`
+- `tests/unit/football_data_db_write_preflight.test.js`
+- `tests/unit/football_data_adapter_dry_run.test.js`
+- `tests/unit/football_data_local_csv_parser.test.js`
+- `tests/unit/acquisition_engine_gate.test.js`
+
+The new packet file preflight test covers missing arguments, successful mock preview, future packet directory / filename / manifest preview, approval defaults, blocked commit, sha256 / row_count mismatch without DB reads, invalid approval form, no legacy import, no network, no file writes, no directory creation, no packet file write, no `pg_dump`, no `pg_restore`, no child process spawn, and SELECT-only SQL guard behavior.
+
+## 13. npm test / coverage
+
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`: passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`: passed
+- Coverage thresholds were not modified.
+
+Final coverage:
+
+```text
+lines=88.44
+branches=80.00
+functions=80.88
+```
+
+## 14. DB before / after statistics
+
+Expected before counts:
+
+```text
+matches=2
+bookmaker_odds_history=2
+raw_match_data=2
+l3_features=2
+match_features_training=2
+predictions=2
+```
+
+Observed after counts:
+
+```text
+matches=2
+bookmaker_odds_history=2
+raw_match_data=2
+l3_features=2
+match_features_training=2
+predictions=2
+```
+
+DB row counts were unchanged.
+
+## 15. Next steps
+
+- Phase 4.71C: real packet file creation authorization form, still no DB write and no `pg_dump`; whether to create a real packet file requires separate user authorization.
+- Or Phase 4.56A: prepare runbook work only after the user provides complete real network dry-run parameters.
+
+## 16. Explicitly not executed
+
+- DB writes
+- non-SELECT DB SQL
+- `pg_dump`
+- `pg_restore`
+- backup file writes
+- packet file writes
+- packet directory creation
+- file writes from packet runtime
+- changing `approval_status` to `approved_for_db_write`
+- changing `final_human_confirmation` to `true`
+- external download
+- `curl` / `wget` / `git clone`
+- external football data source access
+- external odds source access
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- network dry-run execution
+- bulk harvest
+- adapted CSV / staging data writes
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/scripts/ops/football_data_packet_file_preflight.js
+++ b/scripts/ops/football_data_packet_file_preflight.js
@@ -1,0 +1,559 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable max-lines -- Phase 4.70C keeps the packet file preflight contract in one audit-focused script. */
+
+const path = require('path');
+
+const {
+    PACKET_SECTIONS,
+    MISSING_ARGS_MESSAGE,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    assertSelectOnlySql,
+    parseArgs: parsePacketArgs,
+    runPacketAssembly,
+} = require('./football_data_small_write_packet_assembly');
+
+const PACKET_FILE_PREFLIGHT_PHASE = 'PHASE4.70C_FOOTBALL_DATA_PACKET_FILE_PREFLIGHT';
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: football-data packet file generation is not wired in Phase 4.70C.';
+const APPROVED_PACKET_ROOT = 'docs/_packets/football_data/small_write';
+const FUTURE_PACKET_METADATA_FIELDS = [
+    'packet_version',
+    'source_manifest_path',
+    'local_csv_path',
+    'approval_form_path',
+    'runbook_template_path',
+    'source_sha256',
+    'row_count',
+    'proposed_match_ids',
+    'insert_candidate_count',
+    'blocked_candidate_count',
+    'manual_review_count',
+    'db_counts_before_preview',
+    'pg_dump_command_preview',
+    'post_write_validation_checklist',
+    'rollback_restore_preview',
+    'generated_at_preview_only',
+    'generated_by_preview_only',
+];
+const REQUIRED_PACKET_SECTION_FIELDS = [
+    'source_manifest_summary',
+    'local_csv_summary',
+    'csv_dry_run_summary',
+    'db_write_preflight_summary',
+    'duplicate_precheck_summary',
+    'insert_policy_summary',
+    'small_write_auth_preview_summary',
+    'runbook_template_summary',
+    'approval_form_summary',
+    'proposed_match_ids',
+    'insert_candidate_table',
+    'blocked_candidate_table',
+    'manual_review_table',
+    'pg_dump_command_preview',
+    'post_write_validation_checklist',
+    'rollback_restore_preview',
+    'final_human_approval_required',
+];
+const DIRECTORY_TIMESTAMP_PREVIEW = '<timestamp>';
+const GENERATED_AT_PREVIEW_ONLY = '<generated_at_preview_only>';
+const GENERATED_BY_PREVIEW_ONLY = '<generated_by_preview_only>';
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_packet_file_preflight.js --source-manifest <path> --local-csv <path> --approval-form <path> --runbook-template <path> [--json]',
+        '  node scripts/ops/football_data_packet_file_preflight.js --source-manifest <path> --local-csv <path> --approval-form <path> --runbook-template <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.70C previews future packet file generation only.',
+        '  No packet directory creation, no packet file writes, no DB writes, no pg_dump, no pg_restore.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    return parsePacketArgs(argv);
+}
+
+function toRelativePath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) {
+        return null;
+    }
+    const absolutePath = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function slugToken(value, fallback = 'source') {
+    const normalized = String(value || '')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+    return normalized || fallback;
+}
+
+function hash8(value) {
+    const compact = String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
+    return `${compact}preview00`.slice(0, 8);
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'select_only_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_packet_file_write',
+        'no_packet_directory_create',
+        'no_legacy_runtime',
+        'no_pg_dump_execution',
+        'no_pg_restore_execution',
+        'no_training',
+        'no_prediction_execution',
+    ];
+}
+
+function buildFutureRealPacketFileRequirements() {
+    return [
+        'user must explicitly authorize packet file creation',
+        'output directory must be explicit',
+        'packet path must be inside approved docs/_packets/football_data/small_write',
+        'packet file must include source manifest hash',
+        'packet file must include proposed_match_ids',
+        'packet file must exclude manual_review and invalid candidates',
+        'approval form must be copied from template into real reviewed file',
+        'approval_status must be changed only by human',
+        'final_human_confirmation must be set only by human',
+        'packet file creation does not authorize DB write',
+        'pg_dump and DB write require later separate authorization',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        select_only_db_reads: true,
+        packet_file_generation_allowed: false,
+        packet_write_allowed: false,
+        db_write_allowed: false,
+        small_write_authorized: false,
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_execute_legacy_runtime: false,
+        would_spawn_child_process: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+        would_load_model_artifact: false,
+        approval_form_is_template: true,
+        approval_granted: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: PACKET_FILE_PREFLIGHT_PHASE,
+        mode: fields.mode || 'football-data-packet-file-preflight',
+        ok: false,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        approval_form: args.approvalForm || null,
+        runbook_template: args.runbookTemplate || null,
+        source_manifest_found: false,
+        local_csv_found: false,
+        approval_form_found: false,
+        runbook_template_found: false,
+        packet_preview_passed: false,
+        approval_form_validation_passed: false,
+        approval_status: null,
+        final_human_confirmation: null,
+        packet_sections: PACKET_SECTIONS,
+        packet_sections_complete: false,
+        packet_sections_missing: PACKET_SECTIONS,
+        future_packet_directory_preview: null,
+        future_packet_file_preview: null,
+        future_packet_manifest_preview: null,
+        future_packet_metadata: null,
+        commit_gate: 'blocked',
+        pg_dump_command_preview: null,
+        pg_restore_command_preview: null,
+        post_write_validation_checklist: [],
+        rollback_restore_preview: [],
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        future_real_packet_file_requirements: buildFutureRealPacketFileRequirements(),
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        select_only_db_reads: false,
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveSourceSha(packetPayload) {
+    return (
+        packetPayload.source_manifest_summary?.sha256 ||
+        packetPayload.local_csv_summary?.actual_sha256 ||
+        packetPayload.local_csv_summary?.expected_sha256 ||
+        ''
+    );
+}
+
+function resolveSourceSlug(args, packetPayload) {
+    const sourceName =
+        packetPayload.source_manifest_summary?.source_name ||
+        packetPayload.csv_dry_run_summary?.source_name ||
+        packetPayload.source_manifest_summary?.source_type ||
+        path.basename(String(args.sourceManifest || ''), path.extname(String(args.sourceManifest || '')));
+    return slugToken(sourceName, 'source');
+}
+
+function validatePacketSections(packetPayload) {
+    const packetSections = Array.isArray(packetPayload.packet_sections) ? packetPayload.packet_sections : [];
+    const missingNamedSections = PACKET_SECTIONS.filter(section => !packetSections.includes(section));
+    const missingMaterializedFields = REQUIRED_PACKET_SECTION_FIELDS.filter(
+        fieldName => !Object.prototype.hasOwnProperty.call(packetPayload, fieldName)
+    );
+    return [...new Set([...missingNamedSections, ...missingMaterializedFields])];
+}
+
+function buildFuturePacketPreviews(args, packetPayload) {
+    const sourceSlug = resolveSourceSlug(args, packetPayload);
+    const sourceHash8 = hash8(resolveSourceSha(packetPayload));
+
+    return {
+        sourceSlug,
+        sourceHash8,
+        future_packet_directory_preview: `${APPROVED_PACKET_ROOT}/${DIRECTORY_TIMESTAMP_PREVIEW}_${sourceSlug}/`,
+        future_packet_file_preview: `football_data_small_write_packet_${sourceSlug}_${sourceHash8}.json`,
+        future_packet_manifest_preview: `football_data_small_write_packet_manifest_${sourceSlug}_${sourceHash8}.json`,
+    };
+}
+
+function buildFuturePacketMetadata(args, packetPayload, previewInfo, cwd = process.cwd()) {
+    return {
+        packet_version: PACKET_FILE_PREFLIGHT_PHASE,
+        source_manifest_path: toRelativePath(args.sourceManifest, cwd),
+        local_csv_path: toRelativePath(args.localCsv, cwd),
+        approval_form_path: toRelativePath(args.approvalForm, cwd),
+        runbook_template_path: toRelativePath(args.runbookTemplate, cwd),
+        source_sha256: resolveSourceSha(packetPayload) || null,
+        row_count:
+            packetPayload.local_csv_summary?.actual_row_count ??
+            packetPayload.local_csv_summary?.expected_row_count ??
+            packetPayload.source_manifest_summary?.row_count ??
+            null,
+        proposed_match_ids: packetPayload.proposed_match_ids || [],
+        insert_candidate_count: (packetPayload.insert_candidate_table || []).length,
+        blocked_candidate_count: (packetPayload.blocked_candidate_table || []).length,
+        manual_review_count: (packetPayload.manual_review_table || []).length,
+        db_counts_before_preview: packetPayload.current_db_counts || null,
+        pg_dump_command_preview: packetPayload.pg_dump_command_preview || null,
+        post_write_validation_checklist: packetPayload.post_write_validation_checklist || [],
+        rollback_restore_preview: packetPayload.rollback_restore_preview || [],
+        generated_at_preview_only: GENERATED_AT_PREVIEW_ONLY,
+        generated_by_preview_only: GENERATED_BY_PREVIEW_ONLY,
+    };
+}
+
+function buildSuccessPayload(args, packetPayload, cwd = process.cwd()) {
+    const previewInfo = buildFuturePacketPreviews(args, packetPayload);
+    const missingSections = validatePacketSections(packetPayload);
+    const futurePacketMetadata = buildFuturePacketMetadata(args, packetPayload, previewInfo, cwd);
+
+    return {
+        phase: PACKET_FILE_PREFLIGHT_PHASE,
+        mode: 'football-data-packet-file-preflight',
+        ok: true,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        approval_form: args.approvalForm,
+        runbook_template: args.runbookTemplate,
+        source_manifest_found: packetPayload.source_manifest_found,
+        local_csv_found: packetPayload.local_csv_found,
+        approval_form_found: packetPayload.approval_form_found,
+        runbook_template_found: packetPayload.runbook_template_found,
+        packet_preview_passed: true,
+        approval_form_validation_passed: packetPayload.approval_form_validation_passed,
+        approval_status: packetPayload.approval_status,
+        final_human_confirmation: packetPayload.final_human_confirmation,
+        packet_sections: packetPayload.packet_sections,
+        packet_sections_complete: missingSections.length === 0,
+        packet_sections_missing: missingSections,
+        future_packet_directory_preview: previewInfo.future_packet_directory_preview,
+        future_packet_file_preview: previewInfo.future_packet_file_preview,
+        future_packet_manifest_preview: previewInfo.future_packet_manifest_preview,
+        future_packet_metadata: futurePacketMetadata,
+        commit_gate: 'blocked',
+        pg_dump_command_preview: packetPayload.pg_dump_command_preview || null,
+        pg_restore_command_preview: packetPayload.pg_restore_command_preview || null,
+        post_write_validation_checklist: packetPayload.post_write_validation_checklist || [],
+        rollback_restore_preview: packetPayload.rollback_restore_preview || [],
+        current_db_counts: packetPayload.current_db_counts || null,
+        packet_preview_phase: packetPayload.phase,
+        packet_preview_mode: packetPayload.mode,
+        proposed_match_ids: packetPayload.proposed_match_ids || [],
+        insert_candidate_count: (packetPayload.insert_candidate_table || []).length,
+        blocked_candidate_count: (packetPayload.blocked_candidate_table || []).length,
+        manual_review_count: (packetPayload.manual_review_table || []).length,
+        ...buildSafetyFlags(),
+        approval_form_is_template: packetPayload.approval_form_is_template,
+        approval_granted: false,
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        future_real_packet_file_requirements: buildFutureRealPacketFileRequirements(),
+        warnings: packetPayload.warnings || [],
+        errors: [],
+    };
+}
+
+function buildPacketPreviewFailure(args, packetPayload) {
+    return buildFailurePayload(args, {
+        mode: 'packet-preview-failed',
+        source_manifest_found: packetPayload.source_manifest_found,
+        local_csv_found: packetPayload.local_csv_found,
+        approval_form_found: packetPayload.approval_form_found,
+        runbook_template_found: packetPayload.runbook_template_found,
+        approval_form_validation_passed: packetPayload.approval_form_validation_passed || false,
+        approval_status: packetPayload.approval_status ?? null,
+        final_human_confirmation: packetPayload.final_human_confirmation ?? null,
+        packet_preview_failure_mode: packetPayload.mode || null,
+        select_only_db_reads: Boolean(packetPayload.select_only_db_reads),
+        warnings: packetPayload.warnings || [],
+        errors: packetPayload.errors || ['football-data packet preview failed'],
+    });
+}
+
+async function runPacketFilePreflight(args, dependencies = {}) {
+    if (!args.sourceManifest || !args.localCsv || !args.approvalForm || !args.runbookTemplate) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            errors: [MISSING_ARGS_MESSAGE],
+        });
+    }
+
+    const packetPayload = await (dependencies.runPacketAssembly || runPacketAssembly)(
+        {
+            sourceManifest: args.sourceManifest,
+            localCsv: args.localCsv,
+            approvalForm: args.approvalForm,
+            runbookTemplate: args.runbookTemplate,
+        },
+        dependencies.packetPreviewDependencies || {}
+    );
+
+    if (!packetPayload.ok) {
+        return buildPacketPreviewFailure(args, packetPayload);
+    }
+
+    const payload = buildSuccessPayload(args, packetPayload, dependencies.cwd || process.cwd());
+    if (!payload.packet_sections_complete) {
+        return buildFailurePayload(args, {
+            mode: 'packet-section-validation-failed',
+            source_manifest_found: packetPayload.source_manifest_found,
+            local_csv_found: packetPayload.local_csv_found,
+            approval_form_found: packetPayload.approval_form_found,
+            runbook_template_found: packetPayload.runbook_template_found,
+            packet_preview_passed: true,
+            approval_form_validation_passed: packetPayload.approval_form_validation_passed,
+            approval_status: packetPayload.approval_status,
+            final_human_confirmation: packetPayload.final_human_confirmation,
+            select_only_db_reads: Boolean(packetPayload.select_only_db_reads),
+            packet_sections: packetPayload.packet_sections,
+            packet_sections_complete: false,
+            packet_sections_missing: payload.packet_sections_missing,
+            future_packet_directory_preview: payload.future_packet_directory_preview,
+            future_packet_file_preview: payload.future_packet_file_preview,
+            future_packet_manifest_preview: payload.future_packet_manifest_preview,
+            future_packet_metadata: payload.future_packet_metadata,
+            warnings: packetPayload.warnings || [],
+            errors: [
+                `packet preview is missing required packet sections: ${payload.packet_sections_missing.join(', ')}`,
+            ],
+        });
+    }
+
+    return payload;
+}
+
+function appendListSection(lines, title, values) {
+    lines.push(`${title}:`);
+    for (const value of values || []) {
+        lines.push(`- ${value}`);
+    }
+}
+
+function appendOptionalTextFields(lines, payload) {
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+}
+
+function appendCurrentDbCounts(lines, counts) {
+    if (!counts) {
+        return;
+    }
+    lines.push('current_db_counts:');
+    for (const [tableName, rows] of Object.entries(counts)) {
+        lines.push(`- ${tableName}=${rows}`);
+    }
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `approval_form_found=${payload.approval_form_found}`,
+        `runbook_template_found=${payload.runbook_template_found}`,
+        `packet_preview_passed=${payload.packet_preview_passed}`,
+        `approval_form_validation_passed=${payload.approval_form_validation_passed}`,
+        `select_only_db_reads=${payload.select_only_db_reads}`,
+        `packet_file_generation_allowed=${payload.packet_file_generation_allowed}`,
+        `packet_write_allowed=${payload.packet_write_allowed}`,
+        `would_create_packet_directory=${payload.would_create_packet_directory}`,
+        `would_write_packet_file=${payload.would_write_packet_file}`,
+        `would_write_packet_manifest=${payload.would_write_packet_manifest}`,
+        `would_execute_pg_dump=${payload.would_execute_pg_dump}`,
+        `would_execute_pg_restore=${payload.would_execute_pg_restore}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+        `commit_gate=${payload.commit_gate}`,
+        `future_packet_directory_preview=${payload.future_packet_directory_preview}`,
+        `future_packet_file_preview=${payload.future_packet_file_preview}`,
+        `future_packet_manifest_preview=${payload.future_packet_manifest_preview}`,
+        `approval_status=${payload.approval_status}`,
+        `final_human_confirmation=${payload.final_human_confirmation}`,
+        `approval_form_is_template=${payload.approval_form_is_template}`,
+        `approval_granted=${payload.approval_granted}`,
+        `packet_sections_complete=${payload.packet_sections_complete}`,
+    ];
+
+    appendOptionalTextFields(lines, payload);
+    appendCurrentDbCounts(lines, payload.current_db_counts);
+    appendListSection(lines, 'packet_sections', payload.packet_sections);
+    appendListSection(lines, 'packet_sections_missing', payload.packet_sections_missing);
+    appendListSection(lines, 'future_packet_metadata', Object.keys(payload.future_packet_metadata || {}));
+    appendListSection(lines, 'non_execution_confirmations', payload.non_execution_confirmations);
+    appendListSection(lines, 'future_real_packet_file_requirements', payload.future_real_packet_file_requirements);
+
+    if (payload.future_packet_metadata) {
+        lines.push(`future_packet_metadata_preview=${JSON.stringify(payload.future_packet_metadata)}`);
+    }
+    if (payload.pg_dump_command_preview) {
+        lines.push(`pg_dump_command_preview=${JSON.stringify(payload.pg_dump_command_preview)}`);
+    }
+    if (payload.pg_restore_command_preview) {
+        lines.push(`pg_restore_command_preview=${JSON.stringify(payload.pg_restore_command_preview)}`);
+    }
+    if (payload.post_write_validation_checklist) {
+        lines.push(`post_write_validation_checklist=${JSON.stringify(payload.post_write_validation_checklist)}`);
+    }
+    if (payload.rollback_restore_preview) {
+        lines.push(`rollback_restore_preview=${JSON.stringify(payload.rollback_restore_preview)}`);
+    }
+    if (payload.proposed_match_ids) {
+        lines.push(`proposed_match_ids=${JSON.stringify(payload.proposed_match_ids)}`);
+    }
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+async function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = await runPacketFilePreflight(args, dependencies);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            {
+                sourceManifest: '',
+                localCsv: '',
+                approvalForm: '',
+                runbookTemplate: '',
+            },
+            {
+                mode: 'runtime-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, argv.includes('--json'), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => {
+        process.exitCode = status;
+    });
+}
+
+module.exports = {
+    PACKET_FILE_PREFLIGHT_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    APPROVED_PACKET_ROOT,
+    FUTURE_PACKET_METADATA_FIELDS,
+    DIRECTORY_TIMESTAMP_PREVIEW,
+    GENERATED_AT_PREVIEW_ONLY,
+    GENERATED_BY_PREVIEW_ONLY,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    assertSelectOnlySql,
+    buildNonExecutionConfirmations,
+    buildFutureRealPacketFileRequirements,
+    buildFuturePacketPreviews,
+    buildFuturePacketMetadata,
+    runPacketFilePreflight,
+    payloadToText,
+    main,
+};

--- a/tests/unit/football_data_packet_file_preflight.test.js
+++ b/tests/unit/football_data_packet_file_preflight.test.js
@@ -1,0 +1,820 @@
+'use strict';
+/* eslint-disable max-lines -- Phase 4.70C keeps the packet file preflight safety contract in one test file. */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const { spawnSync } = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_packet_file_preflight.js');
+const PACKET_ASSEMBLY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_small_write_packet_assembly.js');
+const LEGACY_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fetch_and_adapt_euro_leagues.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+const APPROVAL_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md'
+);
+const RUNBOOK_TEMPLATE_PATH = path.join(PROJECT_ROOT, 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md');
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_packet_file_preflight`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+function loadPreflightFresh() {
+    for (const modulePath of [SCRIPT_PATH, PACKET_ASSEMBLY_PATH]) {
+        delete require.cache[modulePath];
+    }
+    return require(SCRIPT_PATH);
+}
+
+function baseArgs(overrides = {}) {
+    return {
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+        approvalForm: APPROVAL_FORM_PATH,
+        runbookTemplate: RUNBOOK_TEMPLATE_PATH,
+        ...overrides,
+    };
+}
+
+function buildPacketPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.69C_FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY',
+        mode: 'football-data-small-write-packet-assembly',
+        ok: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        approval_form_found: true,
+        runbook_template_found: true,
+        csv_dry_run_passed: true,
+        db_write_preflight_passed: true,
+        duplicate_precheck_passed: true,
+        insert_policy_precheck_passed: true,
+        small_write_auth_preview_passed: true,
+        approval_form_validation_passed: true,
+        select_only_db_reads: true,
+        packet_write_allowed: false,
+        db_write_allowed: false,
+        small_write_authorized: false,
+        would_write_packet_file: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        commit_gate: 'blocked',
+        approval_status: 'not_approved',
+        final_human_confirmation: false,
+        approval_form_is_template: true,
+        approval_granted: false,
+        packet_sections: [
+            'source_manifest_summary',
+            'local_csv_summary',
+            'csv_dry_run_summary',
+            'db_write_preflight_summary',
+            'duplicate_precheck_summary',
+            'insert_policy_summary',
+            'small_write_auth_preview_summary',
+            'runbook_template_summary',
+            'approval_form_summary',
+            'proposed_match_ids',
+            'insert_candidate_table',
+            'blocked_candidate_table',
+            'manual_review_table',
+            'pg_dump_command_preview',
+            'post_write_validation_checklist',
+            'rollback_restore_preview',
+            'final_human_approval_required',
+        ],
+        source_manifest_summary: {
+            path: 'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json',
+            source_name: 'football_data_local_synthetic_fixture',
+            sha256: 'abcdef1234567890fedcba0987654321abcdef1234567890fedcba0987654321',
+            row_count: 3,
+        },
+        local_csv_summary: {
+            path: 'tests/fixtures/football_data/football_data_sample_phase462c.csv',
+            actual_sha256: 'abcdef1234567890fedcba0987654321abcdef1234567890fedcba0987654321',
+            expected_sha256: 'abcdef1234567890fedcba0987654321abcdef1234567890fedcba0987654321',
+            actual_row_count: 3,
+            expected_row_count: 3,
+        },
+        csv_dry_run_summary: {
+            phase: 'PHASE4.63C_FOOTBALL_DATA_ADAPTER_DRY_RUN',
+            ok: true,
+        },
+        db_write_preflight_summary: {
+            phase: 'PHASE4.64C_FOOTBALL_DATA_DB_WRITE_PREFLIGHT',
+            ok: true,
+        },
+        duplicate_precheck_summary: {
+            phase: 'PHASE4.65C_FOOTBALL_DATA_DUPLICATE_PRECHECK',
+            ok: true,
+        },
+        insert_policy_summary: {
+            phase: 'PHASE4.66C_FOOTBALL_DATA_INSERT_POLICY',
+            ok: true,
+        },
+        small_write_auth_preview_summary: {
+            phase: 'PHASE4.67C_FOOTBALL_DATA_SMALL_WRITE_AUTH_PREVIEW',
+            ok: true,
+        },
+        runbook_template_summary: {
+            path: 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md',
+        },
+        approval_form_summary: {
+            path: 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md',
+            approval_status: 'not_approved',
+            final_human_confirmation: false,
+        },
+        proposed_match_ids: ['fd_alpha_11111111', 'fd_beta_22222222'],
+        insert_candidate_table: [{ proposed_match_id: 'fd_alpha_11111111' }],
+        blocked_candidate_table: [{ proposed_match_id: 'fd_beta_22222222' }],
+        manual_review_table: [],
+        pg_dump_command_preview: 'docker compose -f docker-compose.dev.yml exec -T db pg_dump ...',
+        pg_restore_command_preview: 'docker compose -f docker-compose.dev.yml exec -T db pg_restore ...',
+        post_write_validation_checklist: ['compare before/after row counts'],
+        rollback_restore_preview: ['restore is not executed automatically'],
+        final_human_approval_required: {
+            required: true,
+            approval_granted: false,
+        },
+        current_db_counts: {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        runPacketAssembly: async () => buildPacketPayload(),
+        ...overrides,
+    };
+}
+
+async function runJsonMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(
+        [...argv, '--json'],
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: JSON.parse(stdout),
+    };
+}
+
+function assertSafetyPayload(payload) {
+    assert.equal(payload.packet_file_generation_allowed, false);
+    assert.equal(payload.packet_write_allowed, false);
+    assert.equal(payload.would_create_packet_directory, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_packet_manifest, false);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.approval_granted, false);
+}
+
+test('packet file preflight module 可以 import 且不加载 legacy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+
+    assert.equal(typeof gate.runPacketFilePreflight, 'function');
+    assert.equal(typeof gate.main, 'function');
+    assert.equal(require.cache[LEGACY_PATH], undefined);
+});
+
+test('缺 source manifest 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs({ sourceManifest: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /provide --source-manifest/);
+});
+
+test('缺 local CSV 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs({ localCsv: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /provide --source-manifest/);
+});
+
+test('缺 approval form 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs({ approvalForm: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /approval-form/);
+});
+
+test('缺 runbook template 失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs({ runbookTemplate: '' }), buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'argument-error');
+    assert.match(payload.errors.join('\n'), /runbook-template/);
+});
+
+test('正确输入 + mock packet preview 成功', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.70C_FOOTBALL_DATA_PACKET_FILE_PREFLIGHT');
+    assert.equal(payload.source_manifest_found, true);
+    assert.equal(payload.local_csv_found, true);
+    assert.equal(payload.approval_form_found, true);
+    assert.equal(payload.runbook_template_found, true);
+    assert.equal(payload.packet_preview_passed, true);
+    assert.equal(payload.approval_form_validation_passed, true);
+    assert.equal(payload.select_only_db_reads, true);
+    assertSafetyPayload(payload);
+});
+
+test('输出 future packet preview 和 metadata', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs(), buildDependencies());
+
+    assert.match(payload.future_packet_directory_preview, /^docs\/_packets\/football_data\/small_write\/<timestamp>_/);
+    assert.match(payload.future_packet_file_preview, /^football_data_small_write_packet_[a-z0-9_]+_[a-z0-9]{8}\.json$/);
+    assert.match(
+        payload.future_packet_manifest_preview,
+        /^football_data_small_write_packet_manifest_[a-z0-9_]+_[a-z0-9]{8}\.json$/
+    );
+    assert.deepEqual(Object.keys(payload.future_packet_metadata), gate.FUTURE_PACKET_METADATA_FIELDS);
+});
+
+test('approval 默认 not_approved 且 final_human_confirmation=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs(), buildDependencies());
+
+    assert.equal(payload.approval_status, 'not_approved');
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.approval_form_is_template, true);
+    assert.equal(payload.approval_granted, false);
+});
+
+test('--commit blocked', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const result = await runJsonMain(gate, [
+        '--source-manifest',
+        MANIFEST_PATH,
+        '--local-csv',
+        CSV_PATH,
+        '--approval-form',
+        APPROVAL_FORM_PATH,
+        '--runbook-template',
+        RUNBOOK_TEMPLATE_PATH,
+        '--commit',
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'blocked-commit');
+    assert.equal(result.payload.blocked, true);
+    assert.match(result.payload.blocked_reason, /not wired in Phase 4\.70C/);
+    assertSafetyPayload(result.payload);
+});
+
+test('sha256 mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    let packetPreviewCalled = false;
+    const payload = await gate.runPacketFilePreflight(
+        baseArgs(),
+        buildDependencies({
+            runPacketAssembly: async () => {
+                packetPreviewCalled = true;
+                return buildPacketPayload({
+                    ok: false,
+                    mode: 'csv-dry-run-failed',
+                    select_only_db_reads: false,
+                    errors: ['sha256 mismatch; parser was not executed'],
+                });
+            },
+        })
+    );
+
+    assert.equal(packetPreviewCalled, true);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'packet-preview-failed');
+    assert.equal(payload.select_only_db_reads, false);
+});
+
+test('row_count mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(
+        baseArgs(),
+        buildDependencies({
+            runPacketAssembly: async () =>
+                buildPacketPayload({
+                    ok: false,
+                    mode: 'csv-dry-run-failed',
+                    select_only_db_reads: false,
+                    errors: ['row_count mismatch; parser was not executed'],
+                }),
+        })
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'packet-preview-failed');
+    assert.equal(payload.select_only_db_reads, false);
+});
+
+test('approval form invalid 时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(
+        baseArgs(),
+        buildDependencies({
+            runPacketAssembly: async () =>
+                buildPacketPayload({
+                    ok: false,
+                    mode: 'approval-form-validation-failed',
+                    approval_form_validation_passed: false,
+                    errors: ['approval_status must remain not_approved'],
+                }),
+        })
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'packet-preview-failed');
+    assert.match(payload.errors.join('\n'), /not_approved/);
+});
+
+test('packet sections 缺失时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(
+        baseArgs(),
+        buildDependencies({
+            runPacketAssembly: async () =>
+                buildPacketPayload({
+                    packet_sections: ['source_manifest_summary'],
+                }),
+        })
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.mode, 'packet-section-validation-failed');
+    assert.equal(payload.packet_preview_passed, true);
+    assert.equal(payload.packet_sections_complete, false);
+    assert.ok(payload.packet_sections_missing.includes('local_csv_summary'));
+});
+
+test('packet file preflight 不访问外网', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_access_network, false);
+    assert.ok(payload.non_execution_confirmations.includes('no_external_network'));
+});
+
+test('packet file preflight 不写文件、不创建目录、不写 packet 文件', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_files, false);
+    assert.equal(payload.would_create_packet_directory, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_packet_manifest, false);
+    assert.ok(payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.ok(payload.non_execution_confirmations.includes('no_packet_directory_create'));
+    assert.ok(payload.non_execution_confirmations.includes('no_packet_file_write'));
+});
+
+test('packet file preflight 不执行 pg_dump / pg_restore', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+    assert.match(payload.pg_dump_command_preview, /pg_dump/);
+    assert.match(payload.pg_restore_command_preview, /pg_restore/);
+});
+
+test('packet file preflight 不 spawn child process', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const payload = await gate.runPacketFilePreflight(baseArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_spawn_child_process, false);
+});
+
+test('SQL 只允许 SELECT / BEGIN READ ONLY / ROLLBACK', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    const allowedSql = [
+        gate.READ_ONLY_BEGIN_SQL,
+        gate.READ_ONLY_ROLLBACK_SQL,
+        'SELECT table_name FROM information_schema.tables',
+    ];
+
+    for (const sql of allowedSql) {
+        assert.doesNotThrow(() => gate.assertSelectOnlySql(sql));
+    }
+    for (const sql of [
+        'INSERT INTO matches(match_id) VALUES ($1)',
+        'UPDATE matches SET status=$1',
+        'DELETE FROM matches',
+        'CREATE TABLE unsafe(id int)',
+        'ALTER TABLE matches ADD COLUMN unsafe text',
+        'DROP TABLE matches',
+        'TRUNCATE matches',
+        'COPY matches TO STDOUT',
+        '\\copy matches to file',
+        'COMMIT',
+    ]) {
+        assert.throws(() => gate.assertSelectOnlySql(sql), /Unsafe SQL rejected/);
+    }
+});
+
+test('CLI --help、等号参数、未知参数和 runtime error 分支可用', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    let helpStdout = '';
+    const helpStatus = await gate.main(['--help'], {
+        stdout: text => {
+            helpStdout += text;
+        },
+        stderr: () => {},
+    });
+    const equalsResult = await runJsonMain(gate, [
+        `--source-manifest=${MANIFEST_PATH}`,
+        `--local-csv=${CSV_PATH}`,
+        `--approval-form=${APPROVAL_FORM_PATH}`,
+        `--runbook-template=${RUNBOOK_TEMPLATE_PATH}`,
+    ]);
+    const unknownResult = await runJsonMain(gate, ['--unknown']);
+    const runtimeResult = await runJsonMain(
+        gate,
+        [
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        {
+            ...buildDependencies(),
+            runPacketAssembly: async () => {
+                throw new Error('synthetic packet preview failure');
+            },
+        }
+    );
+
+    assert.equal(helpStatus, 0);
+    assert.match(helpStdout, /Usage:/);
+    assert.equal(equalsResult.status, 0);
+    assert.equal(equalsResult.payload.ok, true);
+    assert.equal(unknownResult.status, 1);
+    assert.equal(unknownResult.payload.mode, 'runtime-error');
+    assert.match(unknownResult.payload.errors.join('\n'), /Unknown argument: --unknown/);
+    assert.equal(runtimeResult.status, 1);
+    assert.equal(runtimeResult.payload.mode, 'runtime-error');
+    assert.match(runtimeResult.payload.errors.join('\n'), /synthetic packet preview failure/);
+});
+
+test('text output 包含 required summary 字段', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+    let stdout = '';
+    const status = await gate.main(
+        [
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: () => {},
+        },
+        buildDependencies()
+    );
+
+    assert.equal(status, 0);
+    assert.match(stdout, /phase=PHASE4\.70C_FOOTBALL_DATA_PACKET_FILE_PREFLIGHT/);
+    assert.match(stdout, /packet_file_generation_allowed=false/);
+    assert.match(stdout, /future_packet_directory_preview=docs\/_packets\/football_data\/small_write\//);
+    assert.match(stdout, /future_packet_file_preview=football_data_small_write_packet_/);
+    assert.match(stdout, /future_packet_manifest_preview=football_data_small_write_packet_manifest_/);
+    assert.match(stdout, /approval_status=not_approved/);
+});
+
+test('helper functions 覆盖空路径、fallback slug/hash 和 failure text 分支', t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+
+    assert.equal(
+        gate.buildFuturePacketPreviews(
+            baseArgs(),
+            buildPacketPayload({
+                source_manifest_summary: {},
+                local_csv_summary: {},
+                csv_dry_run_summary: {},
+            })
+        ).future_packet_file_preview,
+        'football_data_small_write_packet_football_data_sample_phase463c_manifest_preview0.json'
+    );
+
+    const metadata = gate.buildFuturePacketMetadata(
+        baseArgs({ sourceManifest: '', localCsv: '', approvalForm: '', runbookTemplate: '' }),
+        buildPacketPayload({ current_db_counts: null }),
+        {
+            sourceSlug: 'source',
+            sourceHash8: 'preview0',
+            future_packet_directory_preview: 'docs/_packets/football_data/small_write/<timestamp>_source/',
+            future_packet_file_preview: 'football_data_small_write_packet_source_preview0.json',
+            future_packet_manifest_preview: 'football_data_small_write_packet_manifest_source_preview0.json',
+        },
+        PROJECT_ROOT
+    );
+
+    assert.equal(metadata.packet_version, 'PHASE4.70C_FOOTBALL_DATA_PACKET_FILE_PREFLIGHT');
+    assert.equal(metadata.source_manifest_path, null);
+    assert.equal(metadata.local_csv_path, null);
+    assert.equal(metadata.approval_form_path, null);
+    assert.equal(metadata.runbook_template_path, null);
+    assert.equal(metadata.source_sha256, 'abcdef1234567890fedcba0987654321abcdef1234567890fedcba0987654321');
+    assert.equal(metadata.row_count, 3);
+    assert.deepEqual(metadata.proposed_match_ids, ['fd_alpha_11111111', 'fd_beta_22222222']);
+    assert.equal(metadata.insert_candidate_count, 1);
+    assert.equal(metadata.blocked_candidate_count, 1);
+    assert.equal(metadata.manual_review_count, 0);
+    assert.equal(metadata.db_counts_before_preview, null);
+    assert.match(metadata.pg_dump_command_preview, /pg_dump/);
+    assert.deepEqual(metadata.post_write_validation_checklist, ['compare before/after row counts']);
+    assert.deepEqual(metadata.rollback_restore_preview, ['restore is not executed automatically']);
+    assert.equal(metadata.generated_at_preview_only, '<generated_at_preview_only>');
+    assert.equal(metadata.generated_by_preview_only, '<generated_by_preview_only>');
+
+    const failureText = gate.payloadToText({
+        ...buildPacketPayload(),
+        phase: 'PHASE4.70C_FOOTBALL_DATA_PACKET_FILE_PREFLIGHT',
+        mode: 'blocked-commit',
+        ok: false,
+        packet_preview_passed: false,
+        approval_form_validation_passed: false,
+        packet_file_generation_allowed: false,
+        packet_write_allowed: false,
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        blocked_reason: 'synthetic blocked reason',
+        errors: ['synthetic error'],
+        warnings: ['synthetic warning'],
+        current_db_counts: null,
+        future_packet_directory_preview: null,
+        future_packet_file_preview: null,
+        future_packet_manifest_preview: null,
+        future_packet_metadata: {},
+        packet_sections_missing: [],
+        non_execution_confirmations: gate.buildNonExecutionConfirmations(),
+        future_real_packet_file_requirements: gate.buildFutureRealPacketFileRequirements(),
+        approval_granted: false,
+    });
+
+    assert.match(failureText, /blocked_reason=synthetic blocked reason/);
+    assert.match(failureText, /errors=synthetic error/);
+    assert.match(failureText, /warnings=\["synthetic warning"\]/);
+});
+
+test('helper functions 覆盖 source slug / sha / row_count fallback 和默认失败信息', async t => {
+    installExecutionGuards(t);
+    const gate = loadPreflightFresh();
+
+    const previewFromSourceType = gate.buildFuturePacketPreviews(
+        baseArgs({ sourceManifest: '???.json' }),
+        buildPacketPayload({
+            source_manifest_summary: { source_type: 'Áccented Type' },
+            csv_dry_run_summary: {},
+            local_csv_summary: { actual_sha256: '', expected_sha256: 'AB-CD' },
+        })
+    );
+    assert.equal(previewFromSourceType.sourceSlug, 'accented_type');
+    assert.equal(previewFromSourceType.sourceHash8, 'abcdprev');
+
+    const previewFromEmptyFallback = gate.buildFuturePacketPreviews(
+        baseArgs({ sourceManifest: '' }),
+        buildPacketPayload({
+            source_manifest_summary: {},
+            csv_dry_run_summary: { source_name: '' },
+            local_csv_summary: { actual_sha256: '', expected_sha256: '' },
+        })
+    );
+    assert.equal(previewFromEmptyFallback.sourceSlug, 'source');
+    assert.equal(previewFromEmptyFallback.sourceHash8, 'preview0');
+
+    const metadataFromExpectedRowCount = gate.buildFuturePacketMetadata(
+        baseArgs({
+            sourceManifest: PROJECT_ROOT,
+            localCsv: PROJECT_ROOT,
+            approvalForm: PROJECT_ROOT,
+            runbookTemplate: PROJECT_ROOT,
+        }),
+        buildPacketPayload({
+            source_manifest_summary: {},
+            local_csv_summary: {
+                actual_sha256: '',
+                expected_sha256: '',
+                actual_row_count: undefined,
+                expected_row_count: 9,
+            },
+            proposed_match_ids: null,
+            insert_candidate_table: null,
+            blocked_candidate_table: null,
+            manual_review_table: null,
+            current_db_counts: undefined,
+            pg_dump_command_preview: '',
+            post_write_validation_checklist: null,
+            rollback_restore_preview: null,
+        }),
+        previewFromEmptyFallback,
+        PROJECT_ROOT
+    );
+    assert.equal(metadataFromExpectedRowCount.source_manifest_path, '.');
+    assert.equal(metadataFromExpectedRowCount.local_csv_path, '.');
+    assert.equal(metadataFromExpectedRowCount.approval_form_path, '.');
+    assert.equal(metadataFromExpectedRowCount.runbook_template_path, '.');
+    assert.equal(metadataFromExpectedRowCount.source_sha256, null);
+    assert.equal(metadataFromExpectedRowCount.row_count, 9);
+    assert.deepEqual(metadataFromExpectedRowCount.proposed_match_ids, []);
+    assert.equal(metadataFromExpectedRowCount.insert_candidate_count, 0);
+    assert.equal(metadataFromExpectedRowCount.blocked_candidate_count, 0);
+    assert.equal(metadataFromExpectedRowCount.manual_review_count, 0);
+    assert.equal(metadataFromExpectedRowCount.db_counts_before_preview, null);
+    assert.equal(metadataFromExpectedRowCount.pg_dump_command_preview, null);
+    assert.deepEqual(metadataFromExpectedRowCount.post_write_validation_checklist, []);
+    assert.deepEqual(metadataFromExpectedRowCount.rollback_restore_preview, []);
+
+    const metadataFromSourceRowCount = gate.buildFuturePacketMetadata(
+        baseArgs(),
+        buildPacketPayload({
+            source_manifest_summary: { row_count: 12 },
+            local_csv_summary: {
+                actual_sha256: '',
+                expected_sha256: '',
+                actual_row_count: undefined,
+                expected_row_count: undefined,
+            },
+        }),
+        previewFromEmptyFallback,
+        PROJECT_ROOT
+    );
+    assert.equal(metadataFromSourceRowCount.row_count, 12);
+
+    const failurePayload = await gate.runPacketFilePreflight(
+        baseArgs(),
+        buildDependencies({
+            runPacketAssembly: async () => ({
+                ok: false,
+                source_manifest_found: true,
+                local_csv_found: true,
+                approval_form_found: true,
+                runbook_template_found: true,
+            }),
+        })
+    );
+    assert.equal(failurePayload.ok, false);
+    assert.equal(failurePayload.mode, 'packet-preview-failed');
+    assert.deepEqual(failurePayload.errors, ['football-data packet preview failed']);
+    assert.deepEqual(failurePayload.warnings, []);
+    assert.equal(failurePayload.packet_preview_failure_mode, null);
+});
+
+test('script 作为真实入口执行 --help 应成功', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, '--help'], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Phase 4\.70C previews future packet file generation only/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.70C football-data real packet file generation preflight.

Scope:
- Adds packet file generation preflight
- Previews future packet directory, packet filename, and packet manifest filename
- Keeps packet file generation blocked
- Adds Makefile preflight and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.70C report

Safety:
- No DB writes
- SELECT-only DB reads only
- No pg_dump execution
- No pg_restore execution
- No backup file writes
- No packet file writes
- No packet directory creation
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- packet file preflight passed
- packet file commit gate remained blocked
- existing football-data gates still passed
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed