### PR TITLE
fix(ci): stabilize BrowserFactory coverage gate

### DIFF
--- a/tests/unit/BrowserFactory.test.js
+++ b/tests/unit/BrowserFactory.test.js
@@ -55,18 +55,11 @@ const MockBrowser = class {
     }
 };
 
-// 模拟 Playwright
-const mockPlaywright = {
-    chromium: MockBrowser
-};
+// 模拟 Playwright：加载 playwright 模块后替换 chromium.launch 和 connect 为 mock 实现
+const playwright = require('playwright');
+playwright.chromium.launch = MockBrowser.launch;
+playwright.chromium.connect = MockBrowser.launch;
 
-// 劫持 require
-const originalRequire = require;
-// eslint-disable-next-line no-global-assign
-require = function(id) {
-    if (id === 'playwright') return mockPlaywright;
-    return originalRequire.apply(this, arguments);
-};
 
 const { BrowserFactory, resetBrowserFactory } = require('../../src/infrastructure/browser/BrowserFactory');
 


### PR DESCRIPTION
## Summary

Fixes BrowserFactory CI instability that caused post-merge main push coverage gate failures.

### Root Cause
`BrowserFactory.test.js` used a local `require` override (`require = function(id) {...}`) to mock the `playwright` import. Each CommonJS module has its own `require` scope, so this mock could not intercept `require('playwright')` calls inside `BrowserFactory.js`. The real `chromium.launch()` was called, which fails in CI due to missing Chromium binary.

### Fix
Replaced the local `require` override with `playwright.chromium.launch = mockFn` — directly patching the shared `chromium` object imported from `playwright`. This intercepts ALL `chromium.launch()` calls across all modules that share the same `playwright` instance.

### Validation
- BrowserFactory.test.js: 20/20 pass
- TitanFullRegistry.test.js (also uses BrowserFactory): 28/28 pass when run together
- recovery_injection.test.js: passes when run together
- All standalone: pass
- npm test: 48/48 pass

### Safety
- No coverage threshold changes
- No test deletions or skips
- No gatekeeper changes
- No DB writes, external data access, training, or prediction
- 1 file changed, +4/-11 lines