### PR TITLE
feat(data): add football-data packet file auth review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -596,6 +596,9 @@ Phase 4.57C football-data adapter rules：
 - Phase 4.71C 的 packet file creation auth form 默认 `authorization_status=not_authorized`、默认 `final_packet_creation_confirmation=false`；Codex 不得自行改成 `authorized_for_packet_file_creation` 或 `true`。
 - `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>` 只验证本地 packet file creation authorization 模板；不得读 DB、写 DB、创建目录、写 packet 文件、执行 `pg_dump` / `pg_restore`、训练或预测。
 - `make data-football-data-packet-file-auth-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1` 也不得创建真实 packet 文件、创建 packet 目录、写 packet manifest、执行真实 `pg_dump` 或执行真实 DB write。
+- Phase 4.72C 的 `make data-football-data-packet-file-auth-review AUTH_FORM=<local md> SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv> APPROVAL_FORM=<local md> RUNBOOK_TEMPLATE=<local md>` 只做 dry-run authorization review；不得创建目录、不得写 packet 文件、不得写 DB、不得执行 `pg_dump` / `pg_restore`。
+- `data-football-data-packet-file-auth-review` 不得把 `authorization_status` 改成 `authorized_for_packet_file_creation`，也不得把 `final_packet_creation_confirmation` 改成 `true`；真实 packet file creation authorization 与 DB write / `pg_dump` / training / prediction 权限分离。
+- `make data-football-data-packet-file-auth-review-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW=1` 也不得创建真实 packet 文件、创建 packet 目录、执行真实 `pg_dump` / `pg_restore` 或执行真实 DB write。
 - 真实 packet 文件创建必须在单独阶段进行，且需要用户明确授权、显式输出目录、显式 packet 文件路径；创建 packet 文件不代表允许 DB write、`pg_dump`、training 或 prediction。
 - 真实 packet 文件创建、真实 `pg_dump` 和真实 DB write 必须分别在单独阶段进行，并需要用户明确授权。
 - Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@
         data-football-data-small-write-packet-preview data-football-data-small-write-packet-commit \
         data-football-data-packet-file-preflight data-football-data-packet-file-commit \
         data-football-data-packet-file-auth-validate data-football-data-packet-file-auth-commit \
+        data-football-data-packet-file-auth-review data-football-data-packet-file-auth-review-commit \
         data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
@@ -277,6 +278,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-small-write-packet-preview SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-packet-file-preflight SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-packet-file-auth-validate AUTH_FORM=<path>"
+	@echo "  make data-football-data-packet-file-auth-review AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
 	@echo "  make data-finished-csv-dry-run SAMPLE_CSV=<path>"
 	@echo "  make data-finished-backfill-dry-run MATCH_ID=<id>"
@@ -303,6 +305,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-small-write-packet-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_SMALL_WRITE_PACKET=1  # blocked in Phase 4.69C"
 	@echo "  make data-football-data-packet-file-commit SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE=1  # blocked in Phase 4.70C"
 	@echo "  make data-football-data-packet-file-auth-commit AUTH_FORM=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1  # blocked in Phase 4.71C"
+	@echo "  make data-football-data-packet-file-auth-review-commit AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW=1  # blocked in Phase 4.72C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -667,6 +670,27 @@ data-football-data-packet-file-auth-commit: ## Blocked Football-Data packet file
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data packet file creation authorization commit is not wired in Phase 4.71C."
+	@exit 1
+
+data-football-data-packet-file-auth-review: ## Run Football-Data packet file creation dry-run authorization review. Requires AUTH_FORM, SOURCE_MANIFEST, LOCAL_CSV, APPROVAL_FORM, RUNBOOK_TEMPLATE.
+	@if [ -z "$(AUTH_FORM)" ] || [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ] || [ -z "$(APPROVAL_FORM)" ] || [ -z "$(RUNBOOK_TEMPLATE)" ]; then \
+		echo "ERROR: provide AUTH_FORM=<path>, SOURCE_MANIFEST=<path>, LOCAL_CSV=<path>, APPROVAL_FORM=<path>, and RUNBOOK_TEMPLATE=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data packet file authorization review: AUTH_FORM=$(AUTH_FORM), SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV), APPROVAL_FORM=$(APPROVAL_FORM), RUNBOOK_TEMPLATE=$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(AUTH_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(APPROVAL_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_packet_file_auth_review.js --auth-form "$(AUTH_FORM)" --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)" --approval-form "$(APPROVAL_FORM)" --runbook-template "$(RUNBOOK_TEMPLATE)"
+
+data-football-data-packet-file-auth-review-commit: ## Blocked Football-Data packet file authorization review commit gate. Requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW)" != "1" ]; then \
+		echo "BLOCKED: football-data packet file authorization review requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW=1 and is not wired in Phase 4.72C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data packet file authorization review commit is not wired in Phase 4.72C."
 	@exit 1
 
 data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.

