### PR TITLE
docs(data): add single-target network execution plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、只验证 pre-network runbook draft 和 packet preview 前置条件的本地 validator：`make data-single-target-acquisition-pre-network-runbook-validate RUNBOOK=<path> ARTIFACT_SCHEMA=<path> MANIFEST_SCHEMA=<path> ARTIFACT=<path> MANIFEST=<path> OUTPUT_ROOT=<path> ...`（Phase 4.83D draft-only）
 - 不触网、不写文件、不创建目录、只验证 network dry-run authorization form template 和 pre-network runbook template 的本地 validator：`make data-single-target-acquisition-network-auth-form-validate AUTH_FORM=<path> RUNBOOK=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.84D template-only）
 - 不触网、不写文件、不创建目录、只验证 final readiness checklist template + pre-network runbook template + network auth form template 的本地 validator：`make data-single-target-acquisition-network-readiness-checklist-validate CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.85D template-only）
+- 不触网、不写文件、不创建目录、只验证 execution plan draft + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-execution-plan-validate EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.86D draft-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -731,6 +732,25 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-readiness-checklist-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook / auth form / readiness checklist 全部审核通过。
+
+### Phase 4.86D: single-target acquisition network dry-run execution plan draft
+
+`data-single-target-acquisition-network-execution-plan-validate` 只允许验证 execution plan draft：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 DB
+- execution plan draft 不等于真实 network dry-run authorization
+- 即使 CLI 传入 yes，Phase 4.86D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-execution-plan-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook / auth form / readiness checklist / execution plan 全部审核通过。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@
         data-single-target-acquisition-pre-network-runbook-validate data-single-target-acquisition-pre-network-runbook-commit \
         data-single-target-acquisition-network-auth-form-validate data-single-target-acquisition-network-auth-form-commit \
         data-single-target-acquisition-network-readiness-checklist-validate data-single-target-acquisition-network-readiness-checklist-commit \
+        data-single-target-acquisition-network-execution-plan-validate data-single-target-acquisition-network-execution-plan-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -79,6 +80,7 @@ COMPOSE_DEV=docker compose -f docker-compose.dev.yml
 PRE_NETWORK_RUNBOOK_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTH_FORM_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_READINESS_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_EXECUTION_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -352,6 +354,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-auth-form-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTH_FORM=1  # blocked in Phase 4.84D"
 	@echo "  make data-single-target-acquisition-network-readiness-checklist-validate CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # template-only validate, Phase 4.85D"
 	@echo "  make data-single-target-acquisition-network-readiness-checklist-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_READINESS=1  # blocked in Phase 4.85D"
+	@echo "  make data-single-target-acquisition-network-execution-plan-validate EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # draft-only validate, Phase 4.86D"
+	@echo "  make data-single-target-acquisition-network-execution-plan-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN=1  # blocked in Phase 4.86D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1069,6 +1073,38 @@ data-single-target-acquisition-network-readiness-checklist-commit: ## Blocked ne
 	@echo "BLOCKED: single-target acquisition network dry-run final readiness execution is not wired in Phase 4.85D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_READINESS=1, this path remains blocked."
 	@echo "  Phase 4.85D validates a template only and does not authorize any network dry-run, staging write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-execution-plan-validate: ## Draft-only network execution plan validation. Phase 4.86D. No network, no writes, no DB.
+	@if [ -z "$(EXECUTION_PLAN)" ] || [ -z "$(CHECKLIST)" ] || [ -z "$(RUNBOOK)" ] || [ -z "$(AUTH_FORM)" ] || [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ] || [ -z "$(TARGET_MATCH_ID)" ]; then \
+		echo "ERROR: provide EXECUTION_PLAN=<path>, CHECKLIST=<path>, RUNBOOK=<path>, AUTH_FORM=<path>, TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<type>, TARGET_MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.86D: network execution plan validate (draft-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_EXECUTION_PLAN_NODE) scripts/ops/single_target_acquisition_network_execution_plan_validate.js \
+		--execution-plan "$(EXECUTION_PLAN)" \
+		--checklist "$(CHECKLIST)" \
+		--runbook "$(RUNBOOK)" \
+		--auth-form "$(AUTH_FORM)" \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		--target-match-id "$(TARGET_MATCH_ID)" \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-network-execution-plan-commit: ## Blocked network execution plan gate. Remains not wired in Phase 4.86D.
+	@echo "BLOCKED: single-target acquisition network dry-run execution is not wired in Phase 4.86D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN=1, this path remains blocked."
+	@echo "  Phase 4.86D validates a draft only and does not authorize any network dry-run, staging write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN_PHASE4_86D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN_PHASE4_86D.md
@@ -1,0 +1,148 @@
+# Phase 4.86D: Single-Target Acquisition Network Dry-Run Execution Plan Draft
+
+**Date**: 2026-05-10
+**Status**: Complete (draft-only, local-only)
+**Previous phases**: 4.79D, 4.80D, 4.81D, 4.82D, 4.83D, 4.84D, 4.85D
+**Recommended next phase**: Phase 4.87D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.86D adds a network dry-run execution plan draft and a local validator
+for a future single-target acquisition network dry-run.
+
+This phase did not:
+
+- access network
+- perform acquisition
+- write DB
+- write staging
+- write packet files
+
+The goal is to prepare a future execution sequence and explicit stop gates
+without executing any network, browser, proxy, engine, staging, DB, training, or
+prediction path.
+
+---
+
+## 2. Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_execution_plan_validate.js`
+- `tests/unit/single_target_acquisition_network_execution_plan_validate.test.js`
+- `Makefile` targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN_PHASE4_86D.md`
+
+---
+
+## 3. Execution Plan Sections
+
+The execution plan draft includes:
+
+- `required_prior_artifacts`
+- `required_prior_validations`
+- `target`
+- `execution_steps`
+- `stop_gates`
+- `network_runtime_policy`
+- `staging_policy`
+- `db_training_prediction_policy`
+- `safety`
+- `next_phase_requirements`
+
+The YAML block remains machine-readable and keeps all execution paths blocked.
+
+---
+
+## 4. Validation Behavior
+
+The validator is:
+
+- local-only
+- read-only
+- in-process
+
+It verifies that:
+
+- the execution plan remains `draft_only`
+- `network_dry_run_execution_allowed` remains `false`
+- all authorization fields remain false / no
+- every execution step remains `execution_allowed=false`
+- stop gates remain enabled
+- single-target / no-bulk constraints remain in force
+- no network execution occurs
+- no runtime writes occur
+
+It also keeps the commit path blocked in Phase 4.86D.
+
+---
+
+## 5. Relationship to Previous Phases
+
+- 4.79D handles runtime parameter scaffold
+- 4.80D handles artifact / manifest schema validation
+- 4.81D handles writer path / authorization preflight
+- 4.82D handles staging packet preview
+- 4.83D handles pre-network runbook draft
+- 4.84D handles authorization form template
+- 4.85D handles final readiness checklist
+- 4.86D handles execution plan draft
+
+All eight phases remain non-executing. None equals a real network dry-run.
+
+---
+
+## 6. Recommended Next Phase
+
+Recommended:
+
+`Phase 4.87D: single-target acquisition network dry-run human approval packet`
+
+Goals:
+
+- still no network
+- summarize runbook / auth form / readiness checklist / execution plan
+- only produce an approval packet preview
+
+Alternative:
+
+`Phase 4.56A: 用户给齐真实 network dry-run 参数后才做 runbook`
+
+---
+
+## 7. Explicit Non-Execution
+
+The following were not executed:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md
@@ -1,0 +1,182 @@
+# Single-Target Acquisition Network Dry-Run Execution Plan Template
+
+This document is a Phase 4.86D draft-only execution plan for a future
+single-target acquisition network dry-run.
+
+- This is an execution plan draft, not an execution authorization.
+- `network_dry_run_execution_allowed=false`
+- `network_dry_run_authorized=false`
+- `staging_write_authorized=false`
+- `db_write_authorized=false`
+- Codex must not change this template to execution allowed or authorized on its
+  own.
+- Phase 4.86D does not execute any listed step. It only validates that the
+  execution plan draft remains blocked.
+- A real network dry-run must move to a later, separately authorized phase.
+
+```yaml
+phase: PHASE4.86D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_DRAFT
+execution_plan_status: draft_only
+network_dry_run_execution_allowed: false
+network_dry_run_authorized: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+required_prior_artifacts:
+    runtime_scaffold_present: true
+    staging_schema_validator_present: true
+    staging_writer_preflight_present: true
+    staging_packet_preview_present: true
+    pre_network_runbook_present: true
+    network_auth_form_present: true
+    final_readiness_checklist_present: true
+
+required_prior_validations:
+    runtime_scaffold_validated: false
+    staging_schema_validated: false
+    staging_writer_preflight_validated: false
+    staging_packet_preview_validated: false
+    pre_network_runbook_validated: false
+    network_auth_form_validated: false
+    final_readiness_checklist_validated: false
+
+target:
+    target_source:
+    target_engine_family: titan_discovery
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+    max_targets: 1
+    bulk_scope_allowed: false
+
+execution_steps:
+    - step_id: 1
+      name: confirm_single_target_scope
+      execution_allowed: false
+      stop_if_failed: true
+    - step_id: 2
+      name: confirm_source_terms
+      execution_allowed: false
+      stop_if_failed: true
+    - step_id: 3
+      name: confirm_network_authorization
+      execution_allowed: false
+      stop_if_failed: true
+    - step_id: 4
+      name: confirm_proxy_browser_network_preflight
+      execution_allowed: false
+      stop_if_failed: true
+    - step_id: 5
+      name: confirm_staging_packet_preview
+      execution_allowed: false
+      stop_if_failed: true
+    - step_id: 6
+      name: future_network_dry_run
+      execution_allowed: false
+      stop_if_failed: true
+    - step_id: 7
+      name: future_staging_artifact_validation
+      execution_allowed: false
+      stop_if_failed: true
+
+stop_gates:
+    terms_not_approved: true
+    network_not_authorized: true
+    target_not_single: true
+    bulk_scope_detected: true
+    legacy_runtime_required: true
+    db_write_required: true
+    training_or_prediction_required: true
+    staging_write_not_authorized: true
+    proxy_or_browser_policy_unreviewed: true
+    source_manifest_policy_missing: true
+
+network_runtime_policy:
+    allow_external_network: false
+    allow_browser_runtime: false
+    allow_proxy_runtime: false
+    allow_legacy_titan_discovery_runtime: false
+    allow_bulk_harvest: false
+
+staging_policy:
+    allow_staging_directory_creation: false
+    allow_staging_artifact_write: false
+    allow_source_manifest_write: false
+    output_root_policy_reviewed: false
+    schema_validation_required: true
+
+db_training_prediction_policy:
+    allow_db_write: false
+    allow_pg_dump: false
+    allow_training: false
+    allow_prediction: false
+    allow_model_artifact_loading: false
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+next_phase_requirements:
+    - real_user_authorized_source
+    - real_single_target_scope
+    - explicit_terms_approval
+    - explicit_network_dry_run_authorization
+    - accepted_proxy_browser_network_policy
+    - accepted_staging_policy
+    - accepted_stop_gates
+    - confirmed_no_db_write
+    - confirmed_no_training
+    - confirmed_no_prediction
+```
+
+## Purpose
+
+This template describes the future execution order and the stop gates that must
+be reviewed before a real single-target acquisition network dry-run can be
+considered.
+
+It does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- DB writes
+- training
+- prediction
+
+## Draft-only guardrails
+
+- `execution_plan_status` must remain `draft_only`
+- `network_dry_run_execution_allowed` must remain `false`
+- `network_dry_run_authorized` must remain `false`
+- `staging_write_authorized` must remain `false`
+- `db_write_authorized` must remain `false`
+- `training_authorized` must remain `false`
+- `prediction_authorized` must remain `false`
+- `final_human_confirmation` must remain `false`
+- every `execution_steps[].execution_allowed` value must remain `false`
+- every stop gate must remain enabled
+
+Changing any of the above does not authorize execution inside Phase 4.86D.
+Future network dry-run execution must happen in a separate phase with explicit
+user approval, complete parameters, reviewed terms, approved runbook, approved
+auth form, approved readiness checklist, and an approved execution plan.

--- a/scripts/ops/single_target_acquisition_network_execution_plan_validate.js
+++ b/scripts/ops/single_target_acquisition_network_execution_plan_validate.js
@@ -1,0 +1,679 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    validateParsedYaml: validateReadinessParsedYaml,
+    runValidation: runReadinessValidation,
+} = require('./single_target_acquisition_network_readiness_checklist_validate');
+
+const EXECUTION_PHASE = 'PHASE4.86D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_DRAFT';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition network dry-run execution is not wired in Phase 4.86D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.87D or explicit user-authorized network dry-run preparation';
+const MODE = 'single-target-acquisition-network-execution-plan-validate';
+const EXPECTED_STEPS = [
+    'confirm_single_target_scope',
+    'confirm_source_terms',
+    'confirm_network_authorization',
+    'confirm_proxy_browser_network_preflight',
+    'confirm_staging_packet_preview',
+    'future_network_dry_run',
+    'future_staging_artifact_validation',
+];
+
+const FIELDS = {
+    top: words(`
+        phase execution_plan_status network_dry_run_execution_allowed
+        network_dry_run_authorized staging_write_authorized
+        db_write_authorized training_authorized prediction_authorized
+        final_human_confirmation required_prior_artifacts
+        required_prior_validations target execution_steps stop_gates
+        network_runtime_policy staging_policy db_training_prediction_policy
+        safety next_phase_requirements
+    `),
+    required_prior_artifacts: words(`
+        runtime_scaffold_present staging_schema_validator_present
+        staging_writer_preflight_present staging_packet_preview_present
+        pre_network_runbook_present network_auth_form_present
+        final_readiness_checklist_present
+    `),
+    required_prior_validations: words(`
+        runtime_scaffold_validated staging_schema_validated
+        staging_writer_preflight_validated staging_packet_preview_validated
+        pre_network_runbook_validated network_auth_form_validated
+        final_readiness_checklist_validated
+    `),
+    target: words(`
+        target_source target_engine_family target_scope_type target_match_id
+        target_league target_season target_date max_targets bulk_scope_allowed
+    `),
+    stop_gates: words(`
+        terms_not_approved network_not_authorized target_not_single
+        bulk_scope_detected legacy_runtime_required db_write_required
+        training_or_prediction_required staging_write_not_authorized
+        proxy_or_browser_policy_unreviewed source_manifest_policy_missing
+    `),
+    network_runtime_policy: words(`
+        allow_external_network allow_browser_runtime allow_proxy_runtime
+        allow_legacy_titan_discovery_runtime allow_bulk_harvest
+    `),
+    staging_policy: words(`
+        allow_staging_directory_creation allow_staging_artifact_write
+        allow_source_manifest_write output_root_policy_reviewed
+        schema_validation_required
+    `),
+    db_training_prediction_policy: words(`
+        allow_db_write allow_pg_dump allow_training allow_prediction
+        allow_model_artifact_loading
+    `),
+    safety: words(`
+        would_access_network would_launch_browser would_use_proxy
+        would_execute_engine would_write_staging
+        would_create_staging_directory would_write_source_manifest
+        would_write_packet_file would_write_db would_train
+        would_predict would_bulk_harvest
+    `),
+};
+
+const REQUIRED_NEXT_PHASE = words(`
+    real_user_authorized_source real_single_target_scope explicit_terms_approval
+    explicit_network_dry_run_authorization
+    accepted_proxy_browser_network_policy accepted_staging_policy
+    accepted_stop_gates confirmed_no_db_write confirmed_no_training
+    confirmed_no_prediction
+`);
+
+const CLI_REQUIRED = words(`
+    execution_plan checklist runbook auth_form target_source target_engine_family
+    target_scope_type target_match_id terms_approval
+    network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const CLI_YES_NO = words(`
+    terms_approval network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const TOP_FALSE = {
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true in template is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+    staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+    db_write_authorized: 'db_write_authorized true in template is not allowed',
+    training_authorized: 'training_authorized true in template is not allowed',
+    prediction_authorized: 'prediction_authorized true in template is not allowed',
+    final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+};
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function parseScalar(rawValue) {
+    const value = String(rawValue || '').trim();
+    if (value === '') return null;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    if (/^-?\d+$/.test(value)) return Number(value);
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+
+function pushContainer(parent, key) {
+    parent[key] = key === 'execution_steps' || key === 'next_phase_requirements' ? [] : {};
+}
+
+function parseExecutionPlanYaml(yamlText) {
+    const root = {};
+    let section = '';
+    let currentItem = null;
+
+    String(yamlText || '')
+        .split(/\r?\n/)
+        .forEach(rawLine => {
+            if (!rawLine.trim() || rawLine.trim().startsWith('#')) return;
+            const indent = rawLine.match(/^ */)[0].length;
+            const trimmed = rawLine.trim();
+            if (indent === 0) {
+                const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+                if (!match) throw new Error(`unsupported YAML line: ${trimmed}`);
+                section = match[1];
+                currentItem = null;
+                root[section] = match[2].trim() === '' ? null : parseScalar(match[2]);
+                if (match[2].trim() === '') pushContainer(root, section);
+                return;
+            }
+            if (section === 'execution_steps') {
+                currentItem = parseExecutionStepLine(root.execution_steps, currentItem, indent, trimmed);
+                return;
+            }
+            if (Array.isArray(root[section])) {
+                if (!trimmed.startsWith('- ')) throw new Error(`unsupported YAML list line: ${trimmed}`);
+                root[section].push(parseScalar(trimmed.slice(2)));
+                return;
+            }
+            parseNestedLine(root, section, trimmed);
+        });
+
+    return root;
+}
+
+function parseExecutionStepLine(steps, currentItem, indent, trimmed) {
+    if (indent === 4 && trimmed.startsWith('- ')) {
+        const item = {};
+        steps.push(item);
+        parseNestedAssignment(item, trimmed.slice(2));
+        return item;
+    }
+    if (indent >= 6 && currentItem) {
+        parseNestedAssignment(currentItem, trimmed);
+        return currentItem;
+    }
+    throw new Error(`unsupported execution_steps line: ${trimmed}`);
+}
+
+function parseNestedLine(root, section, trimmed) {
+    if (!root[section] || typeof root[section] !== 'object' || Array.isArray(root[section])) root[section] = {};
+    parseNestedAssignment(root[section], trimmed);
+}
+
+function parseNestedAssignment(target, trimmed) {
+    const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+    if (!match) throw new Error(`unsupported YAML line: ${trimmed}`);
+    target[match[1]] = match[2].trim() === '' ? null : parseScalar(match[2]);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_execution_plan_validate.js --execution-plan <path> --checklist <path> --runbook <path> --auth-form <path> --target-source <src> --target-engine-family titan_discovery --target-scope-type match_id --target-match-id <id> --terms-approval no --network-dry-run-authorization no --allow-browser-runtime no --allow-proxy-runtime no --allow-external-network no --allow-staging-write no --final-human-confirmation no',
+        '  node scripts/ops/single_target_acquisition_network_execution_plan_validate.js --execution-plan <path> --checklist <path> --runbook <path> --auth-form <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.86D validates a local execution plan draft only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = { execution_plan: '', checklist: '', runbook: '', auth_form: '', commit: false, help: false };
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) throw new Error(`Unknown argument: ${token}`);
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        execution_plan_draft_only: true,
+        execution_plan_valid: false,
+        readiness_checklist_valid: false,
+        runbook_template_valid: false,
+        auth_form_template_valid: false,
+        network_dry_run_execution_allowed: false,
+        network_dry_run_authorized: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: EXECUTION_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        execution_plan: args.execution_plan || null,
+        checklist: args.checklist || null,
+        runbook: args.runbook || null,
+        auth_form: args.auth_form || null,
+        execution_plan_found: false,
+        checklist_found: false,
+        runbook_found: false,
+        auth_form_found: false,
+        yaml_block_found: false,
+        checklist_yaml_block_found: false,
+        runbook_yaml_block_found: false,
+        auth_form_yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        ...fields,
+    };
+}
+
+function validateRequiredCliFields(args) {
+    return CLI_REQUIRED.flatMap(field => {
+        if (args[field]) return [];
+        if (field === 'execution_plan') return ['missing execution plan'];
+        if (field === 'checklist') return ['missing checklist'];
+        if (field === 'runbook') return ['missing runbook'];
+        if (field === 'auth_form') return ['missing auth form'];
+        return [`missing ${field.replace(/_/g, ' ')} path or value`];
+    });
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = validateRequiredCliFields(args);
+    CLI_YES_NO.forEach(field => {
+        if (args[field] !== 'yes' && args[field] !== 'no') {
+            errors.push(`--${field.replace(/_/g, '-')} is required (yes/no)`);
+        }
+    });
+    if (args.target_engine_family && args.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${args.target_engine_family}"`);
+    }
+    if (
+        args.target_scope_type &&
+        args.target_scope_type !== 'match_id' &&
+        args.target_scope_type !== 'league_season_date'
+    ) {
+        errors.push(`unsupported scope type "${args.target_scope_type}"`);
+    }
+    if (args.target_scope_type === 'bulk') errors.push('unsupported scope type bulk');
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function loadMarkdownYaml(args, fieldName, modePrefix, missingLabel, yamlFlagField, dependencies) {
+    const targetPath = resolveLocalPath(args[fieldName], dependencies.cwd);
+    if (!dependencies.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: false,
+                errors: [`${missingLabel}: ${toRelativePath(targetPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+    const yamlText = extractYamlBlock(dependencies.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: true,
+                [yamlFlagField]: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+    try {
+        return { parsedYaml: fieldName === 'execution_plan' ? parseExecutionPlanYaml(yamlText) : null, yamlText };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: `${modePrefix}-error`,
+                [`${fieldName}_found`]: true,
+                [yamlFlagField]: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function addMissingNested(root, parentKey, requiredKeys, missingFields) {
+    const value = root[parentKey];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        requiredKeys.forEach(key => missingFields.push(`${parentKey}.${key}`));
+        return;
+    }
+    requiredKeys
+        .filter(key => !Object.prototype.hasOwnProperty.call(value, key))
+        .forEach(key => missingFields.push(`${parentKey}.${key}`));
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = FIELDS.top.filter(key => !Object.prototype.hasOwnProperty.call(parsedYaml, key));
+    Object.entries(FIELDS)
+        .filter(([key]) => key !== 'top')
+        .forEach(([key, requiredKeys]) => addMissingNested(parsedYaml, key, requiredKeys, missingFields));
+    return missingFields;
+}
+
+function ensureNestedValues(root, parentKey, fieldNames, expectedValue, errors, label) {
+    const parent = root[parentKey] || {};
+    fieldNames.forEach(fieldName => {
+        if (parent[fieldName] !== expectedValue) {
+            errors.push(`${parentKey}.${fieldName} must ${label} in the Phase 4.86D template`);
+        }
+    });
+}
+
+function validateExecutionSteps(parsedYaml, errors) {
+    const steps = parsedYaml.execution_steps;
+    if (!Array.isArray(steps)) {
+        errors.push('execution_steps missing');
+        return;
+    }
+    EXPECTED_STEPS.forEach((expectedName, index) => {
+        const step = steps[index];
+        if (!step || step.name !== expectedName) {
+            errors.push(`execution step missing: ${expectedName}`);
+        }
+        if (step && step.execution_allowed !== false) {
+            errors.push('execution step allowed true in template is not allowed');
+        }
+        if (step && step.stop_if_failed !== true) {
+            errors.push(`execution step stop_if_failed must be true: ${expectedName}`);
+        }
+    });
+}
+
+function validateStopGates(parsedYaml, errors) {
+    const stopGates = parsedYaml.stop_gates || {};
+    FIELDS.stop_gates.forEach(fieldName => {
+        if (!Object.prototype.hasOwnProperty.call(stopGates, fieldName)) {
+            errors.push(`stop gate missing: ${fieldName}`);
+        } else if (stopGates[fieldName] !== true) {
+            errors.push(`stop gate disabled: ${fieldName}`);
+        }
+    });
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) errors.push(`missing required fields: ${missingFields.join(',')}`);
+    if (parsedYaml.phase !== EXECUTION_PHASE) errors.push(`phase must be ${EXECUTION_PHASE}`);
+    if (parsedYaml.execution_plan_status !== 'draft_only') {
+        errors.push('execution_plan_status must remain draft_only in the Phase 4.86D template');
+    }
+    Object.entries(TOP_FALSE).forEach(([field, message]) => {
+        if (parsedYaml[field] !== false) errors.push(message);
+    });
+
+    ensureNestedValues(
+        parsedYaml,
+        'required_prior_artifacts',
+        FIELDS.required_prior_artifacts,
+        true,
+        errors,
+        'be true'
+    );
+    ensureNestedValues(
+        parsedYaml,
+        'required_prior_validations',
+        FIELDS.required_prior_validations,
+        false,
+        errors,
+        'remain false'
+    );
+    ensureNestedValues(
+        parsedYaml,
+        'network_runtime_policy',
+        FIELDS.network_runtime_policy,
+        false,
+        errors,
+        'remain false'
+    );
+    ensureNestedValues(
+        parsedYaml,
+        'db_training_prediction_policy',
+        FIELDS.db_training_prediction_policy,
+        false,
+        errors,
+        'remain false'
+    );
+    ensureNestedValues(parsedYaml, 'safety', FIELDS.safety, false, errors, 'remain false');
+    ensureNestedValues(
+        parsedYaml,
+        'staging_policy',
+        FIELDS.staging_policy.filter(field => field !== 'schema_validation_required'),
+        false,
+        errors,
+        'remain false'
+    );
+    ensureNestedValues(parsedYaml, 'staging_policy', ['schema_validation_required'], true, errors, 'be true');
+    validateTargetSection(parsedYaml, errors);
+    validateExecutionSteps(parsedYaml, errors);
+    validateStopGates(parsedYaml, errors);
+    ensureArrayContainsAll(parsedYaml, 'next_phase_requirements', REQUIRED_NEXT_PHASE, errors);
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function validateTargetSection(parsedYaml, errors) {
+    const target = parsedYaml.target || {};
+    if (target.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${target.target_engine_family}"`);
+    }
+    if (target.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+    if (target.bulk_scope_allowed !== false) {
+        errors.push('bulk scope allowed must remain false in the Phase 4.86D template');
+    }
+    if (target.max_targets !== 1) {
+        errors.push('max_targets > 1 is not allowed in the Phase 4.86D template');
+    }
+}
+
+function ensureArrayContainsAll(root, key, requiredValues, errors) {
+    const value = root[key];
+    if (!Array.isArray(value)) {
+        errors.push(`${key} missing`);
+        return;
+    }
+    requiredValues
+        .filter(requiredValue => !value.includes(requiredValue))
+        .forEach(requiredValue => errors.push(`${key} missing required value "${requiredValue}"`));
+}
+
+function validateTargetConsistency(args, executionPlanYaml, readinessArgs) {
+    const planTarget = executionPlanYaml.target || {};
+    const errors = [
+        ['execution_plan.target.target_source', planTarget.target_source, args.target_source],
+        ['execution_plan.target.target_engine_family', planTarget.target_engine_family, args.target_engine_family],
+        ['execution_plan.target.target_scope_type', planTarget.target_scope_type, args.target_scope_type],
+        ['execution_plan.target.target_match_id', planTarget.target_match_id, args.target_match_id],
+    ]
+        .filter(([, templateValue, cliValue]) => templateValue && templateValue !== cliValue)
+        .map(
+            ([label, templateValue, cliValue]) =>
+                `target mismatch: ${label} "${templateValue}" does not match CLI value "${cliValue}"`
+        );
+    if (readinessArgs.errors && readinessArgs.errors.some(error => /target mismatch/i.test(error))) {
+        errors.push(...readinessArgs.errors);
+    }
+    return errors;
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: EXECUTION_PHASE,
+        mode: MODE,
+        ok: true,
+        execution_plan: args.execution_plan,
+        checklist: args.checklist,
+        runbook: args.runbook,
+        auth_form: args.auth_form,
+        execution_plan_found: true,
+        checklist_found: true,
+        runbook_found: true,
+        auth_form_found: true,
+        yaml_block_found: true,
+        checklist_yaml_block_found: true,
+        runbook_yaml_block_found: true,
+        auth_form_yaml_block_found: true,
+        required_fields_present: true,
+        missing_fields: [],
+        execution_plan_valid: true,
+        readiness_checklist_valid: true,
+        runbook_template_valid: true,
+        auth_form_template_valid: true,
+        errors: [],
+        warnings: [
+            'Phase 4.86D remains draft-only.',
+            'CLI authorization yes values do not authorize execution in this phase.',
+        ],
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const localDeps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const planLoad = loadMarkdownYaml(
+        args,
+        'execution_plan',
+        'execution-plan',
+        'missing execution plan',
+        'yaml_block_found',
+        localDeps
+    );
+    if (planLoad.payload) return planLoad.payload;
+    const planValidation = validateParsedYaml(planLoad.parsedYaml);
+    if (!planValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'execution-plan-error',
+            execution_plan_found: true,
+            yaml_block_found: true,
+            required_fields_present: planValidation.missingFields.length === 0,
+            missing_fields: planValidation.missingFields,
+            errors: planValidation.errors,
+        });
+    }
+
+    const readinessPayload = runReadinessValidation(args, localDeps);
+    if (!readinessPayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'readiness-error',
+            execution_plan_found: true,
+            yaml_block_found: true,
+            execution_plan_valid: true,
+            errors: readinessPayload.errors,
+        });
+    }
+
+    const targetErrors = validateTargetConsistency(args, planLoad.parsedYaml, readinessPayload);
+    if (targetErrors.length) {
+        return buildFailurePayload(args, {
+            mode: 'target-error',
+            execution_plan_found: true,
+            checklist_found: true,
+            runbook_found: true,
+            auth_form_found: true,
+            yaml_block_found: true,
+            checklist_yaml_block_found: true,
+            runbook_yaml_block_found: true,
+            auth_form_yaml_block_found: true,
+            required_fields_present: true,
+            execution_plan_valid: true,
+            readiness_checklist_valid: true,
+            runbook_template_valid: true,
+            auth_form_template_valid: true,
+            errors: targetErrors,
+        });
+    }
+    return buildSuccessPayload(args);
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function writePayload(payload, io) {
+    io.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (text => process.stdout.write(text)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [error.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    EXECUTION_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    parseExecutionPlanYaml,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_execution_plan_validate.test.js
+++ b/tests/unit/single_target_acquisition_network_execution_plan_validate.test.js
@@ -1,0 +1,554 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/single_target_acquisition_network_execution_plan_validate.js');
+const EXECUTION_PLAN_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md'
+);
+const CHECKLIST_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md'
+);
+const RUNBOOK_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md'
+);
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md'
+);
+const EXECUTION_PLAN_TEXT = fs.readFileSync(EXECUTION_PLAN_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        execution_plan: EXECUTION_PLAN_PATH,
+        checklist: CHECKLIST_PATH,
+        runbook: RUNBOOK_PATH,
+        auth_form: AUTH_FORM_PATH,
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by single_target_acquisition_network_execution_plan_validate`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) throw new Error(`blocked import: ${request}`);
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(EXECUTION_PLAN_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return EXECUTION_PLAN_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return EXECUTION_PLAN_TEXT.replace(`${line}\n`, '');
+}
+
+function withTempExecutionPlan(markdownText, callback) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'phase486d-'));
+    const executionPlanPath = path.join(tempDir, 'execution-plan.md');
+    fs.writeFileSync(executionPlanPath, markdownText, 'utf8');
+    try {
+        callback(executionPlanPath);
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 execution plan 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.execution_plan;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing execution plan/i);
+});
+
+test('缺 checklist 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.checklist;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing checklist/i);
+});
+
+test('缺 runbook 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.runbook;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook/i);
+});
+
+test('缺 auth form 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.auth_form;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing auth form/i);
+});
+
+test('execution plan 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan('# no yaml\n', executionPlanPath => {
+        const payload = gate.runValidation({ ...buildArgs(), execution_plan: executionPlanPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /missing YAML block/i);
+    });
+});
+
+test('execution plan invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan('```yaml\nnot yaml\n```\n', executionPlanPath => {
+        const payload = gate.runValidation({ ...buildArgs(), execution_plan: executionPlanPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /invalid YAML/i);
+    });
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(
+        removeLineFromTemplate('phase: PHASE4.86D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_DRAFT'),
+        executionPlanPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), execution_plan: executionPlanPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /missing required fields: phase/);
+        }
+    );
+});
+
+test('execution_plan_status 非 draft_only 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(
+        replaceInTemplate('execution_plan_status: draft_only', 'execution_plan_status: approved'),
+        executionPlanPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), execution_plan: executionPlanPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /draft_only/);
+        }
+    );
+});
+
+[
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'staging_write_authorized=true 失败',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    [
+        'db_write_authorized=true 失败',
+        'db_write_authorized: false',
+        'db_write_authorized: true',
+        /db_write_authorized true/,
+    ],
+    [
+        'training_authorized=true 失败',
+        'training_authorized: false',
+        'training_authorized: true',
+        /training_authorized true/,
+    ],
+    [
+        'prediction_authorized=true 失败',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([name, searchValue, replaceValue, pattern]) => {
+    test(name, () => {
+        const gate = loadValidatorFresh();
+        withTempExecutionPlan(replaceInTemplate(searchValue, replaceValue), executionPlanPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), execution_plan: executionPlanPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), pattern);
+        });
+    });
+});
+
+test('任一 execution_steps.execution_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(
+        replaceInTemplate('      execution_allowed: false', '      execution_allowed: true'),
+        executionPlanPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), execution_plan: executionPlanPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /execution step allowed true/);
+        }
+    );
+});
+
+test('stop gate missing 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(removeLineFromTemplate('    terms_not_approved: true'), executionPlanPath => {
+        const payload = gate.runValidation({ ...buildArgs(), execution_plan: executionPlanPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /stop gate missing|stop_gates\.terms_not_approved/);
+    });
+});
+
+test('stop gate disabled 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(
+        replaceInTemplate('    network_not_authorized: true', '    network_not_authorized: false'),
+        executionPlanPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), execution_plan: executionPlanPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /stop gate disabled/);
+        }
+    );
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(
+        replaceInTemplate('    bulk_scope_allowed: false', '    bulk_scope_allowed: true'),
+        executionPlanPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), execution_plan: executionPlanPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /bulk scope allowed/i);
+        }
+    );
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(replaceInTemplate('    max_targets: 1', '    max_targets: 2'), executionPlanPath => {
+        const payload = gate.runValidation({ ...buildArgs(), execution_plan: executionPlanPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+    });
+});
+
+test('unsupported engine family 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_engine_family: 'run_production' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported engine family/);
+});
+
+test('unsupported scope type bulk 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_scope_type: 'bulk' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported scope type "bulk"|unsupported scope type bulk/);
+});
+
+test('target mismatch 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempExecutionPlan(replaceInTemplate('    target_source:', '    target_source: other'), executionPlanPath => {
+        const payload = gate.runValidation({ ...buildArgs(), execution_plan: executionPlanPath }, buildDependencies());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /target mismatch/i);
+    });
+});
+
+test('valid execution plan validate 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.86D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_DRAFT');
+    assert.equal(payload.execution_plan_draft_only, true);
+    assert.equal(payload.execution_plan_valid, true);
+    assert.equal(payload.readiness_checklist_valid, true);
+    assert.equal(payload.runbook_template_valid, true);
+    assert.equal(payload.auth_form_template_valid, true);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('all CLI yes 仍 no-op / execution not allowed', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs({
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            final_human_confirmation: 'yes',
+        }),
+        buildDependencies()
+    );
+    assert.equal(payload.ok, true);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        [
+            '--execution-plan',
+            EXECUTION_PLAN_PATH,
+            '--checklist',
+            CHECKLIST_PATH,
+            '--runbook',
+            RUNBOOK_PATH,
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--commit',
+        ],
+        buildDependencies()
+    );
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.86D/);
+});
+
+test('Makefile validate 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-execution-plan-validate',
+            'NETWORK_EXECUTION_PLAN_NODE=node',
+            `EXECUTION_PLAN=${EXECUTION_PLAN_PATH}`,
+            `CHECKLIST=${CHECKLIST_PATH}`,
+            `RUNBOOK=${RUNBOOK_PATH}`,
+            `AUTH_FORM=${AUTH_FORM_PATH}`,
+            'TARGET_SOURCE=fotmob',
+            'TARGET_ENGINE_FAMILY=titan_discovery',
+            'TARGET_SCOPE_TYPE=match_id',
+            'TARGET_MATCH_ID=sample-match-001',
+            'TERMS_APPROVAL=no',
+            'NETWORK_DRY_RUN_AUTHORIZATION=no',
+            'ALLOW_BROWSER_RUNTIME=no',
+            'ALLOW_PROXY_RUNTIME=no',
+            'ALLOW_EXTERNAL_NETWORK=no',
+            'ALLOW_STAGING_WRITE=no',
+            'FINAL_HUMAN_CONFIRMATION=no',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-execution-plan-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.86D/);
+});
+
+[
+    ['不访问网络', 'would_access_network', false],
+    ['不启动 browser', 'would_launch_browser', false],
+    ['不执行 proxy runtime', 'would_use_proxy', false],
+    ['不执行 engine', 'would_execute_engine', false],
+    ['不写 staging', 'would_write_staging', false],
+    ['不创建目录', 'would_create_staging_directory', false],
+    ['不写 source manifest', 'would_write_source_manifest', false],
+    ['不写 packet file', 'would_write_packet_file', false],
+    ['不写 DB', 'would_write_db', false],
+    ['不 spawn child process', 'would_spawn_child_process', false],
+].forEach(([name, field, expected]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], expected);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.86D single-target acquisition network dry-run execution plan draft.

Scope:
- Adds network dry-run execution plan template
- Adds local-only execution plan validator
- Validates execution plan remains draft-only and execution-blocked
- Validates runbook, auth form, and readiness checklist templates remain non-authorized
- Keeps network dry-run blocked
- Adds Makefile validate and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.86D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- validate missing params failed as expected
- valid execution plan validate passed
- all-yes CLI remained no-op / execution not allowed
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed