### PR TITLE
feat(data): add single-target acquisition runtime scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV、不写 DB、不执行 pg_dump、不训练、不预测的 `make data-football-data-db-write-preflight SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB 查重、不写 DB、不训练、不预测的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB schema / duplicate 查询、不写 DB、不训练、不预测的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
+- 不触网、不启动 browser、不执行 proxy runtime、不写 staging、不写 manifest、不写 DB、不运行 titan_discovery legacy runtime 的 scaffold-only 参数校验和 plan preview：`make data-single-target-acquisition-runtime-scaffold TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> ...`（Phase 4.79D scaffold-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -290,6 +291,8 @@ AI / Codex 不能直接执行：
 - `make data-football-data-packet-file-auth-commit CONFIRM_FOOTBALL_DATA_PACKET_FILE_AUTH=1`
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
+- `make data-single-target-acquisition-runtime-commit`
+- `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
 - `make data-finished-csv-commit`
 - `make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1`
@@ -513,6 +516,8 @@ AI / Codex 默认禁止：
 
 - `make data-single-target-network-commit`
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
+- `make data-single-target-acquisition-runtime-commit`
+- `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
 - `node scripts/ops/run_production.js`
 - `node scripts/ops/titan_discovery.js`
@@ -536,6 +541,36 @@ AI / Codex 默认禁止：
 - 不允许训练
 - 不允许预测
 - 未来真正 network dry-run 必须在单独阶段、获得单独授权
+
+### Phase 4.79D: single-target acquisition runtime scaffold
+
+`data-single-target-acquisition-runtime-scaffold` 只允许参数校验和 runtime plan preview：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得写 staging
+- 它不得写 manifest
+- 它不得写 DB
+- 它不得运行 titan_discovery legacy runtime
+- 它不得执行任何 acquisition engine
+- 它不得 spawn child process
+
+`data-single-target-acquisition-runtime-commit` 当前 blocked。即使用户提供 yes 字段，Phase 4.79D 也只是 scaffold-only，不等于授权真实 network dry-run。
+
+真实 network dry-run 必须后续单独阶段、明确 source / target / terms / network authorization / staging policy。
+
+在 Phase 4.79D 中允许：
+
+- `make data-single-target-acquisition-runtime-scaffold TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> ...`
+- `node scripts/ops/single_target_acquisition_runtime_scaffold.js --target-source=... --target-engine-family=titan_discovery --target-scope-type=... ...`
+
+在 Phase 4.79D 中严格禁止：
+
+- `make data-single-target-acquisition-runtime-commit`
+- `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
+- `node scripts/ops/single_target_acquisition_runtime_scaffold.js --commit`
+- 以及上述所有禁止的 legacy / high-risk 命令
 
 相关背景见：`docs/_reports/ACQUISITION_ENGINE_READINESS_PHASE4_53A.md`、`docs/_reports/REAL_DATA_SOURCE_STRATEGY_PHASE4_51.md` 和 `docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md`
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-single-target-network-dry-run data-single-target-network-commit \
+        data-single-target-acquisition-runtime-scaffold data-single-target-acquisition-runtime-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -328,6 +329,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-raw-commit SAMPLE_RAW=<path> MATCH_ID=<id> CONFIRM_RAW_COMMIT=1  # blocked in Phase 4.21"
 	@echo "  make data-single-target-network-dry-run ENGINE=<engine> TARGET_MATCH_ID=<id> SOURCE_MANIFEST=<path>  # scaffold-only / blocked in Phase 4.54"
 	@echo "  make data-single-target-network-commit ENGINE=<engine> TARGET_MATCH_ID=<id> SOURCE_MANIFEST=<path> CONFIRM_SINGLE_TARGET_NETWORK=1  # blocked in Phase 4.54"
+	@echo "  make data-single-target-acquisition-runtime-scaffold TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> ...  # scaffold-only, Phase 4.79D"
+	@echo "  make data-single-target-acquisition-runtime-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1  # blocked in Phase 4.79D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -838,6 +841,36 @@ data-single-target-network-commit: ## Blocked acquisition network commit gate. R
 		exit 1; \
 	fi
 	@echo "BLOCKED: acquisition network commit is not wired in Phase 4.54."