--- a/docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW_PHASE4_72C.md
+++ b/docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW_PHASE4_72C.md
@@ -1,0 +1,317 @@
+# FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW_PHASE4_72C
+
+## 1. 当前 HEAD / branch
+
+- base HEAD: `f16d969d0ea36db3f00b222df1966460c2d4f56a`
+- 工作分支: `feat/football-data-packet-file-auth-review-phase472c`
+- 阶段: `PHASE4.72C_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW`
+
+## 2. 为什么这次做稍大主题 PR 是合理的
+
+本阶段不是单点脚本补丁，而是把 Phase 4.71C 的 packet file creation authorization template
+推进到下一层治理能力：
+
+- 需要新增独立 review gate
+- 需要把 auth form validator、packet file preflight 和 packet preview 串起来
+- 需要把“ready / authorized 仍为 false”的 dry-run review 结果标准化输出
+- 需要新增 blocked commit 入口、unit tests、AGENTS 规则和阶段报告
+
+这些改动属于单一安全主题，集中在同一个 PR 内更容易审计。
+
+## 3. 新增文件
+
+- `scripts/ops/football_data_packet_file_auth_review.js`
+- `tests/unit/football_data_packet_file_auth_review.test.js`
+- `docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW_PHASE4_72C.md`
+
+同时更新：
+
+- `Makefile`
+- `AGENTS.md`
+
+## 4. authorization review 设计
+
+Phase 4.72C review script 只做 dry-run authorization review，不授予权限，不执行写动作。
+
+输入：
+
+- packet file creation auth form
+- source manifest
+- local CSV
+- approval form
+- runbook template
+
+复用：
+
+- Phase 4.71C `football_data_packet_file_auth_validate.js`
+- Phase 4.70C `football_data_packet_file_preflight.js`
+- Phase 4.69C `football_data_small_write_packet_assembly.js`
+
+额外行为：
+
+- 输出 review summary 到 stdout
+- 显式给出 `packet_file_creation_ready=false`
+- 显式给出 `packet_file_creation_authorized=false`
+- 显式给出 `approval_granted=false`
+- 显式列出缺失的人类授权条件
+- 显式列出 human-only fields
+- 显式列出 permission separation
+- 只做 SELECT-only DB row count inspection
+
+## 5. missing_authorization_requirements
+
+review 输出固定检查并报告以下缺口：
+
+- `authorization_status must be authorized_for_packet_file_creation`
+- `final_packet_creation_confirmation must be true`
+- `operator must be filled`
+- `reviewer must be filled`
+- `packet_directory must be explicit`
+- `packet_file must be explicit`
+- `packet_manifest_file must be explicit`
+- `source_manifest must match reviewed source`
+- `local_csv must match reviewed CSV`
+- `approved_candidate_match_ids must be reviewed`
+- `manual_review_candidate_match_ids must be excluded or resolved`
+- `human_approval_note must be present`
+
+当前模板默认 `not_authorized`，因此本阶段 review 预期仍然输出未满足状态。
+
+## 6. human_only_fields
+
+review 输出固定标记以下字段只能由人类在未来真实授权阶段填写或修改：
+
+- `authorization_status`
+- `final_packet_creation_confirmation`
+- `operator`
+- `reviewer`
+- `human_approval_note`
+- `approved_candidate_match_ids`
+- `excluded_candidate_match_ids`
+- `manual_review_candidate_match_ids`
+- `packet_creation_reason`
+
+## 7. permission_separation
+
+review 输出固定声明：
+
+- packet file creation does not authorize DB write
+- packet file creation does not authorize `pg_dump`
+- packet file creation does not authorize `pg_restore`
+- packet file creation does not authorize training
+- packet file creation does not authorize prediction
+
+这保证 packet file authorization 不会被误解为下游链路总授权。
+
+## 8. 为什么本阶段不创建 packet 文件
+
+因为 Phase 4.72C 的目标是 authorization review，不是 authorization grant，也不是 packet file creation phase。
+
+本阶段只允许：
+
+- 读取本地文件
+- 复用 dry-run gate
+- 输出 stdout summary
+- 做 SELECT-only DB row count inspection
+
+本阶段不允许：
+
+- packet 文件写入
+- packet manifest 写入
+- backup 写入
+
+## 9. 为什么本阶段不创建目录
+
+packet directory 仍属于未来真实 packet file creation 行为的一部分。
+
+当前 review 只判断“未来是否可能被授权”，不触发任何 filesystem side effect，
+因此不得创建输出目录，也不得生成 staging / packet 路径实体。
+
+## 10. 为什么本阶段不写 DB
+
+本阶段的 DB 访问范围仅限 SELECT-only row count inspection。
+
+review 结果不会触发：
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- 任何 schema 变更
+
+因此 `packet_file_creation_ready` 和 `packet_file_creation_authorized` 都保持 false。
+
+## 11. 为什么本阶段不执行 pg_dump
+
+`pg_dump` 仍属于未来真实 DB write 之前的独立授权事项。
+
+即使未来允许 packet file creation，也不代表同时允许：
+
+- `pg_dump`
+- `pg_restore`
+- DB write
+
+因此本阶段只保留 preview / separation 声明，不执行真实备份命令。
+
+## 12. commit gate blocked 结果
+
+新增：
+
+- `make data-football-data-packet-file-auth-review`
+- `make data-football-data-packet-file-auth-review-commit`
+
+其中 commit 入口保持 blocked：
+
+- 默认 blocked
+- 即使提供 `CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW=1` 仍 blocked
+
+blocked message:
+
+`BLOCKED: football-data packet file authorization review commit is not wired in Phase 4.72C.`
+
+本地验证结果：
+
+- 缺参数时 `make data-football-data-packet-file-auth-review` 按预期失败
+- 正确参数下 review 成功
+- 输出确认：
+    - `authorization_review_completed=true`
+    - `packet_file_creation_ready=false`
+    - `packet_file_creation_authorized=false`
+    - `authorization_status=not_authorized`
+    - `final_packet_creation_confirmation=false`
+    - `approval_granted=false`
+- `make data-football-data-packet-file-auth-review-commit` 在无确认参数和有确认参数两种情况下都保持 blocked
+
+## 13. 现有 gates 复验结果
+
+要求复验的既有 gate 继续成功：
+
+- packet file auth validation
+- packet file preflight
+- small write packet preview
+- CSV dry-run
+- DB write preflight
+- duplicate precheck
+- insert policy precheck
+- small write auth preview
+- runbook validation
+
+并保持：
+
+- no DB write
+- no packet file write
+- no packet directory creation
+- no `pg_dump`
+- no `pg_restore`
+
+本地复验结果：以上 gate 全部成功，并保持 dry-run / preview-only 行为。
+
+## 14. unit tests 结果
+
+新增 `tests/unit/football_data_packet_file_auth_review.test.js`，覆盖：
+
+- 缺参数失败
+- 正确 template review 成功
+- summary 字段正确
+- missing authorization requirements
+- human-only fields
+- permission separation
+- authorized-looking form 仍不得触发写动作
+- `--commit` blocked
+- sha256 mismatch 失败且不查 DB
+- auth / approval failure path
+- no network / no file write / no mkdir / no child process
+- SQL 只允许 `BEGIN READ ONLY` / `SELECT` / `ROLLBACK`
+
+执行结果：
+
+- `tests/unit/football_data_packet_file_auth_review.test.js` 通过
+- 相关既有 Football-Data unit tests 全部通过
+
+## 15. npm test / test:coverage 结果
+
+本阶段要求：
+
+- `npm test` 通过
+- `npm run test:coverage` 通过
+- coverage 阈值保持不变：
+    - lines >= 80
+    - functions >= 80
+    - branches >= 80
+
+实际结果：
+
+- `npm test` 通过
+- `npm run test:coverage` 通过
+- coverage:
+    - lines `88.68`
+    - functions `81.10`
+    - branches `80.03`
+
+## 16. DB 前后统计
+
+本阶段前后期望保持：
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+review 脚本只允许 SELECT-only DB row count inspection，不得修改这些计数。
+
+本地前后核对结果保持不变：
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 17. 下一步建议
+
+建议二选一：
+
+- `Phase 4.73C`：packet file creation readiness checklist consolidation  
+  继续不写 packet 文件、不写 DB、不执行 `pg_dump`
+
+- `Phase 4.56A`：用户给齐真实 network dry-run 参数后才做 runbook  
+  仍需单独授权，且不绕过现有 gate
+
+## 18. 明确未执行事项
+
+本阶段明确未执行：
+
+- DB writes
+- non-SELECT DB SQL
+- `pg_dump` execution
+- `pg_restore` execution
+- backup file writes
+- packet file writes
+- packet manifest writes
+- packet directory creation
+- auth review runtime file writes
+- 将 `authorization_status` 改成 `authorized_for_packet_file_creation`
+- 将 `final_packet_creation_confirmation` 改成 `true`
+- 将 `approval_status` 改成 `approved_for_db_write`
+- 将 `final_human_confirmation` 改成 `true`
+- external download
+- `curl` / `wget` / `git clone`
+- 外部足球数据源访问
+- 外部赔率数据源访问
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- network dry-run 真执行
+- bulk harvest
+- adapted CSV / staging 数据写入
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume 清理
+- force push
+- `git fetch --all`
+- `git pull`
+- 删除已有报告
+- 删除文件

--- a/scripts/ops/football_data_packet_file_auth_review.js
+++ b/scripts/ops/football_data_packet_file_auth_review.js
@@ -1,0 +1,908 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable max-lines -- Phase 4.72C keeps the dry-run authorization review contract in one file for auditability. */
+
+const fs = require('fs');
+const path = require('path');
+
+const { runValidation, extractYamlBlock, parseYamlBlock } = require('./football_data_packet_file_auth_validate');
+const { runPacketFilePreflight } = require('./football_data_packet_file_preflight');
+const { runPacketAssembly } = require('./football_data_small_write_packet_assembly');
+const {
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    buildDbConfig,
+    assertSelectOnlySql,
+} = require('./football_data_duplicate_precheck');
+
+const PACKET_FILE_AUTH_REVIEW_PHASE = 'PHASE4.72C_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW';
+const MISSING_ARGS_MESSAGE =
+    'ERROR: provide --auth-form=<path>, --source-manifest=<path>, --local-csv=<path>, --approval-form=<path>, and --runbook-template=<path>';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: football-data packet file authorization review commit is not wired in Phase 4.72C.';
+const CURRENT_DB_TABLES = [
+    'matches',
+    'bookmaker_odds_history',
+    'raw_match_data',
+    'l3_features',
+    'match_features_training',
+    'predictions',
+];
+const CURRENT_DB_COUNTS_SQL = `
+SELECT table_name, rows
+FROM (
+    SELECT 'matches' AS table_name, COUNT(*)::bigint AS rows, 1 AS sort_order FROM matches
+    UNION ALL
+    SELECT 'bookmaker_odds_history', COUNT(*)::bigint, 2 FROM bookmaker_odds_history
+    UNION ALL
+    SELECT 'raw_match_data', COUNT(*)::bigint, 3 FROM raw_match_data
+    UNION ALL
+    SELECT 'l3_features', COUNT(*)::bigint, 4 FROM l3_features
+    UNION ALL
+    SELECT 'match_features_training', COUNT(*)::bigint, 5 FROM match_features_training
+    UNION ALL
+    SELECT 'predictions', COUNT(*)::bigint, 6 FROM predictions
+) counts
+ORDER BY sort_order
+`;
+const PERMISSION_SEPARATION = [
+    'packet file creation does not authorize DB write',
+    'packet file creation does not authorize pg_dump',
+    'packet file creation does not authorize pg_restore',
+    'packet file creation does not authorize training',
+    'packet file creation does not authorize prediction',
+];
+const HUMAN_ONLY_FIELDS = [
+    'authorization_status',
+    'final_packet_creation_confirmation',
+    'operator',
+    'reviewer',
+    'human_approval_note',
+    'approved_candidate_match_ids',
+    'excluded_candidate_match_ids',
+    'manual_review_candidate_match_ids',
+    'packet_creation_reason',
+];
+const NON_EXECUTION_CONFIRMATIONS = [
+    'no_external_network',
+    'select_only_db_reads',
+    'no_db_writes',
+    'no_file_writes',
+    'no_packet_file_write',
+    'no_packet_directory_create',
+    'no_legacy_runtime',
+    'no_pg_dump_execution',
+    'no_pg_restore_execution',
+    'no_training',
+    'no_prediction_execution',
+];
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_packet_file_auth_review.js --auth-form <path> --source-manifest <path> --local-csv <path> --approval-form <path> --runbook-template <path> [--json]',
+        '  node scripts/ops/football_data_packet_file_auth_review.js --auth-form <path> --source-manifest <path> --local-csv <path> --approval-form <path> --runbook-template <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.72C runs a dry-run authorization review only.',
+        '  No packet file writes, no packet directory creation, no DB writes, no pg_dump, no pg_restore, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const valueOptions = new Map([
+        ['--auth-form', 'authForm'],
+        ['--source-manifest', 'sourceManifest'],
+        ['--local-csv', 'localCsv'],
+        ['--approval-form', 'approvalForm'],
+        ['--runbook-template', 'runbookTemplate'],
+    ]);
+    const flagOptions = new Map([
+        ['--commit', 'commit'],
+        ['--json', 'json'],
+        ['--help', 'help'],
+        ['-h', 'help'],
+    ]);
+    const args = {
+        authForm: '',
+        sourceManifest: '',
+        localCsv: '',
+        approvalForm: '',
+        runbookTemplate: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        const matchedValueOption = [...valueOptions.keys()].find(
+            option => token === option || token.startsWith(`${option}=`)
+        );
+        if (matchedValueOption) {
+            const key = valueOptions.get(matchedValueOption);
+            const usesSeparateValue = token === matchedValueOption;
+            args[key] = usesSeparateValue
+                ? String(argv[index + 1] || '')
+                : token.slice(`${matchedValueOption}=`.length);
+            if (usesSeparateValue) {
+                index += 1;
+            }
+            continue;
+        }
+        if (flagOptions.has(token)) {
+            args[flagOptions.get(token)] = true;
+            continue;
+        }
+        throw new Error(`Unknown argument: ${token}`);
+    }
+
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) {
+        return '';
+    }
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) {
+        return '';
+    }
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function normalizePathLike(value) {
+    return String(value || '')
+        .replace(/\\/g, '/')
+        .replace(/\/+$/g, '')
+        .trim();
+}
+
+function compareReviewedPath(authValue, reviewedAbsolutePath, cwd = process.cwd()) {
+    if (!authValue) {
+        return false;
+    }
+    const normalizedAuth = normalizePathLike(authValue);
+    const reviewedRelative = normalizePathLike(toRelativePath(reviewedAbsolutePath, cwd));
+    const reviewedAbsolute = normalizePathLike(path.resolve(reviewedAbsolutePath));
+    const authAbsolute = normalizePathLike(path.resolve(cwd, String(authValue)));
+    return (
+        normalizedAuth === reviewedRelative || normalizedAuth === reviewedAbsolute || authAbsolute === reviewedAbsolute
+    );
+}
+
+function trimToEmpty(value) {
+    return String(value || '').trim();
+}
+
+function toStringArray(value) {
+    return Array.isArray(value) ? value.map(item => String(item || '').trim()).filter(Boolean) : [];
+}
+
+function createPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+async function withDbClient(dependencies, callback) {
+    if (dependencies.dbClient) {
+        return callback(dependencies.dbClient);
+    }
+
+    const pool = dependencies.pool || (dependencies.createPool || createPool)();
+    const client = await pool.connect();
+    try {
+        return await callback(client);
+    } finally {
+        client.release();
+        if (!dependencies.pool && typeof pool.end === 'function') {
+            await pool.end();
+        }
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+function mapCurrentDbCounts(rows) {
+    const mapped = {};
+    for (const tableName of CURRENT_DB_TABLES) {
+        mapped[tableName] = 0;
+    }
+    for (const row of rows || []) {
+        mapped[row.table_name] = Number.parseInt(row.rows, 10);
+    }
+    return mapped;
+}
+
+function buildSafetyFlags() {
+    return {
+        select_only_db_reads: true,
+        authorization_review_completed: true,
+        packet_file_creation_ready: false,
+        packet_file_creation_authorized: false,
+        approval_granted: false,
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_spawn_child_process: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: PACKET_FILE_AUTH_REVIEW_PHASE,
+        mode: fields.mode || 'football-data-packet-file-auth-review',
+        ok: false,
+        auth_form: args.authForm || null,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        approval_form: args.approvalForm || null,
+        runbook_template: args.runbookTemplate || null,
+        auth_form_found: false,
+        source_manifest_found: false,
+        local_csv_found: false,
+        approval_form_found: false,
+        runbook_template_found: false,
+        auth_form_validation_passed: false,
+        packet_file_preflight_passed: false,
+        packet_preview_passed: false,
+        select_only_db_reads: false,
+        authorization_review_completed: false,
+        packet_file_creation_ready: false,
+        packet_file_creation_authorized: false,
+        authorization_status: null,
+        final_packet_creation_confirmation: null,
+        approval_granted: false,
+        commit_gate: 'blocked',
+        current_db_counts: null,
+        missing_authorization_requirements: [],
+        permission_separation: PERMISSION_SEPARATION,
+        human_only_fields: HUMAN_ONLY_FIELDS,
+        non_execution_confirmations: NON_EXECUTION_CONFIRMATIONS,
+        errors: [],
+        warnings: [],
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        would_spawn_child_process: false,
+        would_train_model: false,
+        would_execute_prediction: false,
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function validateRequiredArgs(args) {
+    return Boolean(args.authForm && args.sourceManifest && args.localCsv && args.approvalForm && args.runbookTemplate);
+}
+
+function buildPathContext(args, cwd, existsSync) {
+    const authFormPath = resolveLocalPath(args.authForm, cwd);
+    const sourceManifestPath = resolveLocalPath(args.sourceManifest, cwd);
+    const localCsvPath = resolveLocalPath(args.localCsv, cwd);
+    const approvalFormPath = resolveLocalPath(args.approvalForm, cwd);
+    const runbookTemplatePath = resolveLocalPath(args.runbookTemplate, cwd);
+    return {
+        authFormPath,
+        sourceManifestPath,
+        localCsvPath,
+        approvalFormPath,
+        runbookTemplatePath,
+        authFormFound: existsSync(authFormPath),
+        sourceManifestFound: existsSync(sourceManifestPath),
+        localCsvFound: existsSync(localCsvPath),
+        approvalFormFound: existsSync(approvalFormPath),
+        runbookTemplateFound: existsSync(runbookTemplatePath),
+    };
+}
+
+function buildMissingPathPayload(args, pathContext, cwd) {
+    const baseFields = {
+        auth_form_found: pathContext.authFormFound,
+        source_manifest_found: pathContext.sourceManifestFound,
+        local_csv_found: pathContext.localCsvFound,
+        approval_form_found: pathContext.approvalFormFound,
+        runbook_template_found: pathContext.runbookTemplateFound,
+    };
+
+    if (!pathContext.authFormFound) {
+        return buildFailurePayload(args, {
+            mode: 'auth-form-error',
+            ...baseFields,
+            errors: [`auth form not found: ${toRelativePath(pathContext.authFormPath, cwd)}`],
+        });
+    }
+    if (!pathContext.sourceManifestFound) {
+        return buildFailurePayload(args, {
+            mode: 'manifest-error',
+            ...baseFields,
+            errors: [`source manifest not found: ${toRelativePath(pathContext.sourceManifestPath, cwd)}`],
+        });
+    }
+    if (!pathContext.localCsvFound) {
+        return buildFailurePayload(args, {
+            mode: 'csv-error',
+            ...baseFields,
+            errors: [`local CSV not found: ${toRelativePath(pathContext.localCsvPath, cwd)}`],
+        });
+    }
+    if (!pathContext.approvalFormFound) {
+        return buildFailurePayload(args, {
+            mode: 'approval-form-error',
+            ...baseFields,
+            errors: [`approval form not found: ${toRelativePath(pathContext.approvalFormPath, cwd)}`],
+        });
+    }
+    if (!pathContext.runbookTemplateFound) {
+        return buildFailurePayload(args, {
+            mode: 'runbook-template-error',
+            ...baseFields,
+            errors: [`runbook template not found: ${toRelativePath(pathContext.runbookTemplatePath, cwd)}`],
+        });
+    }
+    return null;
+}
+
+function readReviewedInputs(pathContext, readFileSync) {
+    return {
+        authFormMarkdown: readFileSync(pathContext.authFormPath, 'utf8'),
+        sourceManifestText: readFileSync(pathContext.sourceManifestPath, 'utf8'),
+        localCsvText: readFileSync(pathContext.localCsvPath, 'utf8'),
+        approvalFormMarkdown: readFileSync(pathContext.approvalFormPath, 'utf8'),
+        runbookTemplateMarkdown: readFileSync(pathContext.runbookTemplatePath, 'utf8'),
+    };
+}
+
+function parseAuthFormMarkdown(markdownText) {
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        throw new Error('YAML fenced block not found in packet file authorization form');
+    }
+    return parseYamlBlock(yamlText);
+}
+
+function mapManualReviewIds(packetPreviewPayload) {
+    return (packetPreviewPayload.manual_review_table || []).map(row => row.proposed_match_id).filter(Boolean);
+}
+
+function mapInsertCandidateIds(packetPreviewPayload) {
+    const directIds = (packetPreviewPayload.insert_candidate_table || [])
+        .map(row => row.proposed_match_id)
+        .filter(Boolean);
+    if (directIds.length > 0) {
+        return directIds;
+    }
+    return (packetPreviewPayload.proposed_match_ids || []).filter(Boolean);
+}
+
+function includesAllValues(actualValues, expectedValues) {
+    const actualSet = new Set(toStringArray(actualValues));
+    return toStringArray(expectedValues).every(value => actualSet.has(value));
+}
+
+function collectRequiredLiteralRequirementMessages(authFormData) {
+    const missing = [];
+    if (authFormData.authorization_status !== 'authorized_for_packet_file_creation') {
+        missing.push('authorization_status must be authorized_for_packet_file_creation');
+    }
+    if (authFormData.final_packet_creation_confirmation !== true) {
+        missing.push('final_packet_creation_confirmation must be true');
+    }
+    if (!trimToEmpty(authFormData.operator)) {
+        missing.push('operator must be filled');
+    }
+    if (!trimToEmpty(authFormData.reviewer)) {
+        missing.push('reviewer must be filled');
+    }
+    if (!trimToEmpty(authFormData.packet_directory)) {
+        missing.push('packet_directory must be explicit');
+    }
+    if (!trimToEmpty(authFormData.packet_file)) {
+        missing.push('packet_file must be explicit');
+    }
+    if (!trimToEmpty(authFormData.packet_manifest_file)) {
+        missing.push('packet_manifest_file must be explicit');
+    }
+    return missing;
+}
+
+function collectReviewedPathRequirementMessages(authFormData, context) {
+    const missing = [];
+    if (!compareReviewedPath(authFormData.source_manifest, context.pathContext.sourceManifestPath, context.cwd)) {
+        missing.push('source_manifest must match reviewed source');
+    }
+    if (!compareReviewedPath(authFormData.local_csv, context.pathContext.localCsvPath, context.cwd)) {
+        missing.push('local_csv must match reviewed CSV');
+    }
+    return missing;
+}
+
+function collectCandidateRequirementMessages(authFormData, context) {
+    const missing = [];
+    const approvedCandidateIds = toStringArray(authFormData.approved_candidate_match_ids);
+    const reviewedInsertCandidateIds = mapInsertCandidateIds(context.packetPreviewPayload);
+
+    if (
+        reviewedInsertCandidateIds.length > 0 &&
+        (!includesAllValues(approvedCandidateIds, reviewedInsertCandidateIds) || approvedCandidateIds.length === 0)
+    ) {
+        missing.push('approved_candidate_match_ids must be reviewed');
+    }
+
+    return missing;
+}
+
+function collectManualReviewRequirementMessages(authFormData, context) {
+    const missing = [];
+    const excludedCandidateIds = new Set(toStringArray(authFormData.excluded_candidate_match_ids));
+    const manualReviewCandidateIds = new Set(toStringArray(authFormData.manual_review_candidate_match_ids));
+    const reviewedManualReviewIds = mapManualReviewIds(context.packetPreviewPayload);
+
+    if (
+        manualReviewCandidateIds.size === 0 ||
+        reviewedManualReviewIds.some(
+            matchId => !manualReviewCandidateIds.has(matchId) && !excludedCandidateIds.has(matchId)
+        )
+    ) {
+        missing.push('manual_review_candidate_match_ids must be excluded or resolved');
+    }
+
+    return missing;
+}
+
+function collectHumanApprovalRequirementMessages(authFormData) {
+    return trimToEmpty(authFormData.human_approval_note) ? [] : ['human_approval_note must be present'];
+}
+
+function buildMissingAuthorizationRequirements(authFormData, context) {
+    const missing = [
+        ...collectRequiredLiteralRequirementMessages(authFormData),
+        ...collectReviewedPathRequirementMessages(authFormData, context),
+        ...collectCandidateRequirementMessages(authFormData, context),
+        ...collectManualReviewRequirementMessages(authFormData, context),
+        ...collectHumanApprovalRequirementMessages(authFormData),
+    ];
+    return [...new Set(missing)];
+}
+
+function createAuthorizationReviewRuntime(args, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+
+    if (!validateRequiredArgs(args)) {
+        return {
+            failurePayload: buildFailurePayload(args, {
+                mode: 'argument-error',
+                errors: [MISSING_ARGS_MESSAGE],
+            }),
+        };
+    }
+
+    const pathContext = buildPathContext(args, cwd, existsSync);
+    const missingPathPayload = buildMissingPathPayload(args, pathContext, cwd);
+    if (missingPathPayload) {
+        return {
+            failurePayload: missingPathPayload,
+        };
+    }
+
+    return {
+        cwd,
+        existsSync,
+        readFileSync,
+        pathContext,
+        reviewedInputs: readReviewedInputs(pathContext, readFileSync),
+        authFormData: null,
+        packetPreviewPayload: null,
+        packetFilePreflightPayload: null,
+        dbReview: {},
+    };
+}
+
+function buildAuthValidationStageDependencies(runtime, dependencies = {}) {
+    return {
+        cwd: dependencies.cwd || runtime.cwd,
+        existsSync: dependencies.existsSync || runtime.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || runtime.readFileSync || fs.readFileSync,
+        runAuthValidation: dependencies.runAuthValidation,
+        ...(dependencies.authValidationDependencies || {}),
+    };
+}
+
+function buildPacketPreviewStageDependencies(runtime, dependencies = {}) {
+    return {
+        cwd: dependencies.cwd || runtime.cwd,
+        existsSync: dependencies.existsSync || runtime.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || runtime.readFileSync || fs.readFileSync,
+        dbClient: dependencies.dbClient,
+        pool: dependencies.pool,
+        runPacketAssembly: dependencies.runPacketAssembly,
+        ...(dependencies.packetPreviewDependencies || {}),
+    };
+}
+
+function buildPacketFilePreflightStageDependencies(runtime, dependencies = {}) {
+    return {
+        cwd: dependencies.cwd || runtime.cwd,
+        dbClient: dependencies.dbClient,
+        pool: dependencies.pool,
+        runPacketFilePreflight: dependencies.runPacketFilePreflight,
+        ...(dependencies.packetFilePreflightDependencies || {}),
+    };
+}
+
+async function runAuthorizationReviewStages(args, runtime, dependencies = {}) {
+    const authValidationPayload = await (dependencies.runAuthValidationStage || runAuthValidationStage)(
+        args,
+        runtime,
+        buildAuthValidationStageDependencies(runtime, dependencies)
+    );
+    if (!authValidationPayload.ok) {
+        return buildStageFailurePayload(args, runtime, 'auth-form-validation-failed', authValidationPayload, {
+            auth_form_validation_passed: false,
+            errors: authValidationPayload.errors || ['football-data packet file auth validation failed'],
+        });
+    }
+
+    runtime.authFormData = parseAuthFormMarkdown(runtime.reviewedInputs.authFormMarkdown);
+
+    const packetPreviewPayload = await (dependencies.runPacketPreviewStage || runPacketPreviewStage)(
+        args,
+        runtime,
+        buildPacketPreviewStageDependencies(runtime, dependencies)
+    );
+    runtime.packetPreviewPayload = packetPreviewPayload;
+    if (!packetPreviewPayload.ok) {
+        return buildStageFailurePayload(args, runtime, 'packet-preview-failed', packetPreviewPayload, {
+            auth_form_validation_passed: true,
+            packet_preview_passed: false,
+            errors: packetPreviewPayload.errors || ['football-data packet preview failed'],
+        });
+    }
+
+    const packetFilePreflightPayload = await (dependencies.runPacketFilePreflightStage || runPacketFilePreflightStage)(
+        args,
+        runtime,
+        buildPacketFilePreflightStageDependencies(runtime, dependencies)
+    );
+    runtime.packetFilePreflightPayload = packetFilePreflightPayload;
+    if (!packetFilePreflightPayload.ok) {
+        return buildStageFailurePayload(args, runtime, 'packet-file-preflight-failed', packetFilePreflightPayload, {
+            auth_form_validation_passed: true,
+            packet_preview_passed: true,
+            packet_file_preflight_passed: false,
+            errors: packetFilePreflightPayload.errors || ['football-data packet file preflight failed'],
+        });
+    }
+
+    return null;
+}
+
+async function reviewCurrentDbCounts(dependencies = {}) {
+    return withDbClient(dependencies, async client => {
+        await querySelectOnly(client, READ_ONLY_BEGIN_SQL);
+        try {
+            const countsResult = await querySelectOnly(client, CURRENT_DB_COUNTS_SQL);
+            return {
+                current_db_counts: mapCurrentDbCounts(countsResult.rows || []),
+            };
+        } finally {
+            await querySelectOnly(client, READ_ONLY_ROLLBACK_SQL);
+        }
+    });
+}
+
+function buildSuccessPayload(args, context) {
+    const missingAuthorizationRequirements = buildMissingAuthorizationRequirements(context.authFormData, context);
+
+    return {
+        phase: PACKET_FILE_AUTH_REVIEW_PHASE,
+        mode: 'football-data-packet-file-auth-review',
+        ok: true,
+        auth_form: args.authForm,
+        source_manifest: args.sourceManifest,
+        local_csv: args.localCsv,
+        approval_form: args.approvalForm,
+        runbook_template: args.runbookTemplate,
+        auth_form_found: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        approval_form_found: true,
+        runbook_template_found: true,
+        auth_form_validation_passed: true,
+        packet_file_preflight_passed: true,
+        packet_preview_passed: true,
+        authorization_status: context.authFormData.authorization_status ?? null,
+        final_packet_creation_confirmation: context.authFormData.final_packet_creation_confirmation ?? null,
+        commit_gate: 'blocked',
+        current_db_counts:
+            context.dbReview.current_db_counts ||
+            context.packetPreviewPayload.current_db_counts ||
+            context.packetFilePreflightPayload.current_db_counts ||
+            null,
+        missing_authorization_requirements: missingAuthorizationRequirements,
+        permission_separation: PERMISSION_SEPARATION,
+        human_only_fields: HUMAN_ONLY_FIELDS,
+        non_execution_confirmations: NON_EXECUTION_CONFIRMATIONS,
+        auth_form_reviewed_path: toRelativePath(context.pathContext.authFormPath, context.cwd),
+        reviewed_source_manifest_path: toRelativePath(context.pathContext.sourceManifestPath, context.cwd),
+        reviewed_local_csv_path: toRelativePath(context.pathContext.localCsvPath, context.cwd),
+        reviewed_approval_form_path: toRelativePath(context.pathContext.approvalFormPath, context.cwd),
+        reviewed_runbook_template_path: toRelativePath(context.pathContext.runbookTemplatePath, context.cwd),
+        packet_preview_phase: context.packetPreviewPayload.phase || null,
+        packet_file_preflight_phase: context.packetFilePreflightPayload.phase || null,
+        approved_output_root: context.authFormData.approved_output_root || null,
+        approved_packet_sections: context.authFormData.approved_packet_sections || [],
+        reviewed_proposed_match_ids: context.packetPreviewPayload.proposed_match_ids || [],
+        reviewed_manual_review_match_ids: mapManualReviewIds(context.packetPreviewPayload),
+        warnings: [
+            ...(context.packetPreviewPayload.warnings || []),
+            ...(context.packetFilePreflightPayload.warnings || []),
+        ],
+        errors: [],
+        ...buildSafetyFlags(),
+    };
+}
+
+function buildStageFailurePayload(args, context, mode, payload, fields = {}) {
+    return buildFailurePayload(args, {
+        mode,
+        auth_form_found: Boolean(context.pathContext?.authFormFound),
+        source_manifest_found: Boolean(context.pathContext?.sourceManifestFound),
+        local_csv_found: Boolean(context.pathContext?.localCsvFound),
+        approval_form_found: Boolean(context.pathContext?.approvalFormFound),
+        runbook_template_found: Boolean(context.pathContext?.runbookTemplateFound),
+        auth_form_validation_passed: fields.auth_form_validation_passed || false,
+        packet_preview_passed: fields.packet_preview_passed || false,
+        packet_file_preflight_passed: fields.packet_file_preflight_passed || false,
+        authorization_status: context.authFormData?.authorization_status ?? null,
+        final_packet_creation_confirmation: context.authFormData?.final_packet_creation_confirmation ?? null,
+        errors: payload.errors || [`${mode} failed`],
+        warnings: payload.warnings || [],
+        ...fields,
+    });
+}
+
+async function runAuthorizationReview(args, dependencies = {}) {
+    const runtime = createAuthorizationReviewRuntime(args, dependencies);
+    if (runtime.failurePayload) {
+        return runtime.failurePayload;
+    }
+
+    const stageFailurePayload = await runAuthorizationReviewStages(args, runtime, dependencies);
+    if (stageFailurePayload) {
+        return stageFailurePayload;
+    }
+
+    runtime.dbReview = await reviewCurrentDbCounts({
+        dbClient: dependencies.dbClient,
+        pool: dependencies.pool,
+        createPool: dependencies.createPool,
+    });
+
+    return buildSuccessPayload(args, runtime);
+}
+
+async function runAuthValidationStage(args, context, dependencies) {
+    return (dependencies.runAuthValidation || runValidation)(
+        { authForm: args.authForm },
+        {
+            cwd: dependencies.cwd || context.cwd,
+            existsSync: dependencies.existsSync || fs.existsSync,
+            readFileSync: dependencies.readFileSync || fs.readFileSync,
+            ...(dependencies.authValidationDependencies || {}),
+        }
+    );
+}
+
+async function runPacketPreviewStage(args, context, dependencies) {
+    return (dependencies.runPacketAssembly || runPacketAssembly)(
+        {
+            sourceManifest: args.sourceManifest,
+            localCsv: args.localCsv,
+            approvalForm: args.approvalForm,
+            runbookTemplate: args.runbookTemplate,
+        },
+        {
+            cwd: dependencies.cwd || context.cwd,
+            existsSync: dependencies.existsSync || fs.existsSync,
+            readFileSync: dependencies.readFileSync || fs.readFileSync,
+            dbClient: dependencies.dbClient,
+            pool: dependencies.pool,
+            ...(dependencies.packetPreviewDependencies || {}),
+        }
+    );
+}
+
+async function runPacketFilePreflightStage(args, context, dependencies) {
+    return (dependencies.runPacketFilePreflight || runPacketFilePreflight)(
+        {
+            sourceManifest: args.sourceManifest,
+            localCsv: args.localCsv,
+            approvalForm: args.approvalForm,
+            runbookTemplate: args.runbookTemplate,
+        },
+        {
+            cwd: dependencies.cwd || context.cwd,
+            runPacketAssembly: async () => context.packetPreviewPayload,
+            dbClient: dependencies.dbClient,
+            pool: dependencies.pool,
+            ...(dependencies.packetFilePreflightDependencies || {}),
+        }
+    );
+}
+
+function appendListSection(lines, title, values) {
+    lines.push(`${title}:`);
+    for (const value of values || []) {
+        lines.push(`- ${value}`);
+    }
+}
+
+function appendCurrentDbCounts(lines, counts) {
+    if (!counts) {
+        return;
+    }
+    lines.push('current_db_counts:');
+    for (const tableName of CURRENT_DB_TABLES) {
+        lines.push(`- ${tableName}=${counts[tableName] ?? 'unknown'}`);
+    }
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `phase=${payload.phase}`,
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `auth_form_found=${payload.auth_form_found}`,
+        `source_manifest_found=${payload.source_manifest_found}`,
+        `local_csv_found=${payload.local_csv_found}`,
+        `approval_form_found=${payload.approval_form_found}`,
+        `runbook_template_found=${payload.runbook_template_found}`,
+        `auth_form_validation_passed=${payload.auth_form_validation_passed}`,
+        `packet_file_preflight_passed=${payload.packet_file_preflight_passed}`,
+        `packet_preview_passed=${payload.packet_preview_passed}`,
+        `select_only_db_reads=${payload.select_only_db_reads}`,
+        '',
+        `authorization_review_completed=${payload.authorization_review_completed}`,
+        `packet_file_creation_ready=${payload.packet_file_creation_ready}`,
+        `packet_file_creation_authorized=${payload.packet_file_creation_authorized}`,
+        `authorization_status=${payload.authorization_status}`,
+        `final_packet_creation_confirmation=${payload.final_packet_creation_confirmation}`,
+        `approval_granted=${payload.approval_granted}`,
+        '',
+        `would_create_packet_directory=${payload.would_create_packet_directory}`,
+        `would_write_packet_file=${payload.would_write_packet_file}`,
+        `would_write_packet_manifest=${payload.would_write_packet_manifest}`,
+        `would_execute_pg_dump=${payload.would_execute_pg_dump}`,
+        `would_execute_pg_restore=${payload.would_execute_pg_restore}`,
+        `would_insert_matches=${payload.would_insert_matches}`,
+        `would_insert_odds=${payload.would_insert_odds}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_write_files=${payload.would_write_files}`,
+        `commit_gate=${payload.commit_gate}`,
+    ];
+
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${JSON.stringify(payload.warnings)}`);
+    }
+
+    appendCurrentDbCounts(lines, payload.current_db_counts);
+    appendListSection(lines, 'missing_authorization_requirements', payload.missing_authorization_requirements);
+    appendListSection(lines, 'permission_separation', payload.permission_separation);
+    appendListSection(lines, 'human_only_fields', payload.human_only_fields);
+    appendListSection(lines, 'non_execution_confirmations', payload.non_execution_confirmations);
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+async function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, args.json, output);
+            return 1;
+        }
+
+        const payload = await runAuthorizationReview(args, dependencies);
+        writePayload(payload, args.json, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            {
+                authForm: '',
+                sourceManifest: '',
+                localCsv: '',
+                approvalForm: '',
+                runbookTemplate: '',
+            },
+            {
+                mode: 'runtime-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, argv.includes('--json'), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => {
+        process.exitCode = status;
+    });
+}
+
+module.exports = {
+    PACKET_FILE_AUTH_REVIEW_PHASE,
+    MISSING_ARGS_MESSAGE,
+    BLOCKED_COMMIT_MESSAGE,
+    CURRENT_DB_TABLES,
+    CURRENT_DB_COUNTS_SQL,
+    PERMISSION_SEPARATION,
+    HUMAN_ONLY_FIELDS,
+    NON_EXECUTION_CONFIRMATIONS,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    resolveLocalPath,
+    toRelativePath,
+    querySelectOnly,
+    buildMissingAuthorizationRequirements,
+    reviewCurrentDbCounts,
+    runAuthorizationReview,
+    payloadToText,
+    main,
+};

--- a/tests/unit/football_data_packet_file_auth_review.test.js
+++ b/tests/unit/football_data_packet_file_auth_review.test.js
@@ -1,0 +1,1526 @@
+'use strict';
+/* eslint-disable max-lines -- Phase 4.72C keeps the auth review safety contract in one focused test file. */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const { spawnSync } = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_packet_file_auth_review.js');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md'
+);
+const APPROVAL_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md'
+);
+const RUNBOOK_TEMPLATE_PATH = path.join(PROJECT_ROOT, 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md');
+
+const AUTH_FORM_TEXT = fs.readFileSync(AUTH_FORM_PATH, 'utf8');
+const SOURCE_MANIFEST_TEXT = fs.readFileSync(MANIFEST_PATH, 'utf8');
+const LOCAL_CSV_TEXT = fs.readFileSync(CSV_PATH, 'utf8');
+const APPROVAL_FORM_TEXT = fs.readFileSync(APPROVAL_FORM_PATH, 'utf8');
+const RUNBOOK_TEMPLATE_TEXT = fs.readFileSync(RUNBOOK_TEMPLATE_PATH, 'utf8');
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_packet_file_auth_review`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+function loadReviewFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function baseArgs(overrides = {}) {
+    return {
+        authForm: AUTH_FORM_PATH,
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+        approvalForm: APPROVAL_FORM_PATH,
+        runbookTemplate: RUNBOOK_TEMPLATE_PATH,
+        ...overrides,
+    };
+}
+
+function buildAuthValidationPayload(overrides = {}) {
+    return {
+        ok: true,
+        authorization_status: 'not_authorized',
+        final_packet_creation_confirmation: false,
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildPacketPreviewPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.69C_FOOTBALL_DATA_SMALL_WRITE_PACKET_ASSEMBLY',
+        mode: 'football-data-small-write-packet-assembly',
+        ok: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        approval_form_found: true,
+        runbook_template_found: true,
+        approval_form_validation_passed: true,
+        select_only_db_reads: true,
+        packet_sections: [
+            'source_manifest_summary',
+            'local_csv_summary',
+            'csv_dry_run_summary',
+            'db_write_preflight_summary',
+            'duplicate_precheck_summary',
+            'insert_policy_summary',
+            'small_write_auth_preview_summary',
+            'runbook_template_summary',
+            'approval_form_summary',
+            'proposed_match_ids',
+            'insert_candidate_table',
+            'blocked_candidate_table',
+            'manual_review_table',
+            'pg_dump_command_preview',
+            'post_write_validation_checklist',
+            'rollback_restore_preview',
+            'final_human_approval_required',
+        ],
+        proposed_match_ids: ['fd_alpha_11111111', 'fd_beta_22222222'],
+        insert_candidate_table: [{ proposed_match_id: 'fd_alpha_11111111' }, { proposed_match_id: 'fd_beta_22222222' }],
+        blocked_candidate_table: [],
+        manual_review_table: [{ proposed_match_id: 'fd_manual_33333333' }],
+        current_db_counts: {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildPacketFilePreflightPayload(overrides = {}) {
+    return {
+        phase: 'PHASE4.70C_FOOTBALL_DATA_PACKET_FILE_PREFLIGHT',
+        mode: 'football-data-packet-file-preflight',
+        ok: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        approval_form_found: true,
+        runbook_template_found: true,
+        packet_preview_passed: true,
+        approval_form_validation_passed: true,
+        current_db_counts: {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        warnings: [],
+        errors: [],
+        ...overrides,
+    };
+}
+
+function buildDbClient(rows = []) {
+    const calls = [];
+    return {
+        calls,
+        releaseCalled: false,
+        async query(sql) {
+            calls.push(sql);
+            return { rows };
+        },
+        release() {
+            this.releaseCalled = true;
+        },
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    const dbClient =
+        overrides.dbClient ||
+        buildDbClient([
+            { table_name: 'matches', rows: '2' },
+            { table_name: 'bookmaker_odds_history', rows: '2' },
+            { table_name: 'raw_match_data', rows: '2' },
+            { table_name: 'l3_features', rows: '2' },
+            { table_name: 'match_features_training', rows: '2' },
+            { table_name: 'predictions', rows: '2' },
+        ]);
+
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: filePath =>
+            new Set([AUTH_FORM_PATH, MANIFEST_PATH, CSV_PATH, APPROVAL_FORM_PATH, RUNBOOK_TEMPLATE_PATH]).has(
+                path.resolve(filePath)
+            ),
+        readFileSync: filePath => {
+            const resolved = path.resolve(filePath);
+            if (resolved === AUTH_FORM_PATH) {
+                return AUTH_FORM_TEXT;
+            }
+            if (resolved === MANIFEST_PATH) {
+                return SOURCE_MANIFEST_TEXT;
+            }
+            if (resolved === CSV_PATH) {
+                return LOCAL_CSV_TEXT;
+            }
+            if (resolved === APPROVAL_FORM_PATH) {
+                return APPROVAL_FORM_TEXT;
+            }
+            if (resolved === RUNBOOK_TEMPLATE_PATH) {
+                return RUNBOOK_TEMPLATE_TEXT;
+            }
+            throw new Error(`unexpected readFileSync path: ${resolved}`);
+        },
+        runAuthValidation: () => buildAuthValidationPayload(),
+        runPacketAssembly: async () => buildPacketPreviewPayload(),
+        runPacketFilePreflight: async () => buildPacketFilePreflightPayload(),
+        dbClient,
+        ...overrides,
+    };
+}
+
+async function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+async function runJsonMain(gate, argv, dependencies = buildDependencies()) {
+    const result = await runMain(gate, [...argv, '--json'], dependencies);
+    return {
+        ...result,
+        payload: JSON.parse(result.stdout),
+    };
+}
+
+function assertReviewSafetyPayload(payload) {
+    assert.equal(payload.authorization_review_completed, true);
+    assert.equal(payload.packet_file_creation_ready, false);
+    assert.equal(payload.packet_file_creation_authorized, false);
+    assert.equal(payload.authorization_status, 'not_authorized');
+    assert.equal(payload.final_packet_creation_confirmation, false);
+    assert.equal(payload.approval_granted, false);
+    assert.equal(payload.would_create_packet_directory, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_packet_manifest, false);
+    assert.equal(payload.would_execute_pg_dump, false);
+    assert.equal(payload.would_execute_pg_restore, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_files, false);
+}
+
+test('缺 auth form 参数时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /provide --auth-form=<path>/);
+});
+
+test('缺 source manifest 参数时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /provide --auth-form=<path>.*--source-manifest=<path>/);
+});
+
+test('缺 local CSV 参数时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /--local-csv=<path>/);
+});
+
+test('缺 approval form 参数时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /--approval-form=<path>/);
+});
+
+test('缺 runbook template 参数时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /--runbook-template=<path>/);
+});
+
+test('CLI --help 输出 usage，未知参数进入 runtime-error', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+
+    const helpResult = await runMain(gate, ['--help'], buildDependencies());
+    assert.equal(helpResult.status, 0);
+    assert.match(helpResult.stdout, /Usage:/);
+    assert.match(helpResult.stdout, /dry-run authorization review only/);
+
+    const badArgResult = await runJsonMain(gate, ['--unknown'], buildDependencies());
+    assert.equal(badArgResult.status, 1);
+    assert.equal(badArgResult.payload.mode, 'runtime-error');
+    assert.match(badArgResult.payload.errors.join('\n'), /Unknown argument: --unknown/);
+});
+
+test('正确 template review 成功', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.ok, true);
+    assert.equal(result.payload.auth_form_found, true);
+    assert.equal(result.payload.source_manifest_found, true);
+    assert.equal(result.payload.local_csv_found, true);
+    assert.equal(result.payload.approval_form_found, true);
+    assert.equal(result.payload.runbook_template_found, true);
+    assert.equal(result.payload.auth_form_validation_passed, true);
+    assert.equal(result.payload.packet_file_preflight_passed, true);
+    assert.equal(result.payload.packet_preview_passed, true);
+    assert.equal(result.payload.select_only_db_reads, true);
+    assertReviewSafetyPayload(result.payload);
+});
+
+test('输出包含 ready=false / authorized=false / no-write flags', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /authorization_review_completed=true/);
+    assert.match(result.stdout, /packet_file_creation_ready=false/);
+    assert.match(result.stdout, /packet_file_creation_authorized=false/);
+    assert.match(result.stdout, /authorization_status=not_authorized/);
+    assert.match(result.stdout, /final_packet_creation_confirmation=false/);
+    assert.match(result.stdout, /approval_granted=false/);
+    assert.match(result.stdout, /would_create_packet_directory=false/);
+    assert.match(result.stdout, /would_write_packet_file=false/);
+    assert.match(result.stdout, /would_write_packet_manifest=false/);
+    assert.match(result.stdout, /would_write_db=false/);
+});
+
+test('missing_authorization_requirements 包含必要字段', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.deepEqual(result.payload.missing_authorization_requirements, [
+        'authorization_status must be authorized_for_packet_file_creation',
+        'final_packet_creation_confirmation must be true',
+        'operator must be filled',
+        'reviewer must be filled',
+        'packet_directory must be explicit',
+        'packet_file must be explicit',
+        'packet_manifest_file must be explicit',
+        'source_manifest must match reviewed source',
+        'local_csv must match reviewed CSV',
+        'approved_candidate_match_ids must be reviewed',
+        'manual_review_candidate_match_ids must be excluded or resolved',
+        'human_approval_note must be present',
+    ]);
+});
+
+test('permission_separation 包含 DB write / pg_dump / training / prediction 分离', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.deepEqual(result.payload.permission_separation, [
+        'packet file creation does not authorize DB write',
+        'packet file creation does not authorize pg_dump',
+        'packet file creation does not authorize pg_restore',
+        'packet file creation does not authorize training',
+        'packet file creation does not authorize prediction',
+    ]);
+});
+
+test('human_only_fields 包含 authorization_status / final_packet_creation_confirmation', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.ok(result.payload.human_only_fields.includes('authorization_status'));
+    assert.ok(result.payload.human_only_fields.includes('final_packet_creation_confirmation'));
+    assert.ok(result.payload.human_only_fields.includes('human_approval_note'));
+});
+
+test('authorized-looking form 也不能在 Phase 4.72C 执行写动作', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const fakeAuthorizedForm = AUTH_FORM_TEXT.replace(
+        'authorization_status: not_authorized',
+        'authorization_status: authorized_for_packet_file_creation'
+    )
+        .replace('final_packet_creation_confirmation: false', 'final_packet_creation_confirmation: true')
+        .replace('operator:', 'operator: Alice')
+        .replace('reviewer:', 'reviewer: Bob')
+        .replace('packet_directory:', 'packet_directory: docs/_packets/football_data/small_write/20260509_fixture')
+        .replace('packet_file:', 'packet_file: football_data_small_write_packet_fixture_preview.json')
+        .replace(
+            'packet_manifest_file:',
+            'packet_manifest_file: football_data_small_write_packet_manifest_fixture_preview.json'
+        )
+        .replace(
+            'source_manifest:',
+            'source_manifest: tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+        )
+        .replace('local_csv:', 'local_csv: tests/fixtures/football_data/football_data_sample_phase462c.csv')
+        .replace(
+            'approved_candidate_match_ids: []',
+            'approved_candidate_match_ids:\n  - fd_alpha_11111111\n  - fd_beta_22222222'
+        )
+        .replace('manual_review_candidate_match_ids: []', 'manual_review_candidate_match_ids:\n  - fd_manual_33333333')
+        .replace('packet_creation_reason:', 'packet_creation_reason: human reviewed')
+        .replace('human_approval_note:', 'human_approval_note: reviewed manually');
+
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            readFileSync: filePath => {
+                const resolved = path.resolve(filePath);
+                if (resolved === AUTH_FORM_PATH) {
+                    return fakeAuthorizedForm;
+                }
+                if (resolved === MANIFEST_PATH) {
+                    return SOURCE_MANIFEST_TEXT;
+                }
+                if (resolved === CSV_PATH) {
+                    return LOCAL_CSV_TEXT;
+                }
+                if (resolved === APPROVAL_FORM_PATH) {
+                    return APPROVAL_FORM_TEXT;
+                }
+                if (resolved === RUNBOOK_TEMPLATE_PATH) {
+                    return RUNBOOK_TEMPLATE_TEXT;
+                }
+                throw new Error(`unexpected read path: ${resolved}`);
+            },
+        })
+    );
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.packet_file_creation_ready, false);
+    assert.equal(result.payload.packet_file_creation_authorized, false);
+    assert.equal(result.payload.approval_granted, false);
+    assert.equal(result.payload.would_write_db, false);
+    assert.equal(result.payload.would_write_packet_file, false);
+    assert.equal(result.payload.would_create_packet_directory, false);
+});
+
+test('路径不存在时分别返回 manifest / csv / approval / runbook 错误', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+
+    const missingManifest = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            existsSync: filePath => path.resolve(filePath) !== MANIFEST_PATH,
+        })
+    );
+    assert.equal(missingManifest.status, 1);
+    assert.equal(missingManifest.payload.mode, 'manifest-error');
+
+    const missingCsv = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            existsSync: filePath => path.resolve(filePath) !== CSV_PATH,
+        })
+    );
+    assert.equal(missingCsv.status, 1);
+    assert.equal(missingCsv.payload.mode, 'csv-error');
+
+    const missingApproval = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            existsSync: filePath => path.resolve(filePath) !== APPROVAL_FORM_PATH,
+        })
+    );
+    assert.equal(missingApproval.status, 1);
+    assert.equal(missingApproval.payload.mode, 'approval-form-error');
+
+    const missingRunbook = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            existsSync: filePath => path.resolve(filePath) !== RUNBOOK_TEMPLATE_PATH,
+        })
+    );
+    assert.equal(missingRunbook.status, 1);
+    assert.equal(missingRunbook.payload.mode, 'runbook-template-error');
+});
+
+test('auth form 文件不存在时返回 auth-form-error', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            existsSync: filePath => path.resolve(filePath) !== AUTH_FORM_PATH,
+        })
+    );
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'auth-form-error');
+    assert.match(result.payload.errors.join('\n'), /auth form not found/);
+});
+
+test('commit blocked', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+            '--commit',
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /review commit is not wired in Phase 4\.72C/);
+});
+
+test('packet file preflight 失败时返回 packet-file-preflight-failed', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const dbClient = buildDbClient();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            dbClient,
+            runPacketFilePreflight: async () => ({
+                ok: false,
+                errors: ['packet file preflight failed'],
+                warnings: ['preview warning'],
+            }),
+        })
+    );
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'packet-file-preflight-failed');
+    assert.match(result.payload.errors.join('\n'), /packet file preflight failed/);
+    assert.deepEqual(dbClient.calls, []);
+});
+
+test('sha256 mismatch 时失败且不查 DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const dbClient = buildDbClient();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            dbClient,
+            runPacketAssembly: async () =>
+                buildPacketPreviewPayload({
+                    ok: false,
+                    errors: ['sha256 mismatch between source manifest and local CSV'],
+                    warnings: [],
+                }),
+        })
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /sha256 mismatch/);
+    assert.deepEqual(dbClient.calls, []);
+});
+
+test('approval form invalid 时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            runPacketAssembly: async () => ({
+                ok: false,
+                errors: ['approval form validation failed'],
+                warnings: [],
+            }),
+        })
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /approval form validation failed/);
+});
+
+test('auth form invalid 时失败', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            runAuthValidation: () => ({
+                ok: false,
+                errors: ['authorization_status must remain not_authorized in the Phase 4.71C template'],
+                warnings: [],
+            }),
+        })
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.payload.errors.join('\n'), /authorization_status must remain not_authorized/);
+});
+
+test('auth form 缺少 YAML block 时进入 runtime-error', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            runAuthValidation: () => buildAuthValidationPayload(),
+            readFileSync: filePath => {
+                const resolved = path.resolve(filePath);
+                if (resolved === AUTH_FORM_PATH) {
+                    return '# no yaml block here';
+                }
+                if (resolved === MANIFEST_PATH) {
+                    return SOURCE_MANIFEST_TEXT;
+                }
+                if (resolved === CSV_PATH) {
+                    return LOCAL_CSV_TEXT;
+                }
+                if (resolved === APPROVAL_FORM_PATH) {
+                    return APPROVAL_FORM_TEXT;
+                }
+                if (resolved === RUNBOOK_TEMPLATE_PATH) {
+                    return RUNBOOK_TEMPLATE_TEXT;
+                }
+                throw new Error(`unexpected read path: ${resolved}`);
+            },
+        })
+    );
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.mode, 'runtime-error');
+    assert.match(result.payload.errors.join('\n'), /YAML fenced block not found in packet file authorization form/);
+});
+
+test('不访问外网', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.ok(result.payload.non_execution_confirmations.includes('no_external_network'));
+    assert.equal(result.payload.would_access_network, false);
+});
+
+test('不写文件', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.ok(result.payload.non_execution_confirmations.includes('no_file_writes'));
+    assert.equal(result.payload.would_write_files, false);
+});
+
+test('不创建目录', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.ok(result.payload.non_execution_confirmations.includes('no_packet_directory_create'));
+    assert.equal(result.payload.would_create_packet_directory, false);
+});
+
+test('不写 packet 文件', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.ok(result.payload.non_execution_confirmations.includes('no_packet_file_write'));
+    assert.equal(result.payload.would_write_packet_file, false);
+});
+
+test('不执行 pg_dump', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.ok(result.payload.non_execution_confirmations.includes('no_pg_dump_execution'));
+    assert.equal(result.payload.would_execute_pg_dump, false);
+});
+
+test('不执行 pg_restore', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.ok(result.payload.non_execution_confirmations.includes('no_pg_restore_execution'));
+    assert.equal(result.payload.would_execute_pg_restore, false);
+});
+
+test('不 spawn child process', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(result.payload.would_spawn_child_process, false);
+});
+
+test('reviewCurrentDbCounts 支持 injected pool，并在 createPool 模式下关闭新建 pool', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+
+    const pooledClient = buildDbClient([
+        { table_name: 'matches', rows: '2' },
+        { table_name: 'bookmaker_odds_history', rows: '2' },
+        { table_name: 'raw_match_data', rows: '2' },
+        { table_name: 'l3_features', rows: '2' },
+        { table_name: 'match_features_training', rows: '2' },
+        { table_name: 'predictions', rows: '2' },
+    ]);
+    const injectedPool = {
+        ended: false,
+        async connect() {
+            return pooledClient;
+        },
+        async end() {
+            this.ended = true;
+        },
+    };
+
+    const pooledState = await gate.reviewCurrentDbCounts({ pool: injectedPool });
+    assert.equal(pooledState.current_db_counts.matches, 2);
+    assert.equal(injectedPool.ended, false);
+    assert.equal(pooledClient.releaseCalled, true);
+
+    const createdClient = buildDbClient([
+        { table_name: 'matches', rows: '2' },
+        { table_name: 'bookmaker_odds_history', rows: '2' },
+        { table_name: 'raw_match_data', rows: '2' },
+        { table_name: 'l3_features', rows: '2' },
+        { table_name: 'match_features_training', rows: '2' },
+        { table_name: 'predictions', rows: '2' },
+    ]);
+    const createdPool = {
+        ended: false,
+        async connect() {
+            return createdClient;
+        },
+        async end() {
+            this.ended = true;
+        },
+    };
+
+    const createdState = await gate.reviewCurrentDbCounts({
+        createPool: () => createdPool,
+    });
+    assert.equal(createdState.current_db_counts.predictions, 2);
+    assert.equal(createdPool.ended, true);
+    assert.equal(createdClient.releaseCalled, true);
+});
+
+test('reviewCurrentDbCounts 默认 createPool 分支可通过 pg mock 覆盖', async t => {
+    const originalLoad = Module._load;
+    const fakeClient = buildDbClient([
+        { table_name: 'matches', rows: '2' },
+        { table_name: 'bookmaker_odds_history', rows: '2' },
+        { table_name: 'raw_match_data', rows: '2' },
+        { table_name: 'l3_features', rows: '2' },
+        { table_name: 'match_features_training', rows: '2' },
+        { table_name: 'predictions', rows: '2' },
+    ]);
+    const fakePool = {
+        ended: false,
+        async connect() {
+            return fakeClient;
+        },
+        async end() {
+            this.ended = true;
+        },
+    };
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (request === 'pg' || request === 'node:pg') {
+            return {
+                Pool: class Pool {
+                    constructor() {
+                        return fakePool;
+                    }
+                },
+            };
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        Module._load = originalLoad;
+    });
+
+    const gate = loadReviewFresh();
+    const state = await gate.reviewCurrentDbCounts({});
+
+    assert.equal(state.current_db_counts.matches, 2);
+    assert.equal(fakePool.ended, true);
+    assert.equal(fakeClient.releaseCalled, true);
+});
+
+test('text output 包含 blocked_reason / errors / warnings', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+
+    const blockedResult = await runMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+            '--commit',
+        ],
+        buildDependencies()
+    );
+    assert.equal(blockedResult.status, 1);
+    assert.match(blockedResult.stdout, /blocked_reason=BLOCKED:/);
+    assert.match(blockedResult.stdout, /errors=BLOCKED:/);
+
+    const warningResult = await runMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({
+            runPacketFilePreflight: async () => ({
+                ok: false,
+                errors: ['packet file preflight failed'],
+                warnings: ['warning text'],
+            }),
+        })
+    );
+    assert.equal(warningResult.status, 1);
+    assert.match(warningResult.stdout, /errors=packet file preflight failed/);
+    assert.match(warningResult.stdout, /warnings=\["warning text"\]/);
+});
+
+test('source/local 绝对路径匹配时不应再报告 reviewed source/csv 缺失', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const authFormData = {
+        authorization_status: 'not_authorized',
+        final_packet_creation_confirmation: false,
+        operator: '',
+        reviewer: '',
+        packet_directory: '',
+        packet_file: '',
+        packet_manifest_file: '',
+        source_manifest: MANIFEST_PATH,
+        local_csv: CSV_PATH,
+        approved_candidate_match_ids: [],
+        excluded_candidate_match_ids: ['fd_manual_33333333'],
+        manual_review_candidate_match_ids: ['fd_manual_33333333'],
+        human_approval_note: '',
+    };
+    const missing = gate.buildMissingAuthorizationRequirements(authFormData, {
+        cwd: PROJECT_ROOT,
+        pathContext: {
+            sourceManifestPath: MANIFEST_PATH,
+            localCsvPath: CSV_PATH,
+        },
+        packetPreviewPayload: buildPacketPreviewPayload(),
+    });
+
+    assert.equal(missing.includes('source_manifest must match reviewed source'), false);
+    assert.equal(missing.includes('local_csv must match reviewed CSV'), false);
+});
+
+test('路径 helper 应覆盖空路径、绝对路径与当前目录回退', () => {
+    const gate = loadReviewFresh();
+
+    assert.equal(gate.resolveLocalPath('', PROJECT_ROOT), '');
+    assert.equal(gate.toRelativePath('', PROJECT_ROOT), '');
+    assert.equal(gate.toRelativePath(PROJECT_ROOT, PROJECT_ROOT), '.');
+
+    const absoluteFixturePath = path.resolve(MANIFEST_PATH);
+    assert.equal(gate.resolveLocalPath(absoluteFixturePath, PROJECT_ROOT), absoluteFixturePath);
+});
+
+test('payloadToText 应覆盖 current_db_counts 和列表输出分支', () => {
+    const gate = loadReviewFresh();
+    const text = gate.payloadToText({
+        phase: gate.PACKET_FILE_AUTH_REVIEW_PHASE,
+        mode: 'football-data-packet-file-auth-review',
+        ok: true,
+        auth_form_found: true,
+        source_manifest_found: true,
+        local_csv_found: true,
+        approval_form_found: true,
+        runbook_template_found: true,
+        auth_form_validation_passed: true,
+        packet_file_preflight_passed: true,
+        packet_preview_passed: true,
+        select_only_db_reads: true,
+        authorization_review_completed: true,
+        packet_file_creation_ready: false,
+        packet_file_creation_authorized: false,
+        authorization_status: 'not_authorized',
+        final_packet_creation_confirmation: false,
+        approval_granted: false,
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        commit_gate: 'blocked',
+        current_db_counts: {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        missing_authorization_requirements: ['operator must be filled'],
+        permission_separation: ['packet file creation does not authorize DB write'],
+        human_only_fields: ['authorization_status'],
+        non_execution_confirmations: ['no_external_network'],
+        errors: [],
+        warnings: [],
+    });
+
+    assert.match(text, /current_db_counts:/);
+    assert.match(text, /- matches=2/);
+    assert.match(text, /missing_authorization_requirements:/);
+    assert.match(text, /- operator must be filled/);
+    assert.match(text, /permission_separation:/);
+    assert.match(text, /human_only_fields:/);
+    assert.match(text, /non_execution_confirmations:/);
+});
+
+test('默认 stage 回退路径在未注入 override 时仍可成功', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const result = await gate.runAuthorizationReview(baseArgs(), {
+        cwd: PROJECT_ROOT,
+        existsSync: filePath =>
+            new Set([AUTH_FORM_PATH, MANIFEST_PATH, CSV_PATH, APPROVAL_FORM_PATH, RUNBOOK_TEMPLATE_PATH]).has(
+                path.resolve(filePath)
+            ),
+        readFileSync: filePath => {
+            const resolved = path.resolve(filePath);
+            if (resolved === AUTH_FORM_PATH) {
+                return AUTH_FORM_TEXT;
+            }
+            if (resolved === MANIFEST_PATH) {
+                return SOURCE_MANIFEST_TEXT;
+            }
+            if (resolved === CSV_PATH) {
+                return LOCAL_CSV_TEXT;
+            }
+            if (resolved === APPROVAL_FORM_PATH) {
+                return APPROVAL_FORM_TEXT;
+            }
+            if (resolved === RUNBOOK_TEMPLATE_PATH) {
+                return RUNBOOK_TEMPLATE_TEXT;
+            }
+            throw new Error(`unexpected read path: ${resolved}`);
+        },
+        dbClient: buildDbClient([
+            { table_name: 'matches', rows: '2' },
+            { table_name: 'bookmaker_odds_history', rows: '2' },
+            { table_name: 'raw_match_data', rows: '2' },
+            { table_name: 'l3_features', rows: '2' },
+            { table_name: 'match_features_training', rows: '2' },
+            { table_name: 'predictions', rows: '2' },
+        ]),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.packet_file_creation_ready, false);
+    assert.equal(result.packet_file_creation_authorized, false);
+    assert.equal(result.commit_gate, 'blocked');
+});
+
+test('script 作为真实入口执行 --help 应成功', () => {
+    const result = spawnSync('node', [SCRIPT_PATH, '--help'], {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Usage:/);
+    assert.match(result.stdout, /No packet file writes, no packet directory creation/);
+});
+
+test('main runtime error 分支应返回 runtime-error payload', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    let stdout = '';
+    const status = await gate.main(
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+            '--json',
+        ],
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        {
+            ...buildDependencies(),
+            runPacketAssembly: async () => {
+                throw new Error('forced runtime failure');
+            },
+        }
+    );
+
+    const payload = JSON.parse(stdout);
+    assert.equal(status, 1);
+    assert.equal(payload.mode, 'runtime-error');
+    assert.match(payload.errors.join('\n'), /forced runtime failure/);
+});
+
+test('SQL 只允许 SELECT / BEGIN READ ONLY / ROLLBACK', async t => {
+    installExecutionGuards(t);
+    const gate = loadReviewFresh();
+    const dbClient = buildDbClient([
+        { table_name: 'matches', rows: '2' },
+        { table_name: 'bookmaker_odds_history', rows: '2' },
+        { table_name: 'raw_match_data', rows: '2' },
+        { table_name: 'l3_features', rows: '2' },
+        { table_name: 'match_features_training', rows: '2' },
+        { table_name: 'predictions', rows: '2' },
+    ]);
+
+    const result = await runJsonMain(
+        gate,
+        [
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--source-manifest',
+            MANIFEST_PATH,
+            '--local-csv',
+            CSV_PATH,
+            '--approval-form',
+            APPROVAL_FORM_PATH,
+            '--runbook-template',
+            RUNBOOK_TEMPLATE_PATH,
+        ],
+        buildDependencies({ dbClient })
+    );
+
+    assert.equal(result.status, 0);
+    assert.ok(dbClient.calls.length >= 3);
+    for (const sql of dbClient.calls) {
+        const normalized = String(sql || '')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .toUpperCase();
+        const allowed =
+            normalized === gate.READ_ONLY_BEGIN_SQL ||
+            normalized === gate.READ_ONLY_ROLLBACK_SQL ||
+            normalized.startsWith('SELECT ');
+        const forbidden =
+            /\b(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE|COPY|MERGE|GRANT|REVOKE|COMMIT)\b|\\COPY/.test(
+                normalized
+            );
+        assert.equal(allowed, true, `unexpected SQL: ${normalized}`);
+        assert.equal(forbidden, false, `forbidden SQL: ${normalized}`);
+    }
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.72C football-data packet file creation dry-run authorization review.

Scope:
- Adds packet file authorization review gate
- Reviews packet file auth form, source manifest, local CSV, approval form, and runbook template
- Reports missing authorization requirements
- Keeps packet file creation blocked
- Adds Makefile review and blocked commit targets
- Adds unit tests
- Updates AGENTS.md
- Adds Phase 4.72C report

Safety:
- No DB writes
- SELECT-only DB reads only
- No packet file writes
- No packet directory creation
- No pg_dump execution
- No pg_restore execution
- No backup file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- packet file auth review passed
- packet file auth review commit gate remained blocked
- existing football-data gates still passed
- unit tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- eslint passed
- prettier passed
- git diff --check passed