### PR TITLE
feat(data): add single-target staging writer preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读本地 Football-Data source manifest + 本地 CSV，并只执行 SELECT-only DB schema / duplicate 查询、不写 DB、不训练、不预测的 `make data-football-data-insert-policy-precheck SOURCE_MANIFEST=<local json> LOCAL_CSV=<local csv>`
 - 不触网、不启动 browser、不执行 proxy runtime、不写 staging、不写 manifest、不写 DB、不运行 titan_discovery legacy runtime 的 scaffold-only 参数校验和 plan preview：`make data-single-target-acquisition-runtime-scaffold TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> ...`（Phase 4.79D scaffold-only）
 - 不触网、不写文件、只读本地 schema 和 sample fixture 的 staging artifact / manifest candidate schema 校验：`make data-single-target-acquisition-staging-schema-validate ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path>`（Phase 4.80D local-only）
+- 不触网、不写文件、不创建目录、只做路径预览和授权预检的 staging writer preflight：`make data-single-target-acquisition-staging-writer-preflight ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.81D preflight-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -296,6 +297,8 @@ AI / Codex 不能直接执行：
 - `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
 - `make data-single-target-acquisition-staging-schema-commit`
 - `make data-single-target-acquisition-staging-schema-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1`
+- `make data-single-target-acquisition-staging-writer-commit`
+- `make data-single-target-acquisition-staging-writer-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
 - `make data-finished-csv-commit`
 - `make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1`
@@ -523,6 +526,8 @@ AI / Codex 默认禁止：
 - `make data-single-target-acquisition-runtime-commit CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1`
 - `make data-single-target-acquisition-staging-schema-commit`
 - `make data-single-target-acquisition-staging-schema-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1`
+- `make data-single-target-acquisition-staging-writer-commit`
+- `make data-single-target-acquisition-staging-writer-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
 - `node scripts/ops/run_production.js`
 - `node scripts/ops/titan_discovery.js`
@@ -606,6 +611,36 @@ AI / Codex 默认禁止：
 - `make data-single-target-acquisition-staging-schema-commit`
 - `make data-single-target-acquisition-staging-schema-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1`
 - `node scripts/ops/single_target_acquisition_staging_schema_validator.js --commit`
+
+### Phase 4.81D: single-target acquisition staging writer preflight
+
+`data-single-target-acquisition-staging-writer-preflight` 只允许 staging writer preflight：
+
+- 它不得创建 staging 目录
+- 它不得写 staging artifact
+- 它不得写 source manifest
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 DB
+- staging writer preflight 不等于 staging write authorization
+- 即使 `STAGING_WRITE_AUTHORIZATION=yes` 和 `FINAL_HUMAN_CONFIRMATION=yes`，Phase 4.81D 也不写文件
+
+`data-single-target-acquisition-staging-writer-commit` 当前 blocked。
+
+真实 staging write 必须后续单独阶段、用户明确授权、路径明确、schema validation 通过。
+
+在 Phase 4.81D 中允许：
+
+- `make data-single-target-acquisition-staging-writer-preflight ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ...`
+- `node scripts/ops/single_target_acquisition_staging_writer_preflight.js --artifact-schema=... ...`
+
+在 Phase 4.81D 中严格禁止：
+
+- `make data-single-target-acquisition-staging-writer-commit`
+- `make data-single-target-acquisition-staging-writer-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1`
+- `node scripts/ops/single_target_acquisition_staging_writer_preflight.js --commit`
 
 相关背景见：`docs/_reports/ACQUISITION_ENGINE_READINESS_PHASE4_53A.md`、`docs/_reports/REAL_DATA_SOURCE_STRATEGY_PHASE4_51.md` 和 `docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md`
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
         data-single-target-network-dry-run data-single-target-network-commit \
         data-single-target-acquisition-runtime-scaffold data-single-target-acquisition-runtime-commit \
         data-single-target-acquisition-staging-schema-validate data-single-target-acquisition-staging-schema-commit \
+        data-single-target-acquisition-staging-writer-preflight data-single-target-acquisition-staging-writer-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -334,6 +335,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-runtime-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_RUNTIME=1  # blocked in Phase 4.79D"
 	@echo "  make data-single-target-acquisition-staging-schema-validate ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path>  # local-only, Phase 4.80D"
 	@echo "  make data-single-target-acquisition-staging-schema-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1  # blocked in Phase 4.80D"
+	@echo "  make data-single-target-acquisition-staging-writer-preflight ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...  # preflight-only, Phase 4.81D"
+	@echo "  make data-single-target-acquisition-staging-writer-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1  # blocked in Phase 4.81D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -891,6 +894,34 @@ data-single-target-acquisition-staging-schema-validate: ## Local-only staging ar
 data-single-target-acquisition-staging-schema-commit: ## Blocked staging schema commit gate. Remains not wired in Phase 4.80D.
 	@echo "BLOCKED: single-target acquisition staging schema commit/execution is not wired in Phase 4.80D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1, this path remains blocked."
+	@echo "  Real staging write requires a separate future phase with explicit source/target/terms/network/staging authorization."
+	@exit 1
+
+data-single-target-acquisition-staging-writer-preflight: ## Preflight-only staging writer preflight. Phase 4.81D. Validates schema, target consistency, output root policy, and previews future paths.
+	@if [ -z "$(ARTIFACT_SCHEMA)" ] || [ -z "$(MANIFEST_SCHEMA)" ] || [ -z "$(ARTIFACT)" ] || [ -z "$(MANIFEST)" ] || [ -z "$(OUTPUT_ROOT)" ]; then \
+		echo "ERROR: provide ARTIFACT_SCHEMA=<path>, MANIFEST_SCHEMA=<path>, ARTIFACT=<path>, MANIFEST=<path>, OUTPUT_ROOT=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.81D: staging writer preflight (preflight-only, no writes, no network, no DB)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/single_target_acquisition_staging_writer_preflight.js \
+		--artifact-schema "$(ARTIFACT_SCHEMA)" \
+		--manifest-schema "$(MANIFEST_SCHEMA)" \
+		--artifact "$(ARTIFACT)" \
+		--manifest "$(MANIFEST)" \
+		--output-root "$(OUTPUT_ROOT)" \
+		$(if $(TARGET_SOURCE),--target-source "$(TARGET_SOURCE)") \
+		$(if $(TARGET_ENGINE_FAMILY),--target-engine-family "$(TARGET_ENGINE_FAMILY)") \
+		$(if $(TARGET_SCOPE_TYPE),--target-scope-type "$(TARGET_SCOPE_TYPE)") \
+		$(if $(TARGET_MATCH_ID),--target-match-id "$(TARGET_MATCH_ID)") \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--staging-write-authorization "$(or $(STAGING_WRITE_AUTHORIZATION),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-staging-writer-commit: ## Blocked staging writer commit gate. Remains not wired in Phase 4.81D.
+	@echo "BLOCKED: single-target acquisition staging writer commit/execution is not wired in Phase 4.81D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1, this path remains blocked."
 	@echo "  Real staging write requires a separate future phase with explicit source/target/terms/network/staging authorization."
 	@exit 1
 

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_WRITER_PREFLIGHT_PHASE4_81D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_WRITER_PREFLIGHT_PHASE4_81D.md
@@ -1,0 +1,179 @@
+# Phase 4.81D: Single-Target Acquisition Staging Writer Preflight
+
+**Date**: 2026-05-10
+**Status**: Complete (preflight-only)
+**Previous phases**: Phase 4.79D (scaffold), Phase 4.80D (schema validator)
+**Next recommended phase**: Phase 4.82D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.81D is a **staging writer preflight** phase. It answers the questions:
+
+- If staging were allowed, where would files go?
+- Is the output root in the allowed range?
+- Are artifact/manifest files schema-valid?
+- Do target parameters match across artifact, manifest, and CLI?
+- Are authorization fields present?
+- Why is actual staging write still blocked?
+
+The preflight **does not** create directories, write files, access network, or write DB.
+
+---
+
+## 2. Implemented Files
+
+### Script
+
+```
+scripts/ops/single_target_acquisition_staging_writer_preflight.js
+```
+
+### Makefile Targets
+
+```
+make data-single-target-acquisition-staging-writer-preflight    (preflight-only, Phase 4.81D)
+make data-single-target-acquisition-staging-writer-commit      (blocked, Phase 4.81D)
+```
+
+### Tests
+
+```
+tests/unit/single_target_acquisition_staging_writer_preflight.test.js
+```
+
+### Documentation
+
+```
+AGENTS.md (updated)
+docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_WRITER_PREFLIGHT_PHASE4_81D.md
+```
+
+---
+
+## 3. Preflight Behavior
+
+- **Schema validation**: Reuses Phase 4.80D `validateArtifact` and `validateManifest`
+- **Output root policy**: Validates path is relative, under allowed root, no `..`, no forbidden prefixes
+- **Target consistency**: Verifies source/engine/scope/match_id match across artifact, manifest, and CLI args
+- **Path preview**: Generates future directory and filename previews using safe slugs and hash8
+- **Authorization check**: Validates `staging_write_authorization` and `final_human_confirmation` are provided
+- **No writes**: All `would_*` fields are hardcoded `false`
+
+---
+
+## 4. Output Path Policy
+
+### Allowed output root
+
+```
+docs/_staging_preview/acquisition/single_target
+```
+
+### Forbidden
+
+```
+absolute paths (e.g. /var/staging)
+.. (path traversal)
+docs/_packets
+data/
+. (repo root)
+```
+
+### Generated path structure
+
+```
+<output_root>/<source>/<engine_family>/<scope_type>/<safe_target_slug>/
+  single_target_staging_artifact_<source>_<safe_target_slug>_<hash8>.json
+  source_manifest_candidate_<source>_<safe_target_slug>_<hash8>.json
+```
+
+---
+
+## 5. Authorization Behavior
+
+- `staging_write_authorization` required (yes/no)
+- `final_human_confirmation` required (yes/no)
+- Even when both are `yes`, `would_write_staging` remains `false`
+- `staging_write_authorized` is always `false`
+- `commit_gate` is always `"blocked"`
+
+---
+
+## 6. Relationship to Phase 4.79D / 4.80D
+
+| Phase | Purpose                                                        | Status   |
+| ----- | -------------------------------------------------------------- | -------- |
+| 4.79D | Parameter scaffold — validates input parameters                | Complete |
+| 4.80D | Schema validator — validates artifact/manifest structure       | Complete |
+| 4.81D | Writer preflight — validates paths, consistency, authorization | Complete |
+
+All three phases are **non-executing**: no network, no DB writes, no staging writes.
+
+---
+
+## 7. Test Coverage
+
+Tests: `tests/unit/single_target_acquisition_staging_writer_preflight.test.js`
+
+Coverage includes:
+
+- Missing required fields (10 fields) → failure
+- Invalid output_root (absolute, .., data/, docs/\_packets, outside allowed) → failure
+- Schema validation failure → failure
+- Target consistency mismatches (source, engine, scope, match_id) → failure
+- Unsupported engine/scope → failure
+- Valid match_id preflight → success
+- Authorization yes → still would_write_staging=false
+- Path preview correctness
+- `--commit` blocked
+- Source code audit: no forbidden imports, no fs write methods
+- Temporary dirs cleaned up (os.tmpdir)
+
+---
+
+## 8. Recommended Next Phase
+
+**Phase 4.82D**: Single-target acquisition staging packet preview.
+Summarize scaffold + schema validation + writer preflight into a packet preview,
+still without network, DB, or staging writes.
+
+Or: **Phase 4.56A**: User provides real network dry-run parameters for a real runbook.
+
+---
+
+## 9. Explicit Non-Execution Confirmation
+
+The following were **not** performed during Phase 4.81D:
+
+- DB writes (INSERT/UPDATE/DELETE/CREATE/ALTER/DROP/TRUNCATE/COPY)
+- Non-SELECT DB SQL
+- External downloads (curl/wget/git clone)
+- External football data access
+- External odds data access
+- Scraping
+- Browser automation
+- Proxy runtime execution
+- Harvest / ingest
+- Batch backfill
+- Network dry-run execution
+- Bulk harvest
+- Runtime staging artifact write
+- Runtime staging directory creation
+- Runtime source manifest write
+- Packet file write
+- `pg_dump` / `pg_restore`
+- Model training
+- Real prediction execution
+- Model artifact loading
+- Docker volume cleanup
+- Force push
+- `git fetch --all`
+- `git pull`
+- `rm -rf`
+- File deletion
+- Coverage threshold modification
+- Test skipping
+- Test deletion
+- Gatekeeper bypass

--- a/scripts/ops/single_target_acquisition_staging_writer_preflight.js
+++ b/scripts/ops/single_target_acquisition_staging_writer_preflight.js
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.81D: Single-Target Acquisition Staging Writer Preflight
+ *
+ * Preflight-only command. Validates artifact/manifest schemas, checks target
+ * consistency, validates output root policy, and previews future staging paths.
+ * Does NOT create directories, write files, access network, or write DB.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { validateArtifact, validateManifest } = require('./single_target_acquisition_staging_schema_validator');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ALLOWED_OUTPUT_ROOT = 'docs/_staging_preview/acquisition/single_target';
+
+const FORBIDDEN_OUTPUT_ROOTS = ['docs/_packets', 'data/', '.'];
+
+const ALLOWED_ENGINE_FAMILIES = ['titan_discovery'];
+
+const ALLOWED_SCOPE_TYPES = ['match_id', 'league_season_date'];
+
+const FORBIDDEN_SCOPE_TYPES = ['all', 'bulk', 'production', 'league', 'season', 'full_source'];
+
+// ---------------------------------------------------------------------------
+// Output root policy validation
+// ---------------------------------------------------------------------------
+
+function checkOutputRoot(outputRoot) {
+    const errors = [];
+
+    if (!outputRoot) {
+        errors.push('output_root is required');
+        return errors;
+    }
+
+    // must not be absolute
+    if (path.isAbsolute(outputRoot)) {
+        errors.push('output_root must not be an absolute path');
+    }
+
+    // must not contain ..
+    if (outputRoot.includes('..')) {
+        errors.push('output_root must not contain ".."');
+    }
+
+    // must not be a forbidden root
+    const normalized = outputRoot.replace(/\/+$/, '');
+    for (const forbidden of FORBIDDEN_OUTPUT_ROOTS) {
+        if (normalized === forbidden.replace(/\/+$/, '') || normalized.startsWith(forbidden)) {
+            errors.push(`output_root "${outputRoot}" is not allowed (forbidden prefix: ${forbidden})`);
+        }
+    }
+
+    // must start with allowed root
+    const allowedNorm = ALLOWED_OUTPUT_ROOT.replace(/\/+$/, '');
+    if (!normalized.startsWith(allowedNorm)) {
+        errors.push(`output_root must be under "${ALLOWED_OUTPUT_ROOT}", got "${outputRoot}"`);
+    }
+
+    return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Safe slug for filenames (no slashes, no spaces, no ..)
+// ---------------------------------------------------------------------------
+
+function safeSlug(text) {
+    return (text || 'unknown')
+        .replace(/\.\./g, '__')
+        .replace(/[^a-zA-Z0-9._-]/g, '_')
+        .replace(/_{2,}/g, '_')
+        .replace(/^_|_$/g, '')
+        .slice(0, 64);
+}
+
+// ---------------------------------------------------------------------------
+// sha256 hash8 extraction
+// ---------------------------------------------------------------------------
+
+function extractHash8(artifactData) {
+    const sha = artifactData && artifactData.capture && artifactData.capture.raw_payload_sha256;
+    if (sha && typeof sha === 'string' && sha.length >= 8 && /^[0-9a-fA-F]+$/.test(sha)) {
+        return sha.slice(0, 8);
+    }
+    return '00000000'; // safe fallback
+}
+
+// ---------------------------------------------------------------------------
+// Target consistency helpers
+// ---------------------------------------------------------------------------
+
+function checkSourceMatch(args, artSource, manSource) {
+    const errors = [];
+    if (args.target_source && artSource && args.target_source !== artSource) {
+        errors.push(`target_source "${args.target_source}" does not match artifact source "${artSource}"`);
+    }
+    if (args.target_source && manSource && args.target_source !== manSource) {
+        errors.push(`target_source "${args.target_source}" does not match manifest source "${manSource}"`);
+    }
+    return errors;
+}
+
+function checkEngineMatch(args, artEngine, manEngine) {
+    const errors = [];
+    if (args.target_engine_family && artEngine && args.target_engine_family !== artEngine) {
+        errors.push(
+            `target_engine_family "${args.target_engine_family}" does not match artifact engine "${artEngine}"`
+        );
+    }
+    if (args.target_engine_family && manEngine && args.target_engine_family !== manEngine) {
+        errors.push(
+            `target_engine_family "${args.target_engine_family}" does not match manifest engine "${manEngine}"`
+        );
+    }
+    if (args.target_engine_family && !ALLOWED_ENGINE_FAMILIES.includes(args.target_engine_family)) {
+        errors.push(`target_engine_family "${args.target_engine_family}" is not allowed`);
+    }
+    return errors;
+}
+
+function checkScopeMatch(args, artScope, manScope) {
+    const errors = [];
+    if (args.target_scope_type && artScope && args.target_scope_type !== artScope) {
+        errors.push(`target_scope_type "${args.target_scope_type}" does not match artifact scope "${artScope}"`);
+    }
+    if (args.target_scope_type && manScope && args.target_scope_type !== manScope) {
+        errors.push(`target_scope_type "${args.target_scope_type}" does not match manifest scope "${manScope}"`);
+    }
+    if (args.target_scope_type && FORBIDDEN_SCOPE_TYPES.includes(args.target_scope_type)) {
+        errors.push(`target_scope_type "${args.target_scope_type}" is forbidden`);
+    }
+    return errors;
+}
+
+function checkMatchIdDeps(args, artifactData, manifestData) {
+    const errors = [];
+    if (!args.target_match_id) {
+        errors.push('target_match_id is required when target_scope_type=match_id');
+    }
+    const artId = artifactData && artifactData.target_scope && artifactData.target_scope.match_id;
+    const manId = manifestData && manifestData.target_scope && manifestData.target_scope.match_id;
+    if (args.target_match_id && artId && args.target_match_id !== artId) {
+        errors.push(`target_match_id "${args.target_match_id}" does not match artifact match_id "${artId}"`);
+    }
+    if (args.target_match_id && manId && args.target_match_id !== manId) {
+        errors.push(`target_match_id "${args.target_match_id}" does not match manifest match_id "${manId}"`);
+    }
+    return errors;
+}
+
+function checkLeagueSeasonDateDeps(args) {
+    const errors = [];
+    if (!args.target_league) errors.push('target_league is required for league_season_date');
+    if (!args.target_season) errors.push('target_season is required for league_season_date');
+    if (!args.target_date) errors.push('target_date is required for league_season_date');
+    return errors;
+}
+
+function checkScopeDepsMatch(args, artifactData, manifestData) {
+    if (args.target_scope_type === 'match_id') {
+        return checkMatchIdDeps(args, artifactData, manifestData);
+    }
+    if (args.target_scope_type === 'league_season_date') {
+        return checkLeagueSeasonDateDeps(args);
+    }
+    return [];
+}
+
+// ---------------------------------------------------------------------------
+// Target consistency validation (orchestrates helpers)
+// ---------------------------------------------------------------------------
+
+function checkTargetConsistency(args, artifactData, manifestData) {
+    const artSource = artifactData && artifactData.source && artifactData.source.name;
+    const manSource = manifestData && manifestData.source_name;
+    const artEngine = artifactData && artifactData.engine && artifactData.engine.family;
+    const manEngine = manifestData && manifestData.engine_family;
+    const artScope = artifactData && artifactData.target_scope && artifactData.target_scope.scope_type;
+    const manScope = manifestData && manifestData.target_scope && manifestData.target_scope.scope_type;
+
+    return [
+        ...checkSourceMatch(args, artSource, manSource),
+        ...checkEngineMatch(args, artEngine, manEngine),
+        ...checkScopeMatch(args, artScope, manScope),
+        ...checkScopeDepsMatch(args, artifactData, manifestData),
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Path preview
+// ---------------------------------------------------------------------------
+
+function buildPathPreviews(args, artifactData) {
+    const source = safeSlug(args.target_source || 'unknown');
+    const engine = safeSlug(args.target_engine_family || 'unknown');
+    const scopeType = safeSlug(args.target_scope_type || 'unknown');
+    const scopeValue =
+        args.target_scope_type === 'match_id'
+            ? safeSlug(args.target_match_id || 'unknown')
+            : safeSlug(args.target_league || args.target_date || 'unknown');
+    const hash8 = extractHash8(artifactData);
+    const safeTargetSlug = `${scopeType}_${scopeValue}`.slice(0, 128);
+
+    const dirPreview = `${args.output_root || ALLOWED_OUTPUT_ROOT}/${source}/${engine}/${scopeType}/${safeTargetSlug}`;
+    const artifactFile = `single_target_staging_artifact_${source}_${safeTargetSlug}_${hash8}.json`;
+    const manifestFile = `source_manifest_candidate_${source}_${safeTargetSlug}_${hash8}.json`;
+
+    return { dirPreview, artifactFile, manifestFile };
+}
+
+// ---------------------------------------------------------------------------
+// Validate authorization fields
+// ---------------------------------------------------------------------------
+
+function checkAuthorization(args) {
+    const errors = [];
+    const yesNo = ['staging_write_authorization', 'final_human_confirmation'];
+    for (const field of yesNo) {
+        const val = args[field];
+        if (val === undefined || val === '') {
+            errors.push(`${field} is required (yes or no)`);
+        } else if (val !== 'yes' && val !== 'no') {
+            errors.push(`${field} must be "yes" or "no", got "${val}"`);
+        }
+    }
+    return errors;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--commit') {
+            args.commit = true;
+        } else if (a.startsWith('--')) {
+            const eq = a.indexOf('=');
+            if (eq !== -1) {
+                args[a.slice(2, eq).replace(/-/g, '_')] = a.slice(eq + 1);
+            } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+                args[a.slice(2).replace(/-/g, '_')] = argv[i + 1];
+                i++;
+            }
+        }
+    }
+    return args;
+}
+
+function ensureRequired(args, fields) {
+    const errors = [];
+    for (const f of fields) {
+        if (!args[f]) {
+            const cliName = '--' + f.replace(/_/g, '-');
+            errors.push(`${cliName} is required`);
+        }
+    }
+    return errors;
+}
+
+function baseOutput(args, overrides) {
+    return Object.assign(
+        {
+            phase: 'PHASE4.81D_SINGLE_TARGET_ACQUISITION_STAGING_WRITER_PREFLIGHT',
+            preflight_only: true,
+            artifact_schema_valid: false,
+            manifest_schema_valid: false,
+            artifact_valid: false,
+            manifest_valid: false,
+            output_root_allowed: false,
+            target_consistency_valid: false,
+            staging_write_authorization: args.staging_write_authorization || 'no',
+            final_human_confirmation: args.final_human_confirmation || 'no',
+            staging_write_authorized: false,
+            would_access_network: false,
+            would_launch_browser: false,
+            would_use_proxy: false,
+            would_execute_engine: false,
+            would_write_staging: false,
+            would_create_staging_directory: false,
+            would_write_source_manifest: false,
+            would_write_db: false,
+            would_train: false,
+            would_predict: false,
+            would_spawn_child_process: false,
+            commit_gate: 'blocked',
+        },
+        overrides
+    );
+}
+
+function exitWithOutput(args, output, errors) {
+    for (const e of errors) {
+        console.error('ERROR:', e);
+    }
+    console.log(JSON.stringify(baseOutput(args, output), null, 2));
+    process.exit(1);
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.commit) {
+        console.error(
+            'BLOCKED: single-target acquisition staging writer commit/execution is not wired in Phase 4.81D.'
+        );
+        process.exit(1);
+    }
+
+    const requiredFields = [
+        'artifact_schema',
+        'manifest_schema',
+        'artifact',
+        'manifest',
+        'output_root',
+        'target_source',
+        'target_engine_family',
+        'target_scope_type',
+    ];
+    const fieldErrors = ensureRequired(args, requiredFields);
+    const authErrors = checkAuthorization(args);
+    const allPreErrors = [...fieldErrors, ...authErrors];
+    if (allPreErrors.length > 0) {
+        for (const e of allPreErrors) {
+            console.error('ERROR:', e);
+        }
+        process.exit(1);
+    }
+
+    const rootErrors = checkOutputRoot(args.output_root);
+    if (rootErrors.length > 0) exitWithOutput(args, {}, rootErrors);
+
+    const artifactResult = validateArtifact(args.artifact, args.artifact_schema);
+    const manifestResult = validateManifest(args.manifest, args.manifest_schema);
+
+    if (!artifactResult.valid || !manifestResult.valid) {
+        exitWithOutput(
+            args,
+            {
+                artifact_schema_valid: artifactResult.valid,
+                manifest_schema_valid: manifestResult.valid,
+                artifact_valid: artifactResult.valid,
+                manifest_valid: manifestResult.valid,
+                output_root_allowed: true,
+            },
+            [...artifactResult.errors, ...manifestResult.errors]
+        );
+    }
+
+    const artifactData = JSON.parse(fs.readFileSync(args.artifact, 'utf8'));
+    const manifestData = JSON.parse(fs.readFileSync(args.manifest, 'utf8'));
+
+    const consistencyErrors = checkTargetConsistency(args, artifactData, manifestData);
+    if (consistencyErrors.length > 0) {
+        exitWithOutput(
+            args,
+            {
+                artifact_schema_valid: true,
+                manifest_schema_valid: true,
+                artifact_valid: true,
+                manifest_valid: true,
+                output_root_allowed: true,
+            },
+            consistencyErrors
+        );
+    }
+
+    const previews = buildPathPreviews(args, artifactData);
+    console.log(
+        JSON.stringify(
+            baseOutput(args, {
+                artifact_schema_valid: true,
+                manifest_schema_valid: true,
+                artifact_valid: true,
+                manifest_valid: true,
+                output_root_allowed: true,
+                target_consistency_valid: true,
+                future_staging_directory_preview: previews.dirPreview,
+                future_artifact_file_preview: previews.artifactFile,
+                future_manifest_file_preview: previews.manifestFile,
+            }),
+            null,
+            2
+        )
+    );
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    checkOutputRoot,
+    checkTargetConsistency,
+    checkSourceMatch,
+    checkEngineMatch,
+    checkScopeMatch,
+    checkScopeDepsMatch,
+    buildPathPreviews,
+    safeSlug,
+    extractHash8,
+    checkAuthorization,
+};

--- a/tests/unit/single_target_acquisition_staging_writer_preflight.test.js
+++ b/tests/unit/single_target_acquisition_staging_writer_preflight.test.js
@@ -1,0 +1,525 @@
+/**
+ * Phase 4.81D: Single-Target Acquisition Staging Writer Preflight Unit Tests
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SCRIPT = path.join(__dirname, '../../scripts/ops/single_target_acquisition_staging_writer_preflight.js');
+const ARTIFACT_SCHEMA = path.join(__dirname, '../../schemas/acquisition/single_target_staging_artifact.schema.json');
+const MANIFEST_SCHEMA = path.join(__dirname, '../../schemas/acquisition/source_manifest_candidate.schema.json');
+const SAMPLE_ARTIFACT = path.join(
+    __dirname,
+    '../fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json'
+);
+const SAMPLE_MANIFEST = path.join(__dirname, '../fixtures/acquisition/sample_source_manifest_candidate_phase480d.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function runPreflight(opts) {
+    const args = [];
+    for (const [key, val] of Object.entries(opts)) {
+        if (key === 'commit' && val) {
+            args.push('--commit');
+        } else {
+            args.push(`--${key.replace(/_/g, '-')}=${val}`);
+        }
+    }
+    const result = child_process.spawnSync(process.execPath, [SCRIPT, ...args], {
+        encoding: 'utf8',
+        timeout: 15000,
+        env: { ...process.env, NODE_ENV: 'test' },
+    });
+    return {
+        stdout: (result.stdout || '').trim(),
+        stderr: (result.stderr || '').trim(),
+        exitCode: result.status,
+    };
+}
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'phase481d-'));
+}
+
+function writeTempJson(dir, name, data) {
+    const p = path.join(dir, name);
+    fs.writeFileSync(p, JSON.stringify(data, null, 2), 'utf8');
+    return p;
+}
+
+function baseOpts() {
+    return {
+        artifact_schema: ARTIFACT_SCHEMA,
+        manifest_schema: MANIFEST_SCHEMA,
+        artifact: SAMPLE_ARTIFACT,
+        manifest: SAMPLE_MANIFEST,
+        output_root: 'docs/_staging_preview/acquisition/single_target',
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        staging_write_authorization: 'no',
+        final_human_confirmation: 'no',
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: checkOutputRoot
+// ---------------------------------------------------------------------------
+
+describe('checkOutputRoot', () => {
+    const { checkOutputRoot } = require(SCRIPT);
+
+    it('rejects empty output_root', () => {
+        const errors = checkOutputRoot('');
+        assert.ok(
+            errors.some(e => e.includes('required')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('rejects absolute path', () => {
+        const errors = checkOutputRoot('/absolute/path');
+        assert.ok(
+            errors.some(e => e.includes('absolute')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('rejects path with ..', () => {
+        const errors = checkOutputRoot('docs/../escape');
+        assert.ok(
+            errors.some(e => e.includes('..')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('rejects docs/_packets', () => {
+        const errors = checkOutputRoot('docs/_packets/something');
+        assert.ok(
+            errors.some(e => e.includes('forbidden')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('rejects data/ root', () => {
+        const errors = checkOutputRoot('data/staging');
+        assert.ok(
+            errors.some(e => e.includes('forbidden')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('rejects output_root outside allowed root', () => {
+        const errors = checkOutputRoot('docs/other_dir');
+        assert.ok(
+            errors.some(e => e.includes('must be under')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('accepts valid output root', () => {
+        const errors = checkOutputRoot('docs/_staging_preview/acquisition/single_target');
+        assert.strictEqual(errors.length, 0, `unexpected errors: ${errors.join('; ')}`);
+    });
+
+    it('accepts valid subdirectory', () => {
+        const errors = checkOutputRoot('docs/_staging_preview/acquisition/single_target/fotmob/titan_discovery');
+        assert.strictEqual(errors.length, 0, `unexpected errors: ${errors.join('; ')}`);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: safeSlug, extractHash8
+// ---------------------------------------------------------------------------
+
+describe('safeSlug', () => {
+    const { safeSlug } = require(SCRIPT);
+
+    it('replaces spaces with underscores', () => {
+        assert.strictEqual(safeSlug('hello world'), 'hello_world');
+    });
+
+    it('removes slashes', () => {
+        assert.ok(!safeSlug('a/b').includes('/'));
+    });
+
+    it('removes dot-dot', () => {
+        assert.ok(!safeSlug('a..b').includes('..'));
+    });
+});
+
+describe('extractHash8', () => {
+    const { extractHash8 } = require(SCRIPT);
+
+    it('extracts first 8 hex chars from sha256', () => {
+        const hash8 = extractHash8({
+            capture: { raw_payload_sha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' },
+        });
+        assert.strictEqual(hash8, 'e3b0c442');
+    });
+
+    it('returns fallback for non-hex', () => {
+        const hash8 = extractHash8({ capture: { raw_payload_sha256: 'nothex!!' } });
+        assert.strictEqual(hash8, '00000000');
+    });
+
+    it('returns fallback for missing capture', () => {
+        const hash8 = extractHash8({});
+        assert.strictEqual(hash8, '00000000');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: checkTargetConsistency
+// ---------------------------------------------------------------------------
+
+describe('checkTargetConsistency', () => {
+    const { checkTargetConsistency } = require(SCRIPT);
+    const art = {
+        source: { name: 'fotmob' },
+        engine: { family: 'titan_discovery' },
+        target_scope: { scope_type: 'match_id', match_id: 'sample-match-001' },
+    };
+    const man = {
+        source_name: 'fotmob',
+        engine_family: 'titan_discovery',
+        target_scope: { scope_type: 'match_id', match_id: 'sample-match-001' },
+    };
+
+    it('passes when all targets match', () => {
+        const errors = checkTargetConsistency(
+            {
+                target_source: 'fotmob',
+                target_engine_family: 'titan_discovery',
+                target_scope_type: 'match_id',
+                target_match_id: 'sample-match-001',
+            },
+            art,
+            man
+        );
+        assert.strictEqual(errors.length, 0, `unexpected: ${errors.join('; ')}`);
+    });
+
+    it('fails when target_source mismatches artifact', () => {
+        const errors = checkTargetConsistency({ target_source: 'other' }, art, man);
+        assert.ok(
+            errors.some(e => e.includes('source')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('fails when engine family mismatches', () => {
+        const errors = checkTargetConsistency({ target_engine_family: 'other' }, art, man);
+        assert.ok(
+            errors.some(e => e.includes('engine')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('fails when scope_type mismatches', () => {
+        const errors = checkTargetConsistency({ target_scope_type: 'league_season_date' }, art, man);
+        assert.ok(
+            errors.some(e => e.includes('scope')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('fails when match_id mismatches', () => {
+        const errors = checkTargetConsistency(
+            {
+                target_scope_type: 'match_id',
+                target_match_id: 'wrong-id',
+            },
+            art,
+            man
+        );
+        assert.ok(
+            errors.some(e => e.includes('match_id')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('fails for unsupported engine family', () => {
+        const errors = checkTargetConsistency({ target_engine_family: 'run_production' }, art, man);
+        assert.ok(
+            errors.some(e => e.includes('not allowed')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+
+    it('fails for forbidden scope type bulk', () => {
+        const errors = checkTargetConsistency({ target_scope_type: 'bulk' }, art, man);
+        assert.ok(
+            errors.some(e => e.includes('forbidden')),
+            `errors: ${errors.join('; ')}`
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: CLI via subprocess
+// ---------------------------------------------------------------------------
+
+describe('preflight CLI (subprocess)', () => {
+    // 24. valid match_id preflight success
+    it('exits 0 for valid match_id preflight', () => {
+        const result = runPreflight(baseOpts());
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.preflight_only, true);
+        assert.strictEqual(parsed.artifact_schema_valid, true);
+        assert.strictEqual(parsed.manifest_schema_valid, true);
+        assert.strictEqual(parsed.output_root_allowed, true);
+        assert.strictEqual(parsed.target_consistency_valid, true);
+        assert.strictEqual(parsed.would_write_staging, false);
+        assert.strictEqual(parsed.would_create_staging_directory, false);
+        assert.strictEqual(parsed.would_write_source_manifest, false);
+        assert.strictEqual(parsed.commit_gate, 'blocked');
+        // path previews present
+        assert.ok(parsed.future_staging_directory_preview);
+        assert.ok(parsed.future_artifact_file_preview);
+        assert.ok(parsed.future_manifest_file_preview);
+    });
+
+    // 26-27: authorization yes still blocks
+    it('outputs would_write_staging=false even when authorization fields are yes', () => {
+        const opts = baseOpts();
+        opts.staging_write_authorization = 'yes';
+        opts.final_human_confirmation = 'yes';
+        const result = runPreflight(opts);
+        assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.would_write_staging, false);
+        assert.strictEqual(parsed.would_create_staging_directory, false);
+        assert.strictEqual(parsed.staging_write_authorized, false);
+    });
+
+    // 1. missing artifact schema
+    it('fails when artifact_schema is missing', () => {
+        const opts = baseOpts();
+        delete opts.artifact_schema;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 2. missing manifest schema
+    it('fails when manifest_schema is missing', () => {
+        const opts = baseOpts();
+        delete opts.manifest_schema;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 3. missing artifact
+    it('fails when artifact is missing', () => {
+        const opts = baseOpts();
+        delete opts.artifact;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 4. missing manifest
+    it('fails when manifest is missing', () => {
+        const opts = baseOpts();
+        delete opts.manifest;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 5. missing output_root
+    it('fails when output_root is missing', () => {
+        const opts = baseOpts();
+        delete opts.output_root;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 6. missing target_source
+    it('fails when target_source is missing', () => {
+        const opts = baseOpts();
+        delete opts.target_source;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 7. missing target_engine_family
+    it('fails when target_engine_family is missing', () => {
+        const opts = baseOpts();
+        delete opts.target_engine_family;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 8. missing target_scope_type
+    it('fails when target_scope_type is missing', () => {
+        const opts = baseOpts();
+        delete opts.target_scope_type;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 9. missing staging_write_authorization
+    it('fails when staging_write_authorization is missing', () => {
+        const opts = baseOpts();
+        delete opts.staging_write_authorization;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 10. missing final_human_confirmation
+    it('fails when final_human_confirmation is missing', () => {
+        const opts = baseOpts();
+        delete opts.final_human_confirmation;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 11-15. output_root policy tests
+    it('fails for absolute output_root', () => {
+        const opts = baseOpts();
+        opts.output_root = '/absolute/path';
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    it('fails for output_root with ..', () => {
+        const opts = baseOpts();
+        opts.output_root = 'docs/../escape';
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    it('fails for output_root=data', () => {
+        const opts = baseOpts();
+        opts.output_root = 'data/staging';
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    it('fails for output_root=docs/_packets', () => {
+        const opts = baseOpts();
+        opts.output_root = 'docs/_packets/something';
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 16-17. schema validation failure
+    it('fails when artifact schema is invalid', () => {
+        const tmpDir = makeTempDir();
+        const badArtifact = writeTempJson(tmpDir, 'bad_artifact.json', { not_valid: true });
+        const opts = baseOpts();
+        opts.artifact = badArtifact;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0, 'should fail for invalid artifact');
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    // 18-20. target mismatch
+    it('fails when target_source mismatches', () => {
+        const opts = baseOpts();
+        opts.target_source = 'other_source';
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    it('fails when target_engine_family mismatches', () => {
+        const opts = baseOpts();
+        opts.target_engine_family = 'bad_engine';
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    it('fails when target_match_id mismatches', () => {
+        const opts = baseOpts();
+        opts.target_match_id = 'wrong-match';
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0);
+    });
+
+    // 31. --commit blocked
+    it('exits non-zero when --commit is passed', () => {
+        const opts = baseOpts();
+        opts.commit = true;
+        const result = runPreflight(opts);
+        assert.notStrictEqual(result.exitCode, 0, 'should exit non-zero for --commit');
+        assert.ok(result.stderr.includes('commit/execution is not wired'), `stderr: ${result.stderr}`);
+    });
+
+    // all would_* false
+    it('outputs all would_* false', () => {
+        const result = runPreflight(baseOpts());
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.would_access_network, false);
+        assert.strictEqual(parsed.would_launch_browser, false);
+        assert.strictEqual(parsed.would_use_proxy, false);
+        assert.strictEqual(parsed.would_execute_engine, false);
+        assert.strictEqual(parsed.would_write_staging, false);
+        assert.strictEqual(parsed.would_create_staging_directory, false);
+        assert.strictEqual(parsed.would_write_source_manifest, false);
+        assert.strictEqual(parsed.would_write_db, false);
+        assert.strictEqual(parsed.would_train, false);
+        assert.strictEqual(parsed.would_predict, false);
+        assert.strictEqual(parsed.would_spawn_child_process, false);
+        assert.strictEqual(parsed.staging_write_authorized, false);
+    });
+
+    // path preview correctness
+    it('generates correct future directory preview', () => {
+        const result = runPreflight(baseOpts());
+        const parsed = JSON.parse(result.stdout);
+        assert.ok(parsed.future_staging_directory_preview.includes('docs/_staging_preview/acquisition/single_target'));
+        assert.ok(parsed.future_staging_directory_preview.includes('fotmob'));
+        assert.ok(parsed.future_staging_directory_preview.includes('titan_discovery'));
+        assert.ok(parsed.future_staging_directory_preview.includes('match_id'));
+        assert.ok(parsed.future_staging_directory_preview.includes('sample-match-001'));
+        assert.ok(parsed.future_artifact_file_preview.endsWith('.json'));
+        assert.ok(parsed.future_manifest_file_preview.endsWith('.json'));
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Source-code audit: no side effects
+// ---------------------------------------------------------------------------
+
+describe('source-code side-effect audit', () => {
+    const source = fs.readFileSync(SCRIPT, 'utf8');
+
+    it('does not import titan_discovery or DiscoveryService', () => {
+        assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source), 'must not import titan_discovery');
+        assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source), 'must not import DiscoveryService');
+    });
+
+    it('does not import pg/redis', () => {
+        assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source), 'must not import pg');
+        assert.ok(!/require\s*\(\s*['"]redis/.test(source), 'must not import redis');
+    });
+
+    it('does not import playwright', () => {
+        assert.ok(!/require\s*\(\s*['"]playwright/.test(source), 'must not import playwright');
+    });
+
+    it('does not import http/https/net', () => {
+        assert.ok(!/require\s*\(\s*['"]https?['"]/.test(source), 'must not import http/https');
+        assert.ok(!/require\s*\(\s*['"]net['"]/.test(source), 'must not import net');
+    });
+
+    it('does not import child_process', () => {
+        assert.ok(!/require\s*\(\s*['"]child_process['"]/.test(source), 'must not import child_process');
+    });
+
+    it('does not use fs write/mkdir methods', () => {
+        assert.ok(
+            !/writeFileSync|writeFile|createWriteStream|mkdirSync|mkdir/.test(source),
+            'must not use fs write/mkdir'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.81D single-target acquisition staging writer preflight.

Scope:
- Adds local-only staging writer preflight command
- Validates artifact and manifest fixtures through existing schemas
- Validates target consistency (source, engine, scope, match_id)
- Validates output root policy
- Previews future staging directory and filenames
- Keeps staging write blocked (would_write_staging=false)
- Adds Makefile preflight and blocked commit targets
- Adds no-side-effect unit tests (50/50 pass)
- Updates AGENTS.md
- Adds Phase 4.81D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- preflight missing params failed as expected
- valid preflight passed with path previews
- commit gate remained blocked
- unit tests passed (50/50)
- npm test passed (48/48)
- npm run test:coverage passed
- ESLint passed
- Prettier passed
- DB row counts unchanged (2/2/2/2/2/2)
- l1-config residue absent
- no staging preview directory created