+	@exit 1
+
+data-single-target-acquisition-runtime-scaffold: ## Scaffold-only single-target acquisition runtime plan preview. Phase 4.79D. Requires TARGET_SOURCE, TARGET_ENGINE_FAMILY, TARGET_SCOPE_TYPE, plus scope fields and yes/no fields.
+	@if [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ]; then \
+		echo "ERROR: provide TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<match_id|league_season_date>"; \
+		echo "  plus scope-specific fields and yes/no authorization fields."; \
+		echo "  See docs/_reports/SINGLE_TARGET_ACQUISITION_RUNTIME_DESIGN_PHASE4_78D.md for full parameter contract."; \
+		exit 1; \
+	fi
+	@echo "Phase 4.79D: single-target acquisition runtime scaffold (scaffold-only, no network, no DB, no staging)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/single_target_acquisition_runtime_scaffold.js \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		$(if $(TARGET_MATCH_ID),--target-match-id "$(TARGET_MATCH_ID)") \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--confirm-single-target-scope "$(or $(CONFIRM_SINGLE_TARGET_SCOPE),no)"
+
+data-single-target-acquisition-runtime-commit: ## Blocked single-target acquisition runtime commit gate. Remains not wired in Phase 4.79D.
+	@echo "BLOCKED: single-target acquisition runtime commit/execution is not wired in Phase 4.79D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1, this path remains blocked."
+	@echo "  Real network dry-run requires a separate future phase with explicit source/target/terms/network/staging authorization."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_RUNTIME_SCAFFOLD_PHASE4_79D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_RUNTIME_SCAFFOLD_PHASE4_79D.md
@@ -1,0 +1,216 @@
+# Phase 4.79D: Single-Target Acquisition Runtime Scaffold
+
+**Date**: 2026-05-10
+**Status**: Complete (scaffold-only)
+**Previous phase**: Phase 4.78D — Single-Target Acquisition Runtime Design
+**Next recommended phase**: Phase 4.80D or explicit user-authorized network dry-run runbook
+
+---
+
+## 1. Executive Summary
+
+Phase 4.79D is a **scaffold-only** phase. It translates the Phase 4.78D design into a
+concrete, validated, test-covered scaffold command that performs:
+
+1. Parameter validation
+2. Target scope validation
+3. Engine family validation
+4. Authorization field validation
+5. Runtime plan preview (JSON output)
+6. Guardrail summary
+
+The scaffold **does not** access the network, launch a browser, use proxy, write to DB,
+write to staging, execute any acquisition engine, import legacy runtime modules, or
+spawn child processes.
+
+All `would_*` fields in the output are hardcoded to `false`. The `commit_gate` is
+hardcoded to `"blocked"`. Even if all authorization fields are set to `"yes"`, the
+scaffold remains non-executing.
+
+---
+
+## 2. Implemented Command
+
+### Script
+
+```
+scripts/ops/single_target_acquisition_runtime_scaffold.js
+```
+
+### Makefile Targets
+
+```
+make data-single-target-acquisition-runtime-scaffold    (scaffold-only, Phase 4.79D)
+make data-single-target-acquisition-runtime-commit      (blocked, Phase 4.79D)
+```
+
+---
+
+## 3. Parameter Contract
+
+| Parameter                         | Required                             | Allowed                          | Forbidden                                                                                                                                                       | Default |
+| --------------------------------- | ------------------------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--target-source`                 | yes                                  | e.g. `fotmob`                    | empty                                                                                                                                                           | none    |
+| `--target-engine-family`          | yes                                  | `titan_discovery`                | `run_production`, `recon_scanner`, `odds_harvest_pipeline`, `total_war_pipeline`, `titan_marathon`, `batch_historical_backfill`, `fetch_and_adapt_euro_leagues` | none    |
+| `--target-scope-type`             | yes                                  | `match_id`, `league_season_date` | `all`, `bulk`, `production`, `league`, `season`, `full_source`                                                                                                  | none    |
+| `--target-match-id`               | when `scope_type=match_id`           | any non-empty string             | empty                                                                                                                                                           | none    |
+| `--target-league`                 | when `scope_type=league_season_date` | e.g. `EPL`                       | empty                                                                                                                                                           | none    |
+| `--target-season`                 | when `scope_type=league_season_date` | e.g. `2025-2026`                 | empty                                                                                                                                                           | none    |
+| `--target-date`                   | when `scope_type=league_season_date` | ISO date `YYYY-MM-DD`            | empty                                                                                                                                                           | none    |
+| `--terms-approval`                | yes                                  | `yes`, `no`                      | anything else                                                                                                                                                   | `no`    |
+| `--network-dry-run-authorization` | yes                                  | `yes`, `no`                      | anything else                                                                                                                                                   | `no`    |
+| `--allow-browser-runtime`         | yes                                  | `yes`, `no`                      | anything else                                                                                                                                                   | `no`    |
+| `--allow-proxy-runtime`           | yes                                  | `yes`, `no`                      | anything else                                                                                                                                                   | `no`    |
+| `--allow-external-network`        | yes                                  | `yes`, `no`                      | anything else                                                                                                                                                   | `no`    |
+| `--allow-staging-write`           | yes                                  | `yes`, `no`                      | anything else                                                                                                                                                   | `no`    |
+| `--confirm-single-target-scope`   | yes                                  | `yes` (must be `yes`)            | `no`, anything else                                                                                                                                             | `no`    |
+| `--commit`                        | n/a                                  | n/a                              | always blocked                                                                                                                                                  | blocked |
+
+---
+
+## 4. Guardrail Output
+
+All `would_*` fields are hardcoded to `false` in scaffold output:
+
+```json
+{
+    "would_execute_legacy_titan_discovery": false,
+    "would_execute_engine": false,
+    "would_access_network": false,
+    "would_launch_browser": false,
+    "would_use_proxy": false,
+    "would_write_staging": false,
+    "would_create_staging_directory": false,
+    "would_write_source_manifest": false,
+    "would_write_db": false,
+    "would_train": false,
+    "would_predict": false,
+    "would_bulk_harvest": false,
+    "would_spawn_child_process": false,
+    "commit_gate": "blocked"
+}
+```
+
+Guardrails enforced:
+
+1. `no_external_network`
+2. `no_browser_automation`
+3. `no_proxy_runtime_execution`
+4. `no_db_writes`
+5. `no_staging_writes`
+6. `no_legacy_runtime`
+7. `no_training`
+8. `no_prediction`
+
+---
+
+## 5. Blocked Commit Behavior
+
+The `--commit` flag is unconditionally blocked. The scaffold exits non-zero with:
+
+```
+BLOCKED: single-target acquisition runtime commit/execution is not wired in Phase 4.79D.
+```
+
+The Makefile `data-single-target-acquisition-runtime-commit` target is likewise blocked
+even when `CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`.
+
+---
+
+## 6. Why titan_discovery Legacy Runtime Remains Blocked
+
+The legacy `scripts/ops/titan_discovery.js` entrypoint remains blocked because:
+
+1. The current `--dry-run` flag is not propagated end-to-end to the service layer
+2. It may construct a DB pool via `DiscoveryService` constructor
+3. It may construct browser/proxy/network runtime via service wiring
+4. `FixtureRepository.persist` can write to `matches` table
+5. It defaults to all P0 leagues when no target is provided
+6. CLI flag propagation is not proven with no-network/no-db tests
+
+The `titan_discovery` engine family is registered as `adapter_candidate` in
+`config/acquisition_engines.phase454.json`, not as a canonical runtime. A future
+extracted discovery-only adapter must prove it does not write DB, launch browser,
+or access network before it can be used.
+
+---
+
+## 7. Test Coverage
+
+Tests: `tests/unit/single_target_acquisition_runtime_scaffold.test.js`
+
+Coverage includes validation for:
+
+- Missing `target_source` → exit non-zero
+- Missing `target_engine_family` → exit non-zero
+- Non-`titan_discovery` engine family → exit non-zero
+- Legacy engines (`run_production`, `recon_scanner`, `odds_harvest_pipeline`) → blocked
+- Forbidden scope types (`all`, `bulk`, `production`) → blocked
+- Missing scope-dependent fields → exit non-zero
+- `confirm_single_target_scope=no` → exit non-zero
+- Invalid yes/no values → exit non-zero
+- Valid `match_id` scaffold → exit 0, correct JSON output
+- Valid `league_season_date` scaffold → exit 0, correct JSON output
+- All `would_*` fields are `false` even when all authorization fields are `yes`
+- `--commit` → exit non-zero
+- Source code audit: no imports of `titan_discovery`, `DiscoveryService`, `pg`, `redis`, `playwright`, `axios`, `http`, `https`, `net`, `fs` write methods, `child_process`
+
+The tests prove zero runtime side effects through both unit tests on exported functions
+and subprocess integration tests.
+
+---
+
+## 8. Recommended Next Phase
+
+**Phase 4.80D**: Single-target acquisition staging artifact schema validator.
+
+This would define and validate:
+
+- Staging artifact JSON schema
+- Source manifest JSON schema
+- Provenance field requirements
+- sha256/hash verification
+- Row/object count requirements
+- Still no network, no DB writes, no staging writes
+
+Alternatively:
+
+**Phase 4.56A**: User provides explicit real source, engine, target, manifest, terms
+approval, and network authorization before executing a real network dry-run runbook.
+
+---
+
+## 9. Explicit Non-Execution Confirmation
+
+The following were **not** performed during Phase 4.79D:
+
+- DB writes (INSERT/UPDATE/DELETE/CREATE/ALTER/DROP/TRUNCATE/COPY)
+- Non-SELECT DB SQL
+- External downloads (curl/wget/git clone)
+- External football data access
+- External odds data access
+- Scraping
+- Browser automation
+- Proxy runtime execution
+- Harvest / ingest
+- Batch backfill
+- Network dry-run execution
+- Bulk harvest
+- Staging artifact write
+- Staging directory creation
+- Source manifest write
+- Packet file write
+- `pg_dump` / `pg_restore`
+- Model training
+- Real prediction execution
+- Model artifact loading
+- Docker volume cleanup (`docker system prune`, `docker volume prune`)
+- Force push
+- `git fetch --all`
+- `git pull`
+- `rm -rf`
+- File deletion
+- Coverage threshold modification
+- Test skipping
+- Test deletion
+- Gatekeeper bypass

--- a/scripts/ops/single_target_acquisition_runtime_scaffold.js
+++ b/scripts/ops/single_target_acquisition_runtime_scaffold.js
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.79D: Single-Target Acquisition Runtime Scaffold
+ *
+ * Scaffold-only command. Validates parameters and outputs a runtime plan preview.
+ * Does NOT access network, launch browser, use proxy, write DB, write staging,
+ * execute any acquisition engine, or spawn child processes.
+ */
+
+'use strict';
+
+const ALLOWED_ENGINE_FAMILIES = ['titan_discovery'];
+
+const FORBIDDEN_ENGINES = [
+    'run_production',
+    'recon_scanner',
+    'odds_harvest_pipeline',
+    'total_war_pipeline',
+    'titan_marathon',
+    'batch_historical_backfill',
+    'fetch_and_adapt_euro_leagues',
+];
+
+const ALLOWED_SCOPE_TYPES = ['match_id', 'league_season_date'];
+
+const FORBIDDEN_SCOPE_TYPES = ['all', 'bulk', 'production', 'league', 'season', 'full_source'];
+
+const YES_NO_FIELDS = [
+    'terms_approval',
+    'network_dry_run_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'confirm_single_target_scope',
+];
+
+/**
+ * Parse CLI arguments into a key/value map.
+ * Recognizes --key=value and --key value forms.
+ * --commit is captured as a boolean flag.
+ */
+function parseArgs(argv) {
+    const args = {};
+    const positional = [];
+
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--commit') {
+            args.commit = true;
+        } else if (a.startsWith('--')) {
+            const eq = a.indexOf('=');
+            if (eq !== -1) {
+                const key = a.slice(2, eq);
+                const val = a.slice(eq + 1);
+                args[key.replace(/-/g, '_')] = val;
+            } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+                args[a.slice(2).replace(/-/g, '_')] = argv[i + 1];
+                i++;
+            } else {
+                args[a.slice(2).replace(/-/g, '_')] = 'true';
+            }
+        } else {
+            positional.push(a);
+        }
+    }
+
+    return { args, positional };
+}
+
+function validateCommit(params, errors) {
+    if (params.commit) {
+        errors.push('BLOCKED: single-target acquisition runtime commit/execution is not wired in Phase 4.79D.');
+    }
+}
+
+function validateRequired(params, errors) {
+    if (!params.target_source) {
+        errors.push('ERROR: --target-source is required (e.g. fotmob).');
+    }
+    if (!params.target_engine_family) {
+        errors.push('ERROR: --target-engine-family is required. Allowed: titan_discovery.');
+    }
+    if (!params.target_scope_type) {
+        errors.push('ERROR: --target-scope-type is required. Allowed: match_id, league_season_date.');
+    }
+}
+
+function validateEngineFamily(params, errors) {
+    const f = params.target_engine_family;
+    if (!f) return;
+    if (FORBIDDEN_ENGINES.includes(f)) {
+        errors.push(`BLOCKED: engine family "${f}" is a forbidden legacy runtime. Allowed: titan_discovery.`);
+    }
+    if (!ALLOWED_ENGINE_FAMILIES.includes(f)) {
+        errors.push(`ERROR: unknown engine family "${f}". Allowed: titan_discovery.`);
+    }
+}
+
+function validateScopeType(params, errors) {
+    const s = params.target_scope_type;
+    if (!s) return;
+    if (FORBIDDEN_SCOPE_TYPES.includes(s)) {
+        errors.push(`BLOCKED: scope type "${s}" is forbidden. Allowed: match_id, league_season_date.`);
+    }
+    if (!ALLOWED_SCOPE_TYPES.includes(s)) {
+        errors.push(`ERROR: unknown scope type "${s}". Allowed: match_id, league_season_date.`);
+    }
+}
+
+function validateScopeDependent(params, errors) {
+    if (params.target_scope_type === 'match_id' && !params.target_match_id) {
+        errors.push('ERROR: --target-match-id is required when target_scope_type=match_id.');
+    }
+    if (params.target_scope_type === 'league_season_date') {
+        if (!params.target_league) {
+            errors.push('ERROR: --target-league is required when target_scope_type=league_season_date.');
+        }
+        if (!params.target_season) {
+            errors.push('ERROR: --target-season is required when target_scope_type=league_season_date.');
+        }
+        if (!params.target_date) {
+            errors.push('ERROR: --target-date is required when target_scope_type=league_season_date.');
+        }
+    }
+}
+
+function validateYesNoFields(params, errors) {
+    for (const field of YES_NO_FIELDS) {
+        const val = params[field];
+        if (val === undefined || val === '') {
+            errors.push(`ERROR: --${field.replace(/_/g, '-')} is required (yes or no).`);
+        } else if (val !== 'yes' && val !== 'no') {
+            errors.push(`ERROR: --${field.replace(/_/g, '-')} must be "yes" or "no", got "${val}".`);
+        }
+    }
+}
+
+function validateConfirmScope(params, errors) {
+    if (
+        params.confirm_single_target_scope === 'no' &&
+        !errors.some(e => e.includes('confirm-single-target-scope must be'))
+    ) {
+        errors.push('ERROR: --confirm-single-target-scope must be "yes" for a valid scaffold plan.');
+    }
+}
+
+/**
+ * Collect all validation errors. Returns an array of error message strings.
+ */
+function validate(params) {
+    const errors = [];
+    validateCommit(params, errors);
+    validateRequired(params, errors);
+    validateEngineFamily(params, errors);
+    validateScopeType(params, errors);
+    validateScopeDependent(params, errors);
+    validateYesNoFields(params, errors);
+    validateConfirmScope(params, errors);
+    return errors;
+}
+
+/**
+ * Build the scaffold output JSON.
+ */
+function buildOutput(params) {
+    return {
+        phase: 'PHASE4.79D_SINGLE_TARGET_ACQUISITION_RUNTIME_SCAFFOLD',
+        scaffold_only: true,
+        runtime_plan_created: true,
+        target_source: params.target_source || null,
+        target_engine_family: params.target_engine_family || null,
+        target_scope_type: params.target_scope_type || null,
+        single_target_scope_confirmed: params.confirm_single_target_scope === 'yes',
+        legacy_runtime_blocked: true,
+        would_execute_legacy_titan_discovery: false,
+        would_execute_engine: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_bulk_harvest: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: 'Phase 4.80D or explicit user-authorized network dry-run runbook',
+        guardrails: [
+            'no_external_network',
+            'no_browser_automation',
+            'no_proxy_runtime_execution',
+            'no_db_writes',
+            'no_staging_writes',
+            'no_legacy_runtime',
+            'no_training',
+            'no_prediction',
+        ],
+    };
+}
+
+/**
+ * Main entry point.
+ */
+function main() {
+    const { args } = parseArgs(process.argv.slice(2));
+
+    const errors = validate(args);
+    if (errors.length > 0) {
+        for (const e of errors) {
+            console.error(e);
+        }
+        process.exit(1);
+    }
+
+    const output = buildOutput(args);
+    console.log(JSON.stringify(output, null, 2));
+}
+
+// Only run when executed directly, not when required for testing.
+if (require.main === module) {
+    main();
+}
+
+// Export for unit test parity checks (no side effects).
+module.exports = {
+    parseArgs,
+    validate,
+    buildOutput,
+    ALLOWED_ENGINE_FAMILIES,
+    FORBIDDEN_ENGINES,
+    ALLOWED_SCOPE_TYPES,
+    FORBIDDEN_SCOPE_TYPES,
+};

--- a/tests/unit/single_target_acquisition_runtime_scaffold.test.js
+++ b/tests/unit/single_target_acquisition_runtime_scaffold.test.js
@@ -1,0 +1,758 @@
+/**
+ * Phase 4.79D: Single-Target Acquisition Runtime Scaffold Unit Tests
+ *
+ * Validates parameter validation, output structure, and proves no runtime side effects.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const child_process = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const SCRIPT = path.join(__dirname, '../../scripts/ops/single_target_acquisition_runtime_scaffold.js');
+
+// ---------------------------------------------------------------------------
+// Guard helpers: functions that must NOT be called by the scaffold.
+// These are NOT installed globally to avoid breaking the test runner itself.
+// Instead, we verify via source-code audit and subprocess execution.
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify the scaffold source does not import any forbidden module.
+ */
+function assertNoForbiddenImports(source) {
+    const forbidden = [
+        { pattern: /require\s*\(\s*['"](.*titan_discovery[^'"]*)['"]\s*\)/, name: 'titan_discovery' },
+        { pattern: /require\s*\(\s*['"](.*DiscoveryService[^'"]*)['"]\s*\)/, name: 'DiscoveryService' },
+        { pattern: /require\s*\(\s*['"](.*FixtureRepository[^'"]*)['"]\s*\)/, name: 'FixtureRepository' },
+        { pattern: /require\s*\(\s*['"](.*playwright[^'"]*)['"]\s*\)/i, name: 'Playwright' },
+        { pattern: /require\s*\(\s*['"]pg['"]\s*\)/, name: 'pg (node-postgres)' },
+        { pattern: /require\s*\(\s*['"]redis[^'"]*['"]\s*\)/, name: 'Redis' },
+        { pattern: /require\s*\(\s*['"]axios[^'"]*['"]\s*\)/, name: 'axios' },
+        { pattern: /require\s*\(\s*['"]node-fetch[^'"]*['"]\s*\)/, name: 'node-fetch' },
+    ];
+
+    for (const { pattern, name } of forbidden) {
+        assert.ok(!pattern.test(source), `scaffold must NOT import ${name}`);
+    }
+}
+
+/**
+ * Build CLI args array from an options object.
+ */
+function buildCliArgs(opts) {
+    const args = [];
+    for (const [key, val] of Object.entries(opts)) {
+        if (key === 'commit' && val) {
+            args.push('--commit');
+        } else {
+            args.push(`--${key.replace(/_/g, '-')}=${val}`);
+        }
+    }
+    return args;
+}
+
+/**
+ * Run scaffold as subprocess and return { stdout, stderr, exitCode }.
+ */
+function runScaffold(opts) {
+    const args = buildCliArgs(opts);
+    const result = child_process.spawnSync(process.execPath, [SCRIPT, ...args], {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: { ...process.env, NODE_ENV: 'test' },
+    });
+    return {
+        stdout: (result.stdout || '').trim(),
+        stderr: (result.stderr || '').trim(),
+        exitCode: result.status,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+    const { parseArgs } = require(SCRIPT);
+
+    it('parses --key=value pairs', () => {
+        const { args } = parseArgs(['--target-source=fotmob', '--terms-approval=yes']);
+        assert.strictEqual(args.target_source, 'fotmob');
+        assert.strictEqual(args.terms_approval, 'yes');
+    });
+
+    it('parses --key value form', () => {
+        const { args } = parseArgs(['--target-source', 'fotmob', '--target-match-id', 'm123']);
+        assert.strictEqual(args.target_source, 'fotmob');
+        assert.strictEqual(args.target_match_id, 'm123');
+    });
+
+    it('captures --commit as boolean flag', () => {
+        const { args } = parseArgs(['--commit', '--target-source=fotmob']);
+        assert.strictEqual(args.commit, true);
+    });
+
+    it('converts hyphens to underscores in keys', () => {
+        const { args } = parseArgs(['--target-source=fotmob']);
+        assert.strictEqual(args.target_source, 'fotmob');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: validate
+// ---------------------------------------------------------------------------
+
+describe('validate', () => {
+    const { validate } = require(SCRIPT);
+
+    // 1. missing target_source
+    it('fails when target_source is missing', () => {
+        const errors = validate({});
+        const found = errors.some(e => e.includes('target-source is required'));
+        assert.ok(found, 'should error on missing target_source');
+    });
+
+    // 2. missing target_engine_family
+    it('fails when target_engine_family is missing', () => {
+        const errors = validate({ target_source: 'fotmob' });
+        const found = errors.some(e => e.includes('target-engine-family is required'));
+        assert.ok(found, 'should error on missing target_engine_family');
+    });
+
+    // 3. non-titan_discovery engine family fails
+    it('fails when engine family is not titan_discovery', () => {
+        const errors = validate({ target_source: 'fotmob', target_engine_family: 'unknown_engine' });
+        const found = errors.some(e => e.includes('unknown engine family'));
+        assert.ok(found, 'should error on unknown engine family');
+    });
+
+    // 4. legacy engine run_production fails
+    it('fails when engine family is run_production (legacy)', () => {
+        const errors = validate({ target_source: 'fotmob', target_engine_family: 'run_production' });
+        const found = errors.some(e => e.includes('forbidden legacy runtime'));
+        assert.ok(found, 'should block run_production');
+    });
+
+    // 5. legacy engine recon_scanner fails
+    it('fails when engine family is recon_scanner (legacy)', () => {
+        const errors = validate({ target_source: 'fotmob', target_engine_family: 'recon_scanner' });
+        const found = errors.some(e => e.includes('forbidden legacy runtime'));
+        assert.ok(found, 'should block recon_scanner');
+    });
+
+    // 6. odds_harvest_pipeline fails
+    it('fails when engine family is odds_harvest_pipeline (forbidden)', () => {
+        const errors = validate({ target_source: 'fotmob', target_engine_family: 'odds_harvest_pipeline' });
+        const found = errors.some(e => e.includes('forbidden legacy runtime'));
+        assert.ok(found, 'should block odds_harvest_pipeline');
+    });
+
+    // 7. scope_type=all fails
+    it('fails when target_scope_type is "all"', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'all',
+        });
+        const found = errors.some(e => e.includes('forbidden'));
+        assert.ok(found, 'should block scope_type=all');
+    });
+
+    // 8. scope_type=bulk fails
+    it('fails when target_scope_type is "bulk"', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'bulk',
+        });
+        const found = errors.some(e => e.includes('forbidden'));
+        assert.ok(found, 'should block scope_type=bulk');
+    });
+
+    // 9. scope_type=production fails
+    it('fails when target_scope_type is "production"', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'production',
+        });
+        const found = errors.some(e => e.includes('forbidden'));
+        assert.ok(found, 'should block scope_type=production');
+    });
+
+    // 10. match_id scope missing target_match_id
+    it('fails when scope_type=match_id but target_match_id is missing', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+        });
+        const found = errors.some(e => e.includes('target-match-id is required'));
+        assert.ok(found, 'should error on missing target_match_id');
+    });
+
+    // 11. league_season_date scope missing target_league
+    it('fails when scope_type=league_season_date but target_league is missing', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'league_season_date',
+            target_season: '2025-2026',
+            target_date: '2026-05-09',
+        });
+        const found = errors.some(e => e.includes('target-league is required'));
+        assert.ok(found, 'should error on missing target_league');
+    });
+
+    // 12. league_season_date scope missing target_season
+    it('fails when scope_type=league_season_date but target_season is missing', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'league_season_date',
+            target_league: 'EPL',
+            target_date: '2026-05-09',
+        });
+        const found = errors.some(e => e.includes('target-season is required'));
+        assert.ok(found, 'should error on missing target_season');
+    });
+
+    // 13. league_season_date scope missing target_date
+    it('fails when scope_type=league_season_date but target_date is missing', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'league_season_date',
+            target_league: 'EPL',
+            target_season: '2025-2026',
+        });
+        const found = errors.some(e => e.includes('target-date is required'));
+        assert.ok(found, 'should error on missing target_date');
+    });
+
+    // 14. confirm_single_target_scope=no fails
+    it('fails when confirm_single_target_scope is "no"', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'sample-match-001',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'no',
+        });
+        const found = errors.some(e => e.includes('confirm-single-target-scope must be "yes"'));
+        assert.ok(found, 'should error on confirm_single_target_scope=no');
+    });
+
+    // 15. invalid yes/no field
+    it('fails when a yes/no field has an invalid value', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'sample-001',
+            terms_approval: 'invalid',
+        });
+        const found = errors.some(e => e.includes('must be "yes" or "no"'));
+        assert.ok(found, 'should error on invalid yes/no value');
+    });
+
+    // --commit blocked
+    it('fails when --commit flag is present', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'sample-001',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+            commit: true,
+        });
+        const found = errors.some(e => e.includes('commit/execution is not wired'));
+        assert.ok(found, 'should block --commit');
+    });
+
+    // 16. valid match_id scaffold succeeds
+    it('returns no errors for a valid match_id scaffold', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'sample-match-001',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(errors.length, 0, `unexpected errors: ${errors.join('; ')}`);
+    });
+
+    // 17. valid league_season_date scaffold succeeds
+    it('returns no errors for a valid league_season_date scaffold', () => {
+        const errors = validate({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'league_season_date',
+            target_league: 'EPL',
+            target_season: '2025-2026',
+            target_date: '2026-05-09',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(errors.length, 0, `unexpected errors: ${errors.join('; ')}`);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: buildOutput — all would_* are false regardless of yes fields
+// ---------------------------------------------------------------------------
+
+describe('buildOutput', () => {
+    const { buildOutput } = require(SCRIPT);
+
+    function assertAllWouldFalse(output) {
+        const falseFields = [
+            'would_execute_legacy_titan_discovery',
+            'would_execute_engine',
+            'would_access_network',
+            'would_launch_browser',
+            'would_use_proxy',
+            'would_write_staging',
+            'would_create_staging_directory',
+            'would_write_source_manifest',
+            'would_write_db',
+            'would_train',
+            'would_predict',
+            'would_bulk_harvest',
+            'would_spawn_child_process',
+        ];
+        for (const field of falseFields) {
+            assert.strictEqual(output[field], false, `${field} must be false in scaffold output`);
+        }
+    }
+
+    // 18. even with terms_approval=yes, would_access_network stays false
+    it('outputs would_access_network=false even when terms_approval=yes', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assertAllWouldFalse(output);
+        assert.strictEqual(output.would_access_network, false);
+        assert.strictEqual(output.commit_gate, 'blocked');
+    });
+
+    // 19. even with network_dry_run_authorization=yes, no network
+    it('outputs would_access_network=false even when network_dry_run_authorization=yes', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assertAllWouldFalse(output);
+        assert.strictEqual(output.would_access_network, false);
+    });
+
+    // 20. even with allow_browser_runtime=yes, no browser
+    it('outputs would_launch_browser=false even when allow_browser_runtime=yes', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assertAllWouldFalse(output);
+        assert.strictEqual(output.would_launch_browser, false);
+    });
+
+    // 21. even with allow_proxy_runtime=yes, no proxy
+    it('outputs would_use_proxy=false even when allow_proxy_runtime=yes', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assertAllWouldFalse(output);
+        assert.strictEqual(output.would_use_proxy, false);
+    });
+
+    // 22. even with allow_staging_write=yes, no staging write
+    it('outputs would_write_staging=false even when allow_staging_write=yes', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'yes',
+            confirm_single_target_scope: 'yes',
+        });
+        assertAllWouldFalse(output);
+        assert.strictEqual(output.would_write_staging, false);
+    });
+
+    // 23-28: explicit would_* false checks
+    it('outputs would_execute_legacy_titan_discovery=false', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(output.would_execute_legacy_titan_discovery, false);
+    });
+
+    it('outputs would_write_db=false', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(output.would_write_db, false);
+    });
+
+    it('outputs would_write_staging=false', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(output.would_write_staging, false);
+    });
+
+    it('outputs would_execute_engine=false', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(output.would_execute_engine, false);
+    });
+
+    it('outputs commit_gate=blocked', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(output.commit_gate, 'blocked');
+    });
+
+    it('outputs scaffold_only=true and runtime_plan_created=true', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(output.scaffold_only, true);
+        assert.strictEqual(output.runtime_plan_created, true);
+    });
+
+    it('includes all 8 guardrails', () => {
+        const output = buildOutput({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'm1',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(output.guardrails.length, 8);
+        assert.ok(output.guardrails.includes('no_external_network'));
+        assert.ok(output.guardrails.includes('no_browser_automation'));
+        assert.ok(output.guardrails.includes('no_proxy_runtime_execution'));
+        assert.ok(output.guardrails.includes('no_db_writes'));
+        assert.ok(output.guardrails.includes('no_staging_writes'));
+        assert.ok(output.guardrails.includes('no_legacy_runtime'));
+        assert.ok(output.guardrails.includes('no_training'));
+        assert.ok(output.guardrails.includes('no_prediction'));
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: scaffold as subprocess
+// ---------------------------------------------------------------------------
+
+describe('scaffold CLI (subprocess)', () => {
+    // 16. valid match_id scaffold success
+    it('exits 0 and outputs valid JSON for match_id scaffold', () => {
+        const result = runScaffold({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'sample-match-001',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.scaffold_only, true);
+        assert.strictEqual(parsed.would_access_network, false);
+        assert.strictEqual(parsed.would_write_db, false);
+        assert.strictEqual(parsed.would_write_staging, false);
+        assert.strictEqual(parsed.commit_gate, 'blocked');
+    });
+
+    // 17. valid league_season_date scaffold success
+    it('exits 0 and outputs valid JSON for league_season_date scaffold', () => {
+        const result = runScaffold({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'league_season_date',
+            target_league: 'EPL',
+            target_season: '2025-2026',
+            target_date: '2026-05-09',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.target_scope_type, 'league_season_date');
+        assert.strictEqual(parsed.would_access_network, false);
+    });
+
+    // --commit blocked in CLI
+    it('exits non-zero when --commit is passed', () => {
+        const result = runScaffold({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'sample-match-001',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+            commit: true,
+        });
+        assert.notStrictEqual(result.exitCode, 0, 'should exit non-zero for --commit');
+        assert.ok(
+            result.stderr.includes('commit/execution is not wired'),
+            `stderr should mention blocked commit: ${result.stderr}`
+        );
+    });
+
+    // missing required field fails
+    it('exits non-zero when target_source is missing', () => {
+        const result = runScaffold({});
+        assert.notStrictEqual(result.exitCode, 0, 'should exit non-zero');
+        assert.ok(result.stderr.includes('target-source'), `stderr: ${result.stderr}`);
+    });
+
+    // Invalid scope type fails
+    it('exits non-zero when scope_type is "all"', () => {
+        const result = runScaffold({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'all',
+            target_match_id: 'sample-match-001',
+            terms_approval: 'no',
+            network_dry_run_authorization: 'no',
+            allow_browser_runtime: 'no',
+            allow_proxy_runtime: 'no',
+            allow_external_network: 'no',
+            allow_staging_write: 'no',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.notStrictEqual(result.exitCode, 0, 'should exit non-zero for scope=all');
+    });
+
+    // all yes fields still produce would_* false
+    it('outputs all would_* false even when all yes/no fields are yes', () => {
+        const result = runScaffold({
+            target_source: 'fotmob',
+            target_engine_family: 'titan_discovery',
+            target_scope_type: 'match_id',
+            target_match_id: 'sample-match-001',
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            confirm_single_target_scope: 'yes',
+        });
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.would_access_network, false);
+        assert.strictEqual(parsed.would_launch_browser, false);
+        assert.strictEqual(parsed.would_use_proxy, false);
+        assert.strictEqual(parsed.would_write_staging, false);
+        assert.strictEqual(parsed.would_write_db, false);
+        assert.strictEqual(parsed.would_execute_engine, false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Source-code audit: no forbidden imports, no side effects
+// ---------------------------------------------------------------------------
+
+describe('source-code side-effect audit', () => {
+    const source = fs.readFileSync(SCRIPT, 'utf8');
+
+    // 29. no titan_discovery import
+    it('does not import or reference titan_discovery module', () => {
+        assertNoForbiddenImports(source);
+    });
+
+    // 30. no child_process
+    it('does not import child_process', () => {
+        assert.ok(!/require\s*\(\s*['"]child_process['"]\s*\)/.test(source), 'must not import child_process');
+    });
+
+    // 31-34: no fs writes, no mkdir, no network, no DB
+    it('does not import fs write methods', () => {
+        assert.ok(
+            !/fs\.writeFileSync|fs\.writeFile|fs\.createWriteStream/.test(source),
+            'must not import fs write methods'
+        );
+        assert.ok(!/fs\.mkdirSync|fs\.mkdir/.test(source), 'must not import fs mkdir methods');
+    });
+
+    it('does not import http/https modules', () => {
+        assert.ok(!/require\s*\(\s*['"]https?['"]\s*\)/.test(source), 'must not import http or https');
+    });
+
+    it('does not import net module', () => {
+        assert.ok(!/require\s*\(\s*['"]net['"]\s*\)/.test(source), 'must not import net module');
+    });
+
+    it('does not import pg module', () => {
+        assert.ok(!/require\s*\(\s*['"]pg['"]\s*\)/.test(source), 'must not import pg');
+    });
+
+    it('does not import redis module', () => {
+        assert.ok(!/require\s*\(\s*['"]redis/.test(source), 'must not import redis');
+    });
+
+    it('does not import playwright', () => {
+        assert.ok(!/require\s*\(\s*['"]playwright/.test(source), 'must not import playwright');
+    });
+
+    it('does not import fetch/axios', () => {
+        assert.ok(!/require\s*\(\s*['"]axios/.test(source), 'must not import axios');
+        assert.ok(!/require\s*\(\s*['"]node-fetch/.test(source), 'must not import node-fetch');
+    });
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.79D single-target acquisition runtime scaffold.

Scope:
- Adds scaffold-only single-target acquisition runtime command
- Validates target source, engine family, target scope, and authorization fields
- Keeps titan_discovery legacy runtime blocked
- Keeps commit/execution path blocked
- Adds Makefile scaffold and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.79D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No staging writes
- No source manifest writes
- No packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- scaffold missing params failed as expected
- valid scaffold returned would_access_network=false
- valid scaffold returned would_write_db=false
- valid scaffold returned would_write_staging=false
- commit gate remained blocked
- unit tests passed (49/49)
- npm test passed
- npm run test:coverage passed
- integration tests passed (19 pass, 5 skipped)
- DB row counts unchanged (2/2/2/2/2/2)
- l1-config residue absent
- eslint / prettier / git diff --check passed