### PR TITLE
docs(data): add single-target network input closure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、只验证 final readiness checklist template + pre-network runbook template + network auth form template 的本地 validator：`make data-single-target-acquisition-network-readiness-checklist-validate CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.85D template-only）
 - 不触网、不写文件、不创建目录、只验证 execution plan draft + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-execution-plan-validate EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.86D draft-only）
 - 不触网、不写文件、不创建目录、只预览 human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-approval-packet-preview APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.87D preview-only）
+- 不触网、不写文件、不创建目录、只预览 user input requirements closure + human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-user-input-closure-preview INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.88D closure-preview-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -772,6 +773,28 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-approval-packet-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确授权、参数齐全、terms approval 齐全、runbook / auth form / readiness checklist / execution plan / human approval packet 全部审核通过。
+
+### Phase 4.88D: single-target acquisition network dry-run user input requirements closure
+
+`data-single-target-acquisition-network-user-input-closure-preview` 只允许预览 user input requirements closure：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 approval packet file
+- 它不得写 user input closure file
+- 它不得写 DB
+- user input requirements closure 不等于真实 network dry-run authorization
+- Codex 不得自行填写真实 source / target / terms / authorization
+- 即使 CLI 传入 yes，Phase 4.88D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-user-input-closure-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、terms approval、network authorization、runbook / auth form / readiness checklist / execution plan / approval packet 全部审核通过。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@
         data-single-target-acquisition-network-readiness-checklist-validate data-single-target-acquisition-network-readiness-checklist-commit \
         data-single-target-acquisition-network-execution-plan-validate data-single-target-acquisition-network-execution-plan-commit \
         data-single-target-acquisition-network-approval-packet-preview data-single-target-acquisition-network-approval-packet-commit \
+        data-single-target-acquisition-network-user-input-closure-preview data-single-target-acquisition-network-user-input-closure-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -83,6 +84,7 @@ NETWORK_AUTH_FORM_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_READINESS_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_EXECUTION_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_APPROVAL_PACKET_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_USER_INPUT_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -360,6 +362,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-execution-plan-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_EXECUTION_PLAN=1  # blocked in Phase 4.86D"
 	@echo "  make data-single-target-acquisition-network-approval-packet-preview APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # preview-only validate, Phase 4.87D"
 	@echo "  make data-single-target-acquisition-network-approval-packet-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET=1  # blocked in Phase 4.87D"
+	@echo "  make data-single-target-acquisition-network-user-input-closure-preview INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # closure-preview-only validate, Phase 4.88D"
+	@echo "  make data-single-target-acquisition-network-user-input-closure-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE=1  # blocked in Phase 4.88D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1142,6 +1146,40 @@ data-single-target-acquisition-network-approval-packet-commit: ## Blocked networ
 	@echo "BLOCKED: single-target acquisition network dry-run human approval packet execution is not wired in Phase 4.87D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET=1, this path remains blocked."
 	@echo "  Phase 4.87D previews a packet only and does not authorize any network dry-run, staging write, approval packet write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-user-input-closure-preview: ## Preview-only user input requirements closure validation. Phase 4.88D. No network, no writes, no DB.
+	@if [ -z "$(INPUT_CLOSURE)" ] || [ -z "$(APPROVAL_PACKET)" ] || [ -z "$(EXECUTION_PLAN)" ] || [ -z "$(CHECKLIST)" ] || [ -z "$(RUNBOOK)" ] || [ -z "$(AUTH_FORM)" ] || [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ] || [ -z "$(TARGET_MATCH_ID)" ]; then \
+		echo "ERROR: provide INPUT_CLOSURE=<path>, APPROVAL_PACKET=<path>, EXECUTION_PLAN=<path>, CHECKLIST=<path>, RUNBOOK=<path>, AUTH_FORM=<path>, TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<type>, TARGET_MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.88D: network user input requirements closure preview (preview-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_USER_INPUT_CLOSURE_NODE) scripts/ops/single_target_acquisition_network_user_input_requirements_closure.js \
+		--input-closure "$(INPUT_CLOSURE)" \
+		--approval-packet "$(APPROVAL_PACKET)" \
+		--execution-plan "$(EXECUTION_PLAN)" \
+		--checklist "$(CHECKLIST)" \
+		--runbook "$(RUNBOOK)" \
+		--auth-form "$(AUTH_FORM)" \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		--target-match-id "$(TARGET_MATCH_ID)" \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-network-user-input-closure-commit: ## Blocked network user input requirements closure gate. Remains not wired in Phase 4.88D.
+	@echo "BLOCKED: single-target acquisition network dry-run user input requirements closure execution is not wired in Phase 4.88D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE=1, this path remains blocked."
+	@echo "  Phase 4.88D previews required user inputs only and does not authorize any network dry-run, staging write, user input closure file write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE_PHASE4_88D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE_PHASE4_88D.md
@@ -1,0 +1,156 @@
+# Phase 4.88D: Single-Target Acquisition Network Dry-Run User Input Requirements Closure
+
+**Date**: 2026-05-10
+**Status**: Complete (closure-preview-only, local-only)
+**Previous phases**: 4.79D, 4.80D, 4.81D, 4.82D, 4.83D, 4.84D, 4.85D, 4.86D, 4.87D
+**Recommended next phase**: Phase 4.89D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.88D is the network dry-run user input requirements closure stage for a
+future single-target acquisition network dry-run.
+
+This phase did not:
+
+- access network
+- perform acquisition
+- write DB
+- write staging
+- write packet files
+
+The goal is to close the list of real user inputs required before a future
+single-target network dry-run can even be proposed. It confirms that execution
+cannot continue without a real source, real single-target scope, terms/license
+review, network authorization, browser/proxy/external network policy, staging
+policy, no-DB/no-training/no-prediction confirmation, and final human
+confirmation.
+
+---
+
+## 2. Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_user_input_requirements_closure.js`
+- `tests/unit/single_target_acquisition_network_user_input_requirements_closure.test.js`
+- `Makefile` targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE_PHASE4_88D.md`
+
+---
+
+## 3. Required User Inputs
+
+The closure keeps these input groups incomplete by default:
+
+- `real_target_source`
+- `real_single_target_scope`
+- `source_terms`
+- `network_authorization`
+- `proxy_browser_network_policy`
+- `staging_policy`
+- `no_db_training_prediction_policy`
+- `final_human_confirmation`
+
+Codex must not fill these real values for the user and must not flip any
+`required_user_inputs.*.provided` value to `true`.
+
+---
+
+## 4. Validation Behavior
+
+The validator is:
+
+- local-only
+- read-only
+- in-process
+
+It verifies that:
+
+- the closure remains `closure_preview_only`
+- `user_inputs_complete=false`
+- all required input groups remain `provided=false`
+- all authorization fields remain false / no
+- single-target / no-bulk constraints remain in force
+- no network execution occurs
+- no runtime writes occur
+
+It also validates the existing human approval packet, execution plan, readiness
+checklist, pre-network runbook, and auth form templates remain non-authorized.
+
+---
+
+## 5. Relationship to Previous Phases
+
+- 4.79D handles runtime parameter scaffold
+- 4.80D handles artifact / manifest schema validation
+- 4.81D handles writer path / authorization preflight
+- 4.82D handles staging packet preview
+- 4.83D handles pre-network runbook draft
+- 4.84D handles authorization form template
+- 4.85D handles final readiness checklist
+- 4.86D handles execution plan draft
+- 4.87D handles human approval packet preview
+- 4.88D handles user input requirements closure
+
+All ten phases remain non-executing. None equals a real network dry-run.
+
+---
+
+## 6. Recommended Next Phase
+
+Recommended:
+
+`Phase 4.89D: single-target acquisition network dry-run blocked final preflight summary`
+
+Goals:
+
+- still no network
+- still no DB writes
+- still no staging writes
+- summarize that the current system cannot continue because real user inputs
+  are still missing
+
+Alternative:
+
+`Phase 4.56A: 用户给齐真实 network dry-run 参数后才做 runbook`
+
+---
+
+## 7. Explicit Non-Execution
+
+The following were not executed:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- approval packet file write
+- user input closure file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE_TEMPLATE.md
@@ -1,0 +1,188 @@
+# Single-Target Acquisition Network Dry-Run User Input Requirements Closure Template
+
+This document is a Phase 4.88D preview-only user input requirements closure for
+a future single-target acquisition network dry-run.
+
+- This is a user input requirements closure preview, not an approval document.
+- `user_inputs_complete=false`
+- `network_dry_run_authorized=false`
+- `network_dry_run_execution_allowed=false`
+- `human_approval_packet_ready=false`
+- `staging_write_authorized=false`
+- `db_write_authorized=false`
+- Codex must not fill real source, target, terms, or authorization values for
+  the user.
+- Codex must not change any `provided` value to `true` on its own.
+- Phase 4.88D does not write a user input closure file. It only validates this
+  template and produces a local preview.
+- A real network dry-run must move to a later, separately authorized phase
+  after the user supplies all real parameters.
+
+```yaml
+phase: PHASE4_88D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE
+closure_status: closure_preview_only
+user_inputs_complete: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+human_approval_packet_ready: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+required_user_inputs:
+    real_target_source:
+        required: true
+        provided: false
+        value:
+    real_target_scope:
+        required: true
+        provided: false
+        scope_type:
+        target_match_id:
+        target_league:
+        target_season:
+        target_date:
+        max_targets: 1
+        bulk_scope_allowed: false
+    source_terms:
+        terms_url_required: true
+        license_url_required: true
+        allowed_use_required: true
+        terms_review_required: true
+        terms_approval_required: true
+        provided: false
+    network_authorization:
+        network_dry_run_authorization_required: true
+        allow_external_network_required: true
+        allow_browser_runtime_required: true
+        allow_proxy_runtime_required: true
+        provided: false
+    proxy_browser_network_policy:
+        proxy_policy_required: true
+        browser_policy_required: true
+        rate_limit_policy_required: true
+        retry_policy_required: true
+        user_agent_policy_required: true
+        no_login_paywall_bypass_confirmation_required: true
+        no_anti_bot_bypass_confirmation_required: true
+        no_bulk_expansion_confirmation_required: true
+        provided: false
+    staging_policy:
+        allow_staging_write_required: true
+        output_root_policy_required: true
+        schema_validation_required: true
+        source_manifest_policy_required: true
+        provided: false
+    no_db_training_prediction_policy:
+        no_db_write_confirmation_required: true
+        no_training_confirmation_required: true
+        no_prediction_confirmation_required: true
+        no_model_artifact_loading_confirmation_required: true
+        provided: false
+    final_human_confirmation:
+        required: true
+        provided: false
+        confirmed_by:
+
+input_blocking_reasons:
+    - real_target_source_missing
+    - real_single_target_scope_missing
+    - source_terms_missing
+    - network_authorization_missing
+    - proxy_browser_network_policy_missing
+    - staging_policy_missing
+    - no_db_training_prediction_confirmation_missing
+    - final_human_confirmation_missing
+
+included_artifacts:
+    approval_packet: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md
+    execution_plan: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md
+    readiness_checklist: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md
+    pre_network_runbook: docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md
+    network_auth_form: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_user_input_closure_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+next_phase_requirements:
+    - user_supplied_real_target_source
+    - user_supplied_real_single_target_scope
+    - user_supplied_terms_url
+    - user_supplied_license_url
+    - user_confirmed_allowed_use
+    - user_confirmed_network_dry_run_authorization
+    - user_confirmed_external_network_policy
+    - user_confirmed_browser_proxy_policy
+    - user_confirmed_staging_policy
+    - user_confirmed_no_db_write
+    - user_confirmed_no_training
+    - user_confirmed_no_prediction
+    - user_final_human_confirmation
+```
+
+## Purpose
+
+This template closes the list of real user inputs required before any future
+single-target acquisition network dry-run can be proposed.
+
+It does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- approval packet file writes
+- user input closure file writes
+- DB writes
+- training
+- prediction
+
+## Required User Inputs
+
+A future real network dry-run cannot continue without all of the following:
+
+- real target source
+- real single-target scope
+- source terms, license, and allowed-use review
+- explicit network dry-run authorization
+- explicit browser, proxy, and external network authorization
+- explicit staging policy
+- explicit no-DB-write, no-training, and no-prediction confirmation
+- final human confirmation
+
+Codex cannot supply or infer these values for the user. CLI `yes` values in
+Phase 4.88D do not authorize execution and do not complete the inputs.
+
+## Preview-only Guardrails
+
+- `closure_status` must remain `closure_preview_only`
+- `user_inputs_complete` must remain `false`
+- `network_dry_run_authorized` must remain `false`
+- `network_dry_run_execution_allowed` must remain `false`
+- `human_approval_packet_ready` must remain `false`
+- every `required_user_inputs.*.provided` value must remain `false`
+- every safety `would_*` value must remain `false`
+- every blocking reason must remain listed
+
+Changing any of the above does not authorize execution inside Phase 4.88D.
+Future network dry-run execution must happen in a separate phase with explicit
+user-supplied real parameters, reviewed terms, network authorization, staging
+policy, no-DB/no-training/no-prediction confirmation, and final human approval.

--- a/scripts/ops/single_target_acquisition_network_user_input_requirements_closure.js
+++ b/scripts/ops/single_target_acquisition_network_user_input_requirements_closure.js
@@ -1,0 +1,645 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    runValidation: runApprovalPacketValidation,
+    parseApprovalPacketYaml: parseClosureYaml,
+} = require('./single_target_acquisition_network_approval_packet_preview');
+
+const OUTPUT_PHASE = 'PHASE4.88D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE';
+const TEMPLATE_PHASE = 'PHASE4_88D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE';
+const MODE = 'single-target-acquisition-network-user-input-requirements-closure-preview';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition network dry-run user input requirements closure execution is not wired in Phase 4.88D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.89D or explicit user-supplied network dry-run parameters';
+
+const REQUIRED_CLI_FIELDS = words(`
+    input_closure approval_packet execution_plan checklist runbook auth_form
+    target_source target_engine_family target_scope_type target_match_id
+    terms_approval network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const YES_NO_FIELDS = words(`
+    terms_approval network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const REQUIRED_TOP_FIELDS = words(`
+    phase closure_status user_inputs_complete network_dry_run_authorized
+    network_dry_run_execution_allowed human_approval_packet_ready
+    staging_write_authorized db_write_authorized training_authorized
+    prediction_authorized final_human_confirmation required_user_inputs
+    input_blocking_reasons included_artifacts safety next_phase_requirements
+`);
+
+const REQUIRED_INPUT_SECTIONS = {
+    real_target_source: words('required provided value'),
+    real_target_scope: words(`
+        required provided scope_type target_match_id target_league target_season
+        target_date max_targets bulk_scope_allowed
+    `),
+    source_terms: words(`
+        terms_url_required license_url_required allowed_use_required
+        terms_review_required terms_approval_required provided
+    `),
+    network_authorization: words(`
+        network_dry_run_authorization_required allow_external_network_required
+        allow_browser_runtime_required allow_proxy_runtime_required provided
+    `),
+    proxy_browser_network_policy: words(`
+        proxy_policy_required browser_policy_required rate_limit_policy_required
+        retry_policy_required user_agent_policy_required
+        no_login_paywall_bypass_confirmation_required
+        no_anti_bot_bypass_confirmation_required
+        no_bulk_expansion_confirmation_required provided
+    `),
+    staging_policy: words(`
+        allow_staging_write_required output_root_policy_required
+        schema_validation_required source_manifest_policy_required provided
+    `),
+    no_db_training_prediction_policy: words(`
+        no_db_write_confirmation_required no_training_confirmation_required
+        no_prediction_confirmation_required
+        no_model_artifact_loading_confirmation_required provided
+    `),
+    final_human_confirmation: words('required provided confirmed_by'),
+};
+
+const INPUT_GROUP_NAMES = Object.keys(REQUIRED_INPUT_SECTIONS);
+
+const REQUIRED_BOOLEAN_TRUE_FIELDS = {
+    real_target_source: words('required'),
+    real_target_scope: words('required'),
+    source_terms: words(`
+        terms_url_required license_url_required allowed_use_required
+        terms_review_required terms_approval_required
+    `),
+    network_authorization: words(`
+        network_dry_run_authorization_required allow_external_network_required
+        allow_browser_runtime_required allow_proxy_runtime_required
+    `),
+    proxy_browser_network_policy: words(`
+        proxy_policy_required browser_policy_required rate_limit_policy_required
+        retry_policy_required user_agent_policy_required
+        no_login_paywall_bypass_confirmation_required
+        no_anti_bot_bypass_confirmation_required
+        no_bulk_expansion_confirmation_required
+    `),
+    staging_policy: words(`
+        allow_staging_write_required output_root_policy_required
+        schema_validation_required source_manifest_policy_required
+    `),
+    no_db_training_prediction_policy: words(`
+        no_db_write_confirmation_required no_training_confirmation_required
+        no_prediction_confirmation_required
+        no_model_artifact_loading_confirmation_required
+    `),
+    final_human_confirmation: words('required'),
+};
+
+const TOP_FALSE = {
+    user_inputs_complete: 'user_inputs_complete true in template is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true in template is not allowed',
+    human_approval_packet_ready: 'human_approval_packet_ready true in template is not allowed',
+    staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+    db_write_authorized: 'db_write_authorized true in template is not allowed',
+    training_authorized: 'training_authorized true in template is not allowed',
+    prediction_authorized: 'prediction_authorized true in template is not allowed',
+    final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+};
+
+const SAFETY_FIELDS = words(`
+    would_access_network would_launch_browser would_use_proxy would_execute_engine
+    would_write_staging would_create_staging_directory would_write_source_manifest
+    would_write_packet_file would_write_approval_packet_file
+    would_write_user_input_closure_file would_write_db would_train would_predict
+    would_bulk_harvest
+`);
+
+const EXPECTED_ARTIFACTS = {
+    approval_packet: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md',
+    execution_plan: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md',
+    readiness_checklist:
+        'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md',
+    pre_network_runbook: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md',
+    network_auth_form: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md',
+};
+
+const REQUIRED_BLOCKING_REASONS = words(`
+    real_target_source_missing real_single_target_scope_missing
+    source_terms_missing network_authorization_missing
+    proxy_browser_network_policy_missing staging_policy_missing
+    no_db_training_prediction_confirmation_missing final_human_confirmation_missing
+`);
+
+const REQUIRED_NEXT_PHASE_REQUIREMENTS = words(`
+    user_supplied_real_target_source user_supplied_real_single_target_scope
+    user_supplied_terms_url user_supplied_license_url user_confirmed_allowed_use
+    user_confirmed_network_dry_run_authorization
+    user_confirmed_external_network_policy user_confirmed_browser_proxy_policy
+    user_confirmed_staging_policy user_confirmed_no_db_write
+    user_confirmed_no_training user_confirmed_no_prediction
+    user_final_human_confirmation
+`);
+
+const MISSING_USER_INPUTS = [
+    'real_target_source',
+    'real_single_target_scope',
+    'source_terms',
+    'network_authorization',
+    'proxy_browser_network_policy',
+    'staging_policy',
+    'no_db_training_prediction_policy',
+    'final_human_confirmation',
+];
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_user_input_requirements_closure.js --input-closure <path> --approval-packet <path> --execution-plan <path> --checklist <path> --runbook <path> --auth-form <path> --target-source <src> --target-engine-family titan_discovery --target-scope-type match_id --target-match-id <id> --terms-approval no --network-dry-run-authorization no --allow-browser-runtime no --allow-proxy-runtime no --allow-external-network no --allow-staging-write no --final-human-confirmation no',
+        '  node scripts/ops/single_target_acquisition_network_user_input_requirements_closure.js --input-closure <path> ... --commit',
+        '',
+        'Safety:',
+        '  Phase 4.88D previews local user input requirements only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        input_closure: '',
+        approval_packet: '',
+        execution_plan: '',
+        checklist: '',
+        runbook: '',
+        auth_form: '',
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        input_requirements_closure_preview_only: true,
+        input_closure_valid: false,
+        approval_packet_valid: false,
+        execution_plan_valid: false,
+        readiness_checklist_valid: false,
+        runbook_template_valid: false,
+        auth_form_template_valid: false,
+        user_inputs_complete: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        human_approval_packet_ready: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        missing_user_inputs: MISSING_USER_INPUTS,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_user_input_closure_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: OUTPUT_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        input_closure: args.input_closure || null,
+        approval_packet: args.approval_packet || null,
+        execution_plan: args.execution_plan || null,
+        checklist: args.checklist || null,
+        runbook: args.runbook || null,
+        auth_form: args.auth_form || null,
+        input_closure_found: false,
+        approval_packet_found: false,
+        execution_plan_found: false,
+        checklist_found: false,
+        runbook_found: false,
+        auth_form_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_approval_packet_file_writes',
+            'no_user_input_closure_file_writes',
+        ],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function validateRequiredCliFields(args) {
+    return REQUIRED_CLI_FIELDS.flatMap(field => {
+        if (args[field]) return [];
+        if (field === 'input_closure') return ['missing input closure'];
+        if (field === 'approval_packet') return ['missing approval packet'];
+        if (field === 'execution_plan') return ['missing execution plan'];
+        if (field === 'checklist') return ['missing checklist'];
+        if (field === 'runbook') return ['missing runbook'];
+        if (field === 'auth_form') return ['missing auth form'];
+        return [`missing ${field.replace(/_/g, ' ')} path or value`];
+    });
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = validateRequiredCliFields(args);
+    YES_NO_FIELDS.forEach(field => {
+        if (args[field] !== 'yes' && args[field] !== 'no') {
+            errors.push(`--${field.replace(/_/g, '-')} is required (yes/no)`);
+        }
+    });
+    if (args.target_engine_family && args.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${args.target_engine_family}"`);
+    }
+    if (
+        args.target_scope_type &&
+        args.target_scope_type !== 'match_id' &&
+        args.target_scope_type !== 'league_season_date'
+    ) {
+        errors.push(`unsupported scope type "${args.target_scope_type}"`);
+    }
+    if (args.target_scope_type === 'bulk') errors.push('unsupported scope type bulk');
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function loadClosureYaml(args, dependencies) {
+    const targetPath = resolveLocalPath(args.input_closure, dependencies.cwd);
+    if (!dependencies.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'input-closure-error',
+                input_closure_found: false,
+                errors: [`missing input closure: ${toRelativePath(targetPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+
+    const yamlText = extractYamlBlock(dependencies.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'input-closure-error',
+                input_closure_found: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseClosureYaml(yamlText), yamlText };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'input-closure-error',
+                input_closure_found: true,
+                yaml_block_found: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function addMissingNested(root, parentKey, requiredKeys, missingFields) {
+    const value = root[parentKey];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        requiredKeys.forEach(key => missingFields.push(`${parentKey}.${key}`));
+        return;
+    }
+    requiredKeys
+        .filter(key => !Object.prototype.hasOwnProperty.call(value, key))
+        .forEach(key => missingFields.push(`${parentKey}.${key}`));
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_FIELDS.filter(key => !Object.prototype.hasOwnProperty.call(parsedYaml, key));
+    const inputs = parsedYaml.required_user_inputs || {};
+    Object.entries(REQUIRED_INPUT_SECTIONS).forEach(([sectionName, requiredKeys]) => {
+        addMissingNested(inputs, sectionName, requiredKeys, missingFields);
+    });
+    addMissingNested(parsedYaml, 'included_artifacts', Object.keys(EXPECTED_ARTIFACTS), missingFields);
+    addMissingNested(parsedYaml, 'safety', SAFETY_FIELDS, missingFields);
+    return missingFields;
+}
+
+function ensureArrayContainsAll(root, key, requiredValues, errors, missingMessage) {
+    const value = root[key];
+    if (!Array.isArray(value)) {
+        errors.push(missingMessage || `${key} missing`);
+        return;
+    }
+    requiredValues
+        .filter(requiredValue => !value.includes(requiredValue))
+        .forEach(requiredValue => errors.push(`${key} missing required value "${requiredValue}"`));
+}
+
+function ensureObjectValues(root, parentKey, expectedValues, errors) {
+    const parent = root[parentKey] || {};
+    Object.entries(expectedValues).forEach(([fieldName, expectedValue]) => {
+        if (parent[fieldName] !== expectedValue) {
+            errors.push(`${parentKey}.${fieldName} must be ${expectedValue}`);
+        }
+    });
+}
+
+function validateRequiredInputSections(parsedYaml, errors) {
+    const inputs = parsedYaml.required_user_inputs || {};
+    INPUT_GROUP_NAMES.forEach(sectionName => {
+        const section = inputs[sectionName];
+        if (!section || typeof section !== 'object' || Array.isArray(section)) {
+            errors.push(`required_user_inputs.${sectionName} missing`);
+            return;
+        }
+        if (section.provided !== false) {
+            errors.push(`required_user_inputs.${sectionName}.provided true in template is not allowed`);
+        }
+        (REQUIRED_BOOLEAN_TRUE_FIELDS[sectionName] || []).forEach(fieldName => {
+            if (section[fieldName] !== true) {
+                errors.push(`required_user_inputs.${sectionName}.${fieldName} must be true`);
+            }
+        });
+    });
+
+    const targetScope = inputs.real_target_scope || {};
+    if (targetScope.bulk_scope_allowed !== false) {
+        errors.push('bulk scope allowed must remain false in the Phase 4.88D template');
+    }
+    if (targetScope.max_targets !== 1) {
+        errors.push('max_targets > 1 is not allowed in the Phase 4.88D template');
+    }
+}
+
+function validateSafety(parsedYaml, errors) {
+    const safety = parsedYaml.safety || {};
+    SAFETY_FIELDS.forEach(fieldName => {
+        if (safety[fieldName] !== false) {
+            errors.push(`safety.${fieldName} must remain false`);
+        }
+    });
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) errors.push(`missing required fields: ${missingFields.join(',')}`);
+    if (parsedYaml.phase !== TEMPLATE_PHASE) errors.push(`phase must be ${TEMPLATE_PHASE}`);
+    if (parsedYaml.closure_status !== 'closure_preview_only') {
+        errors.push('closure_status must remain closure_preview_only in the Phase 4.88D template');
+    }
+    Object.entries(TOP_FALSE).forEach(([fieldName, message]) => {
+        if (parsedYaml[fieldName] !== false) errors.push(message);
+    });
+    validateRequiredInputSections(parsedYaml, errors);
+    ensureObjectValues(parsedYaml, 'included_artifacts', EXPECTED_ARTIFACTS, errors);
+    validateSafety(parsedYaml, errors);
+    ensureArrayContainsAll(
+        parsedYaml,
+        'input_blocking_reasons',
+        REQUIRED_BLOCKING_REASONS,
+        errors,
+        'input_blocking_reasons missing'
+    );
+    ensureArrayContainsAll(parsedYaml, 'next_phase_requirements', REQUIRED_NEXT_PHASE_REQUIREMENTS, errors);
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function validateTargetConsistency(args, closureYaml, approvalPacketPayload) {
+    const inputs = closureYaml.required_user_inputs || {};
+    const source = inputs.real_target_source || {};
+    const scope = inputs.real_target_scope || {};
+    const candidates = [
+        ['required_user_inputs.real_target_source.value', source.value, args.target_source],
+        ['required_user_inputs.real_target_scope.scope_type', scope.scope_type, args.target_scope_type],
+        ['required_user_inputs.real_target_scope.target_match_id', scope.target_match_id, args.target_match_id],
+        ['required_user_inputs.real_target_scope.target_league', scope.target_league, args.target_league],
+        ['required_user_inputs.real_target_scope.target_season', scope.target_season, args.target_season],
+        ['required_user_inputs.real_target_scope.target_date', scope.target_date, args.target_date],
+    ];
+    const errors = candidates
+        .filter(([, templateValue, cliValue]) => templateValue && templateValue !== cliValue)
+        .map(
+            ([label, templateValue, cliValue]) =>
+                `target mismatch: input closure ${label} "${templateValue}" does not match CLI value "${cliValue}"`
+        );
+    if (approvalPacketPayload.errors && approvalPacketPayload.errors.some(error => /target mismatch/i.test(error))) {
+        errors.push(...approvalPacketPayload.errors);
+    }
+    return errors;
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: OUTPUT_PHASE,
+        mode: MODE,
+        ok: true,
+        input_closure: args.input_closure,
+        approval_packet: args.approval_packet,
+        execution_plan: args.execution_plan,
+        checklist: args.checklist,
+        runbook: args.runbook,
+        auth_form: args.auth_form,
+        input_closure_found: true,
+        approval_packet_found: true,
+        execution_plan_found: true,
+        checklist_found: true,
+        runbook_found: true,
+        auth_form_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        input_closure_valid: true,
+        approval_packet_valid: true,
+        execution_plan_valid: true,
+        readiness_checklist_valid: true,
+        runbook_template_valid: true,
+        auth_form_template_valid: true,
+        errors: [],
+        warnings: [
+            'Phase 4.88D remains closure-preview-only.',
+            'CLI authorization yes values do not complete user inputs or authorize execution in this phase.',
+        ],
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_approval_packet_file_writes',
+            'no_user_input_closure_file_writes',
+        ],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const localDeps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const closureLoad = loadClosureYaml(args, localDeps);
+    if (closureLoad.payload) return closureLoad.payload;
+
+    const closureValidation = validateParsedYaml(closureLoad.parsedYaml);
+    if (!closureValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'input-closure-error',
+            input_closure_found: true,
+            yaml_block_found: true,
+            required_fields_present: closureValidation.missingFields.length === 0,
+            missing_fields: closureValidation.missingFields,
+            errors: closureValidation.errors,
+        });
+    }
+
+    const approvalPacketPayload = runApprovalPacketValidation(args, localDeps);
+    if (!approvalPacketPayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'approval-packet-error',
+            input_closure_found: true,
+            yaml_block_found: true,
+            input_closure_valid: true,
+            errors: approvalPacketPayload.errors,
+        });
+    }
+
+    const targetErrors = validateTargetConsistency(args, closureLoad.parsedYaml, approvalPacketPayload);
+    if (targetErrors.length) {
+        return buildFailurePayload(args, {
+            mode: 'target-error',
+            input_closure_found: true,
+            approval_packet_found: true,
+            execution_plan_found: true,
+            checklist_found: true,
+            runbook_found: true,
+            auth_form_found: true,
+            yaml_block_found: true,
+            required_fields_present: true,
+            input_closure_valid: true,
+            approval_packet_valid: true,
+            execution_plan_valid: true,
+            readiness_checklist_valid: true,
+            runbook_template_valid: true,
+            auth_form_template_valid: true,
+            errors: targetErrors,
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(payload, io) {
+    io.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (text => process.stdout.write(text)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [error.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    OUTPUT_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_user_input_requirements_closure.test.js
+++ b/tests/unit/single_target_acquisition_network_user_input_requirements_closure.test.js
@@ -1,0 +1,649 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(
+    PROJECT_ROOT,
+    'scripts/ops/single_target_acquisition_network_user_input_requirements_closure.js'
+);
+const INPUT_CLOSURE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE_TEMPLATE.md'
+);
+const APPROVAL_PACKET_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md'
+);
+const EXECUTION_PLAN_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md'
+);
+const CHECKLIST_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md'
+);
+const RUNBOOK_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md'
+);
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md'
+);
+const INPUT_CLOSURE_TEXT = fs.readFileSync(INPUT_CLOSURE_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        input_closure: INPUT_CLOSURE_PATH,
+        approval_packet: APPROVAL_PACKET_PATH,
+        execution_plan: EXECUTION_PLAN_PATH,
+        checklist: CHECKLIST_PATH,
+        runbook: RUNBOOK_PATH,
+        auth_form: AUTH_FORM_PATH,
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function buildClosureTextDependencies(markdownText) {
+    const targetPath = INPUT_CLOSURE_PATH;
+    return buildDependencies({
+        existsSync: currentPath => currentPath === targetPath || fs.existsSync(currentPath),
+        readFileSync: (currentPath, encoding) => {
+            if (currentPath === targetPath) return markdownText;
+            return fs.readFileSync(currentPath, encoding);
+        },
+    });
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(
+            `${name} should not be called by single_target_acquisition_network_user_input_requirements_closure`
+        );
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) throw new Error(`blocked import: ${request}`);
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(INPUT_CLOSURE_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return INPUT_CLOSURE_TEXT.replace(searchValue, replaceValue);
+}
+
+function replaceInSection(sectionName, searchValue, replaceValue) {
+    const sectionHeader = `    ${sectionName}:\n`;
+    const startIndex = INPUT_CLOSURE_TEXT.indexOf(sectionHeader);
+    assert.notEqual(startIndex, -1, `missing section ${sectionName}`);
+    const nextSectionMatch = INPUT_CLOSURE_TEXT.slice(startIndex + sectionHeader.length).match(
+        /\n {4}[A-Za-z0-9_]+:\n/
+    );
+    const endIndex =
+        nextSectionMatch && typeof nextSectionMatch.index === 'number'
+            ? startIndex + sectionHeader.length + nextSectionMatch.index
+            : INPUT_CLOSURE_TEXT.length;
+    const sectionText = INPUT_CLOSURE_TEXT.slice(startIndex, endIndex);
+    assert.match(sectionText, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return `${INPUT_CLOSURE_TEXT.slice(0, startIndex)}${sectionText.replace(searchValue, replaceValue)}${INPUT_CLOSURE_TEXT.slice(endIndex)}`;
+}
+
+function removeLineFromTemplate(line) {
+    return INPUT_CLOSURE_TEXT.replace(`${line}\n`, '');
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 input closure 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.input_closure;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing input closure/i);
+});
+
+test('缺 approval packet 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.approval_packet;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing approval packet/i);
+});
+
+test('缺 execution plan 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.execution_plan;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing execution plan/i);
+});
+
+test('缺 checklist 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.checklist;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing checklist/i);
+});
+
+test('缺 runbook 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.runbook;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook/i);
+});
+
+test('缺 auth form 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.auth_form;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing auth form/i);
+});
+
+test('input closure 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildClosureTextDependencies('# no yaml\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing YAML block/i);
+});
+
+test('input closure invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildClosureTextDependencies('```yaml\nnot yaml\n```\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /invalid YAML/i);
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(
+            removeLineFromTemplate(
+                'phase: PHASE4_88D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing required fields: phase|phase must be/);
+});
+
+test('closure_status 非 closure_preview_only 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(
+            replaceInTemplate('closure_status: closure_preview_only', 'closure_status: approved')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /closure_preview_only/);
+});
+
+test('user_inputs_complete=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(replaceInTemplate('user_inputs_complete: false', 'user_inputs_complete: true'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /user_inputs_complete true/);
+});
+
+[
+    'real_target_source',
+    'real_target_scope',
+    'source_terms',
+    'network_authorization',
+    'proxy_browser_network_policy',
+    'staging_policy',
+    'no_db_training_prediction_policy',
+    'final_human_confirmation',
+].forEach(sectionName => {
+    test(`required_user_inputs.${sectionName}.provided=true 失败`, () => {
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildClosureTextDependencies(
+                replaceInSection(sectionName, '        provided: false', '        provided: true')
+            )
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), new RegExp(`required_user_inputs.${sectionName}.provided true`));
+    });
+});
+
+[
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'human_approval_packet_ready=true 失败',
+        'human_approval_packet_ready: false',
+        'human_approval_packet_ready: true',
+        /human_approval_packet_ready true/,
+    ],
+    [
+        'staging_write_authorized=true 失败',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    [
+        'db_write_authorized=true 失败',
+        'db_write_authorized: false',
+        'db_write_authorized: true',
+        /db_write_authorized true/,
+    ],
+    [
+        'training_authorized=true 失败',
+        'training_authorized: false',
+        'training_authorized: true',
+        /training_authorized true/,
+    ],
+    [
+        'prediction_authorized=true 失败',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([name, searchValue, replaceValue, pattern]) => {
+    test(name, () => {
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildClosureTextDependencies(replaceInTemplate(searchValue, replaceValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+test('input_blocking_reasons missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(removeLineFromTemplate('    - real_target_source_missing'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(
+        payload.errors.join('\n'),
+        /input_blocking_reasons missing required value|input_blocking_reasons missing/
+    );
+});
+
+test('next_phase_requirements missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(removeLineFromTemplate('    - user_supplied_real_target_source'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(
+        payload.errors.join('\n'),
+        /next_phase_requirements missing required value|next_phase_requirements missing/
+    );
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(
+            replaceInSection(
+                'real_target_scope',
+                '        bulk_scope_allowed: false',
+                '        bulk_scope_allowed: true'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /bulk scope allowed/i);
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(
+            replaceInSection('real_target_scope', '        max_targets: 1', '        max_targets: 2')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+});
+
+test('unsupported engine family 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_engine_family: 'run_production' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported engine family/);
+});
+
+test('unsupported scope type bulk 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_scope_type: 'bulk' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported scope type "bulk"|unsupported scope type bulk/);
+});
+
+test('target mismatch 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildClosureTextDependencies(replaceInSection('real_target_source', '        value:', '        value: other'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /target mismatch/i);
+});
+
+test('valid user input closure preview 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.88D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE');
+    assert.equal(payload.input_requirements_closure_preview_only, true);
+    assert.equal(payload.input_closure_valid, true);
+    assert.equal(payload.approval_packet_valid, true);
+    assert.equal(payload.execution_plan_valid, true);
+    assert.equal(payload.readiness_checklist_valid, true);
+    assert.equal(payload.runbook_template_valid, true);
+    assert.equal(payload.auth_form_template_valid, true);
+    assert.equal(payload.user_inputs_complete, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.human_approval_packet_ready, false);
+    assert.deepEqual(payload.missing_user_inputs, [
+        'real_target_source',
+        'real_single_target_scope',
+        'source_terms',
+        'network_authorization',
+        'proxy_browser_network_policy',
+        'staging_policy',
+        'no_db_training_prediction_policy',
+        'final_human_confirmation',
+    ]);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_approval_packet_file, false);
+    assert.equal(payload.would_write_user_input_closure_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('all CLI yes 仍 no-op / inputs incomplete / not authorized', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs({
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            final_human_confirmation: 'yes',
+        }),
+        buildDependencies()
+    );
+    assert.equal(payload.ok, true);
+    assert.equal(payload.user_inputs_complete, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.human_approval_packet_ready, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_user_input_closure_file, false);
+    assert.equal(payload.would_write_db, false);
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        [
+            '--input-closure',
+            INPUT_CLOSURE_PATH,
+            '--approval-packet',
+            APPROVAL_PACKET_PATH,
+            '--execution-plan',
+            EXECUTION_PLAN_PATH,
+            '--checklist',
+            CHECKLIST_PATH,
+            '--runbook',
+            RUNBOOK_PATH,
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--commit',
+        ],
+        buildDependencies()
+    );
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.88D/);
+});
+
+test('Makefile preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-user-input-closure-preview',
+            'NETWORK_USER_INPUT_CLOSURE_NODE=node',
+            `INPUT_CLOSURE=${INPUT_CLOSURE_PATH}`,
+            `APPROVAL_PACKET=${APPROVAL_PACKET_PATH}`,
+            `EXECUTION_PLAN=${EXECUTION_PLAN_PATH}`,
+            `CHECKLIST=${CHECKLIST_PATH}`,
+            `RUNBOOK=${RUNBOOK_PATH}`,
+            `AUTH_FORM=${AUTH_FORM_PATH}`,
+            'TARGET_SOURCE=fotmob',
+            'TARGET_ENGINE_FAMILY=titan_discovery',
+            'TARGET_SCOPE_TYPE=match_id',
+            'TARGET_MATCH_ID=sample-match-001',
+            'TERMS_APPROVAL=no',
+            'NETWORK_DRY_RUN_AUTHORIZATION=no',
+            'ALLOW_BROWSER_RUNTIME=no',
+            'ALLOW_PROXY_RUNTIME=no',
+            'ALLOW_EXTERNAL_NETWORK=no',
+            'ALLOW_STAGING_WRITE=no',
+            'FINAL_HUMAN_CONFIRMATION=no',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.input_closure_valid, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-user-input-closure-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.88D/);
+});
+
+[
+    ['不访问网络', 'would_access_network', false],
+    ['不启动 browser', 'would_launch_browser', false],
+    ['不执行 proxy runtime', 'would_use_proxy', false],
+    ['不执行 engine', 'would_execute_engine', false],
+    ['不写 staging', 'would_write_staging', false],
+    ['不创建目录', 'would_create_staging_directory', false],
+    ['不写 source manifest', 'would_write_source_manifest', false],
+    ['不写 packet file', 'would_write_packet_file', false],
+    ['不写 approval packet file', 'would_write_approval_packet_file', false],
+    ['不写 user input closure file', 'would_write_user_input_closure_file', false],
+    ['不写 DB', 'would_write_db', false],
+    ['不 spawn child process', 'would_spawn_child_process', false],
+].forEach(([name, field, expected]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], expected);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.88D single-target acquisition network dry-run user input requirements closure.

Scope:
- Adds user input requirements closure template
- Adds local-only user input closure preview validator
- Validates user inputs remain incomplete and non-authorized
- Validates approval packet, execution plan, readiness checklist, runbook, and auth form templates remain non-authorized
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.88D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No approval packet file writes
- No user input closure file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- preview missing params failed as expected
- valid user input closure preview passed
- all-yes CLI remained no-op / inputs incomplete / not authorized
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed