### PR TITLE
feat(data): add football-data packet auth packet draft

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,6 +606,12 @@ Phase 4.57C football-data adapter rules：
 - `make data-football-data-packet-file-readiness-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_PACKET_FILE_READINESS=1` 也不得创建目录、不写 packet 文件、不写 packet manifest、不执行 `pg_dump` / `pg_restore`、不写 DB、不触网。
 - readiness checklist 不等于 packet file creation authorization；packet file creation authorization 不等于 DB write authorization。
 - 真实 packet 文件创建必须单独阶段、用户明确授权、真实 auth form、显式路径。
+- Phase 4.74C 的 `docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_PACKET_DRAFT_TEMPLATE.md` 是未来提交给人类审核的 packet file creation authorization packet 草案模板，不是授权，不是 packet 文件。
+- Phase 4.74C 的 draft template 默认 `draft_status=draft_only`、默认 `ready_for_packet_file_creation=false`、默认 `authorized_for_packet_file_creation=false`；Codex 不得自行改成 `approved` 或 `true`。
+- `make data-football-data-packet-file-auth-packet-draft DRAFT_TEMPLATE=<local md> READINESS_CHECKLIST=<local md> AUTH_FORM=<local md> SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv> APPROVAL_FORM=<local md> RUNBOOK_TEMPLATE=<local md>` 只生成 authorization packet draft review；不得创建目录、不得写 packet 文件、不得写 DB、不得执行 `pg_dump` / `pg_restore`。
+- `data-football-data-packet-file-auth-packet-draft` 不得把 `draft_status` 改成 `approved`、不得把 `readiness_status` 改成 `ready`、不得把 `authorization_status` 改成 `authorized_for_packet_file_creation`、不得把 `final_packet_creation_confirmation` 改成 `true`。
+- `make data-football-data-packet-file-auth-packet-draft-commit` 当前 blocked / not wired，即使带 `CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT=1` 也不得创建目录、不写 packet 文件、不写 DB、不执行 `pg_dump` / `pg_restore`。
+- authorization packet draft 不等于 packet file creation authorization；packet file creation authorization 不等于 DB write authorization。
 - 真实 packet 文件创建、真实 `pg_dump` 和真实 DB write 必须分别在单独阶段进行，并需要用户明确授权。
 - Phase 4.66C 的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>` 是 deterministic match_id + insert candidate policy preview；只能读取本地 manifest / CSV，并对 DB 执行 SELECT-only schema / duplicate 查询。
 - `data-football-data-insert-policy-precheck` 不得写 DB、不得执行 `pg_dump`、不得写文件、不得触网、不得 import legacy downloader runtime；`make data-football-data-insert-policy-commit` 当前 blocked / not wired。

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@
         data-football-data-packet-file-auth-validate data-football-data-packet-file-auth-commit \
         data-football-data-packet-file-auth-review data-football-data-packet-file-auth-review-commit \
         data-football-data-packet-file-readiness-review data-football-data-packet-file-readiness-commit \
+        data-football-data-packet-file-auth-packet-draft data-football-data-packet-file-auth-packet-draft-commit \
         data-football-data-insert-policy-precheck data-football-data-insert-policy-commit \
         data-finished-csv-dry-run data-finished-csv-commit \
         data-finished-backfill-dry-run data-finished-backfill-commit \
@@ -309,6 +310,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-packet-file-auth-commit AUTH_FORM=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1  # blocked in Phase 4.71C"
 	@echo "  make data-football-data-packet-file-auth-review-commit AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_REVIEW=1  # blocked in Phase 4.72C"
 	@echo "  make data-football-data-packet-file-readiness-review-commit READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_READINESS=1  # blocked in Phase 4.73C"
+	@echo "  make data-football-data-packet-file-auth-packet-draft DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
+	@echo "  make data-football-data-packet-file-auth-packet-draft-commit DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT=1  # blocked in Phase 4.74C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
@@ -716,6 +719,29 @@ data-football-data-packet-file-readiness-commit: ## Blocked Football-Data packet
 		exit 1; \
 	fi
 	@echo "BLOCKED: football-data packet file readiness commit is not wired in Phase 4.73C."
+	@exit 1
+
+data-football-data-packet-file-auth-packet-draft: ## Run Football-Data packet file creation authorization packet draft review. Requires DRAFT_TEMPLATE, READINESS_CHECKLIST, AUTH_FORM, SOURCE_MANIFEST, LOCAL_CSV, APPROVAL_FORM, RUNBOOK_TEMPLATE.
+	@if [ -z "$(DRAFT_TEMPLATE)" ] || [ -z "$(READINESS_CHECKLIST)" ] || [ -z "$(AUTH_FORM)" ] || [ -z "$(SOURCE_MANIFEST)" ] || [ -z "$(LOCAL_CSV)" ] || [ -z "$(APPROVAL_FORM)" ] || [ -z "$(RUNBOOK_TEMPLATE)" ]; then \
+		echo "ERROR: provide DRAFT_TEMPLATE=<path>, READINESS_CHECKLIST=<path>, AUTH_FORM=<path>, SOURCE_MANIFEST=<path>, LOCAL_CSV=<path>, APPROVAL_FORM=<path>, and RUNBOOK_TEMPLATE=<path>"; \
+		exit 1; \
+	fi
+	@echo "Running Football-Data auth packet draft review: DRAFT_TEMPLATE=$(DRAFT_TEMPLATE), READINESS_CHECKLIST=$(READINESS_CHECKLIST), AUTH_FORM=$(AUTH_FORM), SOURCE_MANIFEST=$(SOURCE_MANIFEST), LOCAL_CSV=$(LOCAL_CSV), APPROVAL_FORM=$(APPROVAL_FORM), RUNBOOK_TEMPLATE=$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(DRAFT_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(READINESS_CHECKLIST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(AUTH_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(SOURCE_MANIFEST)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(LOCAL_CSV)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(APPROVAL_FORM)"
+	$(COMPOSE_DEV) exec -T dev test -f "$(RUNBOOK_TEMPLATE)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/football_data_packet_file_auth_packet_draft.js --draft-template "$(DRAFT_TEMPLATE)" --readiness-checklist "$(READINESS_CHECKLIST)" --auth-form "$(AUTH_FORM)" --source-manifest "$(SOURCE_MANIFEST)" --local-csv "$(LOCAL_CSV)" --approval-form "$(APPROVAL_FORM)" --runbook-template "$(RUNBOOK_TEMPLATE)"
+
+data-football-data-packet-file-auth-packet-draft-commit: ## Blocked Football-Data auth packet draft commit gate. Requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT=1 but remains not wired.
+	@if [ "$(CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT)" != "1" ]; then \
+		echo "BLOCKED: football-data auth packet draft requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT=1 and is not wired in Phase 4.74C."; \
+		exit 1; \
+	fi
+	@echo "BLOCKED: football-data auth packet draft commit is not wired in Phase 4.74C."
 	@exit 1
 
 data-football-data-insert-policy-precheck: ## Run SELECT-only Football-Data deterministic match_id + insert policy precheck. Requires SOURCE_MANIFEST and LOCAL_CSV.

--- a/docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT_PHASE4_74C.md
+++ b/docs/_reports/FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT_PHASE4_74C.md
@@ -1,0 +1,285 @@
+# Phase 4.74C：Football-Data Packet File Creation Authorization Packet Draft
+
+**日期**: 2026-05-09
+**分支**: feat/football-data-packet-file-auth-packet-draft-phase474c
+**起始 HEAD**: f82af575ae1c1392117d235e7fcc19368ccc5e5a
+
+---
+
+## 1. 概述
+
+Phase 4.74C 准备"未来创建真实 packet 文件前，提交给人类审核的授权材料包草案模板和 dry-run draft review"。
+
+本阶段不创建 `docs/_packets` 目录、不写真实 packet 文件、不写 packet manifest、不写 DB、不执行 pg_dump / pg_restore。
+
+---
+
+## 2. 为什么做稍大主题 PR 是合理的
+
+Phase 4.74C 需要同时交付以下内容才能形成完整的 authorization packet draft 体系：
+
+- Authorization packet draft template（定义草案格式）
+- Draft review script（生成 draft review，复用 5 个已有 gates）
+- Makefile entries（review + blocked commit）
+- Unit tests（26 个测试用例，保证安全边界）
+- AGENTS.md updates（规则文档化）
+- Phase report（可追溯性）
+
+这 6 个交付物互相依赖，拆分会导致中间态的 PR 无法独立验证。作为一个 consolidation PR 一次性交付是最合理的方式。
+
+---
+
+## 3. 新增文件
+
+| 文件                                                                             | 用途                            |
+| -------------------------------------------------------------------------------- | ------------------------------- |
+| `docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_PACKET_DRAFT_TEMPLATE.md` | Authorization packet draft 模板 |
+| `scripts/ops/football_data_packet_file_auth_packet_draft.js`                     | Draft review 脚本               |
+| `tests/unit/football_data_packet_file_auth_packet_draft.test.js`                 | Unit tests (26 个)              |
+
+## 4. 修改文件
+
+| 文件        | 变更                                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `Makefile`  | 新增 `data-football-data-packet-file-auth-packet-draft` 和 `data-football-data-packet-file-auth-packet-draft-commit` 入口 |
+| `AGENTS.md` | 新增 Phase 4.74C 规则                                                                                                     |
+
+---
+
+## 5. Authorization Packet Draft Template 设计
+
+模板包含 machine-readable YAML block，覆盖以下部分：
+
+- **draft status**: `draft_status=draft_only`
+- **authorization**: `packet_file_creation_authorized=false`, `readiness_status=not_ready`
+- **draft_inputs**: 7 个必需输入项
+- **required_human_fields**: 10 个人工填写字段
+- **permission_separation**: 5 个权限分离声明
+- **safety_defaults**: 9 个安全默认值（全 false）
+- **final_decision**: `ready_for_human_review=false`, `ready_for_packet_file_creation=false`, `authorized_for_packet_file_creation=false`
+
+### 5.1 Draft Review Script
+
+`football_data_packet_file_auth_packet_draft.js` 复用已有 gates：
+
+- Phase 4.73C `runReadinessReview`
+- Phase 4.72C `runAuthorizationReview`
+- Phase 4.71C `runValidation` (auth form)
+- Phase 4.70C `runPacketFilePreflight`
+- Phase 4.69C `runPacketAssembly` (packet preview)
+- SELECT-only DB row count inspection
+
+### 5.2 依赖注入
+
+支持 `dependencies` 参数注入：`existsSync`, `readFileSync`, `dbClient`, `createPool`，允许 unit test 不连接真实 DB。
+
+---
+
+## 6. draft_status=draft_only 的原因
+
+当前所有检查项的默认值都是不满足状态：
+
+- `draft_status=draft_only`
+- `ready_for_human_review=false`
+- `ready_for_packet_file_creation=false`
+- `authorized_for_packet_file_creation=false`
+- `packet_file_creation_authorized=false`
+- `readiness_status=not_ready`
+- `authorization_status=not_authorized`
+- `final_packet_creation_confirmation=false`
+
+这些只有在用户手动填写 draft、提供真实参数、完成所有 gates 并经过人类审核后才能变为 approved。
+
+---
+
+## 7. Authorization Packet Draft Sections
+
+```
+- packet_creation_scope
+- source_inputs_summary
+- gate_results_summary
+- readiness_review_summary
+- authorization_review_summary
+- proposed_packet_paths
+- proposed_packet_metadata
+- proposed_candidate_match_ids
+- blocked_candidate_summary
+- manual_review_summary
+- human_only_fields
+- missing_readiness_items
+- permission_separation
+- final_human_decision_required
+```
+
+---
+
+## 8. Missing Draft Requirements
+
+```
+- draft_status must remain draft_only until human review
+- readiness_status must be ready before creation
+- authorization_status must be authorized_for_packet_file_creation
+- final_packet_creation_confirmation must be true
+- operator must be filled
+- reviewer must be filled
+- human_approval_note must be present
+- packet_creation_reason must be present
+- packet_directory must be explicit
+- packet_file must be explicit
+- packet_manifest_file must be explicit
+- approved_candidate_match_ids must be reviewed
+- manual_review_candidate_match_ids must be excluded or resolved
+```
+
+---
+
+## 9. Permission Separation
+
+```
+- authorization packet draft does not authorize packet file creation
+- packet file creation does not authorize DB write
+- packet file creation does not authorize pg_dump
+- packet file creation does not authorize pg_restore
+- packet file creation does not authorize training
+- packet file creation does not authorize prediction
+```
+
+---
+
+## 10. Why No Actions Were Performed
+
+### 为什么不创建 packet 文件？
+
+Packet 文件创建需要：
+
+1. 用户明确授权
+2. 真实 auth form（非模板/草案）
+3. 显式输出目录和文件路径
+4. 所有 gates + readiness + human review 全部通过
+5. 单独阶段执行
+
+当前 `draft_status=draft_only`、`authorized_for_packet_file_creation=false`，这些条件均不满足。
+
+### 为什么不创建目录？
+
+目录创建是 packet 文件创建的前置操作，同样需要用户明确授权。
+
+### 为什么不写 DB？
+
+DB write 是与 packet 文件创建独立的操作，需要单独授权、真实 pg_dump、非空备份验证。
+
+### 为什么不执行 pg_dump？
+
+pg_dump 是 DB write 前的前置保护操作，需要用户明确授权。不写 DB 时不需要 pg_dump。
+
+---
+
+## 11. Commit Gate Blocked
+
+`make data-football-data-packet-file-auth-packet-draft-commit` 双重 blocked：
+
+- 无 `CONFIRM`: `BLOCKED: football-data auth packet draft requires CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT=1 and is not wired in Phase 4.74C.`
+- 有 `CONFIRM=1`: `BLOCKED: football-data auth packet draft commit is not wired in Phase 4.74C.`
+
+---
+
+## 12. Existing Gates Re-verification
+
+| Gate                         | 状态                                  |
+| ---------------------------- | ------------------------------------- |
+| packet file readiness review | OK (`readiness_status=not_ready`)     |
+| packet file auth review      | OK (`ok=true`, `commit_gate=blocked`) |
+| packet file auth validate    | OK                                    |
+| packet file preflight        | OK                                    |
+| packet preview               | OK                                    |
+| CSV dry-run                  | OK                                    |
+| DB write preflight           | OK                                    |
+| duplicate precheck           | OK                                    |
+| insert policy precheck       | OK                                    |
+| small write auth preview     | OK                                    |
+| runbook validation           | OK                                    |
+
+---
+
+## 13. Test Results
+
+| Command                                               | Result                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------ |
+| `football_data_packet_file_auth_packet_draft.test.js` | 26/26 pass                                             |
+| All football-data tests (14 files)                    | 314/314 pass                                           |
+| `npm test`                                            | 48/48 pass                                             |
+| `npm run test:coverage`                               | PASS (lines=88.48%, branches=80.06%, functions=81.28%) |
+
+---
+
+## 14. DB Row Counts (Before and After)
+
+| Table                   | Before | After |
+| ----------------------- | ------ | ----- |
+| matches                 | 2      | 2     |
+| bookmaker_odds_history  | 2      | 2     |
+| raw_match_data          | 2      | 2     |
+| l3_features             | 2      | 2     |
+| match_features_training | 2      | 2     |
+| predictions             | 2      | 2     |
+
+DB 行数未变化。
+
+---
+
+## 15. Next Steps
+
+### Option A: Phase 4.75C — packet file creation authorization packet review consolidation
+
+- 将 draft review、readiness review、auth review 合并为统一的 final authorization packet review
+- 不创建 packet 文件
+- 不写 DB
+- 不执行 pg_dump
+
+### Option B: Phase 4.56A — 真实 network dry-run
+
+用户给齐真实 network dry-run 参数后才做 runbook：
+
+- 真实 ENGINE / TARGET_MATCH_ID / SOURCE_MANIFEST
+- 不执行真实 network 请求
+- 不写 DB
+
+---
+
+## 16. 明确未执行事项
+
+以下操作均未执行：
+
+- DB writes (INSERT/UPDATE/DELETE/CREATE/ALTER/DROP/TRUNCATE/COPY)
+- non-SELECT DB SQL
+- pg_dump execution
+- pg_restore execution
+- backup file writes
+- packet file writes
+- packet manifest writes
+- packet directory creation (`docs/_packets/` 不存在)
+- file writes from auth packet draft runtime
+- draft_status 改为 approved
+- readiness_status 改为 ready
+- authorization_status 改为 authorized_for_packet_file_creation
+- final_packet_creation_confirmation 改为 true
+- approval_status 改为 approved_for_db_write
+- final_human_confirmation 改为 true
+- external download
+- curl / wget / git clone
+- 外部足球数据源访问
+- 外部赔率数据源访问
+- scraping / browser automation
+- harvest / ingest
+- batch backfill
+- network dry-run 真执行
+- bulk harvest
+- adapted CSV / staging 数据写入
+- model training
+- real prediction execution
+- model artifact loading
+- Docker volume 清理
+- force push
+- git fetch --all
+- git pull
+- 删除文件

--- a/docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_PACKET_DRAFT_TEMPLATE.md
+++ b/docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_PACKET_DRAFT_TEMPLATE.md
@@ -1,0 +1,91 @@
+# Football-Data Packet File Creation Authorization Packet Draft Template
+
+> 模板用途：未来提交给人类审核的 packet file creation authorization packet 草案模板。
+>
+> 本文件在 Phase 4.74C 只是草案模板，不是授权；不允许据此创建目录、写 packet 文件、写 packet manifest、写 DB、执行 `pg_dump` / `pg_restore`、训练或预测。
+
+```yaml
+phase: PHASE4_PACKET_FILE_CREATION_AUTH_PACKET_DRAFT
+draft_status: draft_only
+packet_file_creation_authorized: false
+packet_file_creation_ready: false
+readiness_status: not_ready
+authorization_status: not_authorized
+final_packet_creation_confirmation: false
+
+operator:
+reviewer:
+source_manifest:
+local_csv:
+approval_form:
+runbook_template:
+packet_auth_form:
+readiness_checklist:
+packet_directory:
+packet_file:
+packet_manifest_file:
+approved_output_root: docs/_packets/football_data/small_write
+
+draft_inputs:
+    source_manifest_summary_required: true
+    local_csv_summary_required: true
+    packet_preview_required: true
+    packet_file_preflight_required: true
+    auth_form_validation_required: true
+    auth_review_required: true
+    readiness_review_required: true
+
+required_human_fields:
+    - operator
+    - reviewer
+    - human_approval_note
+    - packet_creation_reason
+    - packet_directory
+    - packet_file
+    - packet_manifest_file
+    - approved_candidate_match_ids
+    - excluded_candidate_match_ids
+    - manual_review_candidate_match_ids
+
+permission_separation:
+    packet_file_creation_authorizes_db_write: false
+    packet_file_creation_authorizes_pg_dump: false
+    packet_file_creation_authorizes_pg_restore: false
+    packet_file_creation_authorizes_training: false
+    packet_file_creation_authorizes_prediction: false
+
+safety_defaults:
+    allow_packet_directory_creation: false
+    allow_packet_file_write: false
+    allow_packet_manifest_write: false
+    allow_db_write: false
+    allow_pg_dump: false
+    allow_pg_restore: false
+    allow_external_network: false
+    allow_training: false
+    allow_prediction: false
+
+final_decision:
+    ready_for_human_review: false
+    ready_for_packet_file_creation: false
+    authorized_for_packet_file_creation: false
+```
+
+## 说明
+
+- 默认 `draft_status=draft_only`，不可在未经人工审批的情况下改为 `approved`。
+- 默认 `packet_file_creation_authorized=false`，不允许创建 packet 文件。
+- 默认 `packet_file_creation_ready=false`，不允许创建 packet 文件。
+- 默认 `readiness_status=not_ready`。
+- 默认 `authorization_status=not_authorized`。
+- 默认 `final_packet_creation_confirmation=false`。
+- 默认所有 `permission_separation` 标志均为 false。
+- 默认所有 `safety_defaults` 标志均为 false。
+- 本模板不是授权。
+- 本模板不是 packet 文件。
+- 本模板不等于 packet file creation authorization。
+- Codex 不得自行把 `draft_status` 改成 `approved`。
+- Codex 不得自行把 `ready_for_human_review` 改成 `true`。
+- Codex 不得自行把 `ready_for_packet_file_creation` 改成 `true`。
+- Codex 不得自行把 `authorized_for_packet_file_creation` 改成 `true`。
+- 真实 packet 文件创建必须单独阶段、用户明确授权、真实 auth form、显式路径。

--- a/scripts/ops/football_data_packet_file_auth_packet_draft.js
+++ b/scripts/ops/football_data_packet_file_auth_packet_draft.js
@@ -1,0 +1,782 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable max-lines -- Phase 4.74C auth packet draft review in one audit-friendly file. */
+
+const fs = require('fs');
+const path = require('path');
+
+const { runValidation, extractYamlBlock, parseYamlBlock } = require('./football_data_packet_file_auth_validate');
+const { runPacketFilePreflight } = require('./football_data_packet_file_preflight');
+const { runPacketAssembly } = require('./football_data_small_write_packet_assembly');
+const { runAuthorizationReview } = require('./football_data_packet_file_auth_review');
+const { runReadinessReview } = require('./football_data_packet_file_readiness_review');
+const {
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    buildDbConfig,
+    assertSelectOnlySql,
+} = require('./football_data_duplicate_precheck');
+
+const AUTH_PACKET_DRAFT_PHASE = 'PHASE4.74C_FOOTBALL_DATA_PACKET_FILE_AUTH_PACKET_DRAFT';
+const DRAFT_TEMPLATE_PHASE = 'PHASE4_PACKET_FILE_CREATION_AUTH_PACKET_DRAFT';
+const MISSING_ARGS_MESSAGE =
+    'ERROR: provide --draft-template=<path>, --readiness-checklist=<path>, --auth-form=<path>, --source-manifest=<path>, --local-csv=<path>, --approval-form=<path>, and --runbook-template=<path>';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: football-data packet file authorization packet draft commit is not wired in Phase 4.74C.';
+
+const CURRENT_DB_TABLES = [
+    'matches',
+    'bookmaker_odds_history',
+    'raw_match_data',
+    'l3_features',
+    'match_features_training',
+    'predictions',
+];
+
+const CURRENT_DB_COUNTS_SQL = `
+SELECT table_name, rows
+FROM (
+    SELECT 'matches' AS table_name, COUNT(*)::bigint AS rows, 1 AS sort_order FROM matches
+    UNION ALL
+    SELECT 'bookmaker_odds_history', COUNT(*)::bigint, 2 FROM bookmaker_odds_history
+    UNION ALL
+    SELECT 'raw_match_data', COUNT(*)::bigint, 3 FROM raw_match_data
+    UNION ALL
+    SELECT 'l3_features', COUNT(*)::bigint, 4 FROM l3_features
+    UNION ALL
+    SELECT 'match_features_training', COUNT(*)::bigint, 5 FROM match_features_training
+    UNION ALL
+    SELECT 'predictions', COUNT(*)::bigint, 6 FROM predictions
+) counts
+ORDER BY sort_order
+`;
+
+const AUTHORIZATION_PACKET_DRAFT_SECTIONS = [
+    'packet_creation_scope',
+    'source_inputs_summary',
+    'gate_results_summary',
+    'readiness_review_summary',
+    'authorization_review_summary',
+    'proposed_packet_paths',
+    'proposed_packet_metadata',
+    'proposed_candidate_match_ids',
+    'blocked_candidate_summary',
+    'manual_review_summary',
+    'human_only_fields',
+    'missing_readiness_items',
+    'permission_separation',
+    'final_human_decision_required',
+];
+
+const MISSING_DRAFT_REQUIREMENTS = [
+    'draft_status must remain draft_only until human review',
+    'readiness_status must be ready before creation',
+    'authorization_status must be authorized_for_packet_file_creation',
+    'final_packet_creation_confirmation must be true',
+    'operator must be filled',
+    'reviewer must be filled',
+    'human_approval_note must be present',
+    'packet_creation_reason must be present',
+    'packet_directory must be explicit',
+    'packet_file must be explicit',
+    'packet_manifest_file must be explicit',
+    'approved_candidate_match_ids must be reviewed',
+    'manual_review_candidate_match_ids must be excluded or resolved',
+];
+
+const PERMISSION_SEPARATION = [
+    'authorization packet draft does not authorize packet file creation',
+    'packet file creation does not authorize DB write',
+    'packet file creation does not authorize pg_dump',
+    'packet file creation does not authorize pg_restore',
+    'packet file creation does not authorize training',
+    'packet file creation does not authorize prediction',
+];
+
+const NON_EXECUTION_CONFIRMATIONS = [
+    'no_external_network',
+    'select_only_db_reads',
+    'no_db_writes',
+    'no_file_writes',
+    'no_packet_file_write',
+    'no_packet_directory_create',
+    'no_legacy_runtime',
+    'no_pg_dump_execution',
+    'no_pg_restore_execution',
+    'no_training',
+    'no_prediction_execution',
+];
+
+const REQUIRED_DRAFT_FIELDS = [
+    'phase',
+    'draft_status',
+    'packet_file_creation_authorized',
+    'packet_file_creation_ready',
+    'readiness_status',
+    'authorization_status',
+    'final_packet_creation_confirmation',
+    'operator',
+    'reviewer',
+    'source_manifest',
+    'local_csv',
+    'approval_form',
+    'runbook_template',
+    'packet_auth_form',
+    'readiness_checklist',
+    'packet_directory',
+    'packet_file',
+    'packet_manifest_file',
+    'approved_output_root',
+];
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/football_data_packet_file_auth_packet_draft.js --draft-template <path> --readiness-checklist <path> --auth-form <path> --source-manifest <path> --local-csv <path> --approval-form <path> --runbook-template <path>',
+        '  node scripts/ops/football_data_packet_file_auth_packet_draft.js ... --commit',
+        '',
+        'Safety:',
+        '  Phase 4.74C generates authorization packet draft review only.',
+        '  No packet file writes, no packet directory creation, no DB writes, no pg_dump, no pg_restore, no child processes, no network.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const valueOptions = new Map([
+        ['--draft-template', 'draftTemplate'],
+        ['--readiness-checklist', 'readinessChecklist'],
+        ['--auth-form', 'authForm'],
+        ['--source-manifest', 'sourceManifest'],
+        ['--local-csv', 'localCsv'],
+        ['--approval-form', 'approvalForm'],
+        ['--runbook-template', 'runbookTemplate'],
+    ]);
+    const flagOptions = new Map([
+        ['--commit', 'commit'],
+        ['--json', 'json'],
+        ['--help', 'help'],
+        ['-h', 'help'],
+    ]);
+    const args = {
+        draftTemplate: '',
+        readinessChecklist: '',
+        authForm: '',
+        sourceManifest: '',
+        localCsv: '',
+        approvalForm: '',
+        runbookTemplate: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        const matchedValueOption = [...valueOptions.keys()].find(
+            option => token === option || token.startsWith(`${option}=`)
+        );
+        if (matchedValueOption) {
+            const key = valueOptions.get(matchedValueOption);
+            const usesSeparateValue = token === matchedValueOption;
+            args[key] = usesSeparateValue
+                ? String(argv[index + 1] || '')
+                : token.slice(`${matchedValueOption}=`.length);
+            if (usesSeparateValue) {
+                index += 1;
+            }
+            continue;
+        }
+        if (flagOptions.has(token)) {
+            args[flagOptions.get(token)] = true;
+            continue;
+        }
+        throw new Error(`Unknown argument: ${token}`);
+    }
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function validateRequiredArgs(args) {
+    return Boolean(
+        args.draftTemplate &&
+        args.readinessChecklist &&
+        args.authForm &&
+        args.sourceManifest &&
+        args.localCsv &&
+        args.approvalForm &&
+        args.runbookTemplate
+    );
+}
+
+function buildPathContext(args, cwd, existsSync) {
+    const paths = {
+        draftTemplatePath: resolveLocalPath(args.draftTemplate, cwd),
+        readinessChecklistPath: resolveLocalPath(args.readinessChecklist, cwd),
+        authFormPath: resolveLocalPath(args.authForm, cwd),
+        sourceManifestPath: resolveLocalPath(args.sourceManifest, cwd),
+        localCsvPath: resolveLocalPath(args.localCsv, cwd),
+        approvalFormPath: resolveLocalPath(args.approvalForm, cwd),
+        runbookTemplatePath: resolveLocalPath(args.runbookTemplate, cwd),
+    };
+    return {
+        ...paths,
+        draftTemplateFound: existsSync(paths.draftTemplatePath),
+        readinessChecklistFound: existsSync(paths.readinessChecklistPath),
+        authFormFound: existsSync(paths.authFormPath),
+        sourceManifestFound: existsSync(paths.sourceManifestPath),
+        localCsvFound: existsSync(paths.localCsvPath),
+        approvalFormFound: existsSync(paths.approvalFormPath),
+        runbookTemplateFound: existsSync(paths.runbookTemplatePath),
+        cwd,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: AUTH_PACKET_DRAFT_PHASE,
+        mode: fields.mode || 'football-data-packet-file-auth-packet-draft',
+        ok: false,
+        draft_template: args.draftTemplate || null,
+        readiness_checklist: args.readinessChecklist || null,
+        auth_form: args.authForm || null,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        approval_form: args.approvalForm || null,
+        runbook_template: args.runbookTemplate || null,
+        draft_template_found: false,
+        readiness_checklist_found: false,
+        auth_form_found: false,
+        source_manifest_found: false,
+        local_csv_found: false,
+        approval_form_found: false,
+        runbook_template_found: false,
+        readiness_review_passed: false,
+        auth_review_passed: false,
+        auth_validation_passed: false,
+        packet_file_preflight_passed: false,
+        packet_preview_passed: false,
+        select_only_db_reads: false,
+        draft_review_completed: false,
+        draft_status: 'draft_only',
+        ready_for_human_review: false,
+        ready_for_packet_file_creation: false,
+        authorized_for_packet_file_creation: false,
+        packet_file_creation_ready: false,
+        packet_file_creation_authorized: false,
+        readiness_status: 'not_ready',
+        authorization_status: 'not_authorized',
+        final_packet_creation_confirmation: false,
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        commit_gate: 'blocked',
+        authorization_packet_draft_sections: AUTHORIZATION_PACKET_DRAFT_SECTIONS,
+        missing_draft_requirements: MISSING_DRAFT_REQUIREMENTS,
+        permission_separation: PERMISSION_SEPARATION,
+        non_execution_confirmations: NON_EXECUTION_CONFIRMATIONS,
+        errors: [],
+        warnings: [],
+        current_db_counts: null,
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function buildMissingPathPayload(args, pathContext) {
+    const fields = [
+        'draftTemplate',
+        'readinessChecklist',
+        'authForm',
+        'sourceManifest',
+        'localCsv',
+        'approvalForm',
+        'runbookTemplate',
+    ];
+    const foundKeys = {
+        draftTemplate: 'draft_template_found',
+        readinessChecklist: 'readiness_checklist_found',
+        authForm: 'auth_form_found',
+        sourceManifest: 'source_manifest_found',
+        localCsv: 'local_csv_found',
+        approvalForm: 'approval_form_found',
+        runbookTemplate: 'runbook_template_found',
+    };
+    for (const field of fields) {
+        const found = pathContext[`${field}Found`];
+        if (!found) {
+            return buildFailurePayload(args, {
+                mode: `${field}-error`,
+                ...Object.fromEntries(Object.entries(foundKeys).map(([k, v]) => [v, pathContext[`${k}Found`]])),
+                errors: [
+                    `${field
+                        .replace(/([A-Z])/g, ' $1')
+                        .toLowerCase()
+                        .trim()} not found: ${toRelativePath(pathContext[`${field}Path`], pathContext.cwd)}`,
+                ],
+            });
+        }
+    }
+    return null;
+}
+
+function readAllInputs(pathContext, readFileSync) {
+    return {
+        draftTemplateMarkdown: readFileSync(pathContext.draftTemplatePath, 'utf8'),
+        readinessChecklistMarkdown: readFileSync(pathContext.readinessChecklistPath, 'utf8'),
+        authFormMarkdown: readFileSync(pathContext.authFormPath, 'utf8'),
+        sourceManifestText: readFileSync(pathContext.sourceManifestPath, 'utf8'),
+        localCsvText: readFileSync(pathContext.localCsvPath, 'utf8'),
+        approvalFormMarkdown: readFileSync(pathContext.approvalFormPath, 'utf8'),
+        runbookTemplateMarkdown: readFileSync(pathContext.runbookTemplatePath, 'utf8'),
+    };
+}
+
+function parseDraftTemplate(markdownText) {
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        throw new Error('YAML fenced block not found in auth packet draft template');
+    }
+    return parseYamlBlock(yamlText);
+}
+
+function validateDraftTemplateStructure(draftData) {
+    const errors = [];
+    if (!draftData || typeof draftData !== 'object') {
+        errors.push('draft template YAML is not a valid object');
+        return errors;
+    }
+    if (draftData.phase !== DRAFT_TEMPLATE_PHASE) {
+        errors.push(`draft template phase must be ${DRAFT_TEMPLATE_PHASE}, got: ${draftData.phase}`);
+    }
+    if (draftData.draft_status !== 'draft_only') {
+        errors.push(`draft_status must be draft_only, got: ${draftData.draft_status}`);
+    }
+    if (
+        draftData.packet_file_creation_authorized !== false &&
+        draftData.packet_file_creation_authorized !== undefined
+    ) {
+        errors.push(`packet_file_creation_authorized must be false, got: ${draftData.packet_file_creation_authorized}`);
+    }
+    if (draftData.readiness_status !== 'not_ready') {
+        errors.push(`readiness_status must be not_ready, got: ${draftData.readiness_status}`);
+    }
+    for (const key of [
+        'ready_for_human_review',
+        'ready_for_packet_file_creation',
+        'authorized_for_packet_file_creation',
+    ]) {
+        const val = (draftData.final_decision || {})[key];
+        if (val !== false && val !== undefined) {
+            errors.push(`final_decision.${key} must be false, got: ${val}`);
+        }
+    }
+    for (const field of REQUIRED_DRAFT_FIELDS) {
+        if (draftData[field] === undefined) {
+            errors.push(`required field missing from draft template: ${field}`);
+        }
+    }
+    return errors;
+}
+
+function createPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+async function withDbClient(dependencies, callback) {
+    if (dependencies.dbClient) {
+        return callback(dependencies.dbClient);
+    }
+    const pool = dependencies.pool || (dependencies.createPool || createPool)();
+    const client = await pool.connect();
+    try {
+        return await callback(client);
+    } finally {
+        client.release();
+        if (!dependencies.pool && typeof pool.end === 'function') {
+            await pool.end();
+        }
+    }
+}
+
+async function querySelectOnly(client, sql) {
+    assertSelectOnlySql(sql);
+    return client.query(sql);
+}
+
+function mapCurrentDbCounts(rows) {
+    const mapped = {};
+    for (const tableName of CURRENT_DB_TABLES) {
+        mapped[tableName] = 0;
+    }
+    for (const row of rows || []) {
+        mapped[row.table_name] = Number.parseInt(row.rows, 10);
+    }
+    return mapped;
+}
+
+function validateAndParseDraft(inputs) {
+    const errors = [];
+    let draftData = null;
+    try {
+        draftData = parseDraftTemplate(inputs.draftTemplateMarkdown);
+    } catch (err) {
+        errors.push(`draft template parse failed: ${err.message}`);
+    }
+    if (draftData) {
+        errors.push(...validateDraftTemplateStructure(draftData));
+    } else {
+        errors.push('draft template could not be parsed');
+    }
+    return { draftData, errors };
+}
+
+function resolveDraftInputs(args, dependencies) {
+    const {
+        cwd = process.cwd(),
+        existsSync: se = fs.existsSync.bind(fs),
+        readFileSync: sr = fs.readFileSync.bind(fs),
+    } = dependencies;
+    if (!validateRequiredArgs(args)) {
+        return { earlyPayload: buildFailurePayload(args, { errors: [MISSING_ARGS_MESSAGE] }) };
+    }
+    if (args.commit) {
+        return { earlyPayload: buildBlockedCommitPayload(args) };
+    }
+    const pathContext = buildPathContext(args, cwd, se);
+    const missingPayload = buildMissingPathPayload(args, pathContext);
+    if (missingPayload) {
+        return { earlyPayload: missingPayload };
+    }
+    try {
+        const inputs = readAllInputs(pathContext, sr);
+        return { pathContext, inputs, errors: validateAndParseDraft(inputs).errors, sr };
+    } catch (err) {
+        return {
+            earlyPayload: buildFailurePayload(args, {
+                draft_template_found: pathContext.draftTemplateFound,
+                readiness_checklist_found: pathContext.readinessChecklistFound,
+                auth_form_found: pathContext.authFormFound,
+                source_manifest_found: pathContext.sourceManifestFound,
+                local_csv_found: pathContext.localCsvFound,
+                approval_form_found: pathContext.approvalFormFound,
+                runbook_template_found: pathContext.runbookTemplateFound,
+                errors: [`failed to read input files: ${err.message}`],
+            }),
+        };
+    }
+}
+
+async function runAllGates(args, inputs, dependencies, sr) {
+    const warnings = [];
+    const gates = {
+        authValidationPassed: false,
+        packetPreviewPassed: false,
+        preflightPassed: false,
+        authReviewPassed: false,
+        readinessReviewPassed: false,
+        dbReadOk: false,
+        dbCounts: null,
+    };
+
+    try {
+        const r = runValidation(inputs.authFormMarkdown, sr);
+        gates.authValidationPassed = r && r.ok;
+    } catch (e) {
+        warnings.push(`auth validation threw: ${e.message}`);
+    }
+    try {
+        const r = await runPacketAssembly(
+            {
+                sourceManifest: args.sourceManifest,
+                localCsv: args.localCsv,
+                approvalForm: args.approvalForm,
+                runbookTemplate: args.runbookTemplate,
+                commit: false,
+                json: true,
+            },
+            dependencies
+        );
+        gates.packetPreviewPassed = r && r.ok;
+    } catch (e) {
+        warnings.push(`packet preview threw: ${e.message}`);
+    }
+    try {
+        const r = await runPacketFilePreflight(
+            {
+                sourceManifest: args.sourceManifest,
+                localCsv: args.localCsv,
+                approvalForm: args.approvalForm,
+                runbookTemplate: args.runbookTemplate,
+                commit: false,
+                json: true,
+            },
+            dependencies
+        );
+        gates.preflightPassed = r && r.ok;
+    } catch (e) {
+        warnings.push(`preflight threw: ${e.message}`);
+    }
+    try {
+        const r = await runAuthorizationReview(
+            {
+                authForm: args.authForm,
+                sourceManifest: args.sourceManifest,
+                localCsv: args.localCsv,
+                approvalForm: args.approvalForm,
+                runbookTemplate: args.runbookTemplate,
+                commit: false,
+                json: true,
+            },
+            dependencies
+        );
+        gates.authReviewPassed = r && r.ok;
+    } catch (e) {
+        warnings.push(`auth review threw: ${e.message}`);
+    }
+    try {
+        const r = await runReadinessReview(
+            {
+                readinessChecklist: args.readinessChecklist,
+                authForm: args.authForm,
+                sourceManifest: args.sourceManifest,
+                localCsv: args.localCsv,
+                approvalForm: args.approvalForm,
+                runbookTemplate: args.runbookTemplate,
+                commit: false,
+                json: true,
+            },
+            dependencies
+        );
+        gates.readinessReviewPassed = r && r.readiness_review_completed;
+    } catch (e) {
+        warnings.push(`readiness review threw: ${e.message}`);
+    }
+    try {
+        const r = await withDbClient(dependencies, async c => (await querySelectOnly(c, CURRENT_DB_COUNTS_SQL)).rows);
+        gates.dbCounts = mapCurrentDbCounts(r);
+        gates.dbReadOk = true;
+    } catch (e) {
+        warnings.push(`SELECT-only DB read failed: ${e.message}`);
+    }
+
+    return { gates, warnings };
+}
+
+function buildDraftPayload(args, pathContext, gates, errors, warnings) {
+    return {
+        phase: AUTH_PACKET_DRAFT_PHASE,
+        mode: 'football-data-packet-file-auth-packet-draft',
+        ok: errors.length === 0,
+        draft_template: args.draftTemplate || null,
+        readiness_checklist: args.readinessChecklist || null,
+        auth_form: args.authForm || null,
+        source_manifest: args.sourceManifest || null,
+        local_csv: args.localCsv || null,
+        approval_form: args.approvalForm || null,
+        runbook_template: args.runbookTemplate || null,
+
+        draft_template_found: pathContext.draftTemplateFound,
+        readiness_checklist_found: pathContext.readinessChecklistFound,
+        auth_form_found: pathContext.authFormFound,
+        source_manifest_found: pathContext.sourceManifestFound,
+        local_csv_found: pathContext.localCsvFound,
+        approval_form_found: pathContext.approvalFormFound,
+        runbook_template_found: pathContext.runbookTemplateFound,
+
+        readiness_review_passed: gates.readinessReviewPassed,
+        auth_review_passed: gates.authReviewPassed,
+        auth_validation_passed: gates.authValidationPassed,
+        packet_file_preflight_passed: gates.preflightPassed,
+        packet_preview_passed: gates.packetPreviewPassed,
+        select_only_db_reads: gates.dbReadOk,
+
+        draft_review_completed: true,
+        draft_status: 'draft_only',
+        ready_for_human_review: false,
+        ready_for_packet_file_creation: false,
+        authorized_for_packet_file_creation: false,
+        packet_file_creation_ready: false,
+        packet_file_creation_authorized: false,
+        readiness_status: 'not_ready',
+        authorization_status: 'not_authorized',
+        final_packet_creation_confirmation: false,
+
+        would_create_packet_directory: false,
+        would_write_packet_file: false,
+        would_write_packet_manifest: false,
+        would_execute_pg_dump: false,
+        would_execute_pg_restore: false,
+        would_insert_matches: false,
+        would_insert_odds: false,
+        would_write_db: false,
+        would_access_network: false,
+        would_write_files: false,
+        commit_gate: 'blocked',
+
+        authorization_packet_draft_sections: AUTHORIZATION_PACKET_DRAFT_SECTIONS,
+        missing_draft_requirements: MISSING_DRAFT_REQUIREMENTS,
+        permission_separation: PERMISSION_SEPARATION,
+        non_execution_confirmations: NON_EXECUTION_CONFIRMATIONS,
+
+        current_db_counts: gates.dbCounts,
+        errors,
+        warnings,
+    };
+}
+
+async function runDraftReview(args, dependencies = {}) {
+    const resolved = resolveDraftInputs(args, dependencies);
+    if (resolved.earlyPayload) return resolved.earlyPayload;
+
+    const { pathContext, inputs, errors, sr } = resolved;
+    const { gates, warnings } = await runAllGates(args, inputs, dependencies, sr);
+    return buildDraftPayload(args, pathContext, gates, errors, warnings);
+}
+
+async function main(argv = process.argv.slice(2)) {
+    let args;
+    try {
+        args = parseArgs(argv);
+    } catch (err) {
+        console.error(`ERROR: ${err.message}`);
+        console.error(usage());
+        process.exitCode = 1;
+        return;
+    }
+    if (args.help) {
+        console.error(usage());
+        return;
+    }
+
+    const result = await runDraftReview(args);
+
+    if (result.errors && result.errors.length > 0) {
+        console.error('ERROR:', result.errors.join('\n'));
+    }
+    if (result.warnings && result.warnings.length > 0) {
+        console.error('WARN:', result.warnings.join('\n'));
+    }
+
+    if (args.json) {
+        console.log(JSON.stringify(result, null, 2));
+    } else {
+        const lines = [
+            `phase=${result.phase}`,
+            `draft_template_found=${result.draft_template_found}`,
+            `readiness_checklist_found=${result.readiness_checklist_found}`,
+            `auth_form_found=${result.auth_form_found}`,
+            `source_manifest_found=${result.source_manifest_found}`,
+            `local_csv_found=${result.local_csv_found}`,
+            `approval_form_found=${result.approval_form_found}`,
+            `runbook_template_found=${result.runbook_template_found}`,
+            '',
+            `readiness_review_passed=${result.readiness_review_passed}`,
+            `auth_review_passed=${result.auth_review_passed}`,
+            `auth_validation_passed=${result.auth_validation_passed}`,
+            `packet_file_preflight_passed=${result.packet_file_preflight_passed}`,
+            `packet_preview_passed=${result.packet_preview_passed}`,
+            `select_only_db_reads=${result.select_only_db_reads}`,
+            '',
+            `draft_review_completed=${result.draft_review_completed}`,
+            `draft_status=${result.draft_status}`,
+            `ready_for_human_review=${result.ready_for_human_review}`,
+            `ready_for_packet_file_creation=${result.ready_for_packet_file_creation}`,
+            `authorized_for_packet_file_creation=${result.authorized_for_packet_file_creation}`,
+            `packet_file_creation_ready=${result.packet_file_creation_ready}`,
+            `packet_file_creation_authorized=${result.packet_file_creation_authorized}`,
+            `readiness_status=${result.readiness_status}`,
+            `authorization_status=${result.authorization_status}`,
+            `final_packet_creation_confirmation=${result.final_packet_creation_confirmation}`,
+            '',
+            `would_create_packet_directory=${result.would_create_packet_directory}`,
+            `would_write_packet_file=${result.would_write_packet_file}`,
+            `would_write_packet_manifest=${result.would_write_packet_manifest}`,
+            `would_execute_pg_dump=${result.would_execute_pg_dump}`,
+            `would_execute_pg_restore=${result.would_execute_pg_restore}`,
+            `would_insert_matches=${result.would_insert_matches}`,
+            `would_insert_odds=${result.would_insert_odds}`,
+            `would_write_db=${result.would_write_db}`,
+            `would_access_network=${result.would_access_network}`,
+            `would_write_files=${result.would_write_files}`,
+            `commit_gate=${result.commit_gate}`,
+            '',
+            'authorization_packet_draft_sections:',
+            ...result.authorization_packet_draft_sections.map(s => `- ${s}`),
+            '',
+            'missing_draft_requirements:',
+            ...result.missing_draft_requirements.map(s => `- ${s}`),
+            '',
+            'permission_separation:',
+            ...result.permission_separation.map(s => `- ${s}`),
+            '',
+            'non_execution_confirmations:',
+            ...result.non_execution_confirmations.map(s => `- ${s}`),
+        ];
+        if (result.current_db_counts) {
+            lines.push('', 'current_db_counts:');
+            for (const [table, count] of Object.entries(result.current_db_counts)) {
+                lines.push(`  ${table}=${count}`);
+            }
+        }
+        console.log(lines.join('\n'));
+    }
+
+    if (!result.ok) {
+        process.exitCode = 1;
+    }
+}
+
+if (require.main === module) {
+    main().catch(err => {
+        console.error('FATAL:', err.message);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = {
+    runDraftReview,
+    parseDraftTemplate,
+    validateDraftTemplateStructure,
+    validateRequiredArgs,
+    buildPathContext,
+    parseArgs,
+    buildFailurePayload,
+    buildBlockedCommitPayload,
+    MISSING_ARGS_MESSAGE,
+    BLOCKED_COMMIT_MESSAGE,
+    AUTH_PACKET_DRAFT_PHASE,
+    DRAFT_TEMPLATE_PHASE,
+    AUTHORIZATION_PACKET_DRAFT_SECTIONS,
+    MISSING_DRAFT_REQUIREMENTS,
+    PERMISSION_SEPARATION,
+    NON_EXECUTION_CONFIRMATIONS,
+    REQUIRED_DRAFT_FIELDS,
+    CURRENT_DB_TABLES,
+    CURRENT_DB_COUNTS_SQL,
+    mapCurrentDbCounts,
+};

--- a/tests/unit/football_data_packet_file_auth_packet_draft.test.js
+++ b/tests/unit/football_data_packet_file_auth_packet_draft.test.js
@@ -1,0 +1,485 @@
+'use strict';
+/* eslint-disable max-lines -- Phase 4.74C keeps the auth packet draft safety contract in one focused test file. */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/football_data_packet_file_auth_packet_draft.js');
+const DRAFT_TEMPLATE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_PACKET_DRAFT_TEMPLATE.md'
+);
+const READINESS_CHECKLIST_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_READINESS_CHECKLIST_TEMPLATE.md'
+);
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_PACKET_FILE_CREATION_AUTH_FORM_TEMPLATE.md'
+);
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/football_data/source_manifests/football_data_sample_phase463c_manifest.json'
+);
+const CSV_PATH = path.join(PROJECT_ROOT, 'tests/fixtures/football_data/football_data_sample_phase462c.csv');
+const APPROVAL_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_APPROVAL_FORM_TEMPLATE.md'
+);
+const RUNBOOK_TEMPLATE_PATH = path.join(PROJECT_ROOT, 'docs/runbooks/FOOTBALL_DATA_SMALL_DB_WRITE_RUNBOOK_TEMPLATE.md');
+
+const DRAFT_TEMPLATE_TEXT = fs.readFileSync(DRAFT_TEMPLATE_PATH, 'utf8');
+const READINESS_CHECKLIST_TEXT = fs.readFileSync(READINESS_CHECKLIST_PATH, 'utf8');
+const AUTH_FORM_TEXT = fs.readFileSync(AUTH_FORM_PATH, 'utf8');
+const SOURCE_MANIFEST_TEXT = fs.readFileSync(MANIFEST_PATH, 'utf8');
+const LOCAL_CSV_TEXT = fs.readFileSync(CSV_PATH, 'utf8');
+const APPROVAL_FORM_TEXT = fs.readFileSync(APPROVAL_FORM_PATH, 'utf8');
+const RUNBOOK_TEMPLATE_TEXT = fs.readFileSync(RUNBOOK_TEMPLATE_PATH, 'utf8');
+
+const ALL_PATHS = [
+    DRAFT_TEMPLATE_PATH,
+    READINESS_CHECKLIST_PATH,
+    AUTH_FORM_PATH,
+    MANIFEST_PATH,
+    CSV_PATH,
+    APPROVAL_FORM_PATH,
+    RUNBOOK_TEMPLATE_PATH,
+];
+
+function installExecutionGuards(t) {
+    const originals = {
+        httpRequest: http.request,
+        httpsRequest: https.request,
+        fetch: global.fetch,
+        spawn: childProcess.spawn,
+        exec: childProcess.exec,
+        execFile: childProcess.execFile,
+        writeFile: fs.writeFile,
+        writeFileSync: fs.writeFileSync,
+        createWriteStream: fs.createWriteStream,
+        mkdir: fs.mkdir,
+        mkdirSync: fs.mkdirSync,
+        load: Module._load,
+    };
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by football_data_packet_file_auth_packet_draft`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request) || String(request || '').includes('fetch_and_adapt_euro_leagues')) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originals.load.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originals.httpRequest;
+        https.request = originals.httpsRequest;
+        global.fetch = originals.fetch;
+        childProcess.spawn = originals.spawn;
+        childProcess.exec = originals.exec;
+        childProcess.execFile = originals.execFile;
+        fs.writeFile = originals.writeFile;
+        fs.writeFileSync = originals.writeFileSync;
+        fs.createWriteStream = originals.createWriteStream;
+        fs.mkdir = originals.mkdir;
+        fs.mkdirSync = originals.mkdirSync;
+        Module._load = originals.load;
+    });
+}
+
+function loadFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function baseArgs(overrides = {}) {
+    return {
+        draftTemplate: DRAFT_TEMPLATE_PATH,
+        readinessChecklist: READINESS_CHECKLIST_PATH,
+        authForm: AUTH_FORM_PATH,
+        sourceManifest: MANIFEST_PATH,
+        localCsv: CSV_PATH,
+        approvalForm: APPROVAL_FORM_PATH,
+        runbookTemplate: RUNBOOK_TEMPLATE_PATH,
+        commit: false,
+        ...overrides,
+    };
+}
+
+function buildDbClient(rows = []) {
+    const calls = [];
+    return {
+        calls,
+        releaseCalled: false,
+        async query(sql) {
+            calls.push(sql);
+            return { rows };
+        },
+        release() {
+            this.releaseCalled = true;
+        },
+    };
+}
+
+function defaultDbRows() {
+    return [
+        { table_name: 'matches', rows: '2' },
+        { table_name: 'bookmaker_odds_history', rows: '2' },
+        { table_name: 'raw_match_data', rows: '2' },
+        { table_name: 'l3_features', rows: '2' },
+        { table_name: 'match_features_training', rows: '2' },
+        { table_name: 'predictions', rows: '2' },
+    ];
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        dbClient: overrides.dbClient || buildDbClient(defaultDbRows()),
+        existsSync: fs.existsSync.bind(fs),
+        readFileSync: fs.readFileSync.bind(fs),
+        ...overrides,
+    };
+}
+
+function fakeExistsSync(allowedPaths) {
+    return filePath => {
+        const normalized = path.resolve(filePath);
+        for (const allowed of allowedPaths) {
+            if (path.resolve(allowed) === normalized) return true;
+        }
+        return false;
+    };
+}
+
+// Test 1: missing draft template
+test('缺 draft template 参数时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview({ ...baseArgs(), draftTemplate: '' }, buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('--draft-template')));
+});
+
+// Test 2: missing readiness checklist
+test('缺 readiness checklist 参数时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview({ ...baseArgs(), readinessChecklist: '' }, buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('--readiness-checklist')));
+});
+
+// Test 3: missing auth form
+test('缺 auth form 参数时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview({ ...baseArgs(), authForm: '' }, buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('--auth-form')));
+});
+
+// Test 4: missing source manifest
+test('缺 source manifest 参数时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview({ ...baseArgs(), sourceManifest: '' }, buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('--source-manifest')));
+});
+
+// Test 5: missing local CSV
+test('缺 local CSV 参数时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview({ ...baseArgs(), localCsv: '' }, buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('--local-csv')));
+});
+
+// Test 6: missing approval form
+test('缺 approval form 参数时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview({ ...baseArgs(), approvalForm: '' }, buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('--approval-form')));
+});
+
+// Test 7: missing runbook template
+test('缺 runbook template 参数时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview({ ...baseArgs(), runbookTemplate: '' }, buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some(e => e.includes('--runbook-template')));
+});
+
+// Test 8: correct draft review succeeds
+test('正确 draft review 成功', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    // Draft review always concludes draft_only ready=false authorized=false
+    assert.strictEqual(result.draft_review_completed, true);
+    assert.strictEqual(result.draft_status, 'draft_only');
+    assert.strictEqual(result.draft_template_found, true);
+});
+
+// Test 9: output fields all false
+test('输出关键字段全为 false', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.draft_review_completed, true);
+    assert.strictEqual(result.draft_status, 'draft_only');
+    assert.strictEqual(result.ready_for_human_review, false);
+    assert.strictEqual(result.ready_for_packet_file_creation, false);
+    assert.strictEqual(result.authorized_for_packet_file_creation, false);
+    assert.strictEqual(result.packet_file_creation_ready, false);
+    assert.strictEqual(result.packet_file_creation_authorized, false);
+    assert.strictEqual(result.would_create_packet_directory, false);
+    assert.strictEqual(result.would_write_packet_file, false);
+    assert.strictEqual(result.would_write_packet_manifest, false);
+    assert.strictEqual(result.would_write_db, false);
+    assert.strictEqual(result.would_execute_pg_dump, false);
+    assert.strictEqual(result.would_execute_pg_restore, false);
+    assert.strictEqual(result.commit_gate, 'blocked');
+});
+
+// Test 10: authorization_packet_draft_sections 完整
+test('authorization_packet_draft_sections 完整', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview, AUTHORIZATION_PACKET_DRAFT_SECTIONS } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.ok(Array.isArray(result.authorization_packet_draft_sections));
+    assert.ok(result.authorization_packet_draft_sections.includes('packet_creation_scope'));
+    assert.ok(result.authorization_packet_draft_sections.includes('gate_results_summary'));
+    assert.ok(result.authorization_packet_draft_sections.includes('readiness_review_summary'));
+    assert.ok(result.authorization_packet_draft_sections.includes('authorization_review_summary'));
+    assert.ok(result.authorization_packet_draft_sections.includes('final_human_decision_required'));
+});
+
+// Test 11: missing_draft_requirements 包含必要字段
+test('missing_draft_requirements 包含必要字段', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.ok(Array.isArray(result.missing_draft_requirements));
+    const items = result.missing_draft_requirements;
+    assert.ok(items.some(i => i.includes('draft_status must remain draft_only')));
+    assert.ok(items.some(i => i.includes('readiness_status must be ready')));
+    assert.ok(items.some(i => i.includes('authorization_status must be authorized')));
+    assert.ok(items.some(i => i.includes('final_packet_creation_confirmation must be true')));
+    assert.ok(items.some(i => i.includes('operator must be filled')));
+    assert.ok(items.some(i => i.includes('reviewer must be filled')));
+});
+
+// Test 12: permission_separation 包含分离声明
+test('permission_separation 包含 packet / DB write / pg_dump / training / prediction 分离', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.ok(Array.isArray(result.permission_separation));
+    const items = result.permission_separation;
+    assert.ok(items.some(i => i.includes('authorization packet draft does not authorize packet file creation')));
+    assert.ok(items.some(i => i.includes('packet file creation does not authorize DB write')));
+    assert.ok(items.some(i => i.includes('packet file creation does not authorize pg_dump')));
+    assert.ok(items.some(i => i.includes('packet file creation does not authorize pg_restore')));
+    assert.ok(items.some(i => i.includes('packet file creation does not authorize training')));
+    assert.ok(items.some(i => i.includes('packet file creation does not authorize prediction')));
+});
+
+// Test 13: draft-looking authorized form 也不能执行写动作
+test('draft-looking authorized form 也不能在 Phase 4.74C 执行写动作', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.would_create_packet_directory, false);
+    assert.strictEqual(result.would_write_packet_file, false);
+    assert.strictEqual(result.would_write_packet_manifest, false);
+    assert.strictEqual(result.would_write_db, false);
+    assert.strictEqual(result.would_execute_pg_dump, false);
+    assert.strictEqual(result.would_execute_pg_restore, false);
+    assert.strictEqual(result.would_insert_matches, false);
+    assert.strictEqual(result.would_access_network, false);
+});
+
+// Test 14: --commit blocked
+test('--commit blocked', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs({ commit: true }), buildDependencies());
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.mode, 'blocked-commit');
+    assert.ok(result.blocked);
+    assert.ok(result.blocked_reason.includes('not wired in Phase 4.74C'));
+});
+
+// Test 15: sha256 mismatch still passes draft review
+test('sha256 mismatch 时仍完成 draft review 且不写 DB', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const deps = buildDependencies();
+    const result = await runDraftReview(baseArgs(), deps);
+    assert.strictEqual(result.would_write_db, false);
+    assert.strictEqual(result.draft_review_completed, true);
+});
+
+// Test 16: draft template invalid 时失败
+test('draft template invalid 时失败', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const badDraft = '# Bad\n```yaml\nphase: WRONG_PHASE\ndraft_status: approved\n```\n';
+    const deps = buildDependencies({
+        existsSync: fakeExistsSync(ALL_PATHS),
+        readFileSync: filePath => {
+            if (path.resolve(filePath) === path.resolve(DRAFT_TEMPLATE_PATH)) return badDraft;
+            return fs.readFileSync(filePath, 'utf8');
+        },
+    });
+    const result = await runDraftReview(baseArgs(), deps);
+    assert.ok(result.errors.length > 0);
+    assert.ok(result.errors.some(e => e.includes('phase must be')));
+});
+
+// Test 17: readiness checklist invalid 时失败
+test('readiness checklist invalid 时仍完成 draft review', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const badChecklist = '# Bad\n```yaml\nphase: WRONG\ndraft_status: approved\n```\n';
+    const deps = buildDependencies({
+        existsSync: fakeExistsSync(ALL_PATHS),
+        readFileSync: filePath => {
+            if (path.resolve(filePath) === path.resolve(READINESS_CHECKLIST_PATH)) return badChecklist;
+            return fs.readFileSync(filePath, 'utf8');
+        },
+    });
+    const result = await runDraftReview(baseArgs(), deps);
+    assert.strictEqual(result.draft_review_completed, true);
+});
+
+// Test 18: auth form invalid 时仍完成 draft review
+test('auth form invalid 时仍完成 draft review', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const badAuth = '# Just markdown\nNo YAML block.\n';
+    const deps = buildDependencies({
+        existsSync: fakeExistsSync(ALL_PATHS),
+        readFileSync: filePath => {
+            if (path.resolve(filePath) === path.resolve(AUTH_FORM_PATH)) return badAuth;
+            return fs.readFileSync(filePath, 'utf8');
+        },
+    });
+    const result = await runDraftReview(baseArgs(), deps);
+    assert.strictEqual(result.draft_review_completed, true);
+});
+
+// Test 19: 不访问外网
+test('不访问外网', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.would_access_network, false);
+    assert.ok(result.non_execution_confirmations.includes('no_external_network'));
+});
+
+// Test 20: 不写文件
+test('不写文件', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.would_write_files, false);
+    assert.ok(result.non_execution_confirmations.includes('no_file_writes'));
+});
+
+// Test 21: 不创建目录
+test('不创建目录', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.would_create_packet_directory, false);
+    assert.ok(result.non_execution_confirmations.includes('no_packet_directory_create'));
+});
+
+// Test 22: 不写 packet 文件
+test('不写 packet 文件', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.would_write_packet_file, false);
+    assert.strictEqual(result.would_write_packet_manifest, false);
+    assert.ok(result.non_execution_confirmations.includes('no_packet_file_write'));
+});
+
+// Test 23: 不执行 pg_dump
+test('不执行 pg_dump', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.would_execute_pg_dump, false);
+    assert.ok(result.non_execution_confirmations.includes('no_pg_dump_execution'));
+});
+
+// Test 24: 不执行 pg_restore
+test('不执行 pg_restore', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.would_execute_pg_restore, false);
+    assert.ok(result.non_execution_confirmations.includes('no_pg_restore_execution'));
+});
+
+// Test 25: 不 spawn child process
+test('不 spawn child process', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const result = await runDraftReview(baseArgs(), buildDependencies());
+    assert.strictEqual(result.draft_review_completed, true);
+});
+
+// Test 26: SQL 只允许 SELECT / BEGIN READ ONLY / ROLLBACK
+test('SQL 只允许 SELECT / BEGIN READ ONLY / ROLLBACK，不允许写操作关键词', async t => {
+    installExecutionGuards(t);
+    const { runDraftReview } = loadFresh();
+    const dbClient = buildDbClient(defaultDbRows());
+    const result = await runDraftReview(baseArgs(), buildDependencies({ dbClient }));
+    assert.strictEqual(result.draft_review_completed, true);
+    for (const sql of dbClient.calls) {
+        const upper = sql.trim().toUpperCase();
+        assert.ok(
+            upper.startsWith('SELECT') || upper.startsWith('BEGIN') || upper.startsWith('ROLLBACK'),
+            `SQL call should be SELECT/BEGIN/ROLLBACK only, got: ${sql.substring(0, 50)}`
+        );
+        const forbidden = ['INSERT', 'UPDATE', 'DELETE', 'CREATE', 'ALTER', 'DROP', 'TRUNCATE', 'COPY'];
+        for (const kw of forbidden) {
+            assert.ok(!upper.includes(kw), `SQL call must not contain ${kw}: ${sql.substring(0, 50)}`);
+        }
+    }
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.74C football-data packet file creation authorization packet draft.

Scope:
- Adds packet file creation authorization packet draft template
- Adds packet auth packet draft review gate
- Consolidates packet creation scope, inputs, gate results, readiness review, auth review, missing draft requirements, and permission separation
- Keeps packet file creation blocked
- Adds Makefile review and blocked commit targets
- Adds unit tests (26 test cases)
- Updates AGENTS.md
- Adds Phase 4.74C report

Safety:
- No DB writes
- SELECT-only DB reads only
- No packet file writes
- No packet directory creation
- No pg_dump execution
- No pg_restore execution
- No backup file writes
- No external downloads
- No external football data access
- No curl / wget / git clone
- No scraping / browser automation / harvest / ingest
- No network dry-run execution
- No training
- No prediction execution
- No model artifact loading

Validation:
- packet auth packet draft review passed
- packet auth packet draft commit gate remained blocked
- existing football-data gates still passed
- unit tests passed (26/26 new, 314/314 total)
- npm test passed (48/48)
- npm run test:coverage passed (lines=88.48%, branches=80.06%, functions=81.28%)
- DB row counts unchanged (2/2/2/2/2/2)
- eslint passed
- prettier passed
- git diff --check passed