### PR TITLE
docs(data): add single-target network auth form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、只做路径预览和授权预检的 staging writer preflight：`make data-single-target-acquisition-staging-writer-preflight ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.81D preflight-only）
 - 不触网、不写文件、不创建目录、汇总 4.79D+4.80D+4.81D 安全门禁的 staging packet preview：`make data-single-target-acquisition-staging-packet-preview ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.82D preview-only）
 - 不触网、不写文件、不创建目录、只验证 pre-network runbook draft 和 packet preview 前置条件的本地 validator：`make data-single-target-acquisition-pre-network-runbook-validate RUNBOOK=<path> ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path> OUTPUT_ROOT=<path> ...`（Phase 4.83D draft-only）
+- 不触网、不写文件、不创建目录、只验证 network dry-run authorization form template 和 pre-network runbook template 的本地 validator：`make data-single-target-acquisition-network-auth-form-validate AUTH_FORM=<path> RUNBOOK=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.84D template-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -689,6 +690,25 @@ AI / Codex 默认禁止：
 - 即使 CLI 传入 yes，Phase 4.83D 也不触网、不写文件、不写 DB
 
 `data-single-target-acquisition-pre-network-runbook-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook 审核通过。
+
+### Phase 4.84D: single-target acquisition network dry-run authorization form
+
+`data-single-target-acquisition-network-auth-form-validate` 只允许验证 network dry-run authorization form template：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 DB
+- authorization form template 不等于真实 network dry-run authorization
+- 即使 CLI 传入 yes，Phase 4.84D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-auth-form-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook 审核通过。
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
         data-single-target-acquisition-staging-writer-preflight data-single-target-acquisition-staging-writer-commit \
         data-single-target-acquisition-staging-packet-preview data-single-target-acquisition-staging-packet-commit \
         data-single-target-acquisition-pre-network-runbook-validate data-single-target-acquisition-pre-network-runbook-commit \
+        data-single-target-acquisition-network-auth-form-validate data-single-target-acquisition-network-auth-form-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -75,6 +76,7 @@ help: ## 显示帮助信息
 # ============================================
 COMPOSE_DEV=docker compose -f docker-compose.dev.yml
 PRE_NETWORK_RUNBOOK_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_AUTH_FORM_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -344,6 +346,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-staging-packet-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_STAGING_PACKET=1  # blocked in Phase 4.82D"
 	@echo "  make data-single-target-acquisition-pre-network-runbook-validate RUNBOOK=<path> ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path> OUTPUT_ROOT=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # draft-only validate, Phase 4.83D"
 	@echo "  make data-single-target-acquisition-pre-network-runbook-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK=1  # blocked in Phase 4.83D"
+	@echo "  make data-single-target-acquisition-network-auth-form-validate AUTH_FORM=<path> RUNBOOK=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # template-only validate, Phase 4.84D"
+	@echo "  make data-single-target-acquisition-network-auth-form-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM=1  # blocked in Phase 4.84D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1000,6 +1004,36 @@ data-single-target-acquisition-pre-network-runbook-commit: ## Blocked pre-networ
 	@echo "BLOCKED: single-target acquisition pre-network runbook execution is not wired in Phase 4.83D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK=1, this path remains blocked."
 	@echo "  Phase 4.83D validates a draft only and does not authorize any network dry-run, staging write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-auth-form-validate: ## Template-only network auth form validation. Phase 4.84D. No network, no writes, no DB.
+	@if [ -z "$(AUTH_FORM)" ] || [ -z "$(RUNBOOK)" ] || [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ] || [ -z "$(TARGET_MATCH_ID)" ]; then \
+		echo "ERROR: provide AUTH_FORM=<path>, RUNBOOK=<path>, TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<type>, TARGET_MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.84D: network auth form validate (template-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_AUTH_FORM_NODE) scripts/ops/single_target_acquisition_network_auth_form_validate.js \
+		--auth-form "$(AUTH_FORM)" \
+		--runbook "$(RUNBOOK)" \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		--target-match-id "$(TARGET_MATCH_ID)" \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-network-auth-form-commit: ## Blocked network auth form execution gate. Remains not wired in Phase 4.84D.
+	@echo "BLOCKED: single-target acquisition network dry-run authorization execution is not wired in Phase 4.84D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM=1, this path remains blocked."
+	@echo "  Phase 4.84D validates a template only and does not authorize any network dry-run, staging write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM_PHASE4_84D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM_PHASE4_84D.md
@@ -1,0 +1,138 @@
+# Phase 4.84D: Single-Target Acquisition Network Dry-Run Authorization Form
+
+**Date**: 2026-05-10
+**Status**: Complete (template-only, local-only)
+**Previous phases**: 4.79D, 4.80D, 4.81D, 4.82D, 4.83D
+**Recommended next phase**: Phase 4.85D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.84D adds a network dry-run authorization form template and a local
+validator for the future first single-target acquisition network dry-run.
+
+This phase did not:
+
+- access network
+- perform acquisition
+- write DB
+- write staging
+- write packet files
+
+The goal is to define the authorization form that humans must complete before a
+future real single-target network dry-run can even be proposed.
+
+---
+
+## 2. Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_auth_form_validate.js`
+- `tests/unit/single_target_acquisition_network_auth_form_validate.test.js`
+- `Makefile` targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM_PHASE4_84D.md`
+
+---
+
+## 3. Authorization Form Sections
+
+The authorization form template includes these sections:
+
+- `request`
+- `source_terms`
+- `network_authorization`
+- `proxy_browser_network_preflight`
+- `required_inputs`
+- `safety`
+- `approvals`
+
+The YAML block remains machine-readable and enforces template-only status.
+
+---
+
+## 4. Validation Behavior
+
+The validator is:
+
+- local-only
+- read-only
+- in-process
+
+It verifies that:
+
+- the form remains `template_only`
+- all authorization fields remain false / no in the template
+- single-target / no-bulk constraints remain in force
+- no network execution occurs
+- no runtime writes occur
+
+It also keeps the commit path blocked in Phase 4.84D.
+
+---
+
+## 5. Relationship to Previous Phases
+
+- 4.79D handles runtime parameter scaffold
+- 4.80D handles artifact / manifest schema validation
+- 4.81D handles writer path / authorization preflight
+- 4.82D handles staging packet preview
+- 4.83D handles pre-network runbook draft
+- 4.84D handles authorization form template
+
+All six phases remain non-executing. None equals a real network dry-run.
+
+---
+
+## 6. Recommended Next Phase
+
+Recommended:
+
+`Phase 4.85D: single-target acquisition network dry-run final readiness checklist`
+
+Goals:
+
+- still no network
+- consolidate runbook + auth form + packet preview
+
+Alternative:
+
+`Phase 4.56A: 用户给齐真实 network dry-run 参数后才做 runbook`
+
+---
+
+## 7. Explicit Non-Execution
+
+The following were not executed:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md
@@ -1,0 +1,146 @@
+# Single-Target Acquisition Network Dry-Run Authorization Form Template
+
+This document is a Phase 4.84D template-only authorization form for a future
+single-target acquisition network dry-run.
+
+- This is an authorization form template, not an actual authorization.
+- `network_dry_run_authorized=false`
+- `staging_write_authorized=false`
+- `db_write_authorized=false`
+- `training_authorized=false`
+- `prediction_authorized=false`
+- Codex must not change this template to authorized on its own.
+- A real network dry-run requires explicit user-supplied source, target, terms,
+  and authorization details.
+- Even if a future operator fills `yes` in the form or CLI, execution must still
+  move to a later, separately authorized phase. Phase 4.84D does not permit
+  network execution.
+
+```yaml
+phase: PHASE4.84D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM
+authorization_form_status: template_only
+network_dry_run_authorized: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+request:
+    requested_by:
+    requested_at:
+    target_source:
+    target_engine_family: titan_discovery
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+
+source_terms:
+    source_url:
+    terms_url:
+    license_url:
+    allowed_use:
+    terms_reviewed_by:
+    terms_approval: no
+    human_approval_note:
+
+network_authorization:
+    network_dry_run_authorization: no
+    allow_external_network: no
+    allow_browser_runtime: no
+    allow_proxy_runtime: no
+    allow_staging_write: no
+    max_targets: 1
+    bulk_scope_allowed: false
+    allowed_runtime: scaffolded_single_target_only
+    allowed_engine_family: titan_discovery
+    forbidden_legacy_runtime: true
+
+proxy_browser_network_preflight:
+    proxy_required:
+    proxy_provider:
+    proxy_health_check_required:
+    browser_required:
+    browser_provider:
+    rate_limit_policy:
+    retry_policy:
+    user_agent_policy:
+    no_login_paywall_bypass: true
+    no_anti_bot_bypass: true
+    no_bulk_expansion: true
+
+required_inputs:
+    pre_network_runbook_required: true
+    staging_packet_preview_required: true
+    artifact_schema_required: true
+    manifest_schema_required: true
+    output_root_policy_required: true
+    stop_conditions_required: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+approvals:
+    source_terms_approved_by:
+    network_dry_run_approved_by:
+    staging_policy_approved_by:
+    final_human_confirmation_by:
+```
+
+## Purpose
+
+This template defines what a human must provide and approve before a future
+single-target acquisition network dry-run can even be proposed.
+
+It does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- DB writes
+- training
+- prediction
+
+## Required sections
+
+The authorization form template must explicitly describe:
+
+1. request metadata and single-target scope
+2. source URL, terms, license, and allowed use
+3. network authorization and allowed runtime constraints
+4. proxy/browser/network preflight requirements
+5. pre-network runbook and packet preview prerequisites
+6. safety flags that remain false in this phase
+7. human approval roles for any future phase
+
+## Template-only guardrails
+
+- `authorization_form_status` must remain `template_only`
+- `network_dry_run_authorized` must remain `false`
+- `staging_write_authorized` must remain `false`
+- `db_write_authorized` must remain `false`
+- `training_authorized` must remain `false`
+- `prediction_authorized` must remain `false`
+- `final_human_confirmation` must remain `false`
+
+Changing any of the above does not authorize execution inside Phase 4.84D.
+Future network dry-run authorization must happen in a separate phase with
+explicit user approval, complete parameters, reviewed terms, and an approved
+follow-up readiness process.

--- a/scripts/ops/single_target_acquisition_network_auth_form_validate.js
+++ b/scripts/ops/single_target_acquisition_network_auth_form_validate.js
@@ -1,0 +1,770 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    PRE_NETWORK_PHASE,
+    extractYamlBlock,
+    parseYamlBlock,
+    validateParsedYaml: validateRunbookParsedYaml,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+
+const AUTH_PHASE = 'PHASE4.84D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition network dry-run authorization execution is not wired in Phase 4.84D.';
+const REQUIRED_TOP_LEVEL_FIELDS = [
+    'phase',
+    'authorization_form_status',
+    'network_dry_run_authorized',
+    'staging_write_authorized',
+    'db_write_authorized',
+    'training_authorized',
+    'prediction_authorized',
+    'final_human_confirmation',
+    'request',
+    'source_terms',
+    'network_authorization',
+    'proxy_browser_network_preflight',
+    'required_inputs',
+    'safety',
+    'approvals',
+];
+const REQUIRED_REQUEST_FIELDS = [
+    'requested_by',
+    'requested_at',
+    'target_source',
+    'target_engine_family',
+    'target_scope_type',
+    'target_match_id',
+    'target_league',
+    'target_season',
+    'target_date',
+];
+const REQUIRED_SOURCE_TERMS_FIELDS = [
+    'source_url',
+    'terms_url',
+    'license_url',
+    'allowed_use',
+    'terms_reviewed_by',
+    'terms_approval',
+    'human_approval_note',
+];
+const REQUIRED_NETWORK_AUTHORIZATION_FIELDS = [
+    'network_dry_run_authorization',
+    'allow_external_network',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_staging_write',
+    'max_targets',
+    'bulk_scope_allowed',
+    'allowed_runtime',
+    'allowed_engine_family',
+    'forbidden_legacy_runtime',
+];
+const REQUIRED_PROXY_BROWSER_NETWORK_FIELDS = [
+    'proxy_required',
+    'proxy_provider',
+    'proxy_health_check_required',
+    'browser_required',
+    'browser_provider',
+    'rate_limit_policy',
+    'retry_policy',
+    'user_agent_policy',
+    'no_login_paywall_bypass',
+    'no_anti_bot_bypass',
+    'no_bulk_expansion',
+];
+const REQUIRED_INPUT_FIELDS = [
+    'pre_network_runbook_required',
+    'staging_packet_preview_required',
+    'artifact_schema_required',
+    'manifest_schema_required',
+    'output_root_policy_required',
+    'stop_conditions_required',
+];
+const REQUIRED_SAFETY_FIELDS = [
+    'would_access_network',
+    'would_launch_browser',
+    'would_use_proxy',
+    'would_execute_engine',
+    'would_write_staging',
+    'would_create_staging_directory',
+    'would_write_source_manifest',
+    'would_write_packet_file',
+    'would_write_db',
+    'would_train',
+    'would_predict',
+    'would_bulk_harvest',
+];
+const REQUIRED_APPROVAL_FIELDS = [
+    'source_terms_approved_by',
+    'network_dry_run_approved_by',
+    'staging_policy_approved_by',
+    'final_human_confirmation_by',
+];
+const REQUIRED_CLI_FIELDS = [
+    'auth_form',
+    'runbook',
+    'target_source',
+    'target_engine_family',
+    'target_scope_type',
+    'target_match_id',
+    'terms_approval',
+    'network_dry_run_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'final_human_confirmation',
+];
+const YES_NO_FIELDS = [
+    'terms_approval',
+    'network_dry_run_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'final_human_confirmation',
+];
+const TOP_LEVEL_FALSE_FIELD_RULES = [
+    ['network_dry_run_authorized', 'network_dry_run_authorized true in template is not allowed'],
+    ['staging_write_authorized', 'staging_write_authorized true in template is not allowed'],
+    ['db_write_authorized', 'db_write_authorized true in template is not allowed'],
+    ['training_authorized', 'training_authorized true in template is not allowed'],
+    ['prediction_authorized', 'prediction_authorized true in template is not allowed'],
+    ['final_human_confirmation', 'final_human_confirmation true in template is not allowed'],
+];
+const SOURCE_TERMS_NO_FIELDS = ['terms_approval'];
+const NETWORK_AUTHORIZATION_NO_FIELDS = [
+    'network_dry_run_authorization',
+    'allow_external_network',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_staging_write',
+];
+const REQUIRED_INPUT_TRUE_FIELDS = REQUIRED_INPUT_FIELDS;
+const REQUIRED_SAFETY_FALSE_FIELDS = REQUIRED_SAFETY_FIELDS;
+const PROXY_BROWSER_NETWORK_TRUE_FIELDS = ['no_login_paywall_bypass', 'no_anti_bot_bypass', 'no_bulk_expansion'];
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_auth_form_validate.js --auth-form <path> --runbook <path> --target-source <src> --target-engine-family titan_discovery --target-scope-type match_id --target-match-id <id> --terms-approval no --network-dry-run-authorization no --allow-browser-runtime no --allow-proxy-runtime no --allow-external-network no --allow-staging-write no --final-human-confirmation no',
+        '  node scripts/ops/single_target_acquisition_network_auth_form_validate.js --auth-form <path> --runbook <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.84D validates a local network dry-run authorization form template only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        auth_form: '',
+        runbook: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+        } else if (token === '--json') {
+            args.json = true;
+        } else if (token === '--help' || token === '-h') {
+            args.help = true;
+        } else if (token.startsWith('--')) {
+            const eqIndex = token.indexOf('=');
+            if (eqIndex !== -1) {
+                args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+            } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+                args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+                index += 1;
+            } else {
+                throw new Error(`Unknown argument: ${token}`);
+            }
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) {
+        return '';
+    }
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) {
+        return '';
+    }
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function buildSafetyFlags() {
+    return {
+        authorization_form_template_only: true,
+        auth_form_valid: false,
+        runbook_template_valid: false,
+        network_dry_run_authorized: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: 'Phase 4.85D or explicit user-authorized network dry-run preparation',
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: AUTH_PHASE,
+        mode: fields.mode || 'single-target-acquisition-network-auth-form-validate',
+        ok: false,
+        auth_form: args.auth_form || null,
+        runbook: args.runbook || null,
+        auth_form_found: false,
+        runbook_found: false,
+        yaml_block_found: false,
+        runbook_yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function collectMissingFields(parsedYaml, parentKey, requiredKeys, missingFields) {
+    const value = parsedYaml[parentKey];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        for (const key of requiredKeys) {
+            missingFields.push(`${parentKey}.${key}`);
+        }
+        return;
+    }
+    for (const key of requiredKeys) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+            missingFields.push(`${parentKey}.${key}`);
+        }
+    }
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_LEVEL_FIELDS.filter(
+        field => !Object.prototype.hasOwnProperty.call(parsedYaml, field)
+    );
+    collectMissingFields(parsedYaml, 'request', REQUIRED_REQUEST_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'source_terms', REQUIRED_SOURCE_TERMS_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'network_authorization', REQUIRED_NETWORK_AUTHORIZATION_FIELDS, missingFields);
+    collectMissingFields(
+        parsedYaml,
+        'proxy_browser_network_preflight',
+        REQUIRED_PROXY_BROWSER_NETWORK_FIELDS,
+        missingFields
+    );
+    collectMissingFields(parsedYaml, 'required_inputs', REQUIRED_INPUT_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'safety', REQUIRED_SAFETY_FIELDS, missingFields);
+    collectMissingFields(parsedYaml, 'approvals', REQUIRED_APPROVAL_FIELDS, missingFields);
+    return missingFields;
+}
+
+function ensureNestedNoFields(parsedYaml, parentKey, fieldNames, errors) {
+    const parent = parsedYaml[parentKey] || {};
+    for (const fieldName of fieldNames) {
+        if (parent[fieldName] !== 'no') {
+            errors.push(`${parentKey}.${fieldName} must remain no in the Phase 4.84D template`);
+        }
+    }
+}
+
+function ensureNestedTrueFields(parsedYaml, parentKey, fieldNames, errors) {
+    const parent = parsedYaml[parentKey] || {};
+    for (const fieldName of fieldNames) {
+        if (parent[fieldName] !== true) {
+            errors.push(`${parentKey}.${fieldName} must be true in the Phase 4.84D template`);
+        }
+    }
+}
+
+function ensureNestedFalseFields(parsedYaml, parentKey, fieldNames, errors) {
+    const parent = parsedYaml[parentKey] || {};
+    for (const fieldName of fieldNames) {
+        if (parent[fieldName] !== false) {
+            errors.push(`${parentKey}.${fieldName} must remain false in the Phase 4.84D template`);
+        }
+    }
+}
+
+function pushMissingFieldsError(missingFields, errors) {
+    if (missingFields.length > 0) {
+        errors.push(`missing required fields: ${missingFields.join(',')}`);
+    }
+}
+
+function validateTopLevelTemplateFields(parsedYaml, errors) {
+    if (parsedYaml.phase !== AUTH_PHASE) {
+        errors.push(`phase must be ${AUTH_PHASE}`);
+    }
+    if (parsedYaml.authorization_form_status !== 'template_only') {
+        errors.push('authorization_form_status must remain template_only in the Phase 4.84D template');
+    }
+    for (const [fieldName, message] of TOP_LEVEL_FALSE_FIELD_RULES) {
+        if (parsedYaml[fieldName] !== false) {
+            errors.push(message);
+        }
+    }
+}
+
+function validateRequestSection(parsedYaml, errors) {
+    const request = parsedYaml.request || {};
+    if (request.target_engine_family !== 'titan_discovery') {
+        errors.push('unsupported engine family "template target_engine_family must remain titan_discovery"');
+    }
+    if (request.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+}
+
+function validateSourceTermsSection(parsedYaml, errors) {
+    ensureNestedNoFields(parsedYaml, 'source_terms', SOURCE_TERMS_NO_FIELDS, errors);
+}
+
+function validateNetworkAuthorizationSection(parsedYaml, errors) {
+    const networkAuthorization = parsedYaml.network_authorization || {};
+    ensureNestedNoFields(parsedYaml, 'network_authorization', NETWORK_AUTHORIZATION_NO_FIELDS, errors);
+
+    if (networkAuthorization.max_targets !== 1) {
+        errors.push('max_targets > 1 is not allowed in the Phase 4.84D template');
+    }
+    if (networkAuthorization.bulk_scope_allowed !== false) {
+        errors.push('bulk scope allowed must remain false in the Phase 4.84D template');
+    }
+    if (networkAuthorization.allowed_runtime !== 'scaffolded_single_target_only') {
+        errors.push('network_authorization.allowed_runtime must remain scaffolded_single_target_only');
+    }
+    if (networkAuthorization.allowed_engine_family !== 'titan_discovery') {
+        errors.push(
+            'unsupported engine family "network_authorization.allowed_engine_family must remain titan_discovery"'
+        );
+    }
+    if (networkAuthorization.forbidden_legacy_runtime !== true) {
+        errors.push('network_authorization.forbidden_legacy_runtime must be true in the Phase 4.84D template');
+    }
+}
+
+function validateProxyBrowserNetworkSection(parsedYaml, errors) {
+    ensureNestedTrueFields(parsedYaml, 'proxy_browser_network_preflight', PROXY_BROWSER_NETWORK_TRUE_FIELDS, errors);
+}
+
+function validateRequiredInputsSection(parsedYaml, errors) {
+    ensureNestedTrueFields(parsedYaml, 'required_inputs', REQUIRED_INPUT_TRUE_FIELDS, errors);
+}
+
+function validateSafetySection(parsedYaml, errors) {
+    ensureNestedFalseFields(parsedYaml, 'safety', REQUIRED_SAFETY_FALSE_FIELDS, errors);
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    pushMissingFieldsError(missingFields, errors);
+    validateTopLevelTemplateFields(parsedYaml, errors);
+    validateRequestSection(parsedYaml, errors);
+    validateSourceTermsSection(parsedYaml, errors);
+    validateNetworkAuthorizationSection(parsedYaml, errors);
+    validateProxyBrowserNetworkSection(parsedYaml, errors);
+    validateRequiredInputsSection(parsedYaml, errors);
+    validateSafetySection(parsedYaml, errors);
+    return {
+        ok: errors.length === 0,
+        missingFields,
+        errors,
+    };
+}
+
+function validateCliYesNoFields(args) {
+    const errors = [];
+    for (const field of YES_NO_FIELDS) {
+        const value = args[field];
+        if (value !== 'yes' && value !== 'no') {
+            errors.push(`--${field.replace(/_/g, '-')} is required (yes/no)`);
+        }
+    }
+    return errors;
+}
+
+function validateCliTargetFields(args) {
+    const errors = [];
+    if (args.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${args.target_engine_family}"`);
+    }
+    if (args.target_scope_type !== 'match_id' && args.target_scope_type !== 'league_season_date') {
+        errors.push(`unsupported scope type "${args.target_scope_type}"`);
+    }
+    if (args.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+    if (args.target_scope_type === 'match_id' && !args.target_match_id) {
+        errors.push('--target-match-id is required when target_scope_type=match_id');
+    }
+    return errors;
+}
+
+function validateRequiredCliFields(args) {
+    const errors = [];
+    for (const field of REQUIRED_CLI_FIELDS) {
+        if (!args[field]) {
+            if (field === 'auth_form') {
+                errors.push('missing auth form');
+            } else if (field === 'runbook') {
+                errors.push('missing runbook');
+            } else {
+                errors.push(`missing ${field.replace(/_/g, ' ')} path or value`);
+            }
+        }
+    }
+    return errors;
+}
+
+function buildArgumentErrorPayload(args, errors) {
+    return buildFailurePayload(args, {
+        mode: 'argument-error',
+        errors,
+    });
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: AUTH_PHASE,
+        mode: 'single-target-acquisition-network-auth-form-validate',
+        ok: true,
+        auth_form: args.auth_form,
+        runbook: args.runbook,
+        auth_form_found: true,
+        runbook_found: true,
+        yaml_block_found: true,
+        runbook_yaml_block_found: true,
+        required_fields_present: true,
+        missing_fields: [],
+        auth_form_valid: true,
+        runbook_template_valid: true,
+        errors: [],
+        warnings: [
+            'Phase 4.84D remains template-only.',
+            'CLI authorization yes values do not authorize execution in this phase.',
+        ],
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function validateCliArgsOrPayload(args) {
+    const missingCliFields = validateRequiredCliFields(args);
+    if (missingCliFields.length > 0) {
+        return buildArgumentErrorPayload(args, missingCliFields);
+    }
+
+    const cliYesNoErrors = validateCliYesNoFields(args);
+    const cliTargetErrors = validateCliTargetFields(args);
+    if (cliYesNoErrors.length > 0 || cliTargetErrors.length > 0) {
+        return buildArgumentErrorPayload(args, [...cliYesNoErrors, ...cliTargetErrors]);
+    }
+    return null;
+}
+
+function loadMarkdownYaml(args, cwd, existsSync, readFileSync, fieldName, modePrefix, missingLabel) {
+    const targetPath = resolveLocalPath(args[fieldName], cwd);
+    if (!existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: false,
+                errors: [`${missingLabel}: ${toRelativePath(targetPath, cwd)}`],
+            }),
+        };
+    }
+
+    const markdownText = readFileSync(targetPath, 'utf8');
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: true,
+                [fieldName === 'auth_form' ? 'yaml_block_found' : 'runbook_yaml_block_found']: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseYamlBlock(yamlText) };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: true,
+                [fieldName === 'auth_form' ? 'yaml_block_found' : 'runbook_yaml_block_found']: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function validateAuthFormOrPayload(args, parsedYaml) {
+    const parsedValidation = validateParsedYaml(parsedYaml);
+    if (!parsedValidation.ok) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'auth-form-error',
+                auth_form_found: true,
+                yaml_block_found: true,
+                required_fields_present: parsedValidation.missingFields.length === 0,
+                missing_fields: parsedValidation.missingFields,
+                errors: parsedValidation.errors,
+            }),
+        };
+    }
+    return null;
+}
+
+function validateRunbookTemplateOrPayload(args, parsedYaml) {
+    const parsedValidation = validateRunbookParsedYaml(parsedYaml);
+    if (!parsedValidation.ok) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'runbook-error',
+                auth_form_found: true,
+                runbook_found: true,
+                yaml_block_found: true,
+                runbook_yaml_block_found: true,
+                auth_form_valid: true,
+                errors: [`runbook template validation failed: ${parsedValidation.errors.join('; ')}`],
+            }),
+        };
+    }
+    return null;
+}
+
+function validateTargetConsistency(args, authFormYaml, runbookYaml) {
+    const request = authFormYaml.request || {};
+    const runbookTarget = runbookYaml.target || {};
+    const errors = [];
+
+    const comparisons = [
+        ['request.target_source', request.target_source, args.target_source],
+        ['request.target_engine_family', request.target_engine_family, args.target_engine_family],
+        ['request.target_scope_type', request.target_scope_type, args.target_scope_type],
+        ['request.target_match_id', request.target_match_id, args.target_match_id],
+        ['runbook.target.target_source', runbookTarget.target_source, args.target_source],
+        ['runbook.target.target_engine_family', runbookTarget.target_engine_family, args.target_engine_family],
+        ['runbook.target.target_scope_type', runbookTarget.target_scope_type, args.target_scope_type],
+        ['runbook.target.target_match_id', runbookTarget.target_match_id, args.target_match_id],
+    ];
+
+    for (const [label, templateValue, cliValue] of comparisons) {
+        if (templateValue && templateValue !== cliValue) {
+            errors.push(`target mismatch: ${label} "${templateValue}" does not match CLI value "${cliValue}"`);
+        }
+    }
+
+    if (errors.length > 0) {
+        return buildFailurePayload(args, {
+            mode: 'target-error',
+            auth_form_found: true,
+            runbook_found: true,
+            yaml_block_found: true,
+            runbook_yaml_block_found: true,
+            required_fields_present: true,
+            auth_form_valid: true,
+            runbook_template_valid: true,
+            errors,
+        });
+    }
+    return null;
+}
+
+function runValidation(args, dependencies = {}) {
+    const cwd = dependencies.cwd || process.cwd();
+    const existsSync = dependencies.existsSync || fs.existsSync;
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) {
+        return cliPayload;
+    }
+
+    const authFormLoad = loadMarkdownYaml(
+        args,
+        cwd,
+        existsSync,
+        readFileSync,
+        'auth_form',
+        'auth-form',
+        'missing auth form'
+    );
+    if (authFormLoad.payload) {
+        return authFormLoad.payload;
+    }
+
+    const authFormValidation = validateAuthFormOrPayload(args, authFormLoad.parsedYaml);
+    if (authFormValidation && authFormValidation.payload) {
+        return authFormValidation.payload;
+    }
+
+    const runbookLoad = loadMarkdownYaml(args, cwd, existsSync, readFileSync, 'runbook', 'runbook', 'missing runbook');
+    if (runbookLoad.payload) {
+        return runbookLoad.payload;
+    }
+
+    const runbookValidation = validateRunbookTemplateOrPayload(args, runbookLoad.parsedYaml);
+    if (runbookValidation && runbookValidation.payload) {
+        return runbookValidation.payload;
+    }
+
+    const targetConsistencyPayload = validateTargetConsistency(args, authFormLoad.parsedYaml, runbookLoad.parsedYaml);
+    if (targetConsistencyPayload) {
+        return targetConsistencyPayload;
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function payloadToText(payload) {
+    const lines = [
+        `mode=${payload.mode}`,
+        `ok=${payload.ok}`,
+        `auth_form_found=${payload.auth_form_found}`,
+        `runbook_found=${payload.runbook_found}`,
+        `yaml_block_found=${payload.yaml_block_found}`,
+        `runbook_yaml_block_found=${payload.runbook_yaml_block_found}`,
+        `required_fields_present=${payload.required_fields_present}`,
+        `authorization_form_template_only=${payload.authorization_form_template_only}`,
+        `auth_form_valid=${payload.auth_form_valid}`,
+        `runbook_template_valid=${payload.runbook_template_valid}`,
+        `network_dry_run_authorized=${payload.network_dry_run_authorized}`,
+        `staging_write_authorized=${payload.staging_write_authorized}`,
+        `db_write_authorized=${payload.db_write_authorized}`,
+        `training_authorized=${payload.training_authorized}`,
+        `prediction_authorized=${payload.prediction_authorized}`,
+        `final_human_confirmation=${payload.final_human_confirmation}`,
+        `would_access_network=${payload.would_access_network}`,
+        `would_launch_browser=${payload.would_launch_browser}`,
+        `would_use_proxy=${payload.would_use_proxy}`,
+        `would_execute_engine=${payload.would_execute_engine}`,
+        `would_write_staging=${payload.would_write_staging}`,
+        `would_create_staging_directory=${payload.would_create_staging_directory}`,
+        `would_write_source_manifest=${payload.would_write_source_manifest}`,
+        `would_write_packet_file=${payload.would_write_packet_file}`,
+        `would_write_db=${payload.would_write_db}`,
+        `would_train=${payload.would_train}`,
+        `would_predict=${payload.would_predict}`,
+        `would_spawn_child_process=${payload.would_spawn_child_process}`,
+        `commit_gate=${payload.commit_gate}`,
+        `next_required_phase=${payload.next_required_phase}`,
+    ];
+
+    if (payload.blocked_reason) {
+        lines.push(`blocked_reason=${payload.blocked_reason}`);
+    }
+    if (Array.isArray(payload.missing_fields) && payload.missing_fields.length > 0) {
+        lines.push(`missing_fields=${payload.missing_fields.join(',')}`);
+    }
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+        lines.push(`errors=${payload.errors.join('; ')}`);
+    }
+    if (Array.isArray(payload.warnings) && payload.warnings.length > 0) {
+        lines.push(`warnings=${payload.warnings.join('; ')}`);
+    }
+    lines.push('non_execution_confirmations=');
+    for (const confirmation of payload.non_execution_confirmations || []) {
+        lines.push(`  ${confirmation}`);
+    }
+
+    return lines.join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json ? `${JSON.stringify(payload, null, 2)}\n` : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            const payload = buildBlockedCommitPayload(args);
+            writePayload(payload, true, output);
+            return 1;
+        }
+
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, true, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        const payload = buildFailurePayload(
+            { auth_form: '', runbook: '' },
+            {
+                mode: 'argument-error',
+                errors: [error.message],
+            }
+        );
+        writePayload(payload, true, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    AUTH_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_auth_form_validate.test.js
+++ b/tests/unit/single_target_acquisition_network_auth_form_validate.test.js
@@ -1,0 +1,549 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/single_target_acquisition_network_auth_form_validate.js');
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md'
+);
+const RUNBOOK_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md'
+);
+const AUTH_FORM_TEXT = fs.readFileSync(AUTH_FORM_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        auth_form: AUTH_FORM_PATH,
+        runbook: RUNBOOK_PATH,
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by single_target_acquisition_network_auth_form_validate`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(AUTH_FORM_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return AUTH_FORM_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return AUTH_FORM_TEXT.replace(`${line}\n`, '');
+}
+
+function withTempAuthForm(markdownText, callback) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'phase484d-'));
+    const authFormPath = path.join(tempDir, 'auth-form.md');
+    fs.writeFileSync(authFormPath, markdownText, 'utf8');
+    try {
+        callback(authFormPath);
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 auth form 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.auth_form;
+    const payload = gate.runValidation(args, buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing auth form/i);
+});
+
+test('缺 runbook 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.runbook;
+    const payload = gate.runValidation(args, buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook/i);
+});
+
+test('auth form 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm('# no yaml\n', authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /missing YAML block/i);
+    });
+});
+
+test('auth form invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm('```yaml\nnot yaml\n```\n', authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /invalid YAML/i);
+    });
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(
+        removeLineFromTemplate('phase: PHASE4.84D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM'),
+        authFormPath => {
+            const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /missing required fields: phase/);
+        }
+    );
+});
+
+test('authorization_form_status 非 template_only 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(
+        replaceInTemplate('authorization_form_status: template_only', 'authorization_form_status: approved'),
+        authFormPath => {
+            const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /template_only/);
+        }
+    );
+});
+
+test('network_dry_run_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(
+        replaceInTemplate('network_dry_run_authorized: false', 'network_dry_run_authorized: true'),
+        authFormPath => {
+            const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /network_dry_run_authorized true/);
+        }
+    );
+});
+
+test('staging_write_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(
+        replaceInTemplate('staging_write_authorized: false', 'staging_write_authorized: true'),
+        authFormPath => {
+            const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /staging_write_authorized true/);
+        }
+    );
+});
+
+test('db_write_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(replaceInTemplate('db_write_authorized: false', 'db_write_authorized: true'), authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /db_write_authorized true/);
+    });
+});
+
+test('training_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(replaceInTemplate('training_authorized: false', 'training_authorized: true'), authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /training_authorized true/);
+    });
+});
+
+test('prediction_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(replaceInTemplate('prediction_authorized: false', 'prediction_authorized: true'), authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /prediction_authorized true/);
+    });
+});
+
+test('final_human_confirmation=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(
+        replaceInTemplate('final_human_confirmation: false', 'final_human_confirmation: true'),
+        authFormPath => {
+            const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /final_human_confirmation true/);
+        }
+    );
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(replaceInTemplate('bulk_scope_allowed: false', 'bulk_scope_allowed: true'), authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /bulk scope allowed/i);
+    });
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(replaceInTemplate('max_targets: 1', 'max_targets: 2'), authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+    });
+});
+
+test('unsupported engine family 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_engine_family: 'run_production' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported engine family/);
+});
+
+test('unsupported scope type bulk 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_scope_type: 'bulk' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported scope type "bulk"|unsupported scope type bulk/);
+});
+
+test('target mismatch 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempAuthForm(replaceInTemplate('    target_source:', '    target_source: other'), authFormPath => {
+        const payload = gate.runValidation({ ...buildArgs(), auth_form: authFormPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /target mismatch/i);
+    });
+});
+
+test('valid auth form validate 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.84D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM');
+    assert.equal(payload.authorization_form_template_only, true);
+    assert.equal(payload.auth_form_valid, true);
+    assert.equal(payload.runbook_template_valid, true);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('all CLI yes 仍 no-op / not authorized', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs({
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            final_human_confirmation: 'yes',
+        }),
+        buildDependencies()
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        ['--auth-form', AUTH_FORM_PATH, '--runbook', RUNBOOK_PATH, '--commit'],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.84D/);
+});
+
+test('Makefile validate 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-auth-form-validate',
+            'NETWORK_AUTH_FORM_NODE=node',
+            `AUTH_FORM=${AUTH_FORM_PATH}`,
+            `RUNBOOK=${RUNBOOK_PATH}`,
+            'TARGET_SOURCE=fotmob',
+            'TARGET_ENGINE_FAMILY=titan_discovery',
+            'TARGET_SCOPE_TYPE=match_id',
+            'TARGET_MATCH_ID=sample-match-001',
+            'TERMS_APPROVAL=no',
+            'NETWORK_DRY_RUN_AUTHORIZATION=no',
+            'ALLOW_BROWSER_RUNTIME=no',
+            'ALLOW_PROXY_RUNTIME=no',
+            'ALLOW_EXTERNAL_NETWORK=no',
+            'ALLOW_STAGING_WRITE=no',
+            'FINAL_HUMAN_CONFIRMATION=no',
+        ],
+        {
+            cwd: PROJECT_ROOT,
+            encoding: 'utf8',
+            shell: false,
+        }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-auth-form-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM=1',
+        ],
+        {
+            cwd: PROJECT_ROOT,
+            encoding: 'utf8',
+            shell: false,
+        }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.84D/);
+});
+
+test('不访问网络', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_access_network, false);
+});
+
+test('不启动 browser', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_launch_browser, false);
+});
+
+test('不执行 proxy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_use_proxy, false);
+});
+
+test('不执行 engine', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_engine, false);
+});
+
+test('不写 staging', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_staging, false);
+});
+
+test('不创建目录', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_create_staging_directory, false);
+});
+
+test('不写 source manifest', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_source_manifest, false);
+});
+
+test('不写 packet file', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_packet_file, false);
+});
+
+test('不写 DB', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('不 spawn child process', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_spawn_child_process, false);
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.84D single-target acquisition network dry-run authorization form template.

Scope:
- Adds network dry-run authorization form template
- Adds local-only authorization form validator
- Validates form remains template-only and non-authorized
- Keeps network dry-run blocked
- Adds Makefile validate and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.84D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- validate missing params failed as expected
- valid auth form validate passed
- all-yes CLI remained no-op / not authorized
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed