### PR TITLE
docs(data): add single-target network approval packet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、只验证 network dry-run authorization form template 和 pre-network runbook template 的本地 validator：`make data-single-target-acquisition-network-auth-form-validate AUTH_FORM=<path> RUNBOOK=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.84D template-only）
 - 不触网、不写文件、不创建目录、只验证 final readiness checklist template + pre-network runbook template + network auth form template 的本地 validator：`make data-single-target-acquisition-network-readiness-checklist-validate CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.85D template-only）
 - 不触网、不写文件、不创建目录、只验证 execution plan draft + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-execution-plan-validate EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.86D draft-only）
+- 不触网、不写文件、不创建目录、只预览 human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-approval-packet-preview APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.87D preview-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -751,6 +752,26 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-execution-plan-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook / auth form / readiness checklist / execution plan 全部审核通过。
+
+### Phase 4.87D: single-target acquisition network dry-run human approval packet preview
+
+`data-single-target-acquisition-network-approval-packet-preview` 只允许预览 human approval packet：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 approval packet file
+- 它不得写 DB
+- human approval packet preview 不等于真实 network dry-run authorization
+- 即使 CLI 传入 yes，Phase 4.87D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-approval-packet-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook / auth form / readiness checklist / execution plan / human approval packet 全部审核通过。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@
         data-single-target-acquisition-network-auth-form-validate data-single-target-acquisition-network-auth-form-commit \
         data-single-target-acquisition-network-readiness-checklist-validate data-single-target-acquisition-network-readiness-checklist-commit \
         data-single-target-acquisition-network-execution-plan-validate data-single-target-acquisition-network-execution-plan-commit \
+        data-single-target-acquisition-network-approval-packet-preview data-single-target-acquisition-network-approval-packet-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -81,6 +82,7 @@ PRE_NETWORK_RUNBOOK_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTH_FORM_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_READINESS_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_EXECUTION_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_APPROVAL_PACKET_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -356,6 +358,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-readiness-checklist-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_READINESS=1  # blocked in Phase 4.85D"
 	@echo "  make data-single-target-acquisition-network-execution-plan-validate EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # draft-only validate, Phase 4.86D"
 	@echo "  make data-single-target-acquisition-network-execution-plan-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN=1  # blocked in Phase 4.86D"
+	@echo "  make data-single-target-acquisition-network-approval-packet-preview APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # preview-only validate, Phase 4.87D"
+	@echo "  make data-single-target-acquisition-network-approval-packet-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET=1  # blocked in Phase 4.87D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1105,6 +1109,39 @@ data-single-target-acquisition-network-execution-plan-commit: ## Blocked network
 	@echo "BLOCKED: single-target acquisition network dry-run execution is not wired in Phase 4.86D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN=1, this path remains blocked."
 	@echo "  Phase 4.86D validates a draft only and does not authorize any network dry-run, staging write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-approval-packet-preview: ## Preview-only human approval packet validation. Phase 4.87D. No network, no writes, no DB.
+	@if [ -z "$(APPROVAL_PACKET)" ] || [ -z "$(EXECUTION_PLAN)" ] || [ -z "$(CHECKLIST)" ] || [ -z "$(RUNBOOK)" ] || [ -z "$(AUTH_FORM)" ] || [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ] || [ -z "$(TARGET_MATCH_ID)" ]; then \
+		echo "ERROR: provide APPROVAL_PACKET=<path>, EXECUTION_PLAN=<path>, CHECKLIST=<path>, RUNBOOK=<path>, AUTH_FORM=<path>, TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<type>, TARGET_MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.87D: network approval packet preview (preview-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_APPROVAL_PACKET_NODE) scripts/ops/single_target_acquisition_network_approval_packet_preview.js \
+		--approval-packet "$(APPROVAL_PACKET)" \
+		--execution-plan "$(EXECUTION_PLAN)" \
+		--checklist "$(CHECKLIST)" \
+		--runbook "$(RUNBOOK)" \
+		--auth-form "$(AUTH_FORM)" \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		--target-match-id "$(TARGET_MATCH_ID)" \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-network-approval-packet-commit: ## Blocked network approval packet gate. Remains not wired in Phase 4.87D.
+	@echo "BLOCKED: single-target acquisition network dry-run human approval packet execution is not wired in Phase 4.87D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET=1, this path remains blocked."
+	@echo "  Phase 4.87D previews a packet only and does not authorize any network dry-run, staging write, approval packet write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET_PHASE4_87D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET_PHASE4_87D.md
@@ -1,0 +1,148 @@
+# Phase 4.87D: Single-Target Acquisition Network Dry-Run Human Approval Packet Preview
+
+**Date**: 2026-05-10
+**Status**: Complete (preview-only, local-only)
+**Previous phases**: 4.79D, 4.80D, 4.81D, 4.82D, 4.83D, 4.84D, 4.85D, 4.86D
+**Recommended next phase**: Phase 4.88D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.87D adds a network dry-run human approval packet preview for a future
+single-target acquisition network dry-run.
+
+This phase did not:
+
+- access network
+- perform acquisition
+- write DB
+- write staging
+- write packet files
+
+The goal is to summarize Phase 4.83D through Phase 4.86D and prepare a future
+human approval packet preview without executing any network, browser, proxy,
+engine, staging, DB, training, or prediction path.
+
+---
+
+## 2. Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_approval_packet_preview.js`
+- `tests/unit/single_target_acquisition_network_approval_packet_preview.test.js`
+- `Makefile` targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET_PHASE4_87D.md`
+
+---
+
+## 3. Approval Packet Sections
+
+The approval packet preview includes:
+
+- `included_artifacts`
+- `included_validators`
+- `target`
+- `human_required_inputs`
+- `approval_sections`
+- `blocking_reasons`
+- `safety`
+- `next_phase_requirements`
+
+The YAML block remains machine-readable and keeps all approval and execution
+paths blocked.
+
+---
+
+## 4. Validation Behavior
+
+The preview validator is:
+
+- local-only
+- read-only
+- in-process
+
+It verifies that:
+
+- the approval packet remains `preview_only`
+- `human_approval_packet_ready` remains `false`
+- all authorization fields remain false / no
+- all `approval_sections` remain `approved=false`
+- single-target / no-bulk constraints remain in force
+- no network execution occurs
+- no runtime writes occur
+
+It also keeps the commit path blocked in Phase 4.87D.
+
+---
+
+## 5. Relationship to Previous Phases
+
+- 4.79D handles runtime parameter scaffold
+- 4.80D handles artifact / manifest schema validation
+- 4.81D handles writer path / authorization preflight
+- 4.82D handles staging packet preview
+- 4.83D handles pre-network runbook draft
+- 4.84D handles authorization form template
+- 4.85D handles final readiness checklist
+- 4.86D handles execution plan draft
+- 4.87D handles human approval packet preview
+
+All nine phases remain non-executing. None equals a real network dry-run.
+
+---
+
+## 6. Recommended Next Phase
+
+Recommended:
+
+`Phase 4.88D: single-target acquisition network dry-run user input requirements closure`
+
+Goals:
+
+- still no network
+- summarize every user-supplied parameter required before a real network dry-run
+- make clear that execution cannot proceed without real user parameters
+
+Alternative:
+
+`Phase 4.56A: 用户给齐真实 network dry-run 参数后才做 runbook`
+
+---
+
+## 7. Explicit Non-Execution
+
+The following were not executed:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- approval packet file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md
@@ -1,0 +1,169 @@
+# Single-Target Acquisition Network Dry-Run Human Approval Packet Template
+
+This document is a Phase 4.87D preview-only human approval packet for a future
+single-target acquisition network dry-run.
+
+- This is a human approval packet preview, not an approval document.
+- `human_approval_packet_ready=false`
+- `network_dry_run_authorized=false`
+- `network_dry_run_execution_allowed=false`
+- `staging_write_authorized=false`
+- `db_write_authorized=false`
+- Codex must not change this template to approved, ready, or authorized on its
+  own.
+- Phase 4.87D does not write an approval packet file. It only validates that
+  the approval packet preview remains blocked.
+- A real network dry-run must move to a later, separately authorized phase.
+
+```yaml
+phase: PHASE4.87D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET
+approval_packet_status: preview_only
+human_approval_packet_ready: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+included_artifacts:
+    pre_network_runbook: docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md
+    network_auth_form: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md
+    final_readiness_checklist: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md
+    execution_plan: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md
+
+included_validators:
+    runbook_validator: scripts/ops/single_target_acquisition_pre_network_runbook_validate.js
+    auth_form_validator: scripts/ops/single_target_acquisition_network_auth_form_validate.js
+    readiness_validator: scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js
+    execution_plan_validator: scripts/ops/single_target_acquisition_network_execution_plan_validate.js
+
+target:
+    target_source:
+    target_engine_family: titan_discovery
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+    max_targets: 1
+    bulk_scope_allowed: false
+
+human_required_inputs:
+    real_target_source_required: true
+    real_single_target_scope_required: true
+    source_terms_review_required: true
+    license_review_required: true
+    allowed_use_review_required: true
+    network_dry_run_authorization_required: true
+    proxy_browser_network_policy_review_required: true
+    staging_policy_review_required: true
+    no_db_write_confirmation_required: true
+    no_training_confirmation_required: true
+    no_prediction_confirmation_required: true
+
+approval_sections:
+    source_terms_approval:
+        required: true
+        approved: false
+        approved_by:
+    network_dry_run_approval:
+        required: true
+        approved: false
+        approved_by:
+    proxy_browser_network_policy_approval:
+        required: true
+        approved: false
+        approved_by:
+    staging_policy_approval:
+        required: true
+        approved: false
+        approved_by:
+    no_db_write_approval:
+        required: true
+        approved: false
+        approved_by:
+    final_human_confirmation:
+        required: true
+        approved: false
+        approved_by:
+
+blocking_reasons:
+    - approval_packet_preview_only
+    - real_target_source_missing
+    - real_single_target_scope_missing
+    - source_terms_not_approved
+    - network_dry_run_not_authorized
+    - proxy_browser_network_policy_not_approved
+    - staging_policy_not_approved
+    - final_human_confirmation_missing
+    - execution_plan_still_draft_only
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+next_phase_requirements:
+    - explicit_user_supplied_real_source
+    - explicit_user_supplied_single_target
+    - explicit_source_terms_approval
+    - explicit_network_dry_run_authorization
+    - explicit_proxy_browser_network_policy_acceptance
+    - explicit_staging_policy_acceptance
+    - explicit_no_db_write_confirmation
+    - explicit_no_training_confirmation
+    - explicit_no_prediction_confirmation
+    - final_human_confirmation
+```
+
+## Purpose
+
+This template summarizes the pre-network runbook draft, network authorization
+form template, final readiness checklist template, and execution plan draft for
+a future human review packet.
+
+It does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- approval packet file writes
+- DB writes
+- training
+- prediction
+
+## Preview-only guardrails
+
+- `approval_packet_status` must remain `preview_only`
+- `human_approval_packet_ready` must remain `false`
+- `network_dry_run_authorized` must remain `false`
+- `network_dry_run_execution_allowed` must remain `false`
+- `staging_write_authorized` must remain `false`
+- `db_write_authorized` must remain `false`
+- `training_authorized` must remain `false`
+- `prediction_authorized` must remain `false`
+- `final_human_confirmation` must remain `false`
+- every `approval_sections.*.approved` value must remain `false`
+- every blocking reason must remain listed
+
+Changing any of the above does not authorize execution inside Phase 4.87D.
+Future network dry-run execution must happen in a separate phase with explicit
+user approval, complete parameters, reviewed terms, approved runbook, approved
+auth form, approved readiness checklist, approved execution plan, and approved
+human approval packet.

--- a/scripts/ops/single_target_acquisition_network_approval_packet_preview.js
+++ b/scripts/ops/single_target_acquisition_network_approval_packet_preview.js
@@ -1,0 +1,663 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    runValidation: runExecutionPlanValidation,
+} = require('./single_target_acquisition_network_execution_plan_validate');
+
+const APPROVAL_PHASE = 'PHASE4.87D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition network dry-run human approval packet execution is not wired in Phase 4.87D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.88D or explicit user-authorized network dry-run preparation';
+const MODE = 'single-target-acquisition-network-approval-packet-preview';
+
+const FIELDS = {
+    top: words(`
+        phase approval_packet_status human_approval_packet_ready
+        network_dry_run_authorized network_dry_run_execution_allowed
+        staging_write_authorized db_write_authorized training_authorized
+        prediction_authorized final_human_confirmation included_artifacts
+        included_validators target human_required_inputs approval_sections
+        blocking_reasons safety next_phase_requirements
+    `),
+    included_artifacts: words(`
+        pre_network_runbook network_auth_form final_readiness_checklist
+        execution_plan
+    `),
+    included_validators: words(`
+        runbook_validator auth_form_validator readiness_validator
+        execution_plan_validator
+    `),
+    target: words(`
+        target_source target_engine_family target_scope_type target_match_id
+        target_league target_season target_date max_targets bulk_scope_allowed
+    `),
+    human_required_inputs: words(`
+        real_target_source_required real_single_target_scope_required
+        source_terms_review_required license_review_required
+        allowed_use_review_required network_dry_run_authorization_required
+        proxy_browser_network_policy_review_required staging_policy_review_required
+        no_db_write_confirmation_required no_training_confirmation_required
+        no_prediction_confirmation_required
+    `),
+    approval_section: words(`
+        required approved approved_by
+    `),
+    safety: words(`
+        would_access_network would_launch_browser would_use_proxy
+        would_execute_engine would_write_staging
+        would_create_staging_directory would_write_source_manifest
+        would_write_packet_file would_write_approval_packet_file
+        would_write_db would_train would_predict would_bulk_harvest
+    `),
+};
+
+const APPROVAL_SECTION_NAMES = words(`
+    source_terms_approval network_dry_run_approval
+    proxy_browser_network_policy_approval staging_policy_approval
+    no_db_write_approval final_human_confirmation
+`);
+
+const REQUIRED_BLOCKING_REASONS = words(`
+    approval_packet_preview_only real_target_source_missing
+    real_single_target_scope_missing source_terms_not_approved
+    network_dry_run_not_authorized proxy_browser_network_policy_not_approved
+    staging_policy_not_approved final_human_confirmation_missing
+    execution_plan_still_draft_only
+`);
+
+const REQUIRED_NEXT_PHASE = words(`
+    explicit_user_supplied_real_source explicit_user_supplied_single_target
+    explicit_source_terms_approval explicit_network_dry_run_authorization
+    explicit_proxy_browser_network_policy_acceptance
+    explicit_staging_policy_acceptance explicit_no_db_write_confirmation
+    explicit_no_training_confirmation explicit_no_prediction_confirmation
+    final_human_confirmation
+`);
+
+const EXPECTED_ARTIFACTS = {
+    pre_network_runbook: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md',
+    network_auth_form: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md',
+    final_readiness_checklist:
+        'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md',
+    execution_plan: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md',
+};
+
+const EXPECTED_VALIDATORS = {
+    runbook_validator: 'scripts/ops/single_target_acquisition_pre_network_runbook_validate.js',
+    auth_form_validator: 'scripts/ops/single_target_acquisition_network_auth_form_validate.js',
+    readiness_validator: 'scripts/ops/single_target_acquisition_network_readiness_checklist_validate.js',
+    execution_plan_validator: 'scripts/ops/single_target_acquisition_network_execution_plan_validate.js',
+};
+
+const CLI_REQUIRED = words(`
+    approval_packet execution_plan checklist runbook auth_form target_source
+    target_engine_family target_scope_type target_match_id terms_approval
+    network_dry_run_authorization allow_browser_runtime allow_proxy_runtime
+    allow_external_network allow_staging_write final_human_confirmation
+`);
+
+const CLI_YES_NO = words(`
+    terms_approval network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const TOP_FALSE = {
+    human_approval_packet_ready: 'human_approval_packet_ready true in template is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true in template is not allowed',
+    staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+    db_write_authorized: 'db_write_authorized true in template is not allowed',
+    training_authorized: 'training_authorized true in template is not allowed',
+    prediction_authorized: 'prediction_authorized true in template is not allowed',
+    final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+};
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function parseScalar(rawValue) {
+    const value = String(rawValue || '').trim();
+    if (value === '') return null;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    if (/^-?\d+$/.test(value)) return Number(value);
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+
+function parseApprovalPacketYaml(yamlText) {
+    const root = {};
+    const stack = [{ indent: -1, value: root }];
+    const lines = String(yamlText || '').split(/\r?\n/);
+
+    lines.forEach((rawLine, lineIndex) => {
+        if (!rawLine.trim() || rawLine.trim().startsWith('#')) return;
+        const indent = rawLine.match(/^ */)[0].length;
+        const trimmed = rawLine.trim();
+
+        while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop();
+        const parent = stack[stack.length - 1].value;
+
+        if (trimmed.startsWith('- ')) {
+            if (!Array.isArray(parent)) throw new Error(`unsupported YAML list line: ${trimmed}`);
+            parent.push(parseScalar(trimmed.slice(2)));
+            return;
+        }
+
+        const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+        if (!match) throw new Error(`unsupported YAML line: ${trimmed}`);
+        const key = match[1];
+        const valueText = match[2].trim();
+
+        if (valueText !== '') {
+            parent[key] = parseScalar(valueText);
+            return;
+        }
+
+        const nextContainerType = getNextContainerType(lines, lineIndex, indent);
+        if (!nextContainerType) {
+            parent[key] = null;
+            return;
+        }
+        const container = nextContainerType === 'list' ? [] : {};
+        parent[key] = container;
+        stack.push({ indent, value: container });
+    });
+
+    return root;
+}
+
+function getNextContainerType(lines, currentIndex, currentIndent) {
+    for (let index = currentIndex + 1; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (!line.trim() || line.trim().startsWith('#')) continue;
+        const indent = line.match(/^ */)[0].length;
+        if (indent <= currentIndent) return false;
+        return line.trim().startsWith('- ') ? 'list' : 'object';
+    }
+    return false;
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_approval_packet_preview.js --approval-packet <path> --execution-plan <path> --checklist <path> --runbook <path> --auth-form <path> --target-source <src> --target-engine-family titan_discovery --target-scope-type match_id --target-match-id <id> --terms-approval no --network-dry-run-authorization no --allow-browser-runtime no --allow-proxy-runtime no --allow-external-network no --allow-staging-write no --final-human-confirmation no',
+        '  node scripts/ops/single_target_acquisition_network_approval_packet_preview.js --approval-packet <path> --execution-plan <path> --checklist <path> --runbook <path> --auth-form <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.87D previews a local human approval packet only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        approval_packet: '',
+        execution_plan: '',
+        checklist: '',
+        runbook: '',
+        auth_form: '',
+        commit: false,
+        help: false,
+    };
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) throw new Error(`Unknown argument: ${token}`);
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        approval_packet_preview_only: true,
+        approval_packet_valid: false,
+        execution_plan_valid: false,
+        readiness_checklist_valid: false,
+        runbook_template_valid: false,
+        auth_form_template_valid: false,
+        human_approval_packet_ready: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: APPROVAL_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        approval_packet: args.approval_packet || null,
+        execution_plan: args.execution_plan || null,
+        checklist: args.checklist || null,
+        runbook: args.runbook || null,
+        auth_form: args.auth_form || null,
+        approval_packet_found: false,
+        execution_plan_found: false,
+        checklist_found: false,
+        runbook_found: false,
+        auth_form_found: false,
+        yaml_block_found: false,
+        execution_plan_yaml_block_found: false,
+        checklist_yaml_block_found: false,
+        runbook_yaml_block_found: false,
+        auth_form_yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: buildNonExecutionConfirmations(),
+        ...fields,
+    };
+}
+
+function validateRequiredCliFields(args) {
+    return CLI_REQUIRED.flatMap(field => {
+        if (args[field]) return [];
+        if (field === 'approval_packet') return ['missing approval packet'];
+        if (field === 'execution_plan') return ['missing execution plan'];
+        if (field === 'checklist') return ['missing checklist'];
+        if (field === 'runbook') return ['missing runbook'];
+        if (field === 'auth_form') return ['missing auth form'];
+        return [`missing ${field.replace(/_/g, ' ')} path or value`];
+    });
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = validateRequiredCliFields(args);
+    CLI_YES_NO.forEach(field => {
+        if (args[field] !== 'yes' && args[field] !== 'no') {
+            errors.push(`--${field.replace(/_/g, '-')} is required (yes/no)`);
+        }
+    });
+    if (args.target_engine_family && args.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${args.target_engine_family}"`);
+    }
+    if (
+        args.target_scope_type &&
+        args.target_scope_type !== 'match_id' &&
+        args.target_scope_type !== 'league_season_date'
+    ) {
+        errors.push(`unsupported scope type "${args.target_scope_type}"`);
+    }
+    if (args.target_scope_type === 'bulk') errors.push('unsupported scope type bulk');
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function loadApprovalPacketYaml(args, dependencies) {
+    const targetPath = resolveLocalPath(args.approval_packet, dependencies.cwd);
+    if (!dependencies.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'approval-packet-error',
+                approval_packet_found: false,
+                errors: [`missing approval packet: ${toRelativePath(targetPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+    const yamlText = extractYamlBlock(dependencies.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'approval-packet-error',
+                approval_packet_found: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+    try {
+        return { parsedYaml: parseApprovalPacketYaml(yamlText), yamlText };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'approval-packet-error',
+                approval_packet_found: true,
+                yaml_block_found: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function addMissingNested(root, parentKey, requiredKeys, missingFields) {
+    const value = root[parentKey];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        requiredKeys.forEach(key => missingFields.push(`${parentKey}.${key}`));
+        return;
+    }
+    requiredKeys
+        .filter(key => !Object.prototype.hasOwnProperty.call(value, key))
+        .forEach(key => missingFields.push(`${parentKey}.${key}`));
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = FIELDS.top.filter(key => !Object.prototype.hasOwnProperty.call(parsedYaml, key));
+    addMissingNested(parsedYaml, 'included_artifacts', FIELDS.included_artifacts, missingFields);
+    addMissingNested(parsedYaml, 'included_validators', FIELDS.included_validators, missingFields);
+    addMissingNested(parsedYaml, 'target', FIELDS.target, missingFields);
+    addMissingNested(parsedYaml, 'human_required_inputs', FIELDS.human_required_inputs, missingFields);
+    addMissingNested(parsedYaml, 'safety', FIELDS.safety, missingFields);
+    const approvalSections = parsedYaml.approval_sections;
+    if (!approvalSections || typeof approvalSections !== 'object' || Array.isArray(approvalSections)) {
+        APPROVAL_SECTION_NAMES.forEach(sectionName => {
+            FIELDS.approval_section.forEach(field => missingFields.push(`approval_sections.${sectionName}.${field}`));
+        });
+    } else {
+        APPROVAL_SECTION_NAMES.forEach(sectionName => {
+            addMissingNested(approvalSections, sectionName, FIELDS.approval_section, missingFields);
+        });
+    }
+    return missingFields;
+}
+
+function ensureNestedValues(root, parentKey, fieldNames, expectedValue, errors, label) {
+    const parent = root[parentKey] || {};
+    fieldNames.forEach(fieldName => {
+        if (parent[fieldName] !== expectedValue) {
+            errors.push(`${parentKey}.${fieldName} must ${label} in the Phase 4.87D template`);
+        }
+    });
+}
+
+function ensureObjectValues(root, parentKey, expectedValues, errors) {
+    const parent = root[parentKey] || {};
+    Object.entries(expectedValues).forEach(([fieldName, expectedValue]) => {
+        if (parent[fieldName] !== expectedValue) {
+            errors.push(`${parentKey}.${fieldName} must be ${expectedValue}`);
+        }
+    });
+}
+
+function validateApprovalSections(parsedYaml, errors) {
+    const sections = parsedYaml.approval_sections || {};
+    APPROVAL_SECTION_NAMES.forEach(sectionName => {
+        const section = sections[sectionName];
+        if (!section || typeof section !== 'object' || Array.isArray(section)) {
+            errors.push(`approval section missing: ${sectionName}`);
+            return;
+        }
+        if (section.required !== true) errors.push(`approval section required must be true: ${sectionName}`);
+        if (section.approved !== false) errors.push('approval section approved true in template is not allowed');
+    });
+}
+
+function validateTargetSection(parsedYaml, errors) {
+    const target = parsedYaml.target || {};
+    if (target.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${target.target_engine_family}"`);
+    }
+    if (target.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+    if (target.bulk_scope_allowed !== false) {
+        errors.push('bulk scope allowed must remain false in the Phase 4.87D template');
+    }
+    if (target.max_targets !== 1) {
+        errors.push('max_targets > 1 is not allowed in the Phase 4.87D template');
+    }
+}
+
+function ensureArrayContainsAll(root, key, requiredValues, errors, missingMessage) {
+    const value = root[key];
+    if (!Array.isArray(value)) {
+        errors.push(missingMessage || `${key} missing`);
+        return;
+    }
+    requiredValues
+        .filter(requiredValue => !value.includes(requiredValue))
+        .forEach(requiredValue => errors.push(`${key} missing required value "${requiredValue}"`));
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) errors.push(`missing required fields: ${missingFields.join(',')}`);
+    if (parsedYaml.phase !== APPROVAL_PHASE) errors.push(`phase must be ${APPROVAL_PHASE}`);
+    if (parsedYaml.approval_packet_status !== 'preview_only') {
+        errors.push('approval_packet_status must remain preview_only in the Phase 4.87D template');
+    }
+    Object.entries(TOP_FALSE).forEach(([field, message]) => {
+        if (parsedYaml[field] !== false) errors.push(message);
+    });
+
+    ensureObjectValues(parsedYaml, 'included_artifacts', EXPECTED_ARTIFACTS, errors);
+    ensureObjectValues(parsedYaml, 'included_validators', EXPECTED_VALIDATORS, errors);
+    ensureNestedValues(parsedYaml, 'human_required_inputs', FIELDS.human_required_inputs, true, errors, 'be true');
+    ensureNestedValues(parsedYaml, 'safety', FIELDS.safety, false, errors, 'remain false');
+    validateApprovalSections(parsedYaml, errors);
+    validateTargetSection(parsedYaml, errors);
+    ensureArrayContainsAll(
+        parsedYaml,
+        'blocking_reasons',
+        REQUIRED_BLOCKING_REASONS,
+        errors,
+        'blocking reasons missing'
+    );
+    ensureArrayContainsAll(parsedYaml, 'next_phase_requirements', REQUIRED_NEXT_PHASE, errors);
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function validateTargetConsistency(args, approvalPacketYaml, executionPlanPayload) {
+    const target = approvalPacketYaml.target || {};
+    const errors = [
+        ['approval_packet.target.target_source', target.target_source, args.target_source],
+        ['approval_packet.target.target_engine_family', target.target_engine_family, args.target_engine_family],
+        ['approval_packet.target.target_scope_type', target.target_scope_type, args.target_scope_type],
+        ['approval_packet.target.target_match_id', target.target_match_id, args.target_match_id],
+    ]
+        .filter(([, templateValue, cliValue]) => templateValue && templateValue !== cliValue)
+        .map(
+            ([label, templateValue, cliValue]) =>
+                `target mismatch: ${label} "${templateValue}" does not match CLI value "${cliValue}"`
+        );
+    if (executionPlanPayload.errors && executionPlanPayload.errors.some(error => /target mismatch/i.test(error))) {
+        errors.push(...executionPlanPayload.errors);
+    }
+    return errors;
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: APPROVAL_PHASE,
+        mode: MODE,
+        ok: true,
+        approval_packet: args.approval_packet,
+        execution_plan: args.execution_plan,
+        checklist: args.checklist,
+        runbook: args.runbook,
+        auth_form: args.auth_form,
+        approval_packet_found: true,
+        execution_plan_found: true,
+        checklist_found: true,
+        runbook_found: true,
+        auth_form_found: true,
+        yaml_block_found: true,
+        execution_plan_yaml_block_found: true,
+        checklist_yaml_block_found: true,
+        runbook_yaml_block_found: true,
+        auth_form_yaml_block_found: true,
+        required_fields_present: true,
+        missing_fields: [],
+        approval_packet_valid: true,
+        execution_plan_valid: true,
+        readiness_checklist_valid: true,
+        runbook_template_valid: true,
+        auth_form_template_valid: true,
+        errors: [],
+        warnings: [
+            'Phase 4.87D remains preview-only.',
+            'CLI authorization yes values do not authorize execution in this phase.',
+        ],
+        non_execution_confirmations: [...buildNonExecutionConfirmations(), 'no_approval_packet_file_writes'],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const localDeps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const approvalPacketLoad = loadApprovalPacketYaml(args, localDeps);
+    if (approvalPacketLoad.payload) return approvalPacketLoad.payload;
+
+    const approvalPacketValidation = validateParsedYaml(approvalPacketLoad.parsedYaml);
+    if (!approvalPacketValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'approval-packet-error',
+            approval_packet_found: true,
+            yaml_block_found: true,
+            required_fields_present: approvalPacketValidation.missingFields.length === 0,
+            missing_fields: approvalPacketValidation.missingFields,
+            errors: approvalPacketValidation.errors,
+        });
+    }
+
+    const executionPlanPayload = runExecutionPlanValidation(args, localDeps);
+    if (!executionPlanPayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'execution-plan-error',
+            approval_packet_found: true,
+            yaml_block_found: true,
+            approval_packet_valid: true,
+            errors: executionPlanPayload.errors,
+        });
+    }
+
+    const targetErrors = validateTargetConsistency(args, approvalPacketLoad.parsedYaml, executionPlanPayload);
+    if (targetErrors.length) {
+        return buildFailurePayload(args, {
+            mode: 'target-error',
+            approval_packet_found: true,
+            execution_plan_found: true,
+            checklist_found: true,
+            runbook_found: true,
+            auth_form_found: true,
+            yaml_block_found: true,
+            execution_plan_yaml_block_found: true,
+            checklist_yaml_block_found: true,
+            runbook_yaml_block_found: true,
+            auth_form_yaml_block_found: true,
+            required_fields_present: true,
+            approval_packet_valid: true,
+            execution_plan_valid: true,
+            readiness_checklist_valid: true,
+            runbook_template_valid: true,
+            auth_form_template_valid: true,
+            errors: targetErrors,
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function writePayload(payload, io) {
+    io.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (text => process.stdout.write(text)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [error.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    APPROVAL_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    parseApprovalPacketYaml,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_approval_packet_preview.test.js
+++ b/tests/unit/single_target_acquisition_network_approval_packet_preview.test.js
@@ -1,0 +1,583 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/single_target_acquisition_network_approval_packet_preview.js');
+const APPROVAL_PACKET_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md'
+);
+const EXECUTION_PLAN_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md'
+);
+const CHECKLIST_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md'
+);
+const RUNBOOK_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md'
+);
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md'
+);
+const APPROVAL_PACKET_TEXT = fs.readFileSync(APPROVAL_PACKET_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        approval_packet: APPROVAL_PACKET_PATH,
+        execution_plan: EXECUTION_PLAN_PATH,
+        checklist: CHECKLIST_PATH,
+        runbook: RUNBOOK_PATH,
+        auth_form: AUTH_FORM_PATH,
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by single_target_acquisition_network_approval_packet_preview`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) throw new Error(`blocked import: ${request}`);
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(APPROVAL_PACKET_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return APPROVAL_PACKET_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return APPROVAL_PACKET_TEXT.replace(`${line}\n`, '');
+}
+
+function withTempApprovalPacket(markdownText, callback) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'phase487d-'));
+    const approvalPacketPath = path.join(tempDir, 'approval-packet.md');
+    fs.writeFileSync(approvalPacketPath, markdownText, 'utf8');
+    try {
+        callback(approvalPacketPath);
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 approval packet 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.approval_packet;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing approval packet/i);
+});
+
+test('缺 execution plan 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.execution_plan;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing execution plan/i);
+});
+
+test('缺 checklist 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.checklist;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing checklist/i);
+});
+
+test('缺 runbook 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.runbook;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook/i);
+});
+
+test('缺 auth form 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.auth_form;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing auth form/i);
+});
+
+test('approval packet 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket('# no yaml\n', approvalPacketPath => {
+        const payload = gate.runValidation(
+            { ...buildArgs(), approval_packet: approvalPacketPath },
+            buildDependencies()
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /missing YAML block/i);
+    });
+});
+
+test('approval packet invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket('```yaml\nnot yaml\n```\n', approvalPacketPath => {
+        const payload = gate.runValidation(
+            { ...buildArgs(), approval_packet: approvalPacketPath },
+            buildDependencies()
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /invalid YAML/i);
+    });
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket(
+        removeLineFromTemplate('phase: PHASE4.87D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET'),
+        approvalPacketPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), approval_packet: approvalPacketPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /missing required fields: phase/);
+        }
+    );
+});
+
+test('approval_packet_status 非 preview_only 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket(
+        replaceInTemplate('approval_packet_status: preview_only', 'approval_packet_status: approved'),
+        approvalPacketPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), approval_packet: approvalPacketPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /preview_only/);
+        }
+    );
+});
+
+[
+    [
+        'human_approval_packet_ready=true 失败',
+        'human_approval_packet_ready: false',
+        'human_approval_packet_ready: true',
+        /human_approval_packet_ready true/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'staging_write_authorized=true 失败',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    [
+        'db_write_authorized=true 失败',
+        'db_write_authorized: false',
+        'db_write_authorized: true',
+        /db_write_authorized true/,
+    ],
+    [
+        'training_authorized=true 失败',
+        'training_authorized: false',
+        'training_authorized: true',
+        /training_authorized true/,
+    ],
+    [
+        'prediction_authorized=true 失败',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([name, searchValue, replaceValue, pattern]) => {
+    test(name, () => {
+        const gate = loadValidatorFresh();
+        withTempApprovalPacket(replaceInTemplate(searchValue, replaceValue), approvalPacketPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), approval_packet: approvalPacketPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), pattern);
+        });
+    });
+});
+
+test('approval_sections 任一 approved=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket(
+        replaceInTemplate('        approved: false', '        approved: true'),
+        approvalPacketPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), approval_packet: approvalPacketPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /approval section approved true/);
+        }
+    );
+});
+
+test('blocking_reasons missing 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket(removeLineFromTemplate('    - approval_packet_preview_only'), approvalPacketPath => {
+        const payload = gate.runValidation(
+            { ...buildArgs(), approval_packet: approvalPacketPath },
+            buildDependencies()
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /blocking_reasons missing required value|blocking reasons missing/);
+    });
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket(
+        replaceInTemplate('    bulk_scope_allowed: false', '    bulk_scope_allowed: true'),
+        approvalPacketPath => {
+            const payload = gate.runValidation(
+                { ...buildArgs(), approval_packet: approvalPacketPath },
+                buildDependencies()
+            );
+            assert.equal(payload.ok, false);
+            assert.match(payload.errors.join('\n'), /bulk scope allowed/i);
+        }
+    );
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket(replaceInTemplate('    max_targets: 1', '    max_targets: 2'), approvalPacketPath => {
+        const payload = gate.runValidation(
+            { ...buildArgs(), approval_packet: approvalPacketPath },
+            buildDependencies()
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+    });
+});
+
+test('unsupported engine family 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_engine_family: 'run_production' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported engine family/);
+});
+
+test('unsupported scope type bulk 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_scope_type: 'bulk' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported scope type "bulk"|unsupported scope type bulk/);
+});
+
+test('target mismatch 失败', () => {
+    const gate = loadValidatorFresh();
+    withTempApprovalPacket(replaceInTemplate('    target_source:', '    target_source: other'), approvalPacketPath => {
+        const payload = gate.runValidation(
+            { ...buildArgs(), approval_packet: approvalPacketPath },
+            buildDependencies()
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), /target mismatch/i);
+    });
+});
+
+test('valid approval packet preview 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.87D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET');
+    assert.equal(payload.approval_packet_preview_only, true);
+    assert.equal(payload.approval_packet_valid, true);
+    assert.equal(payload.execution_plan_valid, true);
+    assert.equal(payload.readiness_checklist_valid, true);
+    assert.equal(payload.runbook_template_valid, true);
+    assert.equal(payload.auth_form_template_valid, true);
+    assert.equal(payload.human_approval_packet_ready, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_approval_packet_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('all CLI yes 仍 no-op / packet not ready / not authorized', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs({
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            final_human_confirmation: 'yes',
+        }),
+        buildDependencies()
+    );
+    assert.equal(payload.ok, true);
+    assert.equal(payload.human_approval_packet_ready, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_approval_packet_file, false);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        [
+            '--approval-packet',
+            APPROVAL_PACKET_PATH,
+            '--execution-plan',
+            EXECUTION_PLAN_PATH,
+            '--checklist',
+            CHECKLIST_PATH,
+            '--runbook',
+            RUNBOOK_PATH,
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--commit',
+        ],
+        buildDependencies()
+    );
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.87D/);
+});
+
+test('Makefile preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-approval-packet-preview',
+            'NETWORK_APPROVAL_PACKET_NODE=node',
+            `APPROVAL_PACKET=${APPROVAL_PACKET_PATH}`,
+            `EXECUTION_PLAN=${EXECUTION_PLAN_PATH}`,
+            `CHECKLIST=${CHECKLIST_PATH}`,
+            `RUNBOOK=${RUNBOOK_PATH}`,
+            `AUTH_FORM=${AUTH_FORM_PATH}`,
+            'TARGET_SOURCE=fotmob',
+            'TARGET_ENGINE_FAMILY=titan_discovery',
+            'TARGET_SCOPE_TYPE=match_id',
+            'TARGET_MATCH_ID=sample-match-001',
+            'TERMS_APPROVAL=no',
+            'NETWORK_DRY_RUN_AUTHORIZATION=no',
+            'ALLOW_BROWSER_RUNTIME=no',
+            'ALLOW_PROXY_RUNTIME=no',
+            'ALLOW_EXTERNAL_NETWORK=no',
+            'ALLOW_STAGING_WRITE=no',
+            'FINAL_HUMAN_CONFIRMATION=no',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-approval-packet-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.87D/);
+});
+
+[
+    ['不访问网络', 'would_access_network', false],
+    ['不启动 browser', 'would_launch_browser', false],
+    ['不执行 proxy runtime', 'would_use_proxy', false],
+    ['不执行 engine', 'would_execute_engine', false],
+    ['不写 staging', 'would_write_staging', false],
+    ['不创建目录', 'would_create_staging_directory', false],
+    ['不写 source manifest', 'would_write_source_manifest', false],
+    ['不写 packet file', 'would_write_packet_file', false],
+    ['不写 approval packet file', 'would_write_approval_packet_file', false],
+    ['不写 DB', 'would_write_db', false],
+    ['不 spawn child process', 'would_spawn_child_process', false],
+].forEach(([name, field, expected]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], expected);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.87D single-target acquisition network dry-run human approval packet preview.

Scope:
- Adds human approval packet template
- Adds local-only approval packet preview validator
- Validates approval packet remains preview-only and non-authorized
- Validates runbook, auth form, readiness checklist, and execution plan templates remain non-authorized
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.87D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No approval packet file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- preview missing params failed as expected
- valid approval packet preview passed
- all-yes CLI remained no-op / packet not ready / not authorized
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed