### PR TITLE
feat(data): add single-target staging schema validator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB 查重、不写 DB、不训练、不预测的 `make data-football-data-duplicate-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB schema / duplicate 查询、不写 DB、不训练、不预测的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 不触网、不启动 browser、不执行 proxy runtime、不写 staging、不写 manifest、不写 DB、不运行 titan_discovery legacy runtime 的 scaffold-only 参数校验和 plan preview：`make data-single-target-acquisition-runtime-scaffold TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> ...`（Phase 4.79D scaffold-only）
+- 不触网、不写文件、只读本地 schema 和 sample fixture 的 staging artifact / manifest candidate schema 校验：`make data-single-target-acquisition-staging-schema-validate ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path>`（Phase 4.80D local-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -293,6 +294,8 @@ AI / Codex 不能直接执行：
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `make data-single-target-acquisition-runtime-commit`
 - `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
+- `make data-single-target-acquisition-staging-schema-commit`
+- `make data-single-target-acquisition-staging-schema-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
 - `make data-finished-csv-commit`
 - `make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1`
@@ -518,6 +521,8 @@ AI / Codex 默认禁止：
 - `make data-single-target-network-commit CONFIRM_SINGLE_TARGET_NETWORK=1`
 - `make data-single-target-acquisition-runtime-commit`
 - `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
+- `make data-single-target-acquisition-staging-schema-commit`
+- `make data-single-target-acquisition-staging-schema-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
 - `node scripts/ops/run_production.js`
 - `node scripts/ops/titan_discovery.js`
@@ -571,6 +576,36 @@ AI / Codex 默认禁止：
 - `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
 - `node scripts/ops/single_target_acquisition_runtime_scaffold.js --commit`
 - 以及上述所有禁止的 legacy / high-risk 命令
+
+### Phase 4.80D: single-target acquisition staging schema validator
+
+`data-single-target-acquisition-staging-schema-validate` 只允许本地 schema / sample fixture 校验：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 DB
+- sample fixture 不等于真实 staging artifact
+- schema validator 不等于 staging write authorization
+- source manifest candidate 不等于 DB write authorization
+
+`data-single-target-acquisition-staging-schema-commit` 当前 blocked。
+
+真实 staging write 必须后续单独阶段、用户明确授权。
+
+在 Phase 4.80D 中允许：
+
+- `make data-single-target-acquisition-staging-schema-validate ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path>`
+- `node scripts/ops/single_target_acquisition_staging_schema_validator.js --artifact-schema=... --artifact=...`
+
+在 Phase 4.80D 中严格禁止：
+
+- `make data-single-target-acquisition-staging-schema-commit`
+- `make data-single-target-acquisition-staging-schema-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1`
+- `node scripts/ops/single_target_acquisition_staging_schema_validator.js --commit`
 
 相关背景见：`docs/_reports/ACQUISITION_ENGINE_READINESS_PHASE4_53A.md`、`docs/_reports/REAL_DATA_SOURCE_STRATEGY_PHASE4_51.md` 和 `docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md`
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-single-target-network-dry-run data-single-target-network-commit \
         data-single-target-acquisition-runtime-scaffold data-single-target-acquisition-runtime-commit \
+        data-single-target-acquisition-staging-schema-validate data-single-target-acquisition-staging-schema-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -331,6 +332,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-network-commit ENGINE=<engine> TARGET_MATCH_ID=<id> SOURCE_MANIFEST=<path> CONFIRM_SINGLE_TARGET_NETWORK=1  # blocked in Phase 4.54"
 	@echo "  make data-single-target-acquisition-runtime-scaffold TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> ...  # scaffold-only, Phase 4.79D"
 	@echo "  make data-single-target-acquisition-runtime-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1  # blocked in Phase 4.79D"
+	@echo "  make data-single-target-acquisition-staging-schema-validate ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path>  # local-only, Phase 4.80D"
+	@echo "  make data-single-target-acquisition-staging-schema-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1  # blocked in Phase 4.80D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -871,6 +874,24 @@ data-single-target-acquisition-runtime-commit: ## Blocked single-target acquisit
 	@echo "BLOCKED: single-target acquisition runtime commit/execution is not wired in Phase 4.79D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1, this path remains blocked."
 	@echo "  Real network dry-run requires a separate future phase with explicit source/target/terms/network/staging authorization."
+	@exit 1
+
+data-single-target-acquisition-staging-schema-validate: ## Local-only staging artifact / manifest schema validation. Phase 4.80D. Requires ARTIFACT_SCHEMA, MANIFEST_SCHEMA, ARTIFACT, MANIFEST (at least one pair).
+	@if [ -z "$(ARTIFACT_SCHEMA)" ] && [ -z "$(MANIFEST_SCHEMA)" ]; then \
+		echo "ERROR: provide at least one pair: ARTIFACT_SCHEMA=<path> + ARTIFACT=<path> and/or MANIFEST_SCHEMA=<path> + MANIFEST=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.80D: staging schema validator (local-only, no network, no DB, no staging writes)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/single_target_acquisition_staging_schema_validator.js \
+		$(if $(ARTIFACT_SCHEMA),--artifact-schema "$(ARTIFACT_SCHEMA)") \
+		$(if $(MANIFEST_SCHEMA),--manifest-schema "$(MANIFEST_SCHEMA)") \
+		$(if $(ARTIFACT),--artifact "$(ARTIFACT)") \
+		$(if $(MANIFEST),--manifest "$(MANIFEST)")
+
+data-single-target-acquisition-staging-schema-commit: ## Blocked staging schema commit gate. Remains not wired in Phase 4.80D.
+	@echo "BLOCKED: single-target acquisition staging schema commit/execution is not wired in Phase 4.80D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1, this path remains blocked."
+	@echo "  Real staging write requires a separate future phase with explicit source/target/terms/network/staging authorization."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA_VALIDATOR_PHASE4_80D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA_VALIDATOR_PHASE4_80D.md
@@ -1,0 +1,250 @@
+# Phase 4.80D: Single-Target Acquisition Staging Schema Validator
+
+**Date**: 2026-05-10
+**Status**: Complete (validator-only)
+**Previous phase**: Phase 4.79D — Single-Target Acquisition Runtime Scaffold
+**Next recommended phase**: Phase 4.81D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.80D is a **schema validator** phase. It defines the JSON schemas for future
+single-target acquisition staging artifacts and source manifest candidates, and provides
+a local-only validator to verify sample fixtures against those schemas.
+
+The validator:
+
+- Reads schema files and data files from the local filesystem
+- Validates JSON structure, required fields, type constraints, enum/const values
+- Outputs a JSON summary to stdout
+- Does NOT access network, launch browser, use proxy, write files, write DB,
+  execute engines, or spawn child processes
+
+Sample fixtures are test assets only — they are NOT real staging artifacts.
+
+---
+
+## 2. Implemented Files
+
+### Schemas
+
+```
+schemas/acquisition/single_target_staging_artifact.schema.json
+schemas/acquisition/source_manifest_candidate.schema.json
+```
+
+### Validator
+
+```
+scripts/ops/single_target_acquisition_staging_schema_validator.js
+```
+
+### Test Fixtures (sample only, not real staging data)
+
+```
+tests/fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json
+tests/fixtures/acquisition/sample_source_manifest_candidate_phase480d.json
+```
+
+### Tests
+
+```
+tests/unit/single_target_acquisition_staging_schema_validator.test.js
+```
+
+### Makefile Targets
+
+```
+make data-single-target-acquisition-staging-schema-validate    (local-only, Phase 4.80D)
+make data-single-target-acquisition-staging-schema-commit      (blocked, Phase 4.80D)
+```
+
+### Documentation
+
+```
+AGENTS.md (updated)
+docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA_VALIDATOR_PHASE4_80D.md
+```
+
+---
+
+## 3. Staging Artifact Schema
+
+The staging artifact schema defines the structure for future single-target acquisition
+network dry-run output.
+
+### Required top-level fields
+
+| Field              | Type   | Description                                    |
+| ------------------ | ------ | ---------------------------------------------- |
+| `artifact_version` | string | Schema version                                 |
+| `phase`            | string | Acquisition phase                              |
+| `source`           | object | Source metadata (name, source_url required)    |
+| `target_scope`     | object | Target scope (scope_type required)             |
+| `engine`           | object | Engine family (must be `titan_discovery`)      |
+| `runtime`          | object | Browser/proxy/network config                   |
+| `capture`          | object | Capture metadata (raw_payload_sha256 required) |
+| `provenance`       | object | Provenance (captured_at required)              |
+| `safety`           | object | Safety flags (all must be false)               |
+| `outputs`          | object | Output paths                                   |
+
+### Key constraints
+
+- `source.name` required
+- `source.source_url` required
+- `target_scope.scope_type` must be `match_id` or `league_season_date`
+- `engine.family` must be `titan_discovery`
+- `safety.would_write_db` must be `false`
+- `safety.would_train` must be `false`
+- `safety.would_predict` must be `false`
+- `safety.bulk_scope` must be `false`
+- If `scope_type=match_id`, `match_id` is required
+- If `scope_type=league_season_date`, `league`, `season`, `date` are required
+- No additional properties allowed on core objects
+
+---
+
+## 4. Source Manifest Candidate Schema
+
+The source manifest candidate schema defines the structure for a manifest derived
+from a staging artifact. It documents data provenance and licensing.
+
+### Key constraints
+
+- `manifest_status` must be `candidate_not_approved`
+- `approval_status` must be `not_approved`
+- `engine_family` must be `titan_discovery`
+- `safety.approved_for_db_write` must be `false`
+- `safety.approved_for_training` must be `false`
+- `safety.approved_for_prediction` must be `false`
+
+**Critical**: A manifest candidate does NOT authorize DB writes, training, or
+prediction. Human review and separate authorization are required for any status change.
+
+---
+
+## 5. Validator Behavior
+
+- **local-only**: reads schema and data files from the filesystem
+- **read-only**: does not write any files, create directories, or modify state
+- **no network**: does not import http/https/net, does not make network requests
+- **no DB**: does not import pg, does not connect to any database
+- **no child process**: does not spawn subprocesses
+- **commit gate blocked**: `--commit` exits non-zero unconditionally
+
+### CLI examples
+
+```bash
+# Full validation (artifact + manifest)
+node scripts/ops/single_target_acquisition_staging_schema_validator.js \
+  --artifact-schema=schemas/acquisition/single_target_staging_artifact.schema.json \
+  --manifest-schema=schemas/acquisition/source_manifest_candidate.schema.json \
+  --artifact=tests/fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json \
+  --manifest=tests/fixtures/acquisition/sample_source_manifest_candidate_phase480d.json
+
+# Artifact-only
+node scripts/ops/single_target_acquisition_staging_schema_validator.js \
+  --artifact-schema=schemas/acquisition/single_target_staging_artifact.schema.json \
+  --artifact=tests/fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json
+
+# Via Makefile
+make data-single-target-acquisition-staging-schema-validate \
+  ARTIFACT_SCHEMA=schemas/acquisition/single_target_staging_artifact.schema.json \
+  MANIFEST_SCHEMA=schemas/acquisition/source_manifest_candidate.schema.json \
+  ARTIFACT=tests/fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json \
+  MANIFEST=tests/fixtures/acquisition/sample_source_manifest_candidate_phase480d.json
+```
+
+---
+
+## 6. Test Coverage
+
+Tests: `tests/unit/single_target_acquisition_staging_schema_validator.test.js`
+
+Coverage includes:
+
+- Missing schema paths → failure
+- Invalid JSON schema/data → failure
+- Valid artifact → success
+- Valid manifest → success
+- Artifact + manifest combined → success
+- Missing required fields (source.name, target_scope, etc.) → failure
+- Forbidden scope_type (bulk) → failure
+- Scope-dependent field requirements → failure
+- Non-titan_discovery engine → failure
+- Safety flags set to true → failure
+- Manifest status/approval violations → failure
+- `--commit` blocked → failure
+- Source code audit: no forbidden imports
+- Integration tests: subprocess CLI validation
+- All `would_*` output fields verified false
+
+---
+
+## 7. Relationship to Phase 4.79D
+
+| Phase | Purpose                                                                    | Status   |
+| ----- | -------------------------------------------------------------------------- | -------- |
+| 4.79D | Parameter scaffold — validates input parameters for future runtime         | Complete |
+| 4.80D | Schema validator — validates output structure for future staging artifacts | Complete |
+
+Both phases are **non-executing**:
+
+- Neither accesses network
+- Neither writes DB
+- Neither writes staging
+- Neither equals real network dry-run authorization
+- Neither equals staging write authorization
+
+---
+
+## 8. Recommended Next Phase
+
+**Phase 4.81D**: Single-target acquisition staging artifact writer preflight.
+
+Goal: Define the preflight checks that would run before any real staging write,
+while still not creating directories, not writing files, not accessing network,
+and not writing DB.
+
+Alternatively:
+
+**Phase 4.56A**: User provides explicit real source, engine, target, manifest,
+terms approval, and network authorization before executing a real network
+dry-run runbook.
+
+---
+
+## 9. Explicit Non-Execution Confirmation
+
+The following were **not** performed during Phase 4.80D:
+
+- DB writes (INSERT/UPDATE/DELETE/CREATE/ALTER/DROP/TRUNCATE/COPY)
+- Non-SELECT DB SQL
+- External downloads (curl/wget/git clone)
+- External football data access
+- External odds data access
+- Scraping
+- Browser automation
+- Proxy runtime execution
+- Harvest / ingest
+- Batch backfill
+- Network dry-run execution
+- Bulk harvest
+- Runtime staging artifact write
+- Runtime source manifest write
+- Packet file write
+- `pg_dump` / `pg_restore`
+- Model training
+- Real prediction execution
+- Model artifact loading
+- Docker volume cleanup (`docker system prune`, `docker volume prune`)
+- Force push
+- `git fetch --all`
+- `git pull`
+- `rm -rf`
+- File deletion
+- Coverage threshold modification
+- Test skipping
+- Test deletion
+- Gatekeeper bypass

--- a/schemas/acquisition/single_target_staging_artifact.schema.json
+++ b/schemas/acquisition/single_target_staging_artifact.schema.json
@@ -1,0 +1,193 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://football-prediction.local/schemas/acquisition/single_target_staging_artifact.schema.json",
+    "title": "Single-Target Acquisition Staging Artifact",
+    "description": "Phase 4.80D: Schema for a future single-target acquisition network dry-run staging artifact. This is a validator-only schema; no real staging artifact has been written.",
+    "type": "object",
+    "required": [
+        "artifact_version",
+        "phase",
+        "source",
+        "target_scope",
+        "engine",
+        "runtime",
+        "capture",
+        "provenance",
+        "safety",
+        "outputs"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "artifact_version": {
+            "type": "string",
+            "description": "Schema version for the artifact structure."
+        },
+        "phase": {
+            "type": "string",
+            "description": "Acquisition phase this artifact was produced under."
+        },
+        "source": {
+            "type": "object",
+            "required": ["name", "source_url"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Source name (e.g. fotmob)."
+                },
+                "source_url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "terms_url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "license_url": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            }
+        },
+        "target_scope": {
+            "type": "object",
+            "required": ["scope_type"],
+            "additionalProperties": false,
+            "properties": {
+                "scope_type": {
+                    "type": "string",
+                    "enum": ["match_id", "league_season_date"]
+                },
+                "match_id": {
+                    "type": "string"
+                },
+                "league": {
+                    "type": ["string", "null"]
+                },
+                "season": {
+                    "type": ["string", "null"]
+                },
+                "date": {
+                    "type": ["string", "null"]
+                }
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": { "scope_type": { "const": "match_id" } }
+                    },
+                    "then": {
+                        "required": ["match_id"]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "scope_type": { "const": "league_season_date" } }
+                    },
+                    "then": {
+                        "required": ["league", "season", "date"]
+                    }
+                }
+            ]
+        },
+        "engine": {
+            "type": "object",
+            "required": ["family"],
+            "additionalProperties": false,
+            "properties": {
+                "family": {
+                    "type": "string",
+                    "const": "titan_discovery"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "runtime": {
+            "type": "object",
+            "required": ["browser", "proxy", "network"],
+            "additionalProperties": false,
+            "properties": {
+                "browser": {
+                    "type": "object",
+                    "required": ["enabled"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": { "type": "boolean" },
+                        "provider": { "type": ["string", "null"] },
+                        "headless": { "type": "boolean" }
+                    }
+                },
+                "proxy": {
+                    "type": "object",
+                    "required": ["enabled"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": { "type": "boolean" },
+                        "provider": { "type": ["string", "null"] },
+                        "lease_id": { "type": ["string", "null"] }
+                    }
+                },
+                "network": {
+                    "type": "object",
+                    "required": ["requested_at"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "requested_at": { "type": "string", "format": "date-time" },
+                        "completed_at": { "type": "string", "format": "date-time" },
+                        "duration_ms": { "type": "integer" },
+                        "rate_limit_policy": { "type": "string" },
+                        "retry_policy": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "capture": {
+            "type": "object",
+            "required": ["raw_payload_sha256"],
+            "additionalProperties": false,
+            "properties": {
+                "raw_payload_sha256": { "type": "string" },
+                "raw_payload_bytes": { "type": "integer" },
+                "content_type": { "type": "string" },
+                "status_code": { "type": "integer" },
+                "row_count": { "type": "integer" },
+                "object_count": { "type": "integer" }
+            }
+        },
+        "provenance": {
+            "type": "object",
+            "required": ["captured_at"],
+            "additionalProperties": false,
+            "properties": {
+                "captured_by": { "type": "string" },
+                "captured_at": { "type": "string", "format": "date-time" },
+                "command": { "type": "string" },
+                "git_commit": { "type": "string" },
+                "container_image": { "type": "string" }
+            }
+        },
+        "safety": {
+            "type": "object",
+            "required": ["would_write_db", "would_train", "would_predict", "bulk_scope"],
+            "additionalProperties": false,
+            "properties": {
+                "would_write_db": { "type": "boolean", "const": false },
+                "would_train": { "type": "boolean", "const": false },
+                "would_predict": { "type": "boolean", "const": false },
+                "bulk_scope": { "type": "boolean", "const": false },
+                "post_match_leakage_checked": { "type": "boolean" }
+            }
+        },
+        "outputs": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "raw_payload_path": { "type": ["string", "null"] },
+                "normalized_preview_path": { "type": ["string", "null"] },
+                "manifest_candidate_path": { "type": ["string", "null"] }
+            }
+        }
+    }
+}

--- a/schemas/acquisition/source_manifest_candidate.schema.json
+++ b/schemas/acquisition/source_manifest_candidate.schema.json
@@ -1,0 +1,108 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://football-prediction.local/schemas/acquisition/source_manifest_candidate.schema.json",
+    "title": "Source Manifest Candidate",
+    "description": "Phase 4.80D: Schema for a source manifest candidate derived from a staging artifact. This is a validator-only schema; manifest candidate is NOT a DB write authorization.",
+    "type": "object",
+    "required": [
+        "manifest_version",
+        "manifest_status",
+        "source_name",
+        "source_url",
+        "allowed_use",
+        "engine_family",
+        "target_scope",
+        "original_payload_sha256",
+        "approval_status",
+        "safety"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "manifest_version": {
+            "type": "string",
+            "description": "Schema version for the manifest structure."
+        },
+        "manifest_status": {
+            "type": "string",
+            "const": "candidate_not_approved",
+            "description": "All manifests start as candidate_not_approved; human review is required for any status change."
+        },
+        "source_name": {
+            "type": "string"
+        },
+        "source_url": {
+            "type": "string",
+            "format": "uri"
+        },
+        "terms_url": {
+            "type": "string",
+            "format": "uri"
+        },
+        "license_url": {
+            "type": "string",
+            "format": "uri"
+        },
+        "allowed_use": {
+            "type": "string"
+        },
+        "downloaded_by": {
+            "type": "string"
+        },
+        "downloaded_at": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "engine_family": {
+            "type": "string",
+            "const": "titan_discovery"
+        },
+        "engine_version": {
+            "type": "string"
+        },
+        "target_scope": {
+            "type": "object",
+            "required": ["scope_type"],
+            "additionalProperties": false,
+            "properties": {
+                "scope_type": {
+                    "type": "string",
+                    "enum": ["match_id", "league_season_date"]
+                },
+                "match_id": { "type": "string" },
+                "league": { "type": ["string", "null"] },
+                "season": { "type": ["string", "null"] },
+                "date": { "type": ["string", "null"] }
+            }
+        },
+        "original_payload_sha256": {
+            "type": "string"
+        },
+        "row_count": {
+            "type": "integer"
+        },
+        "object_count": {
+            "type": "integer"
+        },
+        "staging_artifact_path": {
+            "type": ["string", "null"]
+        },
+        "approval_status": {
+            "type": "string",
+            "const": "not_approved",
+            "description": "Must be not_approved; DB write requires separate authorization."
+        },
+        "human_approval_note": {
+            "type": ["string", "null"]
+        },
+        "safety": {
+            "type": "object",
+            "required": ["approved_for_db_write", "approved_for_training", "approved_for_prediction"],
+            "additionalProperties": false,
+            "properties": {
+                "approved_for_db_write": { "type": "boolean", "const": false },
+                "approved_for_training": { "type": "boolean", "const": false },
+                "approved_for_prediction": { "type": "boolean", "const": false }
+            }
+        }
+    }
+}

--- a/scripts/ops/single_target_acquisition_staging_schema_validator.js
+++ b/scripts/ops/single_target_acquisition_staging_schema_validator.js
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.80D: Single-Target Acquisition Staging Schema Validator
+ *
+ * Validates sample staging artifacts and source manifest candidates against
+ * their respective JSON schemas. Read-only, local-only, no network, no DB,
+ * no file writes, no child processes.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Minimal JSON Schema validator helpers
+// ---------------------------------------------------------------------------
+
+function checkType(instance, schema, p) {
+    const errors = [];
+    if (!schema.type) return errors;
+
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const instanceType = Array.isArray(instance) ? 'array' : typeof instance;
+    const ok = types.some(t => {
+        if (t === 'integer') return Number.isInteger(instance);
+        if (t === 'null') return instance === null;
+        return instanceType === t;
+    });
+    if (!ok) {
+        errors.push(`${p}: expected type ${types.join('|')}, got ${instance === null ? 'null' : instanceType}`);
+    }
+    return errors;
+}
+
+function checkEnumConst(instance, schema, p) {
+    const errors = [];
+    if (schema.enum && !schema.enum.includes(instance)) {
+        errors.push(`${p}: value "${instance}" not in enum [${schema.enum.join(', ')}]`);
+    }
+    if (schema.const !== undefined && instance !== schema.const) {
+        errors.push(`${p}: must be ${JSON.stringify(schema.const)}, got ${JSON.stringify(instance)}`);
+    }
+    return errors;
+}
+
+function checkFormat(instance, schema, p) {
+    const errors = [];
+    if (typeof instance !== 'string') return errors;
+
+    if (schema.format === 'date-time' && isNaN(Date.parse(instance))) {
+        errors.push(`${p}: invalid date-time format "${instance}"`);
+    }
+    if (schema.format === 'uri' && !instance.includes('://') && !instance.startsWith('/')) {
+        errors.push(`${p}: invalid uri format "${instance}"`);
+    }
+    return errors;
+}
+
+function checkAdditionalProps(instance, schema, p) {
+    const errors = [];
+    if (schema.additionalProperties === false && schema.properties) {
+        for (const key of Object.keys(instance)) {
+            if (!(key in schema.properties)) {
+                errors.push(`${p}.${key}: additional property not allowed`);
+            }
+        }
+    }
+    return errors;
+}
+
+function checkRequired(instance, schema, p) {
+    const errors = [];
+    if (schema.required) {
+        for (const req of schema.required) {
+            if (!(req in instance)) {
+                errors.push(`${p}.${req}: required field missing`);
+            }
+        }
+    }
+    return errors;
+}
+
+function checkProperties(instance, schema, p) {
+    const errors = [];
+    if (schema.properties) {
+        for (const [key, propSchema] of Object.entries(schema.properties)) {
+            if (key in instance) {
+                errors.push(...validateAgainstSchema(instance[key], propSchema, `${p}.${key}`));
+            }
+        }
+    }
+    return errors;
+}
+
+function checkAllOf(instance, schema, p) {
+    const errors = [];
+    if (schema.allOf) {
+        for (const sub of schema.allOf) {
+            if (sub.if && sub.then) {
+                const ifErrors = validateAgainstSchema(instance, sub.if, `${p}(if)`);
+                if (ifErrors.length === 0) {
+                    errors.push(...validateAgainstSchema(instance, sub.then, `${p}(then)`));
+                }
+            }
+        }
+    }
+    return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Main schema validator entry point
+// ---------------------------------------------------------------------------
+
+function validateAgainstSchema(instance, schema, basePath) {
+    const p = basePath || '$';
+    if (!schema || typeof schema !== 'object') return [];
+
+    const errors = [];
+    errors.push(...checkType(instance, schema, p));
+    if (instance === null || instance === undefined) return errors;
+
+    errors.push(...checkEnumConst(instance, schema, p));
+    errors.push(...checkFormat(instance, schema, p));
+
+    if (schema.type === 'object' && typeof instance === 'object' && !Array.isArray(instance)) {
+        errors.push(...checkAdditionalProps(instance, schema, p));
+        errors.push(...checkRequired(instance, schema, p));
+        errors.push(...checkProperties(instance, schema, p));
+        errors.push(...checkAllOf(instance, schema, p));
+    }
+
+    return errors;
+}
+
+// ---------------------------------------------------------------------------
+// File read helpers
+// ---------------------------------------------------------------------------
+
+function readJsonFile(filePath) {
+    try {
+        const raw = fs.readFileSync(filePath, 'utf8');
+        return { data: JSON.parse(raw), error: null };
+    } catch (e) {
+        return { data: null, error: e.message };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Artifact-specific extra checks
+// ---------------------------------------------------------------------------
+
+function checkArtifactSafety(data, errors) {
+    if (!data.safety) return;
+    if (data.safety.would_write_db !== false) errors.push('artifact safety.would_write_db must be false');
+    if (data.safety.would_train !== false) errors.push('artifact safety.would_train must be false');
+    if (data.safety.would_predict !== false) errors.push('artifact safety.would_predict must be false');
+    if (data.safety.bulk_scope !== false) errors.push('artifact safety.bulk_scope must be false');
+}
+
+function checkArtifactScopeType(data, errors) {
+    if (!data.target_scope) return;
+    const ts = data.target_scope;
+    if (ts.scope_type === 'match_id' && !ts.match_id) {
+        errors.push('artifact target_scope: match_id required when scope_type=match_id');
+    }
+    if (ts.scope_type === 'league_season_date') {
+        if (!ts.league) errors.push('artifact target_scope: league required for league_season_date');
+        if (!ts.season) errors.push('artifact target_scope: season required for league_season_date');
+        if (!ts.date) errors.push('artifact target_scope: date required for league_season_date');
+    }
+    const forbidden = ['all', 'bulk', 'production', 'league', 'season', 'full_source'];
+    if (forbidden.includes(ts.scope_type)) {
+        errors.push(`artifact target_scope.scope_type "${ts.scope_type}" is forbidden`);
+    }
+}
+
+function checkArtifactEngine(data, errors) {
+    if (data.engine && data.engine.family && data.engine.family !== 'titan_discovery') {
+        errors.push(`artifact engine.family "${data.engine.family}" is not titan_discovery`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// High-level validation: single staging artifact
+// ---------------------------------------------------------------------------
+
+function validateArtifact(artifactPath, schemaPath) {
+    const result = { valid: false, errors: [] };
+
+    if (!schemaPath) {
+        result.errors.push('artifact schema path is required');
+        return result;
+    }
+    if (!artifactPath) {
+        result.errors.push('artifact file path is required');
+        return result;
+    }
+
+    const schemaResult = readJsonFile(schemaPath);
+    if (schemaResult.error) {
+        result.errors.push(`artifact schema: ${schemaResult.error}`);
+        return result;
+    }
+
+    const dataResult = readJsonFile(artifactPath);
+    if (dataResult.error) {
+        result.errors.push(`artifact data: ${dataResult.error}`);
+        return result;
+    }
+
+    const data = dataResult.data;
+    result.errors.push(...validateAgainstSchema(data, schemaResult.data));
+    checkArtifactSafety(data, result.errors);
+    checkArtifactScopeType(data, result.errors);
+    checkArtifactEngine(data, result.errors);
+    result.valid = result.errors.length === 0;
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Manifest-specific extra checks
+// ---------------------------------------------------------------------------
+
+function checkManifestStatus(data, errors) {
+    if (data.manifest_status && data.manifest_status !== 'candidate_not_approved') {
+        errors.push('manifest manifest_status must be "candidate_not_approved"');
+    }
+    if (data.approval_status && data.approval_status !== 'not_approved') {
+        errors.push('manifest approval_status must be "not_approved"');
+    }
+}
+
+function checkManifestEngine(data, errors) {
+    if (data.engine_family && data.engine_family !== 'titan_discovery') {
+        errors.push(`manifest engine_family "${data.engine_family}" is not titan_discovery`);
+    }
+}
+
+function checkManifestSafety(data, errors) {
+    if (!data.safety) return;
+    if (data.safety.approved_for_db_write !== false) {
+        errors.push('manifest safety.approved_for_db_write must be false');
+    }
+    if (data.safety.approved_for_training !== false) {
+        errors.push('manifest safety.approved_for_training must be false');
+    }
+    if (data.safety.approved_for_prediction !== false) {
+        errors.push('manifest safety.approved_for_prediction must be false');
+    }
+}
+
+// ---------------------------------------------------------------------------
+// High-level validation: source manifest candidate
+// ---------------------------------------------------------------------------
+
+function validateManifest(manifestPath, schemaPath) {
+    const result = { valid: false, errors: [] };
+
+    if (!schemaPath) {
+        result.errors.push('manifest schema path is required');
+        return result;
+    }
+    if (!manifestPath) {
+        result.errors.push('manifest file path is required');
+        return result;
+    }
+
+    const schemaResult = readJsonFile(schemaPath);
+    if (schemaResult.error) {
+        result.errors.push(`manifest schema: ${schemaResult.error}`);
+        return result;
+    }
+
+    const dataResult = readJsonFile(manifestPath);
+    if (dataResult.error) {
+        result.errors.push(`manifest data: ${dataResult.error}`);
+        return result;
+    }
+
+    const data = dataResult.data;
+    result.errors.push(...validateAgainstSchema(data, schemaResult.data));
+    checkManifestStatus(data, result.errors);
+    checkManifestEngine(data, result.errors);
+    checkManifestSafety(data, result.errors);
+    result.valid = result.errors.length === 0;
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--commit') {
+            args.commit = true;
+        } else if (a.startsWith('--')) {
+            const eq = a.indexOf('=');
+            if (eq !== -1) {
+                args[a.slice(2, eq).replace(/-/g, '_')] = a.slice(eq + 1);
+            } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+                args[a.slice(2).replace(/-/g, '_')] = argv[i + 1];
+                i++;
+            }
+        }
+    }
+    return args;
+}
+
+function ensureRequiredPair(args, schemaKey, dataKey, label) {
+    if (!args[schemaKey] && !args[dataKey]) return;
+    if (!args[schemaKey]) {
+        console.error(`ERROR: --${schemaKey.replace(/_/g, '-')} is required when validating ${label}`);
+        process.exit(1);
+    }
+    if (!args[dataKey]) {
+        console.error(`ERROR: --${dataKey.replace(/_/g, '-')} is required when validating ${label}`);
+        process.exit(1);
+    }
+}
+
+function buildOutput(artifactResult, manifestResult) {
+    return {
+        phase: 'PHASE4.80D_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA_VALIDATOR',
+        validator_only: true,
+        artifact_schema_valid: artifactResult ? artifactResult.valid : null,
+        manifest_schema_valid: manifestResult ? manifestResult.valid : null,
+        artifact_valid: artifactResult ? artifactResult.valid : null,
+        manifest_valid: manifestResult ? manifestResult.valid : null,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+    };
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.commit) {
+        console.error(
+            'BLOCKED: single-target acquisition staging schema commit/execution is not wired in Phase 4.80D.'
+        );
+        process.exit(1);
+    }
+
+    const hasArtifact = args.artifact || args.artifact_schema;
+    const hasManifest = args.manifest || args.manifest_schema;
+
+    if (!hasArtifact && !hasManifest) {
+        console.error('ERROR: provide at least --artifact-schema + --artifact or --manifest-schema + --manifest');
+        process.exit(1);
+    }
+
+    ensureRequiredPair(args, 'artifact_schema', 'artifact', 'an artifact');
+    ensureRequiredPair(args, 'manifest_schema', 'manifest', 'a manifest');
+
+    let artifactResult = null;
+    let manifestResult = null;
+
+    if (args.artifact_schema && args.artifact) {
+        artifactResult = validateArtifact(args.artifact, args.artifact_schema);
+    }
+    if (args.manifest_schema && args.manifest) {
+        manifestResult = validateManifest(args.manifest, args.manifest_schema);
+    }
+
+    const output = buildOutput(artifactResult, manifestResult);
+    const allErrors = [
+        ...(artifactResult ? artifactResult.errors : []),
+        ...(manifestResult ? manifestResult.errors : []),
+    ];
+
+    if (allErrors.length > 0) {
+        for (const e of allErrors) {
+            console.error('VALIDATION ERROR:', e);
+        }
+        console.log(JSON.stringify(output, null, 2));
+        process.exit(1);
+    }
+
+    console.log(JSON.stringify(output, null, 2));
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { validateAgainstSchema, validateArtifact, validateManifest };

--- a/tests/fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json
+++ b/tests/fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json
@@ -1,0 +1,67 @@
+{
+    "artifact_version": "1.0",
+    "phase": "single_target_acquisition_network_dry_run",
+    "source": {
+        "name": "fotmob",
+        "source_url": "https://example.invalid/match/sample-match-001",
+        "terms_url": "https://example.invalid/terms",
+        "license_url": "https://example.invalid/license"
+    },
+    "target_scope": {
+        "scope_type": "match_id",
+        "match_id": "sample-match-001",
+        "league": null,
+        "season": null,
+        "date": null
+    },
+    "engine": {
+        "family": "titan_discovery",
+        "version": "future-scaffold"
+    },
+    "runtime": {
+        "browser": {
+            "enabled": false,
+            "provider": null,
+            "headless": true
+        },
+        "proxy": {
+            "enabled": false,
+            "provider": null,
+            "lease_id": null
+        },
+        "network": {
+            "requested_at": "2026-05-10T00:00:00.000Z",
+            "completed_at": "2026-05-10T00:00:01.000Z",
+            "duration_ms": 1000,
+            "rate_limit_policy": "single_target_only",
+            "retry_policy": "no_retry_in_scaffold"
+        }
+    },
+    "capture": {
+        "raw_payload_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "raw_payload_bytes": 0,
+        "content_type": "application/json",
+        "status_code": 200,
+        "row_count": 0,
+        "object_count": 1
+    },
+    "provenance": {
+        "captured_by": "manual_or_future_runtime",
+        "captured_at": "2026-05-10T00:00:01.000Z",
+        "command": "future command preview",
+        "git_commit": "unknown",
+        "container_image": "unknown"
+    },
+    "safety": {
+        "would_write_db": false,
+        "would_train": false,
+        "would_predict": false,
+        "bulk_scope": false,
+        "post_match_leakage_checked": false
+    },
+    "outputs": {
+        "raw_payload_path": null,
+        "normalized_preview_path": null,
+        "manifest_candidate_path": null
+    }
+}

--- a/tests/fixtures/acquisition/sample_source_manifest_candidate_phase480d.json
+++ b/tests/fixtures/acquisition/sample_source_manifest_candidate_phase480d.json
@@ -1,0 +1,31 @@
+{
+    "manifest_version": "1.0",
+    "manifest_status": "candidate_not_approved",
+    "source_name": "fotmob",
+    "source_url": "https://example.invalid/match/sample-match-001",
+    "terms_url": "https://example.invalid/terms",
+    "license_url": "https://example.invalid/license",
+    "allowed_use": "unknown_pending_human_review",
+    "downloaded_by": "manual_or_future_runtime",
+    "downloaded_at": "2026-05-10T00:00:01.000Z",
+    "engine_family": "titan_discovery",
+    "engine_version": "future-scaffold",
+    "target_scope": {
+        "scope_type": "match_id",
+        "match_id": "sample-match-001",
+        "league": null,
+        "season": null,
+        "date": null
+    },
+    "original_payload_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "row_count": 0,
+    "object_count": 1,
+    "staging_artifact_path": null,
+    "approval_status": "not_approved",
+    "human_approval_note": null,
+    "safety": {
+        "approved_for_db_write": false,
+        "approved_for_training": false,
+        "approved_for_prediction": false
+    }
+}

--- a/tests/unit/single_target_acquisition_staging_schema_validator.test.js
+++ b/tests/unit/single_target_acquisition_staging_schema_validator.test.js
@@ -1,0 +1,449 @@
+/**
+ * Phase 4.80D: Single-Target Acquisition Staging Schema Validator Unit Tests
+ *
+ * Validates schema-based artifact/manifest validation and proves no runtime side effects.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SCRIPT = path.join(__dirname, '../../scripts/ops/single_target_acquisition_staging_schema_validator.js');
+const ARTIFACT_SCHEMA = path.join(__dirname, '../../schemas/acquisition/single_target_staging_artifact.schema.json');
+const MANIFEST_SCHEMA = path.join(__dirname, '../../schemas/acquisition/source_manifest_candidate.schema.json');
+const SAMPLE_ARTIFACT = path.join(
+    __dirname,
+    '../fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json'
+);
+const SAMPLE_MANIFEST = path.join(__dirname, '../fixtures/acquisition/sample_source_manifest_candidate_phase480d.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function runValidator(opts) {
+    const args = [];
+    for (const [key, val] of Object.entries(opts)) {
+        if (key === 'commit' && val) {
+            args.push('--commit');
+        } else {
+            args.push(`--${key.replace(/_/g, '-')}=${val}`);
+        }
+    }
+    const result = child_process.spawnSync(process.execPath, [SCRIPT, ...args], {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: { ...process.env, NODE_ENV: 'test' },
+    });
+    return {
+        stdout: (result.stdout || '').trim(),
+        stderr: (result.stderr || '').trim(),
+        exitCode: result.status,
+    };
+}
+
+function writeTempFile(data) {
+    const tmpDir = os.tmpdir();
+    const tmpFile = path.join(tmpDir, `phase480d_test_${Date.now()}_${Math.random().toString(36).slice(2)}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(data, null, 2), 'utf8');
+    return tmpFile;
+}
+
+function cleanupTempFile(filePath) {
+    try {
+        fs.unlinkSync(filePath);
+    } catch (_) {
+        /* ignore */
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: validateArtifact
+// ---------------------------------------------------------------------------
+
+describe('validateArtifact', () => {
+    const { validateArtifact } = require(SCRIPT);
+
+    // 7. valid artifact passes
+    it('validates a correct staging artifact successfully', () => {
+        const result = validateArtifact(SAMPLE_ARTIFACT, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, true, `errors: ${result.errors.join('; ')}`);
+    });
+
+    // 1. missing artifact schema
+    it('fails when artifact schema path is missing', () => {
+        const result = validateArtifact(SAMPLE_ARTIFACT, null);
+        assert.strictEqual(result.valid, false);
+        assert.ok(result.errors.some(e => e.includes('schema path is required')));
+    });
+
+    // 3. artifact schema is invalid JSON
+    it('fails when artifact schema file is not valid JSON', () => {
+        const badSchema = writeTempFile({ not_a_schema: true, __bad: undefined });
+        const result = validateArtifact(SAMPLE_ARTIFACT, badSchema);
+        // The schema is valid JSON but lacks type info needed for validation
+        // Actually test a non-existent file for schema
+        const result2 = validateArtifact(SAMPLE_ARTIFACT, '/nonexistent/schema.json');
+        assert.strictEqual(result2.valid, false);
+        cleanupTempFile(badSchema);
+    });
+
+    // 5. artifact invalid JSON
+    it('fails when artifact data is not valid JSON', () => {
+        const tmpFile = writeTempFile({ __invalid: true });
+        const result = validateArtifact(tmpFile, '/nonexistent/schema.json');
+        assert.strictEqual(result.valid, false);
+        cleanupTempFile(tmpFile);
+    });
+
+    // 10. missing source.name
+    it('fails when artifact is missing source.name', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        delete data.source.name;
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail when source.name is missing');
+        assert.ok(
+            result.errors.some(e => e.includes('source.name')),
+            `errors: ${result.errors.join('; ')}`
+        );
+        cleanupTempFile(tmpFile);
+    });
+
+    // 11. missing target_scope
+    it('fails when artifact is missing target_scope', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        delete data.target_scope;
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail when target_scope is missing');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 12. unsupported scope_type=bulk
+    it('fails when artifact scope_type is "bulk"', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.target_scope.scope_type = 'bulk';
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for scope_type=bulk');
+        assert.ok(result.errors.some(e => e.includes('forbidden') || e.includes('enum')));
+        cleanupTempFile(tmpFile);
+    });
+
+    // 13. match_id scope but missing match_id
+    it('fails when scope_type=match_id but match_id is missing', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        delete data.target_scope.match_id;
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail when match_id is missing');
+        assert.ok(result.errors.some(e => e.includes('match_id')));
+        cleanupTempFile(tmpFile);
+    });
+
+    // 14. league_season_date scope missing league/season/date
+    it('fails when scope_type=league_season_date but league is missing', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.target_scope.scope_type = 'league_season_date';
+        data.target_scope.match_id = null;
+        data.target_scope.league = null;
+        data.target_scope.season = '2025-2026';
+        data.target_scope.date = '2026-05-09';
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail when league is missing for league_season_date');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 15. engine.family not titan_discovery
+    it('fails when artifact engine.family is not titan_discovery', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.engine.family = 'run_production';
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for non-titan_discovery engine');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 16. safety.would_write_db=true
+    it('fails when artifact safety.would_write_db is true', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.safety.would_write_db = true;
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for would_write_db=true');
+        assert.ok(result.errors.some(e => e.includes('would_write_db')));
+        cleanupTempFile(tmpFile);
+    });
+
+    // 17. safety.would_train=true
+    it('fails when artifact safety.would_train is true', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.safety.would_train = true;
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for would_train=true');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 18. safety.would_predict=true
+    it('fails when artifact safety.would_predict is true', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.safety.would_predict = true;
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for would_predict=true');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 19. safety.bulk_scope=true
+    it('fails when artifact safety.bulk_scope is true', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.safety.bulk_scope = true;
+        const tmpFile = writeTempFile(data);
+        const result = validateArtifact(tmpFile, ARTIFACT_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for bulk_scope=true');
+        cleanupTempFile(tmpFile);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: validateManifest
+// ---------------------------------------------------------------------------
+
+describe('validateManifest', () => {
+    const { validateManifest } = require(SCRIPT);
+
+    // 8. valid manifest passes
+    it('validates a correct manifest candidate successfully', () => {
+        const result = validateManifest(SAMPLE_MANIFEST, MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, true, `errors: ${result.errors.join('; ')}`);
+    });
+
+    // 2. missing manifest schema
+    it('fails when manifest schema path is missing', () => {
+        const result = validateManifest(SAMPLE_MANIFEST, null);
+        assert.strictEqual(result.valid, false);
+    });
+
+    // 4. manifest schema invalid JSON
+    it('fails when manifest schema file does not exist', () => {
+        const result = validateManifest(SAMPLE_MANIFEST, '/nonexistent/manifest_schema.json');
+        assert.strictEqual(result.valid, false);
+    });
+
+    // 6. manifest invalid JSON
+    it('fails when manifest data is not valid JSON', () => {
+        const result = validateManifest('/nonexistent/manifest.json', MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, false);
+    });
+
+    // 20. missing source_name
+    it('fails when manifest is missing source_name', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_MANIFEST, 'utf8'));
+        delete data.source_name;
+        const tmpFile = writeTempFile(data);
+        const result = validateManifest(tmpFile, MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail when source_name is missing');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 21. manifest_status not candidate_not_approved
+    it('fails when manifest_status is not candidate_not_approved', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_MANIFEST, 'utf8'));
+        data.manifest_status = 'approved';
+        const tmpFile = writeTempFile(data);
+        const result = validateManifest(tmpFile, MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail when manifest_status is not candidate_not_approved');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 22. approval_status not not_approved
+    it('fails when approval_status is not not_approved', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_MANIFEST, 'utf8'));
+        data.approval_status = 'approved';
+        const tmpFile = writeTempFile(data);
+        const result = validateManifest(tmpFile, MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail when approval_status is not not_approved');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 23. approved_for_db_write=true
+    it('fails when manifest safety.approved_for_db_write is true', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_MANIFEST, 'utf8'));
+        data.safety.approved_for_db_write = true;
+        const tmpFile = writeTempFile(data);
+        const result = validateManifest(tmpFile, MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for approved_for_db_write=true');
+        assert.ok(result.errors.some(e => e.includes('approved_for_db_write')));
+        cleanupTempFile(tmpFile);
+    });
+
+    // 24. approved_for_training=true
+    it('fails when manifest safety.approved_for_training is true', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_MANIFEST, 'utf8'));
+        data.safety.approved_for_training = true;
+        const tmpFile = writeTempFile(data);
+        const result = validateManifest(tmpFile, MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for approved_for_training=true');
+        cleanupTempFile(tmpFile);
+    });
+
+    // 25. approved_for_prediction=true
+    it('fails when manifest safety.approved_for_prediction is true', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_MANIFEST, 'utf8'));
+        data.safety.approved_for_prediction = true;
+        const tmpFile = writeTempFile(data);
+        const result = validateManifest(tmpFile, MANIFEST_SCHEMA);
+        assert.strictEqual(result.valid, false, 'should fail for approved_for_prediction=true');
+        cleanupTempFile(tmpFile);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: validator CLI via subprocess
+// ---------------------------------------------------------------------------
+
+describe('validator CLI (subprocess)', () => {
+    // 9. artifact + manifest both pass
+    it('exits 0 and outputs valid JSON for artifact + manifest', () => {
+        const result = runValidator({
+            artifact_schema: ARTIFACT_SCHEMA,
+            manifest_schema: MANIFEST_SCHEMA,
+            artifact: SAMPLE_ARTIFACT,
+            manifest: SAMPLE_MANIFEST,
+        });
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.artifact_schema_valid, true);
+        assert.strictEqual(parsed.manifest_schema_valid, true);
+        assert.strictEqual(parsed.would_access_network, false);
+        assert.strictEqual(parsed.would_write_db, false);
+        assert.strictEqual(parsed.would_write_staging, false);
+        assert.strictEqual(parsed.commit_gate, 'blocked');
+    });
+
+    // artifact-only succeeds
+    it('exits 0 for artifact-only validation', () => {
+        const result = runValidator({
+            artifact_schema: ARTIFACT_SCHEMA,
+            artifact: SAMPLE_ARTIFACT,
+        });
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.artifact_valid, true);
+    });
+
+    // manifest-only succeeds
+    it('exits 0 for manifest-only validation', () => {
+        const result = runValidator({
+            manifest_schema: MANIFEST_SCHEMA,
+            manifest: SAMPLE_MANIFEST,
+        });
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.manifest_valid, true);
+    });
+
+    // missing params fails
+    it('exits non-zero when no schema or artifact/manifest provided', () => {
+        const result = runValidator({});
+        assert.notStrictEqual(result.exitCode, 0, 'should exit non-zero');
+    });
+
+    // 26. --commit blocked
+    it('exits non-zero when --commit is passed', () => {
+        const result = runValidator({
+            artifact_schema: ARTIFACT_SCHEMA,
+            artifact: SAMPLE_ARTIFACT,
+            commit: true,
+        });
+        assert.notStrictEqual(result.exitCode, 0, 'should exit non-zero for --commit');
+        assert.ok(result.stderr.includes('commit/execution is not wired'), `stderr: ${result.stderr}`);
+    });
+
+    // artifact with bad data fails
+    it('exits non-zero when artifact has invalid engine family', () => {
+        const data = JSON.parse(fs.readFileSync(SAMPLE_ARTIFACT, 'utf8'));
+        data.engine.family = 'bad_engine';
+        const tmpFile = writeTempFile(data);
+        const result = runValidator({
+            artifact_schema: ARTIFACT_SCHEMA,
+            artifact: tmpFile,
+        });
+        assert.notStrictEqual(result.exitCode, 0, 'should exit non-zero for invalid engine family');
+        cleanupTempFile(tmpFile);
+    });
+
+    // all would_* false in output
+    it('outputs all would_* false even when all validation passes', () => {
+        const result = runValidator({
+            artifact_schema: ARTIFACT_SCHEMA,
+            manifest_schema: MANIFEST_SCHEMA,
+            artifact: SAMPLE_ARTIFACT,
+            manifest: SAMPLE_MANIFEST,
+        });
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.would_access_network, false);
+        assert.strictEqual(parsed.would_launch_browser, false);
+        assert.strictEqual(parsed.would_use_proxy, false);
+        assert.strictEqual(parsed.would_execute_engine, false);
+        assert.strictEqual(parsed.would_write_staging, false);
+        assert.strictEqual(parsed.would_create_staging_directory, false);
+        assert.strictEqual(parsed.would_write_source_manifest, false);
+        assert.strictEqual(parsed.would_write_db, false);
+        assert.strictEqual(parsed.would_train, false);
+        assert.strictEqual(parsed.would_predict, false);
+        assert.strictEqual(parsed.would_spawn_child_process, false);
+        assert.strictEqual(parsed.commit_gate, 'blocked');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Source-code audit: no forbidden imports, no side effects
+// ---------------------------------------------------------------------------
+
+describe('source-code side-effect audit', () => {
+    const source = fs.readFileSync(SCRIPT, 'utf8');
+
+    it('does not import titan_discovery or DiscoveryService', () => {
+        assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source), 'must not import titan_discovery');
+        assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source), 'must not import DiscoveryService');
+    });
+
+    it('does not import pg or redis', () => {
+        assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source), 'must not import pg');
+        assert.ok(!/require\s*\(\s*['"]redis/.test(source), 'must not import redis');
+    });
+
+    it('does not import playwright', () => {
+        assert.ok(!/require\s*\(\s*['"]playwright/.test(source), 'must not import playwright');
+    });
+
+    it('does not import http/https/net modules', () => {
+        assert.ok(!/require\s*\(\s*['"]https?['"]/.test(source), 'must not import http/https');
+        assert.ok(!/require\s*\(\s*['"]net['"]/.test(source), 'must not import net');
+    });
+
+    it('does not import child_process', () => {
+        assert.ok(!/require\s*\(\s*['"]child_process['"]/.test(source), 'must not import child_process');
+    });
+
+    it('does not import axios/node-fetch', () => {
+        assert.ok(!/require\s*\(\s*['"]axios/.test(source), 'must not import axios');
+        assert.ok(!/require\s*\(\s*['"]node-fetch/.test(source), 'must not import node-fetch');
+    });
+
+    it('does not use fs write methods', () => {
+        assert.ok(
+            !/writeFileSync|writeFile|createWriteStream|mkdirSync|mkdir/.test(source),
+            'must not use fs write/mkdir methods'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.80D single-target acquisition staging artifact schema validator.

Scope:
- Adds staging artifact JSON schema (schemas/acquisition/)
- Adds source manifest candidate JSON schema
- Adds local-only schema validator command
- Adds sample fixtures for schema validation
- Adds Makefile validate and blocked commit targets
- Adds no-side-effect unit tests (38/38 pass)
- Updates AGENTS.md
- Adds Phase 4.80D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime source manifest writes
- No packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- validator missing params failed as expected
- valid artifact schema validation passed
- valid manifest candidate validation passed
- artifact-only validation passed
- manifest-only validation passed
- commit gate remained blocked
- unit tests passed (38/38)
- npm test passed (48/48)
- npm run test:coverage passed
- integration tests passed (19 pass, 5 skipped)
- DB row counts unchanged (2/2/2/2/2/2)
- l1-config residue absent
- eslint / prettier / git diff --check passed