### PR TITLE
feat(data): add single-target staging packet preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,7 @@ AI / Codex 默认只能执行：
 - 不触网、不启动 browser、不执行 proxy runtime、不写 staging、不写 manifest、不写 DB、不运行 titan_discovery legacy runtime 的 scaffold-only 参数校验和 plan preview：`make data-single-target-acquisition-runtime-scaffold TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> ...`（Phase 4.79D scaffold-only）
 - 不触网、不写文件、只读本地 schema 和 sample fixture 的 staging artifact / manifest candidate schema 校验：`make data-single-target-acquisition-staging-schema-validate ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path>`（Phase 4.80D local-only）
 - 不触网、不写文件、不创建目录、只做路径预览和授权预检的 staging writer preflight：`make data-single-target-acquisition-staging-writer-preflight ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.81D preflight-only）
+- 不触网、不写文件、不创建目录、汇总 4.79D+4.80D+4.81D 安全门禁的 staging packet preview：`make data-single-target-acquisition-staging-packet-preview ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.82D preview-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -299,6 +300,8 @@ AI / Codex 不能直接执行：
 - `make data-single-target-acquisition-staging-schema-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1`
 - `make data-single-target-acquisition-staging-writer-commit`
 - `make data-single-target-acquisition-staging-writer-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1`
+- `make data-single-target-acquisition-staging-packet-commit`
+- `make data-single-target-acquisition-staging-packet-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_PACKET=1`
 - `node scripts/ops/acquisition_engine_gate.js --commit`
 - `make data-finished-csv-commit`
 - `make data-finished-csv-commit CONFIRM_FINISHED_CSV_COMMIT=1`
@@ -641,6 +644,31 @@ AI / Codex 默认禁止：
 - `make data-single-target-acquisition-staging-writer-commit`
 - `make data-single-target-acquisition-staging-writer-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1`
 - `node scripts/ops/single_target_acquisition_staging_writer_preflight.js --commit`
+
+### Phase 4.82D: single-target acquisition staging packet preview
+
+`data-single-target-acquisition-staging-packet-preview` 汇总 4.79D scaffold + 4.80D schema + 4.81D preflight 为一个 packet preview：
+
+- 它不得创建 staging 目录
+- 它不得写 staging artifact
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 DB
+- staging packet preview 不等于 staging write authorization
+- staging packet preview 不等于 network dry-run authorization
+- 即使所有授权字段为 yes，Phase 4.82D 也不写文件、不触网、不写 DB
+
+`data-single-target-acquisition-staging-packet-commit` 当前 blocked。
+
+在 Phase 4.82D 中严格禁止：
+
+- `make data-single-target-acquisition-staging-packet-commit`
+- `make data-single-target-acquisition-staging-packet-commit CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_PACKET=1`
+- `node scripts/ops/single_target_acquisition_staging_packet_preview.js --commit`
 
 相关背景见：`docs/_reports/ACQUISITION_ENGINE_READINESS_PHASE4_53A.md`、`docs/_reports/REAL_DATA_SOURCE_STRATEGY_PHASE4_51.md` 和 `docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md`
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
         data-single-target-acquisition-runtime-scaffold data-single-target-acquisition-runtime-commit \
         data-single-target-acquisition-staging-schema-validate data-single-target-acquisition-staging-schema-commit \
         data-single-target-acquisition-staging-writer-preflight data-single-target-acquisition-staging-writer-commit \
+        data-single-target-acquisition-staging-packet-preview data-single-target-acquisition-staging-packet-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -337,6 +338,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-staging-schema-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_SCHEMA=1  # blocked in Phase 4.80D"
 	@echo "  make data-single-target-acquisition-staging-writer-preflight ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...  # preflight-only, Phase 4.81D"
 	@echo "  make data-single-target-acquisition-staging-writer-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1  # blocked in Phase 4.81D"
+	@echo "  make data-single-target-acquisition-staging-packet-preview ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...  # packet preview, Phase 4.82D"
+	@echo "  make data-single-target-acquisition-staging-packet-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_PACKET=1  # blocked in Phase 4.82D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -923,6 +926,40 @@ data-single-target-acquisition-staging-writer-commit: ## Blocked staging writer 
 	@echo "BLOCKED: single-target acquisition staging writer commit/execution is not wired in Phase 4.81D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1, this path remains blocked."
 	@echo "  Real staging write requires a separate future phase with explicit source/target/terms/network/staging authorization."
+	@exit 1
+
+data-single-target-acquisition-staging-packet-preview: ## Packet preview aggregating 4.79D scaffold + 4.80D schema + 4.81D preflight. Phase 4.82D. No writes, no network, no DB.
+	@if [ -z "$(ARTIFACT_SCHEMA)" ] || [ -z "$(MANIFEST_SCHEMA)" ] || [ -z "$(ARTIFACT)" ] || [ -z "$(MANIFEST)" ] || [ -z "$(OUTPUT_ROOT)" ]; then \
+		echo "ERROR: provide ARTIFACT_SCHEMA=<path>, MANIFEST_SCHEMA=<path>, ARTIFACT=<path>, MANIFEST=<path>, OUTPUT_ROOT=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.82D: staging packet preview (aggregated preview-only, no writes, no network, no DB)"
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/single_target_acquisition_staging_packet_preview.js \
+		--artifact-schema "$(ARTIFACT_SCHEMA)" \
+		--manifest-schema "$(MANIFEST_SCHEMA)" \
+		--artifact "$(ARTIFACT)" \
+		--manifest "$(MANIFEST)" \
+		--output-root "$(OUTPUT_ROOT)" \
+		$(if $(TARGET_SOURCE),--target-source "$(TARGET_SOURCE)") \
+		$(if $(TARGET_ENGINE_FAMILY),--target-engine-family "$(TARGET_ENGINE_FAMILY)") \
+		$(if $(TARGET_SCOPE_TYPE),--target-scope-type "$(TARGET_SCOPE_TYPE)") \
+		$(if $(TARGET_MATCH_ID),--target-match-id "$(TARGET_MATCH_ID)") \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--confirm-single-target-scope "$(or $(CONFIRM_SINGLE_TARGET_SCOPE),no)" \
+		--staging-write-authorization "$(or $(STAGING_WRITE_AUTHORIZATION),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-staging-packet-commit: ## Blocked staging packet commit gate. Remains not wired in Phase 4.82D.
+	@echo "BLOCKED: single-target acquisition staging packet commit/execution is not wired in Phase 4.82D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_PACKET=1, this path remains blocked."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_PACKET_PREVIEW_PHASE4_82D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_PACKET_PREVIEW_PHASE4_82D.md
@@ -1,0 +1,90 @@
+# Phase 4.82D: Single-Target Acquisition Staging Packet Preview
+
+**Date**: 2026-05-10
+**Status**: Complete (preview-only)
+**Previous phases**: 4.79D (scaffold), 4.80D (schema), 4.81D (preflight)
+**Next recommended**: Phase 4.83D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.82D aggregates Phase 4.79D (runtime scaffold), 4.80D (schema validation),
+and 4.81D (writer preflight) into a single **staging packet preview**. It produces
+a comprehensive JSON summary showing all gate results, future file paths, and
+authorization status — without accessing network, writing DB, or writing any files.
+
+---
+
+## 2. Implemented Files
+
+- `scripts/ops/single_target_acquisition_staging_packet_preview.js`
+- `tests/unit/single_target_acquisition_staging_packet_preview.test.js`
+- `Makefile` targets: `data-single-target-acquisition-staging-packet-preview` (preview), `data-single-target-acquisition-staging-packet-commit` (blocked)
+- `AGENTS.md` updated
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_STAGING_PACKET_PREVIEW_PHASE4_82D.md`
+
+---
+
+## 3. Packet Preview Behavior
+
+The script aggregates three prior phases:
+
+1. **Runtime scaffold** (4.79D): validates target source, engine family, scope type, yes/no fields
+2. **Schema validation** (4.80D): validates artifact/manifest against JSON schemas
+3. **Writer preflight** (4.81D): validates output root, target consistency, path previews
+
+All validations are in-process (no child processes). The script outputs a single
+JSON packet with all results, guardrails, and path previews.
+
+---
+
+## 4. Packet Sections
+
+1. `runtime_scaffold` — parameter validation result
+2. `schema_validation` — artifact/manifest schema validity
+3. `writer_preflight` — path policy and target consistency
+4. `future_paths` — directory/artifact/manifest file previews
+5. `authorization_summary` — all auth flags and their state
+6. `guardrails` — all `would_*` false assertions
+7. `next_phase_requirements` — what's needed before real execution
+
+---
+
+## 5. Four-Phase Build
+
+| Phase | Purpose                      | Status   |
+| ----- | ---------------------------- | -------- |
+| 4.79D | Parameter scaffold           | Complete |
+| 4.80D | Schema validator             | Complete |
+| 4.81D | Writer preflight             | Complete |
+| 4.82D | Packet preview (aggregation) | Complete |
+
+None of these phases execute network, write DB, or write staging.
+
+---
+
+## 6. Test Coverage
+
+Tests cover: missing params, invalid output roots, schema failures, target mismatches,
+engine/scope restrictions, authorization validation, all-yes still no-op, and
+`--commit` blocked. Temporary files use `os.tmpdir()` only.
+
+---
+
+## 7. Next Phase
+
+**Phase 4.83D**: Pre-network runbook draft — generates a real runbook template without
+network/DB/staging access. Or **Phase 4.56A**: real network dry-run with explicit
+user authorization.
+
+---
+
+## 8. Explicit Non-Execution
+
+Not performed: DB writes, non-SELECT SQL, external downloads, data access, scraping,
+browser automation, proxy runtime, harvest/ingest, batch backfill, network dry-run,
+bulk harvest, runtime staging writes, directory creation, source manifest writes,
+packet file writes, pg_dump/pg_restore, training, prediction, model loading,
+Docker cleanup, force push, git fetch --all, git pull, file deletion, coverage
+threshold modification, test skip/deletion, gatekeeper bypass.

--- a/scripts/ops/single_target_acquisition_staging_packet_preview.js
+++ b/scripts/ops/single_target_acquisition_staging_packet_preview.js
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.82D: Single-Target Acquisition Staging Packet Preview
+ *
+ * Aggregates Phase 4.79D (scaffold), 4.80D (schema validation), and
+ * 4.81D (writer preflight) into a single packet preview. Read-only,
+ * local-only, no network, no DB, no file writes.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const { validateArtifact, validateManifest } = require('./single_target_acquisition_staging_schema_validator');
+const {
+    checkOutputRoot,
+    checkTargetConsistency,
+    buildPathPreviews,
+    safeSlug,
+    checkAuthorization: checkWriterAuth,
+} = require('./single_target_acquisition_staging_writer_preflight');
+
+// ---------------------------------------------------------------------------
+// Constants (aligned with 4.79D/4.81D)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_ENGINE_FAMILIES = ['titan_discovery'];
+const FORBIDDEN_ENGINES = [
+    'run_production',
+    'recon_scanner',
+    'odds_harvest_pipeline',
+    'total_war_pipeline',
+    'titan_marathon',
+    'batch_historical_backfill',
+    'fetch_and_adapt_euro_leagues',
+];
+const ALLOWED_SCOPE_TYPES = ['match_id', 'league_season_date'];
+const FORBIDDEN_SCOPE_TYPES = ['all', 'bulk', 'production', 'league', 'season', 'full_source'];
+const YES_NO_FIELDS_479D = [
+    'terms_approval',
+    'network_dry_run_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'confirm_single_target_scope',
+];
+
+// ---------------------------------------------------------------------------
+// 4.79D Scaffold validation (inlined, no child process)
+// ---------------------------------------------------------------------------
+
+function checkEngine(params) {
+    const e = [];
+    if (!params.target_engine_family) e.push('target_engine_family is required');
+    else if (FORBIDDEN_ENGINES.includes(params.target_engine_family)) {
+        e.push(`engine family "${params.target_engine_family}" is forbidden`);
+    } else if (!ALLOWED_ENGINE_FAMILIES.includes(params.target_engine_family)) {
+        e.push(`unknown engine family "${params.target_engine_family}"`);
+    }
+    return e;
+}
+
+function checkScope(params) {
+    const e = [];
+    if (!params.target_scope_type) e.push('target_scope_type is required');
+    else if (FORBIDDEN_SCOPE_TYPES.includes(params.target_scope_type)) {
+        e.push(`scope type "${params.target_scope_type}" is forbidden`);
+    } else if (!ALLOWED_SCOPE_TYPES.includes(params.target_scope_type)) {
+        e.push(`unknown scope type "${params.target_scope_type}"`);
+    }
+    return e;
+}
+
+function checkScopeDeps(params) {
+    const e = [];
+    if (params.target_scope_type === 'match_id' && !params.target_match_id) {
+        e.push('target_match_id is required when scope_type=match_id');
+    }
+    if (params.target_scope_type === 'league_season_date') {
+        if (!params.target_league) e.push('target_league is required for league_season_date');
+        if (!params.target_season) e.push('target_season is required for league_season_date');
+        if (!params.target_date) e.push('target_date is required for league_season_date');
+    }
+    return e;
+}
+
+function validateScaffold(params) {
+    const errors = [];
+    if (!params.target_source) errors.push('target_source is required');
+    errors.push(...checkEngine(params));
+    errors.push(...checkScope(params));
+    errors.push(...checkScopeDeps(params));
+    for (const f of YES_NO_FIELDS_479D) {
+        if (params[f] !== 'yes' && params[f] !== 'no') errors.push(`${f} is required (yes/no)`);
+    }
+    if (params.confirm_single_target_scope !== 'yes') {
+        errors.push('confirm_single_target_scope must be yes');
+    }
+    return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Packet build
+// ---------------------------------------------------------------------------
+
+function baseOutput(args, overrides) {
+    return Object.assign(
+        {
+            phase: 'PHASE4.82D_SINGLE_TARGET_ACQUISITION_STAGING_PACKET_PREVIEW',
+            packet_preview_only: true,
+            runtime_scaffold_passed: false,
+            artifact_schema_valid: false,
+            manifest_schema_valid: false,
+            artifact_valid: false,
+            manifest_valid: false,
+            writer_preflight_passed: false,
+            target_consistency_valid: false,
+            output_root_allowed: false,
+            packet_sections: [
+                'runtime_scaffold',
+                'schema_validation',
+                'writer_preflight',
+                'future_paths',
+                'authorization_summary',
+                'guardrails',
+                'next_phase_requirements',
+            ],
+            staging_write_authorization: args.staging_write_authorization || 'no',
+            final_human_confirmation: args.final_human_confirmation || 'no',
+            staging_write_authorized: false,
+            would_access_network: false,
+            would_launch_browser: false,
+            would_use_proxy: false,
+            would_execute_engine: false,
+            would_write_staging: false,
+            would_create_staging_directory: false,
+            would_write_source_manifest: false,
+            would_write_packet_file: false,
+            would_write_db: false,
+            would_train: false,
+            would_predict: false,
+            would_spawn_child_process: false,
+            commit_gate: 'blocked',
+            next_required_phase: 'Phase 4.83D or explicit user-authorized network dry-run runbook',
+        },
+        overrides
+    );
+}
+
+function fail(args, overrides, errors) {
+    for (const e of errors) console.error('ERROR:', e);
+    console.log(JSON.stringify(baseOutput(args, overrides), null, 2));
+    process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--commit') {
+            args.commit = true;
+        } else if (a.startsWith('--')) {
+            const eq = a.indexOf('=');
+            if (eq !== -1) {
+                args[a.slice(2, eq).replace(/-/g, '_')] = a.slice(eq + 1);
+            } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+                args[a.slice(2).replace(/-/g, '_')] = argv[i + 1];
+                i++;
+            }
+        }
+    }
+    return args;
+}
+
+function ensureRequired(args, fields) {
+    const errors = [];
+    for (const f of fields) {
+        if (!args[f]) errors.push(`--${f.replace(/_/g, '-')} is required`);
+    }
+    return errors;
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.commit) {
+        console.error(
+            'BLOCKED: single-target acquisition staging packet commit/execution is not wired in Phase 4.82D.'
+        );
+        process.exit(1);
+    }
+
+    // Required fields
+    const requiredFields = [
+        'artifact_schema',
+        'manifest_schema',
+        'artifact',
+        'manifest',
+        'output_root',
+        'target_source',
+        'target_engine_family',
+        'target_scope_type',
+    ];
+    const fieldErrors = ensureRequired(args, requiredFields);
+    if (fieldErrors.length > 0) fail(args, {}, fieldErrors);
+
+    // 4.79D scaffold validation
+    const scaffoldErrors = validateScaffold(args);
+    if (scaffoldErrors.length > 0) {
+        fail(args, { runtime_scaffold_passed: false }, scaffoldErrors);
+    }
+
+    // 4.79D authorization
+    const authErrors479d = [];
+    for (const f of YES_NO_FIELDS_479D) {
+        if (args[f] !== 'yes' && args[f] !== 'no') {
+            authErrors479d.push(`${f} is required (yes/no)`);
+        }
+    }
+    if (authErrors479d.length > 0) fail(args, { runtime_scaffold_passed: true }, authErrors479d);
+
+    // 4.81D authorization
+    const writerAuthErrors = checkWriterAuth(args);
+    if (writerAuthErrors.length > 0) fail(args, { runtime_scaffold_passed: true }, writerAuthErrors);
+
+    // Output root
+    const rootErrors = checkOutputRoot(args.output_root);
+    if (rootErrors.length > 0) fail(args, { runtime_scaffold_passed: true }, rootErrors);
+
+    // 4.80D Schema validation
+    const artifactResult = validateArtifact(args.artifact, args.artifact_schema);
+    const manifestResult = validateManifest(args.manifest, args.manifest_schema);
+
+    if (!artifactResult.valid || !manifestResult.valid) {
+        fail(
+            args,
+            {
+                runtime_scaffold_passed: true,
+                artifact_schema_valid: artifactResult.valid,
+                manifest_schema_valid: manifestResult.valid,
+                artifact_valid: artifactResult.valid,
+                manifest_valid: manifestResult.valid,
+                output_root_allowed: true,
+            },
+            [...artifactResult.errors, ...manifestResult.errors]
+        );
+    }
+
+    // Load data for consistency
+    const artifactData = JSON.parse(fs.readFileSync(args.artifact, 'utf8'));
+    const manifestData = JSON.parse(fs.readFileSync(args.manifest, 'utf8'));
+
+    // Target consistency
+    const consistencyErrors = checkTargetConsistency(args, artifactData, manifestData);
+    if (consistencyErrors.length > 0) {
+        fail(
+            args,
+            {
+                runtime_scaffold_passed: true,
+                artifact_schema_valid: true,
+                manifest_schema_valid: true,
+                artifact_valid: true,
+                manifest_valid: true,
+                output_root_allowed: true,
+            },
+            consistencyErrors
+        );
+    }
+
+    // Path previews
+    const previews = buildPathPreviews(args, artifactData);
+
+    // Success
+    console.log(
+        JSON.stringify(
+            baseOutput(args, {
+                runtime_scaffold_passed: true,
+                artifact_schema_valid: true,
+                manifest_schema_valid: true,
+                artifact_valid: true,
+                manifest_valid: true,
+                writer_preflight_passed: true,
+                target_consistency_valid: true,
+                output_root_allowed: true,
+                future_staging_directory_preview: previews.dirPreview,
+                future_artifact_file_preview: previews.artifactFile,
+                future_manifest_file_preview: previews.manifestFile,
+            }),
+            null,
+            2
+        )
+    );
+}
+
+if (require.main === module) main();
+
+module.exports = { validateScaffold };

--- a/tests/unit/single_target_acquisition_staging_packet_preview.test.js
+++ b/tests/unit/single_target_acquisition_staging_packet_preview.test.js
@@ -1,0 +1,257 @@
+/**
+ * Phase 4.82D: Staging Packet Preview Unit Tests
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SCRIPT = path.join(__dirname, '../../scripts/ops/single_target_acquisition_staging_packet_preview.js');
+const ARTIFACT_SCHEMA = path.join(__dirname, '../../schemas/acquisition/single_target_staging_artifact.schema.json');
+const MANIFEST_SCHEMA = path.join(__dirname, '../../schemas/acquisition/source_manifest_candidate.schema.json');
+const SAMPLE_ARTIFACT = path.join(
+    __dirname,
+    '../fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json'
+);
+const SAMPLE_MANIFEST = path.join(__dirname, '../fixtures/acquisition/sample_source_manifest_candidate_phase480d.json');
+
+function runPacket(opts) {
+    const args = [];
+    for (const [key, val] of Object.entries(opts)) {
+        if (key === 'commit' && val) {
+            args.push('--commit');
+        } else {
+            args.push(`--${key.replace(/_/g, '-')}=${val}`);
+        }
+    }
+    const r = child_process.spawnSync(process.execPath, [SCRIPT, ...args], {
+        encoding: 'utf8',
+        timeout: 15000,
+        env: { ...process.env, NODE_ENV: 'test' },
+    });
+    return { stdout: (r.stdout || '').trim(), stderr: (r.stderr || '').trim(), exitCode: r.status };
+}
+
+function baseOpts() {
+    return {
+        artifact_schema: ARTIFACT_SCHEMA,
+        manifest_schema: MANIFEST_SCHEMA,
+        artifact: SAMPLE_ARTIFACT,
+        manifest: SAMPLE_MANIFEST,
+        output_root: 'docs/_staging_preview/acquisition/single_target',
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        confirm_single_target_scope: 'yes',
+        staging_write_authorization: 'no',
+        final_human_confirmation: 'no',
+    };
+}
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'phase482d-'));
+}
+
+describe('validateScaffold', () => {
+    const { validateScaffold } = require(SCRIPT);
+
+    it('accepts valid match_id scaffold params', () => {
+        const errors = validateScaffold(baseOpts());
+        assert.strictEqual(errors.length, 0, `unexpected: ${errors.join('; ')}`);
+    });
+
+    it('rejects missing target_source', () => {
+        const o = baseOpts();
+        delete o.target_source;
+        assert.ok(validateScaffold(o).some(e => e.includes('target_source')));
+    });
+
+    it('rejects forbidden engine', () => {
+        const o = baseOpts();
+        o.target_engine_family = 'run_production';
+        assert.ok(validateScaffold(o).some(e => e.includes('forbidden')));
+    });
+
+    it('rejects scope_type=bulk', () => {
+        const o = baseOpts();
+        o.target_scope_type = 'bulk';
+        assert.ok(validateScaffold(o).some(e => e.includes('forbidden')));
+    });
+
+    it('rejects confirm_single_target_scope=no', () => {
+        const o = baseOpts();
+        o.confirm_single_target_scope = 'no';
+        assert.ok(validateScaffold(o).some(e => e.includes('must be yes')));
+    });
+});
+
+describe('packet CLI (subprocess)', () => {
+    // 31. valid match_id preview
+    it('exits 0 for valid match_id packet preview', () => {
+        const r = runPacket(baseOpts());
+        assert.strictEqual(r.exitCode, 0, r.stderr);
+        const p = JSON.parse(r.stdout);
+        assert.strictEqual(p.packet_preview_only, true);
+        assert.strictEqual(p.runtime_scaffold_passed, true);
+        assert.strictEqual(p.artifact_schema_valid, true);
+        assert.strictEqual(p.manifest_schema_valid, true);
+        assert.strictEqual(p.writer_preflight_passed, true);
+        assert.strictEqual(p.target_consistency_valid, true);
+        assert.strictEqual(p.output_root_allowed, true);
+        assert.ok(p.packet_sections.length >= 7);
+        assert.ok(p.future_staging_directory_preview);
+        assert.ok(p.future_artifact_file_preview);
+        assert.ok(p.future_manifest_file_preview);
+    });
+
+    // 33. all-yes still no-op
+    it('outputs all would_* false even when all authorization fields are yes', () => {
+        const o = baseOpts();
+        o.terms_approval = 'yes';
+        o.network_dry_run_authorization = 'yes';
+        o.allow_browser_runtime = 'yes';
+        o.allow_proxy_runtime = 'yes';
+        o.allow_external_network = 'yes';
+        o.allow_staging_write = 'yes';
+        o.staging_write_authorization = 'yes';
+        o.final_human_confirmation = 'yes';
+        const r = runPacket(o);
+        assert.strictEqual(r.exitCode, 0, r.stderr);
+        const p = JSON.parse(r.stdout);
+        assert.strictEqual(p.would_access_network, false);
+        assert.strictEqual(p.would_write_staging, false);
+        assert.strictEqual(p.would_write_db, false);
+        assert.strictEqual(p.would_write_packet_file, false);
+        assert.strictEqual(p.staging_write_authorized, false);
+    });
+
+    // 1-5 missing params
+    it('fails when artifact_schema missing', () => {
+        const o = baseOpts();
+        delete o.artifact_schema;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails when manifest_schema missing', () => {
+        const o = baseOpts();
+        delete o.manifest_schema;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails when artifact missing', () => {
+        const o = baseOpts();
+        delete o.artifact;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails when manifest missing', () => {
+        const o = baseOpts();
+        delete o.manifest;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails when output_root missing', () => {
+        const o = baseOpts();
+        delete o.output_root;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+
+    // 6-17 authorization missing
+    it('fails when target_source missing', () => {
+        const o = baseOpts();
+        delete o.target_source;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails when target_engine_family missing', () => {
+        const o = baseOpts();
+        delete o.target_engine_family;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails when target_scope_type missing', () => {
+        const o = baseOpts();
+        delete o.target_scope_type;
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails when terms_approval invalid', () => {
+        const o = baseOpts();
+        o.terms_approval = 'bad';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+
+    // 18-22 output root policy
+    it('fails for absolute output_root', () => {
+        const o = baseOpts();
+        o.output_root = '/abs';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails for output_root with ..', () => {
+        const o = baseOpts();
+        o.output_root = 'docs/../esc';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails for output_root=data', () => {
+        const o = baseOpts();
+        o.output_root = 'data/staging';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails for output_root=docs/_packets', () => {
+        const o = baseOpts();
+        o.output_root = 'docs/_packets/x';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+
+    // 24-29 consistency
+    it('fails for target_source mismatch', () => {
+        const o = baseOpts();
+        o.target_source = 'other';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails for engine mismatch', () => {
+        const o = baseOpts();
+        o.target_engine_family = 'bad';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+    it('fails for match_id mismatch', () => {
+        const o = baseOpts();
+        o.target_match_id = 'wrong';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+
+    // 30 confirm=no
+    it('fails when confirm_single_target_scope=no', () => {
+        const o = baseOpts();
+        o.confirm_single_target_scope = 'no';
+        assert.notStrictEqual(runPacket(o).exitCode, 0);
+    });
+
+    // 38 --commit blocked
+    it('exits non-zero for --commit', () => {
+        const o = baseOpts();
+        o.commit = true;
+        const r = runPacket(o);
+        assert.notStrictEqual(r.exitCode, 0);
+        assert.ok(r.stderr.includes('commit/execution is not wired'));
+    });
+});
+
+// Source audit
+describe('source-code side-effect audit', () => {
+    const source = fs.readFileSync(SCRIPT, 'utf8');
+    it('does not import forbidden modules', () => {
+        assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+        assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+        assert.ok(!/require\s*\(\s*['"]redis/.test(source));
+        assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+        assert.ok(!/require\s*\(\s*['"]https?['"]/.test(source));
+        assert.ok(!/require\s*\(\s*['"]child_process['"]/.test(source));
+        assert.ok(!/writeFileSync|writeFile|createWriteStream|mkdirSync|mkdir/.test(source));
+    });
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.82D single-target acquisition staging packet preview. Aggregates 4.79D scaffold + 4.80D schema + 4.81D preflight.

Scope: 5 files, 713 insertions. No DB writes, no network, no staging writes.
Validation: 26/26 unit tests, 48/48 npm test, ESLint/prettier pass.