### PR TITLE
docs(data): add single-target pre-network runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、只读本地 schema 和 sample fixture 的 staging artifact / manifest candidate schema 校验：`make data-single-target-acquisition-staging-schema-validate ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path>`（Phase 4.80D local-only）
 - 不触网、不写文件、不创建目录、只做路径预览和授权预检的 staging writer preflight：`make data-single-target-acquisition-staging-writer-preflight ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.81D preflight-only）
 - 不触网、不写文件、不创建目录、汇总 4.79D+4.80D+4.81D 安全门禁的 staging packet preview：`make data-single-target-acquisition-staging-packet-preview ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.82D preview-only）
+- 不触网、不写文件、不创建目录、只验证 pre-network runbook draft 和 packet preview 前置条件的本地 validator：`make data-single-target-acquisition-pre-network-runbook-validate RUNBOOK=<path> ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path> OUTPUT_ROOT=<path> ...`（Phase 4.83D draft-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -671,6 +672,25 @@ AI / Codex 默认禁止：
 - `node scripts/ops/single_target_acquisition_staging_packet_preview.js --commit`
 
 相关背景见：`docs/_reports/ACQUISITION_ENGINE_READINESS_PHASE4_53A.md`、`docs/_reports/REAL_DATA_SOURCE_STRATEGY_PHASE4_51.md` 和 `docs/_reports/REAL_FINISHED_CSV_STAGING_DRY_RUN_PHASE4_52.md`
+
+### Phase 4.83D: single-target acquisition pre-network runbook draft
+
+`data-single-target-acquisition-pre-network-runbook-validate` 只允许验证 pre-network runbook draft：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 DB
+- pre-network runbook draft 不等于 network dry-run authorization
+- 即使 CLI 传入 yes，Phase 4.83D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-pre-network-runbook-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook 审核通过。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
         data-single-target-acquisition-staging-schema-validate data-single-target-acquisition-staging-schema-commit \
         data-single-target-acquisition-staging-writer-preflight data-single-target-acquisition-staging-writer-commit \
         data-single-target-acquisition-staging-packet-preview data-single-target-acquisition-staging-packet-commit \
+        data-single-target-acquisition-pre-network-runbook-validate data-single-target-acquisition-pre-network-runbook-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -73,6 +74,7 @@ help: ## 显示帮助信息
 # Docker 命令
 # ============================================
 COMPOSE_DEV=docker compose -f docker-compose.dev.yml
+PRE_NETWORK_RUNBOOK_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -340,6 +342,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-staging-writer-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_WRITE=1  # blocked in Phase 4.81D"
 	@echo "  make data-single-target-acquisition-staging-packet-preview ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...  # packet preview, Phase 4.82D"
 	@echo "  make data-single-target-acquisition-staging-packet-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_PACKET=1  # blocked in Phase 4.82D"
+	@echo "  make data-single-target-acquisition-pre-network-runbook-validate RUNBOOK=<path> ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path> OUTPUT_ROOT=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # draft-only validate, Phase 4.83D"
+	@echo "  make data-single-target-acquisition-pre-network-runbook-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK=1  # blocked in Phase 4.83D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -960,6 +964,42 @@ data-single-target-acquisition-staging-packet-preview: ## Packet preview aggrega
 data-single-target-acquisition-staging-packet-commit: ## Blocked staging packet commit gate. Remains not wired in Phase 4.82D.
 	@echo "BLOCKED: single-target acquisition staging packet commit/execution is not wired in Phase 4.82D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_PACKET=1, this path remains blocked."
+	@exit 1
+
+data-single-target-acquisition-pre-network-runbook-validate: ## Draft-only pre-network runbook validation. Phase 4.83D. No network, no writes, no DB.
+	@if [ -z "$(RUNBOOK)" ] || [ -z "$(ARTIFACT_SCHEMA)" ] || [ -z "$(MANIFEST_SCHEMA)" ] || [ -z "$(ARTIFACT)" ] || [ -z "$(MANIFEST)" ] || [ -z "$(OUTPUT_ROOT)" ] || [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ] || [ -z "$(TARGET_MATCH_ID)" ]; then \
+		echo "ERROR: provide RUNBOOK=<path>, ARTIFACT_SCHEMA=<path>, MANIFEST_SCHEMA=<path>, ARTIFACT=<path>, MANIFEST=<path>, OUTPUT_ROOT=<path>, TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<type>, TARGET_MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.83D: pre-network runbook validate (draft-only, local-only, no writes, no network, no DB)"
+	$(PRE_NETWORK_RUNBOOK_NODE) scripts/ops/single_target_acquisition_pre_network_runbook_validate.js \
+		--runbook "$(RUNBOOK)" \
+		--artifact-schema "$(ARTIFACT_SCHEMA)" \
+		--manifest-schema "$(MANIFEST_SCHEMA)" \
+		--artifact "$(ARTIFACT)" \
+		--manifest "$(MANIFEST)" \
+		--output-root "$(OUTPUT_ROOT)" \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		--target-match-id "$(TARGET_MATCH_ID)" \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--confirm-single-target-scope "$(or $(CONFIRM_SINGLE_TARGET_SCOPE),no)" \
+		--staging-write-authorization "$(or $(STAGING_WRITE_AUTHORIZATION),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-pre-network-runbook-commit: ## Blocked pre-network runbook execution gate. Remains not wired in Phase 4.83D.
+	@echo "BLOCKED: single-target acquisition pre-network runbook execution is not wired in Phase 4.83D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK=1, this path remains blocked."
+	@echo "  Phase 4.83D validates a draft only and does not authorize any network dry-run, staging write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK_PHASE4_83D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK_PHASE4_83D.md
@@ -1,0 +1,140 @@
+# Phase 4.83D: Single-Target Acquisition Pre-Network Runbook Draft
+
+**Date**: 2026-05-10
+**Status**: Complete (draft-only, local-only)
+**Previous phases**: 4.79D, 4.80D, 4.81D, 4.82D
+**Recommended next phase**: Phase 4.84D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.83D adds a pre-network runbook draft and a local validator for the future first
+single-target acquisition network dry-run.
+
+This phase did not:
+
+- access network
+- perform acquisition
+- write DB
+- write staging
+- write packet files
+
+The goal is to prepare a runbook draft and a local-only validator before any future
+real single-target network dry-run is considered.
+
+---
+
+## 2. Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_pre_network_runbook_validate.js`
+- `tests/unit/single_target_acquisition_pre_network_runbook_validate.test.js`
+- `Makefile` targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK_PHASE4_83D.md`
+
+---
+
+## 3. Runbook Draft Sections
+
+The draft template includes these sections:
+
+- `target`
+- `source_terms`
+- `authorizations`
+- `preflight_inputs`
+- `proxy_browser_network`
+- `safety`
+- `stop_conditions`
+- `next_phase_requirements`
+
+The YAML block remains machine-readable and enforces draft-only status.
+
+---
+
+## 4. Validation Behavior
+
+The validator is:
+
+- local-only
+- read-only
+- in-process
+
+It verifies that:
+
+- the runbook remains `draft_only`
+- all authorization fields remain false / no in the template
+- packet preview prerequisites still validate
+- no runtime writes occur
+- no network execution occurs
+
+It also keeps the commit path blocked in Phase 4.83D.
+
+---
+
+## 5. Relationship to Phase 4.79D / 4.80D / 4.81D / 4.82D
+
+- 4.79D handles runtime parameter scaffold
+- 4.80D handles artifact / manifest schema validation
+- 4.81D handles writer path / authorization preflight
+- 4.82D handles staging packet preview
+- 4.83D handles pre-network runbook draft
+
+All five phases remain non-executing. None equals a real network dry-run. None equals a
+real staging write authorization.
+
+---
+
+## 6. Recommended Next Phase
+
+Recommended:
+
+`Phase 4.84D: single-target acquisition network dry-run authorization form`
+
+Goals:
+
+- still no network
+- only create a real authorization form template
+- make the user explicitly fill source, target, terms, and network authorization
+
+Alternative:
+
+`Phase 4.56A: 用户给齐真实 network dry-run 参数后才做 runbook`
+
+---
+
+## 7. Explicit Non-Execution
+
+The following were not executed:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md
@@ -1,0 +1,150 @@
+# Single-Target Acquisition Pre-Network Dry-Run Runbook Template
+
+This document is a Phase 4.83D draft-only template for a future single-target acquisition
+network dry-run runbook.
+
+- This is a draft, not an authorization.
+- `network_dry_run_authorized=false`
+- `staging_write_authorized=false`
+- `db_write_authorized=false`
+- Even if a future operator fills `yes` in CLI fields, execution must still move to a later,
+  separately authorized phase.
+- Codex must not change this template to approved or authorized on its own.
+- A real network dry-run requires explicit user-supplied parameters and explicit human authorization.
+
+```yaml
+phase: PHASE4.83D_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK_DRAFT
+runbook_status: draft_only
+network_dry_run_ready: false
+network_dry_run_authorized: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+target:
+    target_source:
+    target_engine_family: titan_discovery
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+
+source_terms:
+    terms_url:
+    license_url:
+    allowed_use:
+    terms_approval: no
+    human_approval_note:
+
+authorizations:
+    network_dry_run_authorization: no
+    allow_browser_runtime: no
+    allow_proxy_runtime: no
+    allow_external_network: no
+    allow_staging_write: no
+    staging_write_authorization: no
+    final_human_confirmation: no
+
+preflight_inputs:
+    runtime_scaffold_required: true
+    schema_validation_required: true
+    writer_preflight_required: true
+    staging_packet_preview_required: true
+    source_manifest_candidate_required: true
+    output_root_required: true
+
+proxy_browser_network:
+    proxy_required:
+    proxy_provider:
+    proxy_health_check_required: true
+    browser_required:
+    browser_provider:
+    network_policy:
+    rate_limit_policy:
+    retry_policy:
+    user_agent_policy:
+    no_login_paywall_bypass: true
+    no_anti_bot_bypass: true
+    no_bulk_expansion: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+stop_conditions:
+    - missing_terms_approval
+    - missing_network_authorization
+    - target_scope_not_single_target
+    - output_root_invalid
+    - schema_validation_failed
+    - packet_preview_failed
+    - any_would_write_db_true
+    - any_bulk_scope_detected
+    - any_legacy_runtime_required
+
+next_phase_requirements:
+    - explicit_target_source
+    - explicit_single_target_scope
+    - reviewed_source_terms
+    - explicit_network_dry_run_authorization
+    - accepted_proxy_browser_network_preflight
+    - accepted_staging_packet_preview
+    - confirmed_no_db_write
+    - confirmed_no_training
+    - confirmed_no_prediction
+```
+
+## Purpose
+
+This template captures the information that must exist before a real single-target network
+dry-run can even be proposed. It does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- DB writes
+- training
+- prediction
+
+## Required sections
+
+The runbook draft must explicitly describe:
+
+1. target source and single-target scope
+2. source terms, license, and allowed use
+3. human authorization state
+4. preflight dependencies from Phases 4.79D, 4.80D, 4.81D, and 4.82D
+5. proxy/browser/network policy
+6. stop conditions
+7. next requirements before any future real network dry-run phase
+
+## Draft-only guardrails
+
+- `runbook_status` must remain `draft_only`
+- `network_dry_run_ready` must remain `false`
+- `network_dry_run_authorized` must remain `false`
+- `staging_write_authorized` must remain `false`
+- `db_write_authorized` must remain `false`
+- `training_authorized` must remain `false`
+- `prediction_authorized` must remain `false`
+- `final_human_confirmation` must remain `false`
+
+Changing any of the above does not authorize execution inside Phase 4.83D. Future authorization
+must happen in a separate phase with explicit user approval, complete parameters, reviewed terms,
+and an approved follow-up runbook or authorization form.

--- a/scripts/ops/single_target_acquisition_pre_network_runbook_validate.js
+++ b/scripts/ops/single_target_acquisition_pre_network_runbook_validate.js
@@ -1,0 +1,867 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { validateArtifact, validateManifest } = require('./single_target_acquisition_staging_schema_validator');
+const { checkOutputRoot, checkTargetConsistency } = require('./single_target_acquisition_staging_writer_preflight');
+
+const PRE_NETWORK_PHASE = 'PHASE4.83D_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK_DRAFT';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition pre-network runbook execution is not wired in Phase 4.83D.';
+const REQUIRED_TOP_LEVEL_FIELDS = [
+    'phase',
+    'runbook_status',
+    'network_dry_run_ready',
+    'network_dry_run_authorized',
+    'staging_write_authorized',
+    'db_write_authorized',
+    'training_authorized',
+    'prediction_authorized',
+    'final_human_confirmation',
+    'target',
+    'source_terms',
+    'authorizations',
+    'preflight_inputs',
+    'proxy_browser_network',
+    'safety',
+    'stop_conditions',
+    'next_phase_requirements',
+];
+const REQUIRED_TARGET_FIELDS = [
+    'target_source',
+    'target_engine_family',
+    'target_scope_type',
+    'target_match_id',
+    'target_league',
+    'target_season',
+    'target_date',
+];
+const REQUIRED_SOURCE_TERMS_FIELDS = [
+    'terms_url',
+    'license_url',
+    'allowed_use',
+    'terms_approval',
+    'human_approval_note',
+];
+const REQUIRED_AUTHORIZATION_FIELDS = [
+    'network_dry_run_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'staging_write_authorization',
+    'final_human_confirmation',
+];
+const REQUIRED_PREFLIGHT_FIELDS = [
+    'runtime_scaffold_required',
+    'schema_validation_required',
+    'writer_preflight_required',
+    'staging_packet_preview_required',
+    'source_manifest_candidate_required',
+    'output_root_required',
+];
+const REQUIRED_PROXY_BROWSER_NETWORK_FIELDS = [
+    'proxy_required',
+    'proxy_provider',
+    'proxy_health_check_required',
+    'browser_required',
+    'browser_provider',
+    'network_policy',
+    'rate_limit_policy',
+    'retry_policy',
+    'user_agent_policy',
+    'no_login_paywall_bypass',
+    'no_anti_bot_bypass',
+    'no_bulk_expansion',
+];
+const REQUIRED_SAFETY_FIELDS = [
+    'would_access_network',
+    'would_launch_browser',
+    'would_use_proxy',
+    'would_execute_engine',
+    'would_write_staging',
+    'would_create_staging_directory',
+    'would_write_source_manifest',
+    'would_write_db',
+    'would_train',
+    'would_predict',
+    'would_bulk_harvest',
+];
+const REQUIRED_STOP_CONDITIONS = [
+    'missing_terms_approval',
+    'missing_network_authorization',
+    'target_scope_not_single_target',
+    'output_root_invalid',
+    'schema_validation_failed',
+    'packet_preview_failed',
+    'any_would_write_db_true',
+    'any_bulk_scope_detected',
+    'any_legacy_runtime_required',
+];
+const REQUIRED_NEXT_PHASE_REQUIREMENTS = [
+    'explicit_target_source',
+    'explicit_single_target_scope',
+    'reviewed_source_terms',
+    'explicit_network_dry_run_authorization',
+    'accepted_proxy_browser_network_preflight',
+    'accepted_staging_packet_preview',
+    'confirmed_no_db_write',
+    'confirmed_no_training',
+    'confirmed_no_prediction',
+];
+const REQUIRED_CLI_FIELDS = [
+    'runbook',
+    'artifact_schema',
+    'manifest_schema',
+    'artifact',
+    'manifest',
+    'output_root',
+    'target_source',
+    'target_engine_family',
+    'target_scope_type',
+    'target_match_id',
+    'terms_approval',
+    'network_dry_run_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'confirm_single_target_scope',
+    'staging_write_authorization',
+    'final_human_confirmation',
+];
+const YES_NO_FIELDS = [
+    'terms_approval',
+    'network_dry_run_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'confirm_single_target_scope',
+    'staging_write_authorization',
+    'final_human_confirmation',
+];
+const TOP_LEVEL_FALSE_FIELD_RULES = [
+    ['network_dry_run_ready', 'network_dry_run_ready must remain false in the Phase 4.83D template'],
+    ['network_dry_run_authorized', 'network_dry_run_authorized true in template is not allowed'],
+    ['staging_write_authorized', 'staging_write_authorized true in template is not allowed'],
+    ['db_write_authorized', 'db_write_authorized true in template is not allowed'],
+    ['training_authorized', 'training_authorized true in template is not allowed'],
+    ['prediction_authorized', 'prediction_authorized true in template is not allowed'],
+    ['final_human_confirmation', 'final_human_confirmation true in template is not allowed'],
+];
+const PROXY_BROWSER_NETWORK_TRUE_RULES = [
+    ['proxy_health_check_required', 'proxy_browser_network.proxy_health_check_required must be true'],
+    ['no_login_paywall_bypass', 'proxy_browser_network.no_login_paywall_bypass must be true'],
+    ['no_anti_bot_bypass', 'proxy_browser_network.no_anti_bot_bypass must be true'],
+    ['no_bulk_expansion', 'proxy_browser_network.no_bulk_expansion must be true'],
+];
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_pre_network_runbook_validate.js --runbook <path> --artifact-schema <path> --manifest-schema <path> --artifact <path> --manifest <path> --output-root <path> --target-source <src> --target-engine-family titan_discovery --target-scope-type match_id --target-match-id <id> --terms-approval no --network-dry-run-authorization no --allow-browser-runtime no --allow-proxy-runtime no --allow-external-network no --allow-staging-write no --confirm-single-target-scope yes --staging-write-authorization no --final-human-confirmation no',
+        '  node scripts/ops/single_target_acquisition_pre_network_runbook_validate.js --runbook <path> ... --commit',
+        '',
+        'Safety:',
+        '  Phase 4.83D validates a local pre-network runbook draft only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        runbook: '',
+        artifact_schema: '',
+        manifest_schema: '',
+        artifact: '',
+        manifest: '',
+        output_root: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else if (token.startsWith('--')) {
+            const eqIndex = token.indexOf('=');
+            if (eqIndex !== -1) {
+                args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+            } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+                args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+                index += 1;
+            } else {
+                throw new Error(`Unknown argument: ${token}`);
+            }
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function extractYamlBlock(markdownText) {
+    const match = String(markdownText || '').match(/```ya?ml\s*\n([\s\S]*?)\n```/i);
+    return match ? match[1] : '';
+}
+
+function stripInlineComment(value) {
+    const hashIndex = value.indexOf(' #');
+    if (hashIndex === -1) {
+        return value;
+    }
+    return value.slice(0, hashIndex);
+}
+
+function parseScalar(rawValue) {
+    const value = stripInlineComment(String(rawValue || '')).trim();
+    if (value === '') {
+        return null;
+    }
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+        return false;
+    }
+    if (value === '[]') {
+        return [];
+    }
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    if (/^-?\d+$/.test(value)) {
+        return Number(value);
+    }
+    return value;
+}
+
+function parseTopLevelYamlLine(root, trimmed) {
+    const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+    if (!match) {
+        throw new Error(`unsupported YAML line: ${trimmed}`);
+    }
+    const key = match[1];
+    const value = match[2].trim();
+    root[key] = value === '' ? null : parseScalar(value);
+    return key;
+}
+
+function parseNestedYamlLine(root, currentKey, trimmed) {
+    if (trimmed.startsWith('- ')) {
+        if (!Array.isArray(root[currentKey])) {
+            root[currentKey] = [];
+        }
+        root[currentKey].push(parseScalar(trimmed.slice(2)));
+        return;
+    }
+
+    const nestedMatch = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+    if (!nestedMatch) {
+        throw new Error(`unsupported YAML line: ${trimmed}`);
+    }
+    if (!root[currentKey] || Array.isArray(root[currentKey]) || typeof root[currentKey] !== 'object') {
+        root[currentKey] = {};
+    }
+    root[currentKey][nestedMatch[1]] = nestedMatch[2].trim() === '' ? null : parseScalar(nestedMatch[2]);
+}
+
+function parseYamlBlock(yamlText) {
+    const root = {};
+    let currentKey = '';
+
+    for (const rawLine of String(yamlText || '').split(/\r?\n/)) {
+        if (!rawLine.trim() || rawLine.trim().startsWith('#')) {
+            continue;
+        }
+
+        const indent = rawLine.match(/^ */)[0].length;
+        const trimmed = rawLine.trim();
+
+        if (indent === 0) {
+            currentKey = parseTopLevelYamlLine(root, trimmed);
+            continue;
+        }
+
+        if (indent >= 2 && currentKey) {
+            parseNestedYamlLine(root, currentKey, trimmed);
+            continue;
+        }
+
+        throw new Error(`unsupported YAML indentation: ${trimmed}`);
+    }
+
+    return root;
+}
+
+function buildNonExecutionConfirmations() {
+    return [
+        'no_external_network',
+        'no_browser_automation',
+        'no_proxy_runtime_execution',
+        'no_engine_execution',
+        'no_db_writes',
+        'no_file_writes',
+        'no_staging_writes',
+        'no_source_manifest_writes',
+        'no_packet_file_writes',
+        'no_training',
+        'no_prediction_execution',
+        'no_child_process_spawn',
+    ];
+}
+
+function buildSafetyFlags() {
+    return {
+        runbook_draft_only: true,
+        runbook_valid: false,
+        packet_preview_passed: false,
+        network_dry_run_ready: false,
+        network_dry_run_authorized: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: 'Phase 4.84D or explicit user-authorized network dry-run runbook',
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: PRE_NETWORK_PHASE,
+        mode: fields.mode || 'single-target-acquisition-pre-network-runbook-validate',
+        ok: false,
+        runbook: args.runbook || null,
+        runbook_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function collectMissingFields(parsedYaml, parentKey, requiredKeys, missingFields) {
+    const value = parsedYaml[parentKey];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        for (const key of requiredKeys) {
+            missingFields.push(`${parentKey}.${key}`);
+        }
+        return;
+    }
+    for (const key of requiredKeys) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+            missingFields.push(`${parentKey}.${key}`);
+        }
+    }
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_LEVEL_FIELDS.filter(
+        field => !Object.prototype.hasOwnProperty.call(parsedYaml, field)
+    );
+    collectMissingFields(parsedYaml, 'target', REQUIRED_TARGET_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'source_terms', REQUIRED_SOURCE_TERMS_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'authorizations', REQUIRED_AUTHORIZATION_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'preflight_inputs', REQUIRED_PREFLIGHT_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'proxy_browser_network', REQUIRED_PROXY_BROWSER_NETWORK_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'safety', REQUIRED_SAFETY_FIELDS, missingFields);
+    return missingFields;
+}
+
+function ensureArrayContainsAll(parsedYaml, key, requiredValues, errors) {
+    const value = parsedYaml[key];
+    if (!Array.isArray(value)) {
+        errors.push(`${key} must be an array`);
+        return;
+    }
+    for (const requiredValue of requiredValues) {
+        if (!value.includes(requiredValue)) {
+            errors.push(`${key} missing required value "${requiredValue}"`);
+        }
+    }
+}
+
+function ensureNestedNoFields(parsedYaml, parentKey, fieldNames, errors) {
+    const parent = parsedYaml[parentKey] || {};
+    for (const fieldName of fieldNames) {
+        if (parent[fieldName] !== 'no') {
+            errors.push(`${parentKey}.${fieldName} must remain no in the Phase 4.83D template`);
+        }
+    }
+}
+
+function ensureNestedTrueFields(parsedYaml, parentKey, fieldNames, errors) {
+    const parent = parsedYaml[parentKey] || {};
+    for (const fieldName of fieldNames) {
+        if (parent[fieldName] !== true) {
+            errors.push(`${parentKey}.${fieldName} must be true in the Phase 4.83D template`);
+        }
+    }
+}
+
+function ensureNestedFalseFields(parsedYaml, parentKey, fieldNames, errors) {
+    const parent = parsedYaml[parentKey] || {};
+    for (const fieldName of fieldNames) {
+        if (parent[fieldName] !== false) {
+            errors.push(`${parentKey}.${fieldName} must remain false in the Phase 4.83D template`);
+        }
+    }
+}
+
+function pushMissingFieldsError(missingFields, errors) {
+    if (missingFields.length > 0) {
+        errors.push(`missing required fields: ${missingFields.join(',')}`);
+    }
+}
+
+function validateTopLevelTemplateFields(parsedYaml, errors) {
+    if (parsedYaml.phase !== PRE_NETWORK_PHASE) {
+        errors.push(`phase must be ${PRE_NETWORK_PHASE}`);
+    }
+    if (parsedYaml.runbook_status !== 'draft_only') {
+        errors.push('runbook_status must remain draft_only in the Phase 4.83D template');
+    }
+    for (const [fieldName, message] of TOP_LEVEL_FALSE_FIELD_RULES) {
+        if (parsedYaml[fieldName] !== false) {
+            errors.push(message);
+        }
+    }
+}
+
+function validateTemplatePolicySections(parsedYaml, errors) {
+    if ((parsedYaml.target || {}).target_engine_family !== 'titan_discovery') {
+        errors.push('target.target_engine_family must remain titan_discovery in the Phase 4.83D template');
+    }
+    if ((parsedYaml.source_terms || {}).terms_approval !== 'no') {
+        errors.push('source_terms.terms_approval must remain no in the Phase 4.83D template');
+    }
+
+    ensureNestedNoFields(parsedYaml, 'authorizations', REQUIRED_AUTHORIZATION_FIELDS, errors);
+    ensureNestedTrueFields(parsedYaml, 'preflight_inputs', REQUIRED_PREFLIGHT_FIELDS, errors);
+    ensureNestedFalseFields(parsedYaml, 'safety', REQUIRED_SAFETY_FIELDS, errors);
+}
+
+function validateProxyBrowserNetworkSection(parsedYaml, errors) {
+    const proxyBrowserNetwork = parsedYaml.proxy_browser_network || {};
+    for (const [fieldName, message] of PROXY_BROWSER_NETWORK_TRUE_RULES) {
+        if (proxyBrowserNetwork[fieldName] !== true) {
+            errors.push(message);
+        }
+    }
+}
+
+function validateRequiredArrays(parsedYaml, errors) {
+    ensureArrayContainsAll(parsedYaml, 'stop_conditions', REQUIRED_STOP_CONDITIONS, errors);
+    ensureArrayContainsAll(parsedYaml, 'next_phase_requirements', REQUIRED_NEXT_PHASE_REQUIREMENTS, errors);
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    pushMissingFieldsError(missingFields, errors);
+    validateTopLevelTemplateFields(parsedYaml, errors);
+    validateTemplatePolicySections(parsedYaml, errors);
+    validateProxyBrowserNetworkSection(parsedYaml, errors);
+    validateRequiredArrays(parsedYaml, errors);
+    return {
+        ok: errors.length === 0,
+        missingFields,
+        errors,
+    };
+}
+
+function validateCliYesNoFields(args) {
+    const errors = [];
+    for (const field of YES_NO_FIELDS) {
+        const value = args[field];
+        if (value !== 'yes' && value !== 'no') {
+            errors.push(`--${field.replace(/_/g, '-')} is required (yes/no)`);
+        }
+    }
+    return errors;
+}
+
+function validateCliTargetFields(args) {
+    const errors = [];
+    if (args.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${args.target_engine_family}"`);
+    }
+    if (args.target_scope_type !== 'match_id' && args.target_scope_type !== 'league_season_date') {
+        errors.push(`unsupported scope type "${args.target_scope_type}"`);
+    }
+    if (args.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+    if (args.target_scope_type === 'match_id' && !args.target_match_id) {
+        errors.push('--target-match-id is required when target_scope_type=match_id');
+    }
+    if (args.confirm_single_target_scope !== 'yes') {
+        errors.push('confirm_single_target_scope must be yes');
+    }
+    return errors;
+}
+
+function validateRequiredCliFields(args) {
+    const errors = [];
+    for (const field of REQUIRED_CLI_FIELDS) {
+        if (!args[field]) {
+            errors.push(`missing ${field.replace(/_/g, ' ')} path or value`);
+        }
+    }
+    return errors;
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: PRE_NETWORK_PHASE,
+        mode: 'single-target-acquisition-pre-network-runbook-validate',
+        ok: true,
+        runbook: args.runbook,
+        runbook_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        missing_fields: [],
+        runbook_valid: true,
+        packet_preview_passed: true,
+        errors: [],
+        warnings: [
+            'Phase 4.83D remains draft-only.',
+            'CLI authorization yes values do not authorize execution in this phase.',
+        ],
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function buildArgumentErrorPayload(args, errors) {
+    return buildFailurePayload(args, {
+        mode: 'argument-error',
+        errors,
+    });
+}
+
+function validateCliArgsOrPayload(args) {
+    const missingCliFields = validateRequiredCliFields(args);
+    if (missingCliFields.length > 0) {
+        return buildArgumentErrorPayload(args, [
+            `missing runbook path or required CLI values: ${missingCliFields.join(', ')}`,
+        ]);
+    }
+
+    const cliYesNoErrors = validateCliYesNoFields(args);
+    const cliTargetErrors = validateCliTargetFields(args);
+    if (cliYesNoErrors.length > 0 || cliTargetErrors.length > 0) {
+        return buildArgumentErrorPayload(args, [...cliYesNoErrors, ...cliTargetErrors]);
+    }
+    return null;
+}
+
+function loadRunbookDraft(args, cwd, existsSync, readFileSync) {
+    const runbookPath = resolveLocalPath(args.runbook, cwd);
+    if (!existsSync(runbookPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'runbook-error',
+                runbook_found: false,
+                errors: [`missing runbook path: ${toRelativePath(runbookPath, cwd)}`],
+            }),
+        };
+    }
+
+    const markdownText = readFileSync(runbookPath, 'utf8');
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'runbook-error',
+                runbook_found: true,
+                yaml_block_found: false,
+                errors: ['invalid runbook markdown / missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseYamlBlock(yamlText) };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'runbook-error',
+                runbook_found: true,
+                yaml_block_found: true,
+                errors: [`invalid runbook markdown / missing YAML block: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function validateRunbookDraftOrPayload(args, parsedYaml) {
+    const parsedValidation = validateParsedYaml(parsedYaml);
+    if (!parsedValidation.ok) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'runbook-error',
+                runbook_found: true,
+                yaml_block_found: true,
+                required_fields_present: parsedValidation.missingFields.length === 0,
+                missing_fields: parsedValidation.missingFields,
+                errors: parsedValidation.errors,
+            }),
+        };
+    }
+    return null;
+}
+
+function buildTargetMismatchPayload(args, message) {
+    return buildFailurePayload(args, {
+        mode: 'runbook-error',
+        runbook_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        errors: [message],
+    });
+}
+
+function validateRunbookTargetConsistency(args, parsedYaml) {
+    const templateTarget = parsedYaml.target || {};
+    if (templateTarget.target_source && templateTarget.target_source !== args.target_source) {
+        return buildTargetMismatchPayload(
+            args,
+            `target mismatch: runbook target.target_source "${templateTarget.target_source}" does not match CLI target_source "${args.target_source}"`
+        );
+    }
+    if (templateTarget.target_scope_type && templateTarget.target_scope_type !== args.target_scope_type) {
+        return buildTargetMismatchPayload(
+            args,
+            `target mismatch: runbook target.target_scope_type "${templateTarget.target_scope_type}" does not match CLI target_scope_type "${args.target_scope_type}"`
+        );
+    }
+    if (templateTarget.target_match_id && templateTarget.target_match_id !== args.target_match_id) {
+        return buildTargetMismatchPayload(
+            args,
+            `target mismatch: runbook target.target_match_id "${templateTarget.target_match_id}" does not match CLI target_match_id "${args.target_match_id}"`
+        );
+    }
+    return null;
+}
+
+function buildPacketPreviewFailurePayload(args, errors) {
+    return buildFailurePayload(args, {
+        mode: 'packet-preview-error',
+        runbook_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        runbook_valid: true,
+        errors,
+    });
+}
+
+function validatePacketPreviewOrPayload(args, cwd, readFileSync) {
+    const outputRootErrors = checkOutputRoot(args.output_root);
+    if (outputRootErrors.length > 0) {
+        return buildPacketPreviewFailurePayload(args, outputRootErrors);
+    }
+
+    const artifactResult = validateArtifact(args.artifact, args.artifact_schema);
+    const manifestResult = validateManifest(args.manifest, args.manifest_schema);
+    if (!artifactResult.valid || !manifestResult.valid) {
+        return buildPacketPreviewFailurePayload(args, [
+            'schema validation failed',
+            ...artifactResult.errors,
+            ...manifestResult.errors,
+        ]);
+    }
+
+    const artifactData = JSON.parse(readFileSync(resolveLocalPath(args.artifact, cwd), 'utf8'));
+    const manifestData = JSON.parse(readFileSync(resolveLocalPath(args.manifest, cwd), 'utf8'));
+    const consistencyErrors = checkTargetConsistency(args, artifactData, manifestData);
+    if (consistencyErrors.length > 0) {
+        return buildPacketPreviewFailurePayload(args, ['packet preview failed', ...consistencyErrors]);
+    }
+    return null;
+}
+
+function runValidation(args, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) {
+        return cliPayload;
+    }
+
+    const runbookLoad = loadRunbookDraft(args, cwd, existsSync, readFileSync);
+    if (runbookLoad.payload) {
+        return runbookLoad.payload;
+    }
+
+    const runbookValidation = validateRunbookDraftOrPayload(args, runbookLoad.parsedYaml);
+    if (runbookValidation && runbookValidation.payload) {
+        return runbookValidation.payload;
+    }
+
+    const targetConsistencyPayload = validateRunbookTargetConsistency(args, runbookLoad.parsedYaml);
+    if (targetConsistencyPayload) {
+        return targetConsistencyPayload;
+    }
+
+    const packetPreviewPayload = validatePacketPreviewOrPayload(args, cwd, readFileSync);
+    if (packetPreviewPayload) {
+        return packetPreviewPayload;
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `runbook_found=${payload.runbook_found}`,
+        `yaml_block_found=${payload.yaml_block_found}`,
+        `required_fields_present=${payload.required_fields_present}`,
+        `runbook_draft_only=${payload.runbook_draft_only}`,
+        `runbook_valid=${payload.runbook_valid}`,
+        `packet_preview_passed=${payload.packet_preview_passed}`,
+        `network_dry_run_ready=${payload.network_dry_run_ready}`,
+        `network_dry_run_authorized=${payload.network_dry_run_authorized}`,
+        `staging_write_authorized=${payload.staging_write_authorized}`,
+        `db_write_authorized=${payload.db_write_authorized}`,
+        `training_authorized=${payload.training_authorized}`,
+        `prediction_authorized=${payload.prediction_authorized}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_launch_browser=${payload.would_launch_browser}`,
+        `would_use_proxy=${payload.would_use_proxy}`,
+        `would_execute_engine=${payload.would_execute_engine}`,
+        `would_write_staging=${payload.would_write_staging}`,
+        `would_create_staging_directory=${payload.would_create_staging_directory}`,
+        `would_write_source_manifest=${payload.would_write_source_manifest}`,
+        `would_write_packet_file=${payload.would_write_packet_file}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_train=${payload.would_train}`,
+        `would_predict=${payload.would_predict}`,
+        `would_spawn_child_process=${payload.would_spawn_child_process}`,
+        `commit_gate=${payload.commit_gate}`,
+        `next_required_phase=${payload.next_required_phase}`,
+    ];
+
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.missing_fields) && payload.missing_fields.length > 0) {
+        lines.push(`missing_fields=${payload.missing_fields.join(',')}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${payload.warnings.join('; ')}`);
+    }
+    lines.push('non_execution_confirmations=');
+    for (const confirmation of payload.non_execution_confirmations || []) {
+        lines.push(`  ${confirmation}`);
+    }
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, true, output);
+            return 1;
+        }
+
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, true, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            { runbook: '' },
+            {
+                mode: 'argument-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, true, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    PRE_NETWORK_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    extractYamlBlock,
+    parseYamlBlock,
+    validateParsedYaml,
+    runValidation,
+    buildNonExecutionConfirmations,
+    main,
+};

--- a/tests/unit/single_target_acquisition_pre_network_runbook_validate.test.js
+++ b/tests/unit/single_target_acquisition_pre_network_runbook_validate.test.js
@@ -1,0 +1,595 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/single_target_acquisition_pre_network_runbook_validate.js');
+const RUNBOOK_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md'
+);
+const ARTIFACT_SCHEMA = path.join(PROJECT_ROOT, 'schemas/acquisition/single_target_staging_artifact.schema.json');
+const MANIFEST_SCHEMA = path.join(PROJECT_ROOT, 'schemas/acquisition/source_manifest_candidate.schema.json');
+const SAMPLE_ARTIFACT = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/acquisition/sample_single_target_staging_artifact_phase480d.json'
+);
+const SAMPLE_MANIFEST = path.join(
+    PROJECT_ROOT,
+    'tests/fixtures/acquisition/sample_source_manifest_candidate_phase480d.json'
+);
+const RUNBOOK_TEXT = fs.readFileSync(RUNBOOK_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        runbook: RUNBOOK_PATH,
+        artifact_schema: ARTIFACT_SCHEMA,
+        manifest_schema: MANIFEST_SCHEMA,
+        artifact: SAMPLE_ARTIFACT,
+        manifest: SAMPLE_MANIFEST,
+        output_root: 'docs/_staging_preview/acquisition/single_target',
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        confirm_single_target_scope: 'yes',
+        staging_write_authorization: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by single_target_acquisition_pre_network_runbook_validate`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(RUNBOOK_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return RUNBOOK_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return RUNBOOK_TEXT.replace(`${line}\n`, '');
+}
+
+function withTempRunbook(markdownText, callback) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'phase483d-'));
+    const runbookPath = path.join(tempDir, 'runbook.md');
+    fs.writeFileSync(runbookPath, markdownText, 'utf8');
+    try {
+        callback(runbookPath);
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 runbook 参数时失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.runbook;
+    const payload = gate.runValidation(args, buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook path/i);
+});
+
+test('runbook 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook('# no yaml\n', runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /missing YAML block/i);
+    });
+});
+
+test('runbook invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook('```yaml\nnot yaml\n```\n', runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /unsupported YAML line/i);
+    });
+});
+
+test('runbook missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(
+        removeLineFromTemplate('phase: PHASE4.83D_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK_DRAFT'),
+        runbookPath => {
+            const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /missing required fields: phase/);
+        }
+    );
+});
+
+test('runbook missing runbook_status 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(removeLineFromTemplate('runbook_status: draft_only'), runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /runbook_status/);
+    });
+});
+
+test('runbook_status 非 draft_only 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(replaceInTemplate('runbook_status: draft_only', 'runbook_status: approved'), runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /draft_only/);
+    });
+});
+
+test('network_dry_run_ready=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(replaceInTemplate('network_dry_run_ready: false', 'network_dry_run_ready: true'), runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /network_dry_run_ready must remain false/);
+    });
+});
+
+test('network_dry_run_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(
+        replaceInTemplate('network_dry_run_authorized: false', 'network_dry_run_authorized: true'),
+        runbookPath => {
+            const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /network_dry_run_authorized true in template/);
+        }
+    );
+});
+
+test('staging_write_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(
+        replaceInTemplate('staging_write_authorized: false', 'staging_write_authorized: true'),
+        runbookPath => {
+            const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /staging_write_authorized true in template/);
+        }
+    );
+});
+
+test('db_write_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(replaceInTemplate('db_write_authorized: false', 'db_write_authorized: true'), runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /db_write_authorized true in template/);
+    });
+});
+
+test('training_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(replaceInTemplate('training_authorized: false', 'training_authorized: true'), runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /training_authorized true in template/);
+    });
+});
+
+test('prediction_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(replaceInTemplate('prediction_authorized: false', 'prediction_authorized: true'), runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /prediction_authorized true in template/);
+    });
+});
+
+test('final_human_confirmation=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(
+        replaceInTemplate('final_human_confirmation: false', 'final_human_confirmation: true'),
+        runbookPath => {
+            const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /final_human_confirmation true in template/);
+        }
+    );
+});
+
+test('缺 artifact schema 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.artifact_schema;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook path or required CLI values/i);
+});
+
+test('缺 manifest schema 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.manifest_schema;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /required CLI values/i);
+});
+
+test('缺 artifact 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.artifact;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /required CLI values/i);
+});
+
+test('缺 manifest 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.manifest;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /required CLI values/i);
+});
+
+test('packet preview validation failure 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs({ target_match_id: 'wrong-match-id' });
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /packet preview failed/i);
+});
+
+test('target_source mismatch 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempRunbook(replaceInTemplate('  target_source:', '  target_source: other'), runbookPath => {
+        const payload = gate.runValidation({ ...buildArgs(), runbook: runbookPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /target mismatch/i);
+    });
+});
+
+test('unsupported engine family 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_engine_family: 'run_production' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported engine family/);
+});
+
+test('unsupported scope type bulk 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_scope_type: 'bulk' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported scope type "bulk"|unsupported scope type bulk/);
+});
+
+test('valid runbook validate 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.83D_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK_DRAFT');
+    assert.equal(payload.runbook_draft_only, true);
+    assert.equal(payload.runbook_valid, true);
+    assert.equal(payload.packet_preview_passed, true);
+    assert.equal(payload.network_dry_run_ready, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('all authorization yes in CLI 仍 no-op / not authorized', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs({
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            staging_write_authorization: 'yes',
+            final_human_confirmation: 'yes',
+        }),
+        buildDependencies()
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(gate, ['--runbook', RUNBOOK_PATH, '--commit'], buildDependencies());
+
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.83D/);
+});
+
+test('Makefile validate 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-pre-network-runbook-validate',
+            'PRE_NETWORK_RUNBOOK_NODE=node',
+            `RUNBOOK=${RUNBOOK_PATH}`,
+            `ARTIFACT_SCHEMA=${ARTIFACT_SCHEMA}`,
+            `MANIFEST_SCHEMA=${MANIFEST_SCHEMA}`,
+            `ARTIFACT=${SAMPLE_ARTIFACT}`,
+            `MANIFEST=${SAMPLE_MANIFEST}`,
+            'OUTPUT_ROOT=docs/_staging_preview/acquisition/single_target',
+            'TARGET_SOURCE=fotmob',
+            'TARGET_ENGINE_FAMILY=titan_discovery',
+            'TARGET_SCOPE_TYPE=match_id',
+            'TARGET_MATCH_ID=sample-match-001',
+            'TERMS_APPROVAL=no',
+            'NETWORK_DRY_RUN_AUTHORIZATION=no',
+            'ALLOW_BROWSER_RUNTIME=no',
+            'ALLOW_PROXY_RUNTIME=no',
+            'ALLOW_EXTERNAL_NETWORK=no',
+            'ALLOW_STAGING_WRITE=no',
+            'CONFIRM_SINGLE_TARGET_SCOPE=yes',
+            'STAGING_WRITE_AUTHORIZATION=no',
+            'FINAL_HUMAN_CONFIRMATION=no',
+        ],
+        {
+            cwd: PROJECT_ROOT,
+            encoding: 'utf8',
+            shell: false,
+        }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-pre-network-runbook-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK=1',
+        ],
+        {
+            cwd: PROJECT_ROOT,
+            encoding: 'utf8',
+            shell: false,
+        }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.83D/);
+});
+
+test('不访问网络', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_access_network, false);
+});
+
+test('不启动 browser', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_launch_browser, false);
+});
+
+test('不执行 proxy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_use_proxy, false);
+});
+
+test('不执行 engine', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_engine, false);
+});
+
+test('不写 staging', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_staging, false);
+});
+
+test('不创建目录', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_create_staging_directory, false);
+});
+
+test('不写 source manifest', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_source_manifest, false);
+});
+
+test('不写 packet file', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_packet_file, false);
+});
+
+test('不写 DB', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('不 spawn child process', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_spawn_child_process, false);
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.83D single-target acquisition pre-network runbook draft.

Scope:
- Adds pre-network dry-run runbook template
- Adds local-only runbook validator
- Validates runbook remains draft-only and non-authorized
- Validates packet preview prerequisites
- Keeps network dry-run blocked
- Adds Makefile validate and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.83D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- validate missing params failed as expected
- valid runbook validate passed
- all-yes CLI remained no-op / not authorized
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed