### PR TITLE
docs(data): add football-data packet file auth form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB 查重、不写 DB、不训练、不预测的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB schema / duplicate 查询、不写 DB、不训练、不预测的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
+- 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
 - 用户明确授权、只读 DB 且只读本地 fixture 的 `make data-finished-backfill-dry-run MATCH_ID=<id>`
 - 用户明确授权、只读 DB 且只读本地 JSON 的 `make data-raw-fixture-dry-run MATCH_ID=<id> FIXTURE=<local json>`
@@ -285,6 +286,8 @@ AI / Codex 不能直接执行：
 - `make data-football-data-insert-policy-commit CONFIRM_FOOTBALL_DATA_INSERT_POLICY=1`
 - `make data-football-data-small-write-runbook-commit`
 - `make data-football-data-small-write-runbook-commit CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1`
+- `make data-football-data-packet-file-auth-commit`
+- `make data-football-data-packet-file-auth-commit CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1`
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
@@ -589,6 +592,11 @@ Phase 4.57C football-data adapter rules：
 - Phase 4.70C 的 `make data-football-data-packet-file-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv> APPROVAL_FORM=<local md> RUNBOOK_TEMPLATE=<local md>` 只预览未来 packet 文件路径和 metadata，不创建目录，也不写 packet 文件。
 - `data-football-data-packet-file-preflight` 不得创建目录、不得写 packet 文件、不得写 DB、不得执行 `pg_dump` / `pg_restore`、不得把 approval form 变成真实授权、不得把 `approval_status` 改成 `approved_for_db_write`、不得把 `final_human_confirmation` 改成 `true`。
 - `make data-football-data-packet-file-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_PACKET_FILE=1` 也不得创建真实 packet 文件、执行真实 `pg_dump` 或执行真实 DB write。
+- Phase 4.71C 的 `docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md` 是未来 packet 文件创建授权模板，不是真实授权。
+- Phase 4.71C 的 packet file creation auth form 默认 `authorization_status=not_authorized`、默认 `final_packet_creation_confirmation=false`；Codex 不得自行改成 `authorized_for_packet_file_creation` 或 `true`。
+- `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>` 只验证本地 packet file creation authorization 模板；不得读 DB、写 DB、创建目录、写 packet 文件、执行 `pg_dump` / `pg_restore`、训练或预测。
+- `make data-football-data-packet-file-auth-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1` 也不得创建真实 packet 文件、创建 packet 目录、写 packet manifest、执行真实 `pg_dump` 或执行真实 DB write。
+- 真实 packet 文件创建必须在单独阶段进行，且需要用户明确授权、显式输出目录、显式 packet 文件路径；创建 packet 文件不代表允许 DB write、`pg_dump`、training 或 prediction。
 - 真实 packet 文件创建、真实 `pg_dump` 和真实 DB write 必须分别在单独阶段进行，并需要用户明确授权。
 - Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。
 - `data-football-data-insert-policy-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-insert-policy-commit` 当前 blocked / not wired。

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@
         data-football-data-small-write-runbook-validate data-football-data-small-write-runbook-commit \
         data-football-data-small-write-packet-preview data-football-data-small-write-packet-commit \
         data-football-data-packet-file-preflight data-football-data-packet-file-commit \
+        data-football-data-packet-file-auth-validate data-football-data-packet-file-auth-commit \
         data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
@@ -275,6 +276,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-small-write-runbook-validate APPROVAL_FORM=<path>"
 	@echo "  make data-football-data-small-write-packet-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-packet-file-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
+	@echo "  make data-football-data-packet-file-auth-validate AUTH_FORM=<path>"
 	@echo "  make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
@@ -300,6 +302,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-small-write-runbook-commit APPROVAL_FORM=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_RUNBOOK=1  # blocked in Phase 4.68C"
 	@echo "  make data-football-data-small-write-packet-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1  # blocked in Phase 4.69C"
 	@echo "  make data-football-data-packet-file-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE=1  # blocked in Phase 4.70C"
+	@echo "  make data-football-data-packet-file-auth-commit AUTH_FORM=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1  # blocked in Phase 4.71C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -647,6 +650,23 @@ data-football-data-packet-file-commit: ## Blocked Football-Data packet file gene
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data packet file generation is not wired in Phase 4.70C."
+	@exit 1
+
+data-football-data-packet-file-auth-validate: ## Validate Football-Data packet file creation authorization form template. Requires AUTH_FORM.
+	@if [ -z "$(AUTH_FORM)" ]; then \
+		echo "ERROR: provide AUTH_FORM=<path>"; \
+		exit 1; \
+	fi
+	@echo "Validating Football-Data packet file creation authorization form: AUTH_FORM=$(AUTH_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(AUTH_FORM)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_packet_file_auth_validate.js --auth-form "$(AUTH_FORM)"
+
+data-football-data-packet-file-auth-commit: ## Blocked Football-Data packet file creation authorization commit gate. Requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH)" != "1" ]; then \
+		echo "BLOCKED: football-data packet file creation authorization requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1 and is not wired in Phase 4.71C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data packet file creation authorization commit is not wired in Phase 4.71C."
 	@exit 1
 
 data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.

--- a/docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_FORM_PHASE4_71C.md
+++ b/docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_FORM_PHASE4_71C.md
@@ -1,0 +1,295 @@
+# Football-Data Packet File Creation Authorization Form - Phase 4.71C
+
+## 1. 当前 HEAD / branch
+
+- 起始 HEAD: `ec41c82d18540fd0a02c56eaeea7c9405bf29626`
+- 工作分支: `docs/football-data-packet-file-auth-phase471c`
+- 报告整理时本地分支仍未提交，HEAD 仍指向 `ec41c82d18540fd0a02c56eaeea7c9405bf29626`
+
+## 2. 为什么这次做稍大主题 PR 是合理的
+
+Phase 4.71C 增加的是一个完整但仍然不执行写入的安全层：packet file creation authorization form template、validator、Makefile validate / blocked commit gate、unit tests、AGENTS 规则和阶段报告共同定义了同一个边界。把这些内容放在一个 PR 里，审计对象更集中，也更容易确认“只新增授权模板与校验，不新增任何真实写入能力”。
+
+## 3. 新增 / 修改文件
+
+- `docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md`
+- `scripts/ops/football_data_packet_file_auth_validate.js`
+- `tests/unit/football_data_packet_file_auth_validate.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_FORM_PHASE4_71C.md`
+
+## 4. packet file creation auth form 设计
+
+新的模板文件是：
+
+```text
+docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md
+```
+
+模板内含 machine-readable YAML fenced block，覆盖：
+
+- source manifest / local CSV / approval form / runbook template 引用
+- future packet directory / packet file / packet manifest file 字段
+- source sha256 / row_count
+- `approved_output_root`
+- `approved_packet_sections`
+- candidate / excluded / manual review match_id 列表
+- packet creation reason / human note
+- `final_packet_creation_confirmation`
+
+该模板默认保留人工审批状态，不提供真实 packet file write、packet manifest write、DB write、`pg_dump`、`pg_restore`、training 或 prediction 权限。
+
+## 5. 默认 not_authorized 的原因
+
+本阶段只是在 future packet file creation 之前补一个单独的授权层。只要真实 packet 文件还没有被单独授权，模板就必须保持：
+
+- `authorization_status=not_authorized`
+- `final_packet_creation_confirmation=false`
+
+这样可以明确区分：
+
+- packet file preflight / preview
+- packet file creation authorization review
+- future real packet file creation
+
+Codex 不得自行把 `authorization_status` 改成 `authorized_for_packet_file_creation`，也不得把 `final_packet_creation_confirmation` 改成 `true`。
+
+## 6. validator 设计
+
+新脚本：
+
+```bash
+node scripts/ops/football_data_packet_file_auth_validate.js \
+  --auth-form docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md
+```
+
+validator 只做本地 markdown 读取与 YAML block 校验，不访问外网、不读 DB、不写 DB、不写文件、不创建目录、不执行 `pg_dump`、不执行 `pg_restore`、不 spawn child process。
+
+校验点包括：
+
+- required fields 是否齐全
+- `phase` 是否保持模板值
+- `authorization_status=not_authorized`
+- packet / DB / network / training / prediction 相关布尔字段是否全部为 `false`
+- `final_packet_creation_confirmation=false`
+- `approved_output_root` 是否保持在 `docs/_packets/football_data/small_write`
+- `approved_packet_sections` 是否包含 Phase 4.69C 要求的全部 sections
+
+`--commit` 分支仍然 blocked：
+
+```text
+BLOCKED: football-data packet file creation authorization commit is not wired in Phase 4.71C.
+```
+
+## 7. approved_output_root 规则
+
+`approved_output_root` 必须保持在：
+
+```text
+docs/_packets/football_data/small_write
+```
+
+原因是 packet file 的 future 输出根目录需要在审计范围内固定，不能在 Phase 4.71C 允许自由漂移到其他路径。当前模板默认写死这个安全根目录，validator 也会拒绝任何越界路径。
+
+## 8. approved_packet_sections 规则
+
+`approved_packet_sections` 必须覆盖 Phase 4.69C packet preview 已经定义的全部 section：
+
+- `source_manifest_summary`
+- `local_csv_summary`
+- `csv_dry_run_summary`
+- `db_write_preflight_summary`
+- `duplicate_precheck_summary`
+- `insert_policy_summary`
+- `small_write_auth_preview_summary`
+- `runbook_template_summary`
+- `approval_form_summary`
+- `proposed_match_ids`
+- `insert_candidate_table`
+- `blocked_candidate_table`
+- `manual_review_table`
+- `pg_dump_command_preview`
+- `post_write_validation_checklist`
+- `rollback_restore_preview`
+- `final_human_approval_required`
+
+这样未来即使进入单独授权评审，也不会遗漏 preflight / preview 阶段已经要求过的核心材料。
+
+## 9. 为什么本阶段不创建 packet 文件
+
+Phase 4.71C 只新增授权模板和 validator，没有进入真实 packet file creation。validator 输出和 Makefile gate 都保持：
+
+- `authorization_granted=false`
+- `would_write_packet_file=false`
+- `would_write_packet_manifest=false`
+
+真实 packet file write 仍需未来单独阶段和用户明确授权。
+
+## 10. 为什么本阶段不创建目录
+
+packet 目录创建本身就是实际文件系统变更。本阶段模板和 validator 只允许预先定义未来授权边界，不允许落地创建：
+
+- `would_create_packet_directory=false`
+- `no_packet_directory_create`
+
+## 11. 为什么本阶段不写 DB
+
+packet file creation authorization form 不是 DB write authorization。当前 validator 不读 DB，Makefile auth commit gate 也保持 blocked，因此本阶段没有 `INSERT / UPDATE / DELETE`，也没有任何真实写库行为。
+
+## 12. 为什么本阶段不执行 pg_dump
+
+packet file creation 不等于 DB write pre-write backup。真实 `pg_dump` 仍属于未来真实 DB write 之前的单独授权动作。本阶段 validator 和 blocked commit gate 都不会执行：
+
+- `would_execute_pg_dump=false`
+- `would_execute_pg_restore=false`
+
+## 13. commit gate blocked 结果
+
+以下两个命令都保持 blocked：
+
+- `make data-football-data-packet-file-auth-commit || true`
+- `make data-football-data-packet-file-auth-commit AUTH_FORM=... CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1 || true`
+
+blocked message:
+
+```text
+BLOCKED: football-data packet file creation authorization commit is not wired in Phase 4.71C.
+```
+
+同时也验证了缺确认参数时的 blocked 分支：
+
+```text
+BLOCKED: football-data packet file creation authorization requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1 and is not wired in Phase 4.71C.
+```
+
+## 14. 现有 gates 复验结果
+
+以下已有 gate 已全部继续通过，且未写 DB、未执行 `pg_dump`、未创建 packet 文件：
+
+- `make data-football-data-packet-file-preflight`
+- `make data-football-data-small-write-packet-preview`
+- `make data-football-data-csv-dry-run`
+- `make data-football-data-db-write-preflight`
+- `make data-football-data-duplicate-precheck`
+- `make data-football-data-insert-policy-precheck`
+- `make data-football-data-small-write-auth-preview`
+- `make data-football-data-small-write-runbook-validate`
+
+观测结果：
+
+- packet file preflight: passed
+- small write packet preview: passed
+- CSV dry-run: passed
+- DB write preflight: passed
+- duplicate precheck: passed
+- insert policy precheck: passed
+- small write auth preview: passed
+- runbook validate: passed
+
+## 15. unit tests 结果
+
+本阶段已运行并通过：
+
+- `tests/unit/football_data_packet_file_auth_validate.test.js`
+- `tests/unit/football_data_packet_file_preflight.test.js`
+- `tests/unit/football_data_small_write_packet_assembly.test.js`
+- `tests/unit/football_data_small_write_runbook_validate.test.js`
+- `tests/unit/football_data_small_write_auth_preview.test.js`
+- `tests/unit/football_data_insert_policy_precheck.test.js`
+- `tests/unit/football_data_duplicate_precheck.test.js`
+- `tests/unit/football_data_db_write_preflight.test.js`
+- `tests/unit/football_data_adapter_dry_run.test.js`
+- `tests/unit/football_data_local_csv_parser.test.js`
+- `tests/unit/acquisition_engine_gate.test.js`
+
+其中 `tests/unit/football_data_packet_file_auth_validate.test.js` 为新文件，最终覆盖：
+
+- 缺参数
+- 正常模板 validation
+- help / JSON / text output
+- 未知参数
+- YAML fenced block 缺失
+- YAML 顶层 / nested / indentation 解析失败
+- required field 缺失
+- `phase` / `authorization_status` 错误
+- packet / DB / network / training / prediction 布尔字段越权
+- `approved_output_root` 错误
+- `approved_packet_sections` 缺失
+- blocked commit
+- no-network / no-db / no-file-write / no-directory-create / no-`pg_dump` / no-`pg_restore` / no-child-process
+- 真实 CLI `--help` 入口
+
+## 16. npm test / test:coverage 结果
+
+本阶段已运行并通过：
+
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`
+
+coverage 阈值保持不变，最终结果为：
+
+- lines >= 80
+- functions >= 80
+- branches >= 80
+
+实际 summary：
+
+- lines: `88.52`
+- functions: `80.96`
+- branches: `80.01`
+
+说明：
+
+- 首次全量 coverage 结果是 `branches=79.93`
+- 在不调整阈值、不扩大改动面的前提下，只对新增 `football_data_packet_file_auth_validate` 补充分支测试
+- 第二次结果是 `branches=79.96`
+- 再补两条针对 text output 和真实 CLI 入口的最小测试后，最终达到 `branches=80.01`
+
+## 17. DB 前后统计
+
+本阶段开始和结束都保持：
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 18. 下一步建议
+
+- Phase 4.72C：packet file creation dry-run authorization review，不写 packet 文件、不写 DB、不执行 `pg_dump`
+- 或 Phase 4.56A：用户给齐真实 network dry-run 参数后才做 runbook
+
+## 19. 明确未执行事项
+
+本阶段设计上明确不执行：
+
+- DB writes
+- non-SELECT DB SQL
+- `pg_dump`
+- `pg_restore`
+- backup file writes
+- packet file writes
+- packet manifest writes
+- packet directory creation
+- external download
+- 外部足球数据源访问
+- 外部赔率数据源访问
+- scraping / browser automation
+- harvest / ingest
+- network dry-run 真执行
+- training
+- prediction
+- model artifact loading
+
+另外本阶段实际也未执行：
+
+- packet 目录创建
+- packet manifest 文件写入
+- auth validator runtime 文件写入
+- `authorization_status` 改为 `authorized_for_packet_file_creation`
+- `final_packet_creation_confirmation` 改为 `true`
+- `approval_status` 改为 `approved_for_db_write`
+- `final_human_confirmation` 改为 `true`

--- a/docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md
+++ b/docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md
@@ -1,0 +1,70 @@
+# Football-Data Packet File Creation Authorization Form Template
+
+> 模板用途：未来如需真正创建 packet 文件，先由人工填写和审批这个授权表。
+>
+> 本文件在 Phase 4.71C 只是模板，不是真实授权；不允许据此创建目录、写 packet 文件、写 packet manifest、写 DB、执行 `pg_dump` / `pg_restore`、训练或预测。
+
+```yaml
+phase: PHASE4_PACKET_FILE_CREATION_AUTH
+authorization_status: not_authorized
+operator:
+reviewer:
+source_manifest:
+local_csv:
+approval_form:
+runbook_template:
+packet_directory:
+packet_file:
+packet_manifest_file:
+packet_version:
+source_name:
+source_sha256:
+row_count:
+allow_packet_directory_creation: false
+allow_packet_file_write: false
+allow_packet_manifest_write: false
+allow_db_write: false
+allow_pg_dump: false
+allow_pg_restore: false
+allow_external_network: false
+allow_training: false
+allow_prediction: false
+approved_packet_sections:
+    - source_manifest_summary
+    - local_csv_summary
+    - csv_dry_run_summary
+    - db_write_preflight_summary
+    - duplicate_precheck_summary
+    - insert_policy_summary
+    - small_write_auth_preview_summary
+    - runbook_template_summary
+    - approval_form_summary
+    - proposed_match_ids
+    - insert_candidate_table
+    - blocked_candidate_table
+    - manual_review_table
+    - pg_dump_command_preview
+    - post_write_validation_checklist
+    - rollback_restore_preview
+    - final_human_approval_required
+approved_output_root: docs/_packets/football_data/small_write
+approved_candidate_match_ids: []
+excluded_candidate_match_ids: []
+manual_review_candidate_match_ids: []
+packet_creation_reason:
+human_approval_note:
+final_packet_creation_confirmation: false
+```
+
+## 说明
+
+- 默认 `authorization_status=not_authorized`。
+- 默认 `allow_packet_directory_creation=false`，不允许创建目录。
+- 默认 `allow_packet_file_write=false`，不允许写 packet 文件。
+- 默认 `allow_packet_manifest_write=false`，不允许写 packet manifest。
+- 默认 `allow_db_write=false`，不允许写 DB。
+- 默认 `allow_pg_dump=false`、`allow_pg_restore=false`。
+- 默认 `allow_external_network=false`、`allow_training=false`、`allow_prediction=false`。
+- Codex 不得自行把 `authorization_status` 改成 `authorized_for_packet_file_creation`。
+- Codex 不得自行把 `final_packet_creation_confirmation` 改成 `true`。
+- 本阶段只提供模板和校验 gate，不是真实授权，也不会真正创建 packet 文件。

--- a/scripts/ops/football_data_packet_file_auth_validate.js
+++ b/scripts/ops/football_data_packet_file_auth_validate.js
@@ -1,0 +1,601 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const PACKET_FILE_AUTH_VALIDATE_PHASE = 'PHASE4.71C_FOOTBALL_DATA_PACKET_FILE_AUTH_VALIDATE';
+const TEMPLATE_PHASE = 'PHASE4_PACKET_FILE_CREATION_AUTH';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: football-data packet file creation authorization commit is not wired in Phase 4.71C.';
+const APPROVED_OUTPUT_ROOT = 'docs/_packets/football_data/small_write';
+const REQUIRED_PACKET_SECTIONS = [
+    'source_manifest_summary',
+    'local_csv_summary',
+    'csv_dry_run_summary',
+    'db_write_preflight_summary',
+    'duplicate_precheck_summary',
+    'insert_policy_summary',
+    'small_write_auth_preview_summary',
+    'runbook_template_summary',
+    'approval_form_summary',
+    'proposed_match_ids',
+    'insert_candidate_table',
+    'blocked_candidate_table',
+    'manual_review_table',
+    'pg_dump_command_preview',
+    'post_write_validation_checklist',
+    'rollback_restore_preview',
+    'final_human_approval_required',
+];
+const REQUIRED_FIELDS = [
+    'phase',
+    'authorization_status',
+    'operator',
+    'reviewer',
+    'source_manifest',
+    'local_csv',
+    'approval_form',
+    'runbook_template',
+    'packet_directory',
+    'packet_file',
+    'packet_manifest_file',
+    'packet_version',
+    'source_name',
+    'source_sha256',
+    'row_count',
+    'allow_packet_directory_creation',
+    'allow_packet_file_write',
+    'allow_packet_manifest_write',
+    'allow_db_write',
+    'allow_pg_dump',
+    'allow_pg_restore',
+    'allow_external_network',
+    'allow_training',
+    'allow_prediction',
+    'approved_packet_sections',
+    'approved_output_root',
+    'approved_candidate_match_ids',
+    'excluded_candidate_match_ids',
+    'manual_review_candidate_match_ids',
+    'packet_creation_reason',
+    'human_approval_note',
+    'final_packet_creation_confirmation',
+];
+const REQUIRED_FALSE_FIELDS = [
+    'allow_packet_directory_creation',
+    'allow_packet_file_write',
+    'allow_packet_manifest_write',
+    'allow_db_write',
+    'allow_pg_dump',
+    'allow_pg_restore',
+    'allow_external_network',
+    'allow_training',
+    'allow_prediction',
+    'final_packet_creation_confirmation',
+];
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_packet_file_auth_validate.js --auth-form <path> [--json]',
+        '  node scripts/ops/football_data_packet_file_auth_validate.js --auth-form <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.71C validates a local packet file creation authorization template only.',
+        '  No DB reads, no DB writes, no file writes, no directory creation, no pg_dump, no pg_restore.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        authForm: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token.startsWith('--auth-form=')) {
+            args.authForm = token.slice('--auth-form='.length);
+        } else if (token === '--auth-form') {
+            args.authForm = String(argv[index + 1] || '');
+            index += 1;
+        } else if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) {
+        return '';
+    }
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) {
+        return '';
+    }
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function normalizeRelativePath(value) {
+    return String(value || '')
+        .replace(/\\/g, '/')
+        .replace(/\/+$/g, '');
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'no_db_reads',
+        'no_db_writes',
+        'no_file_writes',
+        'no_packet_directory_create',
+        'no_packet_file_write',
+        'no_packet_manifest_write',
+        'no_pg_dump_execution',
+        'no_pg_restore_execution',
+        'no_child_process_spawn',
+        'no_training',
+        'no_prediction_execution',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        would_read_db: false,
+        would_write_db: false,
+        would_write_files: false,
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_access_network: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_spawn_child_process: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+        authorization_granted: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: PACKET_FILE_AUTH_VALIDATE_PHASE,
+        mode: fields.mode || 'football-data-packet-file-auth-validate',
+        ok: false,
+        auth_form: args.authForm || null,
+        auth_form_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        authorization_status: null,
+        final_packet_creation_confirmation: null,
+        approved_output_root: null,
+        approved_output_root_valid: false,
+        approved_packet_sections: [],
+        approved_packet_sections_complete: false,
+        approved_packet_sections_missing: REQUIRED_PACKET_SECTIONS,
+        commit_gate: 'blocked',
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function extractYamlBlock(markdownText) {
+    const match = String(markdownText || '').match(/```ya?ml\s*\n([\s\S]*?)\n```/i);
+    return match ? match[1] : '';
+}
+
+function stripInlineComment(value) {
+    const hashIndex = value.indexOf(' #');
+    if (hashIndex === -1) {
+        return value;
+    }
+    return value.slice(0, hashIndex);
+}
+
+function parseScalar(rawValue) {
+    const value = stripInlineComment(String(rawValue || '')).trim();
+    if (value === '') {
+        return null;
+    }
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+        return false;
+    }
+    if (value === '[]') {
+        return [];
+    }
+    if (value.startsWith('[') && value.endsWith(']')) {
+        const inner = value.slice(1, -1).trim();
+        if (!inner) {
+            return [];
+        }
+        return inner.split(',').map(item => parseScalar(item.trim()));
+    }
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    if (/^-?\d+$/.test(value)) {
+        return Number(value);
+    }
+    return value;
+}
+
+function parseTopLevelYamlLine(root, trimmed) {
+    const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+    if (!match) {
+        throw new Error(`unsupported YAML line: ${trimmed}`);
+    }
+
+    const key = match[1];
+    const value = match[2].trim();
+    root[key] = value === '' ? null : parseScalar(value);
+    return key;
+}
+
+function parseNestedYamlLine(root, currentKey, trimmed) {
+    if (trimmed.startsWith('- ')) {
+        if (!Array.isArray(root[currentKey])) {
+            root[currentKey] = [];
+        }
+        root[currentKey].push(parseScalar(trimmed.slice(2)));
+        return;
+    }
+
+    const nestedMatch = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+    if (!nestedMatch) {
+        throw new Error(`unsupported YAML line: ${trimmed}`);
+    }
+    if (!root[currentKey] || Array.isArray(root[currentKey]) || typeof root[currentKey] !== 'object') {
+        root[currentKey] = {};
+    }
+    root[currentKey][nestedMatch[1]] = nestedMatch[2].trim() === '' ? null : parseScalar(nestedMatch[2]);
+}
+
+function parseYamlBlock(yamlText) {
+    const root = {};
+    let currentKey = '';
+
+    for (const rawLine of String(yamlText || '').split(/\r?\n/)) {
+        if (!rawLine.trim() || rawLine.trim().startsWith('#')) {
+            continue;
+        }
+
+        const indent = rawLine.match(/^ */)[0].length;
+        const trimmed = rawLine.trim();
+
+        if (indent === 0) {
+            currentKey = parseTopLevelYamlLine(root, trimmed);
+            continue;
+        }
+
+        if (indent >= 2 && currentKey) {
+            parseNestedYamlLine(root, currentKey, trimmed);
+            continue;
+        }
+
+        throw new Error(`unsupported YAML indentation: ${trimmed}`);
+    }
+
+    return root;
+}
+
+function findMissingFields(parsedYaml) {
+    return REQUIRED_FIELDS.filter(field => !Object.prototype.hasOwnProperty.call(parsedYaml, field));
+}
+
+function validateApprovedOutputRoot(value) {
+    const normalized = normalizeRelativePath(value);
+    const normalizedRoot = normalizeRelativePath(APPROVED_OUTPUT_ROOT);
+    return normalized === normalizedRoot;
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    const approvedPacketSections = Array.isArray(parsedYaml.approved_packet_sections)
+        ? parsedYaml.approved_packet_sections
+        : [];
+    const missingPacketSections = REQUIRED_PACKET_SECTIONS.filter(section => !approvedPacketSections.includes(section));
+
+    if (missingFields.length > 0) {
+        errors.push(`missing required fields: ${missingFields.join(',')}`);
+    }
+    if (parsedYaml.phase !== TEMPLATE_PHASE) {
+        errors.push(`phase must remain ${TEMPLATE_PHASE} in the Phase 4.71C template`);
+    }
+    if (parsedYaml.authorization_status !== 'not_authorized') {
+        errors.push('authorization_status must remain not_authorized in the Phase 4.71C template');
+    }
+    for (const field of REQUIRED_FALSE_FIELDS) {
+        if (parsedYaml[field] !== false) {
+            errors.push(`${field} must be false in the Phase 4.71C template`);
+        }
+    }
+    if (!Array.isArray(parsedYaml.approved_packet_sections)) {
+        errors.push('approved_packet_sections must be an array');
+    }
+    if (missingPacketSections.length > 0) {
+        errors.push(`approved_packet_sections is missing required sections: ${missingPacketSections.join(', ')}`);
+    }
+    if (!validateApprovedOutputRoot(parsedYaml.approved_output_root)) {
+        errors.push(`approved_output_root must stay inside ${APPROVED_OUTPUT_ROOT}`);
+    }
+
+    return {
+        ok: errors.length === 0,
+        missingFields,
+        missingPacketSections,
+        errors,
+    };
+}
+
+function buildSuccessPayload(args, parsedYaml, authFormFound) {
+    const validation = validateParsedYaml(parsedYaml);
+
+    return {
+        phase: PACKET_FILE_AUTH_VALIDATE_PHASE,
+        mode: 'football-data-packet-file-auth-validate',
+        ok: true,
+        auth_form: args.authForm,
+        auth_form_found: authFormFound,
+        yaml_block_found: true,
+        required_fields_present: true,
+        missing_fields: [],
+        authorization_status: parsedYaml.authorization_status,
+        final_packet_creation_confirmation: parsedYaml.final_packet_creation_confirmation,
+        approved_output_root: parsedYaml.approved_output_root,
+        approved_output_root_valid: true,
+        approved_packet_sections: parsedYaml.approved_packet_sections,
+        approved_packet_sections_complete: validation.missingPacketSections.length === 0,
+        approved_packet_sections_missing: validation.missingPacketSections,
+        allow_packet_directory_creation: parsedYaml.allow_packet_directory_creation,
+        allow_packet_file_write: parsedYaml.allow_packet_file_write,
+        allow_packet_manifest_write: parsedYaml.allow_packet_manifest_write,
+        allow_db_write: parsedYaml.allow_db_write,
+        allow_pg_dump: parsedYaml.allow_pg_dump,
+        allow_pg_restore: parsedYaml.allow_pg_restore,
+        allow_external_network: parsedYaml.allow_external_network,
+        allow_training: parsedYaml.allow_training,
+        allow_prediction: parsedYaml.allow_prediction,
+        commit_gate: 'blocked',
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        errors: [],
+        warnings: [],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+    const authFormPath = resolveLocalPath(args.authForm, cwd);
+
+    if (!args.authForm) {
+        return buildFailurePayload(args, {
+            mode: 'argument-error',
+            errors: ['ERROR: provide --auth-form=<path>'],
+        });
+    }
+
+    if (!existsSync(authFormPath)) {
+        return buildFailurePayload(args, {
+            mode: 'auth-form-error',
+            auth_form_found: false,
+            errors: [`auth form not found: ${toRelativePath(authFormPath, cwd)}`],
+        });
+    }
+
+    const markdownText = readFileSync(authFormPath, 'utf8');
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        return buildFailurePayload(args, {
+            mode: 'auth-form-error',
+            auth_form_found: true,
+            yaml_block_found: false,
+            errors: ['YAML fenced block not found'],
+        });
+    }
+
+    let parsedYaml;
+    try {
+        parsedYaml = parseYamlBlock(yamlText);
+    } catch (error) {
+        return buildFailurePayload(args, {
+            mode: 'auth-form-error',
+            auth_form_found: true,
+            yaml_block_found: true,
+            errors: [`unable to parse YAML block: ${error.message}`],
+        });
+    }
+
+    const validation = validateParsedYaml(parsedYaml);
+    if (!validation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'auth-form-error',
+            auth_form_found: true,
+            yaml_block_found: true,
+            required_fields_present: validation.missingFields.length === 0,
+            missing_fields: validation.missingFields,
+            authorization_status: parsedYaml.authorization_status || null,
+            final_packet_creation_confirmation: parsedYaml.final_packet_creation_confirmation ?? null,
+            approved_output_root: parsedYaml.approved_output_root || null,
+            approved_output_root_valid: validateApprovedOutputRoot(parsedYaml.approved_output_root),
+            approved_packet_sections: Array.isArray(parsedYaml.approved_packet_sections)
+                ? parsedYaml.approved_packet_sections
+                : [],
+            approved_packet_sections_complete: validation.missingPacketSections.length === 0,
+            approved_packet_sections_missing: validation.missingPacketSections,
+            allow_packet_directory_creation: parsedYaml.allow_packet_directory_creation,
+            allow_packet_file_write: parsedYaml.allow_packet_file_write,
+            allow_packet_manifest_write: parsedYaml.allow_packet_manifest_write,
+            allow_db_write: parsedYaml.allow_db_write,
+            allow_pg_dump: parsedYaml.allow_pg_dump,
+            allow_pg_restore: parsedYaml.allow_pg_restore,
+            allow_external_network: parsedYaml.allow_external_network,
+            allow_training: parsedYaml.allow_training,
+            allow_prediction: parsedYaml.allow_prediction,
+            errors: validation.errors,
+        });
+    }
+
+    return buildSuccessPayload(args, parsedYaml, true);
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `validation_summary=${payload.ok ? 'passed' : 'failed'}`,
+        `auth_form_found=${payload.auth_form_found}`,
+        `yaml_block_found=${payload.yaml_block_found}`,
+        `required_fields_present=${payload.required_fields_present}`,
+        `authorization_status=${payload.authorization_status}`,
+        `approved_output_root=${payload.approved_output_root}`,
+        `approved_output_root_valid=${payload.approved_output_root_valid}`,
+        `approved_packet_sections_complete=${payload.approved_packet_sections_complete}`,
+        `final_packet_creation_confirmation=${payload.final_packet_creation_confirmation}`,
+        `allow_packet_directory_creation=${payload.allow_packet_directory_creation}`,
+        `allow_packet_file_write=${payload.allow_packet_file_write}`,
+        `allow_packet_manifest_write=${payload.allow_packet_manifest_write}`,
+        `allow_db_write=${payload.allow_db_write}`,
+        `allow_pg_dump=${payload.allow_pg_dump}`,
+        `allow_pg_restore=${payload.allow_pg_restore}`,
+        `allow_external_network=${payload.allow_external_network}`,
+        `allow_training=${payload.allow_training}`,
+        `allow_prediction=${payload.allow_prediction}`,
+        `would_read_db=${payload.would_read_db}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_write_files=${payload.would_write_files}`,
+        `would_create_packet_directory=${payload.would_create_packet_directory}`,
+        `would_write_packet_file=${payload.would_write_packet_file}`,
+        `would_write_packet_manifest=${payload.would_write_packet_manifest}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_execute_pg_dump=${payload.would_execute_pg_dump}`,
+        `would_execute_pg_restore=${payload.would_execute_pg_restore}`,
+        `would_spawn_child_process=${payload.would_spawn_child_process}`,
+        `authorization_granted=${payload.authorization_granted}`,
+        `commit_gate=${payload.commit_gate}`,
+    ];
+
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.missing_fields) && payload.missing_fields.length > 0) {
+        lines.push(`missing_fields=${payload.missing_fields.join(',')}`);
+    }
+    if (
+        Array.isArray(payload.approved_packet_sections_missing) &&
+        payload.approved_packet_sections_missing.length > 0
+    ) {
+        lines.push(`approved_packet_sections_missing=${payload.approved_packet_sections_missing.join(',')}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+    lines.push('approved_packet_sections=');
+    for (const section of payload.approved_packet_sections || []) {
+        lines.push(`  ${section}`);
+    }
+    lines.push('non_execution_confirmations=');
+    for (const confirmation of payload.non_execution_confirmations || []) {
+        lines.push(`  ${confirmation}`);
+    }
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            {
+                authForm: '',
+            },
+            {
+                mode: 'argument-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, argv.includes('--json'), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    PACKET_FILE_AUTH_VALIDATE_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    APPROVED_OUTPUT_ROOT,
+    REQUIRED_FIELDS,
+    REQUIRED_FALSE_FIELDS,
+    REQUIRED_PACKET_SECTIONS,
+    parseArgs,
+    extractYamlBlock,
+    parseYamlBlock,
+    validateParsedYaml,
+    runValidation,
+    buildNonExecutionConfirmations,
+    main,
+};

--- a/tests/unit/football_data_packet_file_auth_validate.test.js
+++ b/tests/unit/football_data_packet_file_auth_validate.test.js
@@ -1,0 +1,521 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const { spawnSync } = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_packet_file_auth_validate.js');
+const TEMPLATE_PATH = path.join(PROJECT_ROOT, 'docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md');
+const TEMPLATE_TEXT = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_packet_file_auth_validate`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildDependencies(markdownText = TEMPLATE_TEXT) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: () => true,
+        readFileSync: () => markdownText,
+    };
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(TEMPLATE_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return TEMPLATE_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return TEMPLATE_TEXT.replace(`${line}\n`, '');
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+
+    return {
+        status,
+        stdout,
+        stderr,
+    };
+}
+
+test('缺 auth form 参数时失败', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, [], buildDependencies());
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /ERROR: provide --auth-form=<path>/);
+});
+
+test('正确 template validation 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { authForm: 'docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md' },
+        buildDependencies()
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.authorization_status, 'not_authorized');
+    assert.equal(payload.final_packet_creation_confirmation, false);
+    assert.equal(payload.approved_output_root, 'docs/_packets/football_data/small_write');
+    assert.equal(payload.would_read_db, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+});
+
+test('CLI --help 输出 usage', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--help'], buildDependencies());
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Usage:/);
+    assert.match(result.stdout, /No DB reads, no DB writes/);
+});
+
+test('CLI 支持等号参数和 JSON 输出', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--auth-form=auth.md', '--json'], buildDependencies());
+    const payload = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.authorization_status, 'not_authorized');
+});
+
+test('text output 包含 required summary 字段', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--auth-form', 'auth.md'], buildDependencies());
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /validation_summary=passed/);
+    assert.match(result.stdout, /approved_output_root=docs\/_packets\/football_data\/small_write/);
+    assert.match(result.stdout, /approved_packet_sections=/);
+    assert.match(result.stdout, /source_manifest_summary/);
+    assert.match(result.stdout, /non_execution_confirmations=/);
+});
+
+test('未知参数失败且保持 non-execution flags', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--unknown', '--json'], buildDependencies());
+    const payload = JSON.parse(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.would_read_db, false);
+    assert.equal(payload.would_write_db, false);
+    assert.match(payload.errors.join('\n'), /Unknown argument: --unknown/);
+});
+
+test('auth form 文件不存在时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { authForm: 'missing/auth.md' },
+        {
+            cwd: PROJECT_ROOT,
+            existsSync: () => false,
+            readFileSync: () => {
+                throw new Error('readFileSync should not run for missing auth form');
+            },
+        }
+    );
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.auth_form_found, false);
+    assert.match(payload.errors.join('\n'), /auth form not found: missing\/auth\.md/);
+});
+
+test('YAML block 缺失时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies('# missing yaml\n'));
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.yaml_block_found, false);
+    assert.match(payload.errors.join('\n'), /YAML fenced block not found/);
+});
+
+test('YAML 顶层格式不支持时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies('```yaml\nnot yaml\n```\n'));
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.yaml_block_found, true);
+    assert.match(payload.errors.join('\n'), /unable to parse YAML block: unsupported YAML line/);
+});
+
+test('YAML nested 格式不支持时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { authForm: 'auth.md' },
+        buildDependencies('```yaml\napproved_packet_sections:\n  not yaml\n```\n')
+    );
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unable to parse YAML block: unsupported YAML line/);
+});
+
+test('YAML indentation 不支持时失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        { authForm: 'auth.md' },
+        buildDependencies('```yaml\n  authorization_status:\n```\n')
+    );
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unable to parse YAML block: unsupported YAML indentation/);
+});
+
+test('YAML scalar parser 支持注释、数组、引号、数字和 nested overwrite', () => {
+    const gate = loadValidatorFresh();
+    const parsed = gate.parseYamlBlock(
+        [
+            'phase: PHASE4_PACKET_FILE_CREATION_AUTH # inline comment',
+            'empty_value:',
+            'empty_array: []',
+            'inline_array: [matches, 2, true]',
+            'quoted: "hello"',
+            "single_quoted: 'world'",
+            'number_value: 7',
+            'parent: scalar',
+            '  child:',
+        ].join('\n')
+    );
+
+    assert.equal(parsed.phase, 'PHASE4_PACKET_FILE_CREATION_AUTH');
+    assert.equal(parsed.empty_value, null);
+    assert.deepEqual(parsed.empty_array, []);
+    assert.deepEqual(parsed.inline_array, ['matches', 2, true]);
+    assert.equal(parsed.quoted, 'hello');
+    assert.equal(parsed.single_quoted, 'world');
+    assert.equal(parsed.number_value, 7);
+    assert.deepEqual(parsed.parent, { child: null });
+});
+
+test('required field 缺失时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = removeLineFromTemplate('operator:');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.deepEqual(payload.missing_fields, ['operator']);
+    assert.match(payload.errors.join('\n'), /missing required fields: operator/);
+});
+
+test('phase 不是模板 phase 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate(
+        'phase: PHASE4_PACKET_FILE_CREATION_AUTH',
+        'phase: PHASE4_OTHER_PACKET_FILE_AUTH'
+    );
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /phase must remain PHASE4_PACKET_FILE_CREATION_AUTH/);
+});
+
+test('authorization_status 不是 not_authorized 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate(
+        'authorization_status: not_authorized',
+        'authorization_status: authorized_for_packet_file_creation'
+    );
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /authorization_status must remain not_authorized/);
+});
+
+test('allow_packet_directory_creation=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate(
+        'allow_packet_directory_creation: false',
+        'allow_packet_directory_creation: true'
+    );
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_packet_directory_creation must be false/);
+});
+
+test('allow_packet_file_write=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_packet_file_write: false', 'allow_packet_file_write: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_packet_file_write must be false/);
+});
+
+test('allow_packet_manifest_write=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_packet_manifest_write: false', 'allow_packet_manifest_write: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_packet_manifest_write must be false/);
+});
+
+test('allow_db_write=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_db_write: false', 'allow_db_write: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_db_write must be false/);
+});
+
+test('allow_pg_dump=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_pg_dump: false', 'allow_pg_dump: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_pg_dump must be false/);
+});
+
+test('allow_pg_restore=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_pg_restore: false', 'allow_pg_restore: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_pg_restore must be false/);
+});
+
+test('allow_external_network=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_external_network: false', 'allow_external_network: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_external_network must be false/);
+});
+
+test('allow_training=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_training: false', 'allow_training: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_training must be false/);
+});
+
+test('allow_prediction=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate('allow_prediction: false', 'allow_prediction: true');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /allow_prediction must be false/);
+});
+
+test('final_packet_creation_confirmation=true 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate(
+        'final_packet_creation_confirmation: false',
+        'final_packet_creation_confirmation: true'
+    );
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /final_packet_creation_confirmation must be false/);
+});
+
+test('approved_output_root 不在允许目录时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = replaceInTemplate(
+        'approved_output_root: docs/_packets/football_data/small_write',
+        'approved_output_root: docs/_packets/football_data/other'
+    );
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(
+        payload.errors.join('\n'),
+        /approved_output_root must stay inside docs\/_packets\/football_data\/small_write/
+    );
+});
+
+test('approved_packet_sections 缺少必要 section 时失败', () => {
+    const gate = loadValidatorFresh();
+    const markdownText = removeLineFromTemplate('  - rollback_restore_preview');
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies(markdownText));
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /approved_packet_sections is missing required sections/);
+    assert.ok(payload.approved_packet_sections_missing.includes('rollback_restore_preview'));
+});
+
+test('--commit 始终 blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--auth-form', 'auth.md', '--commit'], buildDependencies());
+
+    assert.equal(result.status, 1);
+    assert.match(
+        result.stdout,
+        /BLOCKED: football-data packet file creation authorization commit is not wired in Phase 4.71C/
+    );
+});
+
+test('validator 不访问外网', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_access_network, false);
+});
+
+test('validator 不读 DB', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_read_db, false);
+});
+
+test('validator 不写 DB', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('validator 不写文件', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_files, false);
+});
+
+test('validator 不创建目录', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_create_packet_directory, false);
+});
+
+test('validator 不执行 pg_dump', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_pg_dump, false);
+});
+
+test('validator 不执行 pg_restore', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_pg_restore, false);
+});
+
+test('validator 不 spawn child process', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation({ authForm: 'auth.md' }, buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_spawn_child_process, false);
+});
+
+test('script 作为真实入口执行 --help 应成功', () => {
+    const result = spawnSync('node', [SCRIPT_PATH, '--help'], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Usage:/);
+    assert.match(result.stdout, /Phase 4\.71C validates a local packet file creation authorization template only/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.71C football-data packet file creation authorization form and validator.

Scope:
- Adds packet file creation authorization form template
- Adds packet file authorization validator
- Adds Makefile validation and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.71C report

Safety:
- No DB writes
- No DB reads from validator
- No packet file writes
- No packet directory creation
- No pg_dump execution
- No pg_restore execution
- No backup file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- packet file auth validation passed
- packet file auth commit gate remained blocked
- existing football-data gates still passed
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed