### PR TITLE
docs(data): add single-target network readiness checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、汇总 4.79D+4.80D+4.81D 安全门禁的 staging packet preview：`make data-single-target-acquisition-staging-packet-preview ARTIFACT_SCHEMA=<path> ... OUTPUT_ROOT=<path> ...`（Phase 4.82D preview-only）
 - 不触网、不写文件、不创建目录、只验证 pre-network runbook draft 和 packet preview 前置条件的本地 validator：`make data-single-target-acquisition-pre-network-runbook-validate RUNBOOK=<path> ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path> OUTPUT_ROOT=<path> ...`（Phase 4.83D draft-only）
 - 不触网、不写文件、不创建目录、只验证 network dry-run authorization form template 和 pre-network runbook template 的本地 validator：`make data-single-target-acquisition-network-auth-form-validate AUTH_FORM=<path> RUNBOOK=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.84D template-only）
+- 不触网、不写文件、不创建目录、只验证 final readiness checklist template + pre-network runbook template + network auth form template 的本地 validator：`make data-single-target-acquisition-network-readiness-checklist-validate CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.85D template-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -711,6 +712,25 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-auth-form-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook 审核通过。
+
+### Phase 4.85D: single-target acquisition network dry-run final readiness checklist
+
+`data-single-target-acquisition-network-readiness-checklist-validate` 只允许验证 final readiness checklist template：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 DB
+- final readiness checklist template 不等于真实 network dry-run authorization
+- 即使 CLI 传入 yes，Phase 4.85D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-readiness-checklist-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook / auth form / readiness checklist 全部审核通过。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@
         data-single-target-acquisition-staging-packet-preview data-single-target-acquisition-staging-packet-commit \
         data-single-target-acquisition-pre-network-runbook-validate data-single-target-acquisition-pre-network-runbook-commit \
         data-single-target-acquisition-network-auth-form-validate data-single-target-acquisition-network-auth-form-commit \
+        data-single-target-acquisition-network-readiness-checklist-validate data-single-target-acquisition-network-readiness-checklist-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -77,6 +78,7 @@ help: ## 显示帮助信息
 COMPOSE_DEV=docker compose -f docker-compose.dev.yml
 PRE_NETWORK_RUNBOOK_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTH_FORM_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_READINESS_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -348,6 +350,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-pre-network-runbook-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_PRE_NETWORK_RUNBOOK=1  # blocked in Phase 4.83D"
 	@echo "  make data-single-target-acquisition-network-auth-form-validate AUTH_FORM=<path> RUNBOOK=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # template-only validate, Phase 4.84D"
 	@echo "  make data-single-target-acquisition-network-auth-form-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM=1  # blocked in Phase 4.84D"
+	@echo "  make data-single-target-acquisition-network-readiness-checklist-validate CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # template-only validate, Phase 4.85D"
+	@echo "  make data-single-target-acquisition-network-readiness-checklist-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_READINESS=1  # blocked in Phase 4.85D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1034,6 +1038,37 @@ data-single-target-acquisition-network-auth-form-commit: ## Blocked network auth
 	@echo "BLOCKED: single-target acquisition network dry-run authorization execution is not wired in Phase 4.84D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM=1, this path remains blocked."
 	@echo "  Phase 4.84D validates a template only and does not authorize any network dry-run, staging write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-readiness-checklist-validate: ## Template-only final readiness checklist validation. Phase 4.85D. No network, no writes, no DB.
+	@if [ -z "$(CHECKLIST)" ] || [ -z "$(RUNBOOK)" ] || [ -z "$(AUTH_FORM)" ] || [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ] || [ -z "$(TARGET_MATCH_ID)" ]; then \
+		echo "ERROR: provide CHECKLIST=<path>, RUNBOOK=<path>, AUTH_FORM=<path>, TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<type>, TARGET_MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.85D: network readiness checklist validate (template-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_READINESS_CHECKLIST_NODE) scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js \
+		--checklist "$(CHECKLIST)" \
+		--runbook "$(RUNBOOK)" \
+		--auth-form "$(AUTH_FORM)" \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		--target-match-id "$(TARGET_MATCH_ID)" \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-network-readiness-checklist-commit: ## Blocked network readiness checklist execution gate. Remains not wired in Phase 4.85D.
+	@echo "BLOCKED: single-target acquisition network dry-run final readiness execution is not wired in Phase 4.85D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_READINESS=1, this path remains blocked."
+	@echo "  Phase 4.85D validates a template only and does not authorize any network dry-run, staging write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_READINESS_CHECKLIST_PHASE4_85D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_READINESS_CHECKLIST_PHASE4_85D.md
@@ -1,0 +1,145 @@
+# Phase 4.85D: Single-Target Acquisition Network Dry-Run Final Readiness Checklist
+
+**Date**: 2026-05-10
+**Status**: Complete (template-only, local-only)
+**Previous phases**: 4.79D, 4.80D, 4.81D, 4.82D, 4.83D, 4.84D
+**Recommended next phase**: Phase 4.86D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.85D adds a network dry-run final readiness checklist template and a
+local validator for the future first single-target acquisition network dry-run.
+
+This phase did not:
+
+- access network
+- perform acquisition
+- write DB
+- write staging
+- write packet files
+
+The goal is to consolidate Phases 4.79D through 4.84D into a final readiness
+checklist before any future real single-target network dry-run is considered.
+
+---
+
+## 2. Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js`
+- `tests/unit/single_target_acquisition_network_readiness_checklist_validate.test.js`
+- `Makefile` targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_READINESS_CHECKLIST_PHASE4_85D.md`
+
+---
+
+## 3. Checklist Sections
+
+The final readiness checklist template includes these sections:
+
+- `required_prior_artifacts`
+- `required_validations`
+- `target`
+- `source_terms`
+- `network_authorization`
+- `proxy_browser_network_preflight`
+- `staging_policy`
+- `db_training_prediction_policy`
+- `safety`
+- `blocking_reasons`
+- `next_phase_requirements`
+
+The YAML block remains machine-readable and enforces template-only status.
+
+---
+
+## 4. Validation Behavior
+
+The validator is:
+
+- local-only
+- read-only
+- in-process
+
+It verifies that:
+
+- the checklist remains `template_only`
+- `network_dry_run_ready` remains `false`
+- all authorization fields remain false / no in the template
+- single-target / no-bulk constraints remain in force
+- no network execution occurs
+- no runtime writes occur
+
+It also keeps the commit path blocked in Phase 4.85D.
+
+---
+
+## 5. Relationship to Previous Phases
+
+- 4.79D handles runtime parameter scaffold
+- 4.80D handles artifact / manifest schema validation
+- 4.81D handles writer path / authorization preflight
+- 4.82D handles staging packet preview
+- 4.83D handles pre-network runbook draft
+- 4.84D handles authorization form template
+- 4.85D handles final readiness checklist
+
+All seven phases remain non-executing. None equals a real network dry-run.
+
+---
+
+## 6. Recommended Next Phase
+
+Recommended:
+
+`Phase 4.86D: single-target acquisition network dry-run execution plan draft`
+
+Goals:
+
+- still no network
+- only design a future execution plan
+- define explicit execution stop gates
+
+Alternative:
+
+`Phase 4.56A: 用户给齐真实 network dry-run 参数后才做 runbook`
+
+---
+
+## 7. Explicit Non-Execution
+
+The following were not executed:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md
@@ -1,0 +1,179 @@
+# Single-Target Acquisition Network Dry-Run Final Readiness Checklist Template
+
+This document is a Phase 4.85D template-only final readiness checklist for a
+future single-target acquisition network dry-run.
+
+- This is a final readiness checklist template, not a readiness approval.
+- `network_dry_run_ready=false`
+- `network_dry_run_authorized=false`
+- `staging_write_authorized=false`
+- `db_write_authorized=false`
+- `training_authorized=false`
+- `prediction_authorized=false`
+- Codex must not change this template to ready or authorized on its own.
+- A real network dry-run requires explicit user-supplied source, target, terms,
+  and authorization details.
+- Even if a future operator fills this checklist as ready, execution must still
+  move to a later, separately authorized phase. Phase 4.85D does not permit
+  network execution.
+
+```yaml
+phase: PHASE4.85D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST
+checklist_status: template_only
+network_dry_run_ready: false
+network_dry_run_authorized: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+required_prior_artifacts:
+    runtime_scaffold_present: true
+    staging_schema_validator_present: true
+    staging_writer_preflight_present: true
+    staging_packet_preview_present: true
+    pre_network_runbook_present: true
+    network_auth_form_present: true
+
+required_validations:
+    runtime_scaffold_validated: false
+    staging_schema_validated: false
+    staging_writer_preflight_validated: false
+    staging_packet_preview_validated: false
+    pre_network_runbook_validated: false
+    network_auth_form_validated: false
+
+target:
+    target_source:
+    target_engine_family: titan_discovery
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+    max_targets: 1
+    bulk_scope_allowed: false
+
+source_terms:
+    source_url:
+    terms_url:
+    license_url:
+    allowed_use:
+    terms_approval: no
+    terms_reviewed_by:
+    human_approval_note:
+
+network_authorization:
+    network_dry_run_authorization: no
+    allow_external_network: no
+    allow_browser_runtime: no
+    allow_proxy_runtime: no
+    allow_staging_write: no
+
+proxy_browser_network_preflight:
+    proxy_required:
+    proxy_provider:
+    proxy_health_check_passed: false
+    browser_required:
+    browser_provider:
+    network_policy_reviewed: false
+    rate_limit_policy_reviewed: false
+    retry_policy_reviewed: false
+    user_agent_policy_reviewed: false
+    no_login_paywall_bypass: true
+    no_anti_bot_bypass: true
+    no_bulk_expansion: true
+
+staging_policy:
+    output_root_reviewed: false
+    output_root_allowed: false
+    schema_validation_passed: false
+    packet_preview_passed: false
+    staging_write_authorized: false
+
+db_training_prediction_policy:
+    db_write_authorized: false
+    training_authorized: false
+    prediction_authorized: false
+    model_artifact_loading_authorized: false
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+blocking_reasons:
+    - checklist_template_only
+    - network_dry_run_not_authorized
+    - staging_write_not_authorized
+    - db_write_not_authorized
+    - final_human_confirmation_missing
+
+next_phase_requirements:
+    - real_target_source
+    - real_single_target_scope
+    - reviewed_source_terms
+    - explicit_network_dry_run_authorization
+    - accepted_proxy_browser_network_preflight
+    - accepted_staging_packet_preview
+    - confirmed_no_db_write
+    - confirmed_no_training
+    - confirmed_no_prediction
+```
+
+## Purpose
+
+This template consolidates the prerequisites that must be reviewed before a
+future single-target acquisition network dry-run can even be proposed.
+
+It does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- DB writes
+- training
+- prediction
+
+## Required sections
+
+The final readiness checklist template must explicitly describe:
+
+1. required prior artifacts from Phases 4.79D through 4.84D
+2. validation state for scaffold, schema, preflight, packet preview, runbook,
+   and auth form
+3. single-target scope and no-bulk constraints
+4. source URL, terms, license, and allowed use
+5. network authorization and proxy/browser preflight review
+6. staging and DB/training/prediction policy constraints
+7. blocking reasons and next requirements for any future phase
+
+## Template-only guardrails
+
+- `checklist_status` must remain `template_only`
+- `network_dry_run_ready` must remain `false`
+- `network_dry_run_authorized` must remain `false`
+- `staging_write_authorized` must remain `false`
+- `db_write_authorized` must remain `false`
+- `training_authorized` must remain `false`
+- `prediction_authorized` must remain `false`
+- `final_human_confirmation` must remain `false`
+
+Changing any of the above does not authorize execution inside Phase 4.85D.
+Future network dry-run readiness must happen in a separate phase with explicit
+user approval, complete parameters, reviewed terms, an approved auth form, and
+an approved follow-up execution plan.

--- a/scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js
+++ b/scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js
@@ -1,0 +1,706 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    parseYamlBlock,
+    validateParsedYaml: validateRunbookParsedYaml,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    validateParsedYaml: validateAuthFormParsedYaml,
+} = require('./single_target_acquisition_network_auth_form_validate');
+
+const READINESS_PHASE = 'PHASE4.85D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition network dry-run final readiness execution is not wired in Phase 4.85D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.86D or explicit user-authorized network dry-run preparation';
+const MODE = 'single-target-acquisition-network-readiness-checklist-validate';
+const TEMPLATE_WARNING = [
+    'Phase 4.85D remains template-only.',
+    'CLI authorization yes values do not authorize execution in this phase.',
+];
+
+const FIELDS = {
+    top: words(`
+        phase checklist_status network_dry_run_ready network_dry_run_authorized
+        staging_write_authorized db_write_authorized training_authorized
+        prediction_authorized final_human_confirmation required_prior_artifacts
+        required_validations target source_terms network_authorization
+        proxy_browser_network_preflight staging_policy
+        db_training_prediction_policy safety blocking_reasons
+        next_phase_requirements
+    `),
+    required_prior_artifacts: words(`
+        runtime_scaffold_present staging_schema_validator_present
+        staging_writer_preflight_present staging_packet_preview_present
+        pre_network_runbook_present network_auth_form_present
+    `),
+    required_validations: words(`
+        runtime_scaffold_validated staging_schema_validated
+        staging_writer_preflight_validated staging_packet_preview_validated
+        pre_network_runbook_validated network_auth_form_validated
+    `),
+    target: words(`
+        target_source target_engine_family target_scope_type target_match_id
+        target_league target_season target_date max_targets bulk_scope_allowed
+    `),
+    source_terms: words(`
+        source_url terms_url license_url allowed_use terms_approval
+        terms_reviewed_by human_approval_note
+    `),
+    network_authorization: words(`
+        network_dry_run_authorization allow_external_network
+        allow_browser_runtime allow_proxy_runtime allow_staging_write
+    `),
+    proxy_browser_network_preflight: words(`
+        proxy_required proxy_provider proxy_health_check_passed
+        browser_required browser_provider network_policy_reviewed
+        rate_limit_policy_reviewed retry_policy_reviewed
+        user_agent_policy_reviewed no_login_paywall_bypass
+        no_anti_bot_bypass no_bulk_expansion
+    `),
+    staging_policy: words(`
+        output_root_reviewed output_root_allowed schema_validation_passed
+        packet_preview_passed staging_write_authorized
+    `),
+    db_training_prediction_policy: words(`
+        db_write_authorized training_authorized prediction_authorized
+        model_artifact_loading_authorized
+    `),
+    safety: words(`
+        would_access_network would_launch_browser would_use_proxy
+        would_execute_engine would_write_staging
+        would_create_staging_directory would_write_source_manifest
+        would_write_packet_file would_write_db would_train
+        would_predict would_bulk_harvest
+    `),
+};
+
+const REQUIRED_ARRAYS = {
+    blocking_reasons: words(`
+        checklist_template_only network_dry_run_not_authorized
+        staging_write_not_authorized db_write_not_authorized
+        final_human_confirmation_missing
+    `),
+    next_phase_requirements: words(`
+        real_target_source real_single_target_scope reviewed_source_terms
+        explicit_network_dry_run_authorization
+        accepted_proxy_browser_network_preflight
+        accepted_staging_packet_preview confirmed_no_db_write
+        confirmed_no_training confirmed_no_prediction
+    `),
+};
+
+const CLI_REQUIRED = words(`
+    checklist runbook auth_form target_source target_engine_family
+    target_scope_type target_match_id terms_approval
+    network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const CLI_YES_NO = words(`
+    terms_approval network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const CHECKS = {
+    topFalse: {
+        network_dry_run_ready: 'network_dry_run_ready true in template is not allowed',
+        network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+        staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+        db_write_authorized: 'db_write_authorized true in template is not allowed',
+        training_authorized: 'training_authorized true in template is not allowed',
+        prediction_authorized: 'prediction_authorized true in template is not allowed',
+        final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+    },
+    nestedNo: {
+        source_terms: ['terms_approval'],
+        network_authorization: words(`
+            network_dry_run_authorization allow_external_network
+            allow_browser_runtime allow_proxy_runtime allow_staging_write
+        `),
+    },
+    nestedFalse: {
+        required_validations: FIELDS.required_validations,
+        staging_policy: FIELDS.staging_policy,
+        db_training_prediction_policy: FIELDS.db_training_prediction_policy,
+        safety: FIELDS.safety,
+        proxy_browser_network_preflight: words(`
+            proxy_health_check_passed network_policy_reviewed
+            rate_limit_policy_reviewed retry_policy_reviewed
+            user_agent_policy_reviewed
+        `),
+    },
+    nestedTrue: {
+        required_prior_artifacts: FIELDS.required_prior_artifacts,
+        proxy_browser_network_preflight: words(`
+            no_login_paywall_bypass no_anti_bot_bypass no_bulk_expansion
+        `),
+    },
+};
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js --checklist <path> --runbook <path> --auth-form <path> --target-source <src> --target-engine-family titan_discovery --target-scope-type match_id --target-match-id <id> --terms-approval no --network-dry-run-authorization no --allow-browser-runtime no --allow-proxy-runtime no --allow-external-network no --allow-staging-write no --final-human-confirmation no',
+        '  node scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js --checklist <path> --runbook <path> --auth-form <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.85D validates a local network readiness checklist template only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        checklist: '',
+        runbook: '',
+        auth_form: '',
+        commit: false,
+        json: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--json') {
+            args.json = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+            continue;
+        }
+        if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+            continue;
+        }
+        throw new Error(`Unknown argument: ${token}`);
+    }
+    return args;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function buildSafetyFlags() {
+    return {
+        readiness_checklist_template_only: true,
+        checklist_valid: false,
+        runbook_template_valid: false,
+        auth_form_template_valid: false,
+        network_dry_run_ready: false,
+        network_dry_run_authorized: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: READINESS_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        checklist: args.checklist || null,
+        runbook: args.runbook || null,
+        auth_form: args.auth_form || null,
+        checklist_found: false,
+        runbook_found: false,
+        auth_form_found: false,
+        yaml_block_found: false,
+        runbook_yaml_block_found: false,
+        auth_form_yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function addMissingNested(root, parentKey, requiredKeys, missingFields) {
+    const value = root[parentKey];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        requiredKeys.forEach(key => missingFields.push(`${parentKey}.${key}`));
+        return;
+    }
+    requiredKeys
+        .filter(key => !Object.prototype.hasOwnProperty.call(value, key))
+        .forEach(key => missingFields.push(`${parentKey}.${key}`));
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = FIELDS.top.filter(key => !Object.prototype.hasOwnProperty.call(parsedYaml, key));
+    Object.entries(FIELDS)
+        .filter(([key]) => key !== 'top')
+        .forEach(([key, requiredKeys]) => addMissingNested(parsedYaml, key, requiredKeys, missingFields));
+    return missingFields;
+}
+
+function ensureNestedValues(root, parentKey, fieldNames, expectedValue, errors, label) {
+    const parent = root[parentKey] || {};
+    fieldNames.forEach(fieldName => {
+        if (parent[fieldName] !== expectedValue) {
+            errors.push(`${parentKey}.${fieldName} must ${label} in the Phase 4.85D template`);
+        }
+    });
+}
+
+function ensureArrayContainsAll(root, key, requiredValues, errors, label) {
+    const value = root[key];
+    if (!Array.isArray(value)) {
+        errors.push(`${label || key} missing`);
+        return;
+    }
+    requiredValues
+        .filter(requiredValue => !value.includes(requiredValue))
+        .forEach(requiredValue => errors.push(`${label || key} missing required value "${requiredValue}"`));
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+
+    if (missingFields.length) {
+        errors.push(`missing required fields: ${missingFields.join(',')}`);
+    }
+    if (parsedYaml.phase !== READINESS_PHASE) {
+        errors.push(`phase must be ${READINESS_PHASE}`);
+    }
+    if (parsedYaml.checklist_status !== 'template_only') {
+        errors.push('checklist_status must remain template_only in the Phase 4.85D template');
+    }
+
+    Object.entries(CHECKS.topFalse).forEach(([field, message]) => {
+        if (parsedYaml[field] !== false) {
+            errors.push(message);
+        }
+    });
+    Object.entries(CHECKS.nestedNo).forEach(([parentKey, fieldNames]) =>
+        ensureNestedValues(parsedYaml, parentKey, fieldNames, 'no', errors, 'remain no')
+    );
+    Object.entries(CHECKS.nestedFalse).forEach(([parentKey, fieldNames]) =>
+        ensureNestedValues(parsedYaml, parentKey, fieldNames, false, errors, 'remain false')
+    );
+    ensureNestedValues(
+        parsedYaml,
+        'proxy_browser_network_preflight',
+        CHECKS.nestedTrue.proxy_browser_network_preflight,
+        true,
+        errors,
+        'be true'
+    );
+
+    const target = parsedYaml.target || {};
+    const priorArtifacts = parsedYaml.required_prior_artifacts || {};
+    FIELDS.required_prior_artifacts.forEach(fieldName => {
+        if (priorArtifacts[fieldName] !== true) {
+            errors.push(`required prior artifact missing: ${fieldName}`);
+        }
+    });
+    if (target.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${target.target_engine_family}"`);
+    }
+    if (target.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+    if (target.bulk_scope_allowed !== false) {
+        errors.push('bulk scope allowed must remain false in the Phase 4.85D template');
+    }
+    if (target.max_targets !== 1) {
+        errors.push('max_targets > 1 is not allowed in the Phase 4.85D template');
+    }
+
+    ensureArrayContainsAll(
+        parsedYaml,
+        'blocking_reasons',
+        REQUIRED_ARRAYS.blocking_reasons,
+        errors,
+        'blocking reasons'
+    );
+    ensureArrayContainsAll(
+        parsedYaml,
+        'next_phase_requirements',
+        REQUIRED_ARRAYS.next_phase_requirements,
+        errors,
+        'next_phase_requirements'
+    );
+
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function validateRequiredCliFields(args) {
+    return CLI_REQUIRED.flatMap(field => {
+        if (args[field]) {
+            return [];
+        }
+        if (field === 'checklist') return ['missing checklist'];
+        if (field === 'runbook') return ['missing runbook'];
+        if (field === 'auth_form') return ['missing auth form'];
+        return [`missing ${field.replace(/_/g, ' ')} path or value`];
+    });
+}
+
+function validateCliYesNoFields(args) {
+    return CLI_YES_NO.flatMap(field => {
+        const value = args[field];
+        return value === 'yes' || value === 'no' ? [] : [`--${field.replace(/_/g, '-')} is required (yes/no)`];
+    });
+}
+
+function validateCliTargetFields(args) {
+    const errors = [];
+    if (args.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${args.target_engine_family}"`);
+    }
+    if (args.target_scope_type !== 'match_id' && args.target_scope_type !== 'league_season_date') {
+        errors.push(`unsupported scope type "${args.target_scope_type}"`);
+    }
+    if (args.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+    if (args.target_scope_type === 'match_id' && !args.target_match_id) {
+        errors.push('--target-match-id is required when target_scope_type=match_id');
+    }
+    return errors;
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = [
+        ...validateRequiredCliFields(args),
+        ...validateCliYesNoFields(args),
+        ...validateCliTargetFields(args),
+    ];
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function loadMarkdownYaml(args, fieldName, modePrefix, missingLabel, yamlFlagField, dependencies) {
+    const { cwd, existsSync, readFileSync } = dependencies;
+    const targetPath = resolveLocalPath(args[fieldName], cwd);
+    if (!existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: false,
+                errors: [`${missingLabel}: ${toRelativePath(targetPath, cwd)}`],
+            }),
+        };
+    }
+
+    const markdownText = readFileSync(targetPath, 'utf8');
+    const yamlText = extractYamlBlock(markdownText);
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: true,
+                [yamlFlagField]: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseYamlBlock(yamlText) };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: true,
+                [yamlFlagField]: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function buildValidatedContext(args, fields = {}) {
+    return buildFailurePayload(args, {
+        checklist_found: true,
+        runbook_found: true,
+        auth_form_found: true,
+        yaml_block_found: true,
+        runbook_yaml_block_found: true,
+        auth_form_yaml_block_found: true,
+        required_fields_present: true,
+        checklist_valid: true,
+        runbook_template_valid: true,
+        auth_form_template_valid: true,
+        ...fields,
+    });
+}
+
+function validateChecklistOrPayload(args, parsedYaml) {
+    const parsedValidation = validateParsedYaml(parsedYaml);
+    if (parsedValidation.ok) return null;
+    return {
+        payload: buildFailurePayload(args, {
+            mode: 'checklist-error',
+            checklist_found: true,
+            yaml_block_found: true,
+            required_fields_present: parsedValidation.missingFields.length === 0,
+            missing_fields: parsedValidation.missingFields,
+            errors: parsedValidation.errors,
+        }),
+    };
+}
+
+function validateTemplateOrPayload(args, parsedYaml, validator, mode, message, fields) {
+    const parsedValidation = validator(parsedYaml);
+    if (parsedValidation.ok) return null;
+    return {
+        payload: buildFailurePayload(args, {
+            mode,
+            ...fields,
+            errors: [`${message}: ${parsedValidation.errors.join('; ')}`],
+        }),
+    };
+}
+
+function validateTargetConsistency(args, checklistYaml, runbookYaml, authFormYaml) {
+    const checklistTarget = checklistYaml.target || {};
+    const runbookTarget = runbookYaml.target || {};
+    const authRequest = authFormYaml.request || {};
+    const errors = [
+        ['checklist.target.target_source', checklistTarget.target_source, args.target_source],
+        ['checklist.target.target_engine_family', checklistTarget.target_engine_family, args.target_engine_family],
+        ['checklist.target.target_scope_type', checklistTarget.target_scope_type, args.target_scope_type],
+        ['checklist.target.target_match_id', checklistTarget.target_match_id, args.target_match_id],
+        ['runbook.target.target_source', runbookTarget.target_source, args.target_source],
+        ['runbook.target.target_engine_family', runbookTarget.target_engine_family, args.target_engine_family],
+        ['runbook.target.target_scope_type', runbookTarget.target_scope_type, args.target_scope_type],
+        ['runbook.target.target_match_id', runbookTarget.target_match_id, args.target_match_id],
+        ['auth_form.request.target_source', authRequest.target_source, args.target_source],
+        ['auth_form.request.target_engine_family', authRequest.target_engine_family, args.target_engine_family],
+        ['auth_form.request.target_scope_type', authRequest.target_scope_type, args.target_scope_type],
+        ['auth_form.request.target_match_id', authRequest.target_match_id, args.target_match_id],
+    ]
+        .filter(([, templateValue, cliValue]) => templateValue && templateValue !== cliValue)
+        .map(
+            ([label, templateValue, cliValue]) =>
+                `target mismatch: ${label} "${templateValue}" does not match CLI value "${cliValue}"`
+        );
+
+    return errors.length ? buildValidatedContext(args, { mode: 'target-error', errors }) : null;
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: READINESS_PHASE,
+        mode: MODE,
+        ok: true,
+        checklist: args.checklist,
+        runbook: args.runbook,
+        auth_form: args.auth_form,
+        checklist_found: true,
+        runbook_found: true,
+        auth_form_found: true,
+        yaml_block_found: true,
+        runbook_yaml_block_found: true,
+        auth_form_yaml_block_found: true,
+        required_fields_present: true,
+        missing_fields: [],
+        checklist_valid: true,
+        runbook_template_valid: true,
+        auth_form_template_valid: true,
+        errors: [],
+        warnings: TEMPLATE_WARNING,
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const localDeps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const checklistLoad = loadMarkdownYaml(
+        args,
+        'checklist',
+        'checklist',
+        'missing checklist',
+        'yaml_block_found',
+        localDeps
+    );
+    if (checklistLoad.payload) return checklistLoad.payload;
+
+    const checklistValidation = validateChecklistOrPayload(args, checklistLoad.parsedYaml);
+    if (checklistValidation) return checklistValidation.payload;
+
+    const runbookLoad = loadMarkdownYaml(
+        args,
+        'runbook',
+        'runbook',
+        'missing runbook',
+        'runbook_yaml_block_found',
+        localDeps
+    );
+    if (runbookLoad.payload) return runbookLoad.payload;
+
+    const runbookValidation = validateTemplateOrPayload(
+        args,
+        runbookLoad.parsedYaml,
+        validateRunbookParsedYaml,
+        'runbook-error',
+        'runbook template validation failed',
+        {
+            checklist_found: true,
+            runbook_found: true,
+            yaml_block_found: true,
+            runbook_yaml_block_found: true,
+            checklist_valid: true,
+        }
+    );
+    if (runbookValidation) return runbookValidation.payload;
+
+    const authFormLoad = loadMarkdownYaml(
+        args,
+        'auth_form',
+        'auth-form',
+        'missing auth form',
+        'auth_form_yaml_block_found',
+        localDeps
+    );
+    if (authFormLoad.payload) return authFormLoad.payload;
+
+    const authFormValidation = validateTemplateOrPayload(
+        args,
+        authFormLoad.parsedYaml,
+        validateAuthFormParsedYaml,
+        'auth-form-error',
+        'auth form template validation failed',
+        {
+            checklist_found: true,
+            runbook_found: true,
+            auth_form_found: true,
+            yaml_block_found: true,
+            runbook_yaml_block_found: true,
+            auth_form_yaml_block_found: true,
+            checklist_valid: true,
+            runbook_template_valid: true,
+        }
+    );
+    if (authFormValidation) return authFormValidation.payload;
+
+    const targetConsistencyPayload = validateTargetConsistency(
+        args,
+        checklistLoad.parsedYaml,
+        runbookLoad.parsedYaml,
+        authFormLoad.parsedYaml
+    );
+    if (targetConsistencyPayload) return targetConsistencyPayload;
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(payload, io) {
+    io.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(
+            buildFailurePayload(
+                { checklist: '', runbook: '', auth_form: '' },
+                { mode: 'argument-error', errors: [error.message] }
+            ),
+            output
+        );
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    READINESS_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_readiness_checklist_validate.test.js
+++ b/tests/unit/single_target_acquisition_network_readiness_checklist_validate.test.js
@@ -1,0 +1,612 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(
+    PROJECT_ROOT,
+    'scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js'
+);
+const CHECKLIST_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md'
+);
+const RUNBOOK_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md'
+);
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md'
+);
+const CHECKLIST_TEXT = fs.readFileSync(CHECKLIST_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        checklist: CHECKLIST_PATH,
+        runbook: RUNBOOK_PATH,
+        auth_form: AUTH_FORM_PATH,
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(
+            `${name} should not be called by single_target_acquisition_network_readiness_checklist_validate`
+        );
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(CHECKLIST_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return CHECKLIST_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return CHECKLIST_TEXT.replace(`${line}\n`, '');
+}
+
+function withTempChecklist(markdownText, callback) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'phase485d-'));
+    const checklistPath = path.join(tempDir, 'checklist.md');
+    fs.writeFileSync(checklistPath, markdownText, 'utf8');
+    try {
+        callback(checklistPath);
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 checklist 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.checklist;
+    const payload = gate.runValidation(args, buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing checklist/i);
+});
+
+test('缺 runbook 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.runbook;
+    const payload = gate.runValidation(args, buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook/i);
+});
+
+test('缺 auth form 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.auth_form;
+    const payload = gate.runValidation(args, buildDependencies());
+
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing auth form/i);
+});
+
+test('checklist 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist('# no yaml\n', checklistPath => {
+        const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /missing YAML block/i);
+    });
+});
+
+test('checklist invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist('```yaml\nnot yaml\n```\n', checklistPath => {
+        const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /invalid YAML/i);
+    });
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        removeLineFromTemplate('phase: PHASE4.85D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /missing required fields: phase/);
+        }
+    );
+});
+
+test('checklist_status 非 template_only 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('checklist_status: template_only', 'checklist_status: approved'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /template_only/);
+        }
+    );
+});
+
+test('network_dry_run_ready=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('network_dry_run_ready: false', 'network_dry_run_ready: true'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /network_dry_run_ready true/);
+        }
+    );
+});
+
+test('network_dry_run_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('network_dry_run_authorized: false', 'network_dry_run_authorized: true'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /network_dry_run_authorized true/);
+        }
+    );
+});
+
+test('staging_write_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('staging_write_authorized: false', 'staging_write_authorized: true'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /staging_write_authorized true/);
+        }
+    );
+});
+
+test('db_write_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(replaceInTemplate('db_write_authorized: false', 'db_write_authorized: true'), checklistPath => {
+        const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /db_write_authorized true/);
+    });
+});
+
+test('training_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(replaceInTemplate('training_authorized: false', 'training_authorized: true'), checklistPath => {
+        const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /training_authorized true/);
+    });
+});
+
+test('prediction_authorized=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('prediction_authorized: false', 'prediction_authorized: true'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /prediction_authorized true/);
+        }
+    );
+});
+
+test('final_human_confirmation=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('final_human_confirmation: false', 'final_human_confirmation: true'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /final_human_confirmation true/);
+        }
+    );
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('    bulk_scope_allowed: false', '    bulk_scope_allowed: true'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /bulk scope allowed/i);
+        }
+    );
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(replaceInTemplate('    max_targets: 1', '    max_targets: 2'), checklistPath => {
+        const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+    });
+});
+
+test('required prior artifact missing 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(
+        replaceInTemplate('    runtime_scaffold_present: true', '    runtime_scaffold_present: false'),
+        checklistPath => {
+            const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /required prior artifact missing/i);
+        }
+    );
+});
+
+test('blocking_reasons missing 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(removeLineFromTemplate('blocking_reasons:'), checklistPath => {
+        const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /blocking reasons missing|blocking_reasons/i);
+    });
+});
+
+test('unsupported engine family 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_engine_family: 'run_production' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported engine family/);
+});
+
+test('unsupported scope type bulk 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_scope_type: 'bulk' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported scope type "bulk"|unsupported scope type bulk/);
+});
+
+test('target mismatch 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempChecklist(replaceInTemplate('    target_source:', '    target_source: other'), checklistPath => {
+        const payload = gate.runValidation({ ...buildArgs(), checklist: checklistPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /target mismatch/i);
+    });
+});
+
+test('valid readiness checklist validate 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.85D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST');
+    assert.equal(payload.readiness_checklist_template_only, true);
+    assert.equal(payload.checklist_valid, true);
+    assert.equal(payload.runbook_template_valid, true);
+    assert.equal(payload.auth_form_template_valid, true);
+    assert.equal(payload.network_dry_run_ready, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('all CLI yes 仍 no-op / not ready / not authorized', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs({
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            final_human_confirmation: 'yes',
+        }),
+        buildDependencies()
+    );
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.network_dry_run_ready, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        ['--checklist', CHECKLIST_PATH, '--runbook', RUNBOOK_PATH, '--auth-form', AUTH_FORM_PATH, '--commit'],
+        buildDependencies()
+    );
+
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.85D/);
+});
+
+test('Makefile validate 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-readiness-checklist-validate',
+            'NETWORK_READINESS_CHECKLIST_NODE=node',
+            `CHECKLIST=${CHECKLIST_PATH}`,
+            `RUNBOOK=${RUNBOOK_PATH}`,
+            `AUTH_FORM=${AUTH_FORM_PATH}`,
+            'TARGET_SOURCE=fotmob',
+            'TARGET_ENGINE_FAMILY=titan_discovery',
+            'TARGET_SCOPE_TYPE=match_id',
+            'TARGET_MATCH_ID=sample-match-001',
+            'TERMS_APPROVAL=no',
+            'NETWORK_DRY_RUN_AUTHORIZATION=no',
+            'ALLOW_BROWSER_RUNTIME=no',
+            'ALLOW_PROXY_RUNTIME=no',
+            'ALLOW_EXTERNAL_NETWORK=no',
+            'ALLOW_STAGING_WRITE=no',
+            'FINAL_HUMAN_CONFIRMATION=no',
+        ],
+        {
+            cwd: PROJECT_ROOT,
+            encoding: 'utf8',
+            shell: false,
+        }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-readiness-checklist-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_READINESS=1',
+        ],
+        {
+            cwd: PROJECT_ROOT,
+            encoding: 'utf8',
+            shell: false,
+        }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.85D/);
+});
+
+test('不访问网络', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_access_network, false);
+});
+
+test('不启动 browser', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_launch_browser, false);
+});
+
+test('不执行 proxy runtime', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_use_proxy, false);
+});
+
+test('不执行 engine', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_execute_engine, false);
+});
+
+test('不写 staging', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_staging, false);
+});
+
+test('不创建目录', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_create_staging_directory, false);
+});
+
+test('不写 source manifest', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_source_manifest, false);
+});
+
+test('不写 packet file', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_packet_file, false);
+});
+
+test('不写 DB', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('不 spawn child process', t => {
+    installExecutionGuards(t);
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.would_spawn_child_process, false);
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.85D single-target acquisition network dry-run final readiness checklist template.

Scope:
- Adds final readiness checklist template
- Adds local-only readiness checklist validator
- Validates checklist remains template-only and non-ready
- Validates runbook and authorization form templates remain non-authorized
- Keeps network dry-run blocked
- Adds Makefile validate and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.85D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- validate missing params failed as expected
- valid readiness checklist validate passed
- all-yes CLI remained no-op / not ready / not authorized
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed