### PR TITLE
docs(data): add single-target network blocked preflight summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、只验证 execution plan draft + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-execution-plan-validate EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.86D draft-only）
 - 不触网、不写文件、不创建目录、只预览 human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-approval-packet-preview APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.87D preview-only）
 - 不触网、不写文件、不创建目录、只预览 user input requirements closure + human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-user-input-closure-preview INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.88D closure-preview-only）
+- 不触网、不写文件、不创建目录、只预览 blocked final preflight summary + user input closure + human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-blocked-final-preflight-summary BLOCKED_SUMMARY=<path> INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.89D blocked-preview-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -795,6 +796,30 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-user-input-closure-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、terms approval、network authorization、runbook / auth form / readiness checklist / execution plan / approval packet 全部审核通过。
+
+### Phase 4.89D: single-target acquisition network dry-run blocked final preflight summary
+
+`data-single-target-acquisition-network-blocked-final-preflight-summary` 只允许预览 blocked final preflight summary：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 approval packet file
+- 它不得写 user input closure file
+- 它不得写 blocked summary file
+- 它不得写 DB
+- blocked final preflight summary 不等于真实 network dry-run authorization
+- Codex 不得自行填写真实 source / target / terms / authorization
+- Codex 不得自行把 blocked 改成 ready
+- 即使 CLI 传入 yes，Phase 4.89D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-blocked-final-preflight-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、terms approval、network authorization、runbook / auth form / readiness checklist / execution plan / approval packet / input closure 全部审核通过。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@
         data-single-target-acquisition-network-execution-plan-validate data-single-target-acquisition-network-execution-plan-commit \
         data-single-target-acquisition-network-approval-packet-preview data-single-target-acquisition-network-approval-packet-commit \
         data-single-target-acquisition-network-user-input-closure-preview data-single-target-acquisition-network-user-input-closure-commit \
+        data-single-target-acquisition-network-blocked-final-preflight-summary data-single-target-acquisition-network-blocked-final-preflight-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -85,6 +86,7 @@ NETWORK_READINESS_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_EXECUTION_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_APPROVAL_PACKET_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_USER_INPUT_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_BLOCKED_PREFLIGHT_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -364,6 +366,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-approval-packet-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_APPROVAL_PACKET=1  # blocked in Phase 4.87D"
 	@echo "  make data-single-target-acquisition-network-user-input-closure-preview INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # closure-preview-only validate, Phase 4.88D"
 	@echo "  make data-single-target-acquisition-network-user-input-closure-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE=1  # blocked in Phase 4.88D"
+	@echo "  make data-single-target-acquisition-network-blocked-final-preflight-summary BLOCKED_SUMMARY=<path> INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # blocked final preflight summary, Phase 4.89D"
+	@echo "  make data-single-target-acquisition-network-blocked-final-preflight-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT=1  # blocked in Phase 4.89D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1180,6 +1184,41 @@ data-single-target-acquisition-network-user-input-closure-commit: ## Blocked net
 	@echo "BLOCKED: single-target acquisition network dry-run user input requirements closure execution is not wired in Phase 4.88D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE=1, this path remains blocked."
 	@echo "  Phase 4.88D previews required user inputs only and does not authorize any network dry-run, staging write, user input closure file write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-blocked-final-preflight-summary: ## Preview-only blocked final preflight summary validation. Phase 4.89D. No network, no writes, no DB.
+	@if [ -z "$(BLOCKED_SUMMARY)" ] || [ -z "$(INPUT_CLOSURE)" ] || [ -z "$(APPROVAL_PACKET)" ] || [ -z "$(EXECUTION_PLAN)" ] || [ -z "$(CHECKLIST)" ] || [ -z "$(RUNBOOK)" ] || [ -z "$(AUTH_FORM)" ] || [ -z "$(TARGET_SOURCE)" ] || [ -z "$(TARGET_ENGINE_FAMILY)" ] || [ -z "$(TARGET_SCOPE_TYPE)" ] || [ -z "$(TARGET_MATCH_ID)" ]; then \
+		echo "ERROR: provide BLOCKED_SUMMARY=<path>, INPUT_CLOSURE=<path>, APPROVAL_PACKET=<path>, EXECUTION_PLAN=<path>, CHECKLIST=<path>, RUNBOOK=<path>, AUTH_FORM=<path>, TARGET_SOURCE=<src>, TARGET_ENGINE_FAMILY=titan_discovery, TARGET_SCOPE_TYPE=<type>, TARGET_MATCH_ID=<id>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.89D: network blocked final preflight summary (preview-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_BLOCKED_PREFLIGHT_NODE) scripts/ops/single_target_acquisition_network_blocked_final_preflight_summary.js \
+		--blocked-summary "$(BLOCKED_SUMMARY)" \
+		--input-closure "$(INPUT_CLOSURE)" \
+		--approval-packet "$(APPROVAL_PACKET)" \
+		--execution-plan "$(EXECUTION_PLAN)" \
+		--checklist "$(CHECKLIST)" \
+		--runbook "$(RUNBOOK)" \
+		--auth-form "$(AUTH_FORM)" \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-engine-family "$(TARGET_ENGINE_FAMILY)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		--target-match-id "$(TARGET_MATCH_ID)" \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-dry-run-authorization "$(or $(NETWORK_DRY_RUN_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-single-target-acquisition-network-blocked-final-preflight-commit: ## Blocked network blocked final preflight gate. Remains not wired in Phase 4.89D.
+	@echo "BLOCKED: single-target acquisition network dry-run blocked final preflight summary execution is not wired in Phase 4.89D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT=1, this path remains blocked."
+	@echo "  Phase 4.89D previews blocked status only and does not authorize any network dry-run, staging write, blocked summary file write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT_PHASE4_89D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT_PHASE4_89D.md
@@ -1,0 +1,158 @@
+# Phase 4.89D: Single-Target Acquisition Network Dry-Run Blocked Final Preflight Summary
+
+**Date**: 2026-05-10
+**Status**: Complete (blocked-preview-only, local-only)
+**Previous phases**: 4.79D, 4.80D, 4.81D, 4.82D, 4.83D, 4.84D, 4.85D, 4.86D, 4.87D, 4.88D
+**Recommended next phase**: Phase 4.90D or Phase 4.56A
+
+---
+
+## 1. Executive Summary
+
+Phase 4.89D is the network dry-run blocked final preflight summary stage for a
+future single-target acquisition network dry-run.
+
+This phase did not:
+
+- access network
+- perform acquisition
+- write DB
+- write staging
+- write packet files
+
+The goal is to summarize Phase 4.79D through Phase 4.88D and make explicit
+that the current flow remains blocked because user-supplied real inputs are
+still missing.
+
+---
+
+## 2. Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_blocked_final_preflight_summary.js`
+- `tests/unit/single_target_acquisition_network_blocked_final_preflight_summary.test.js`
+- `Makefile` targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT_PHASE4_89D.md`
+
+---
+
+## 3. Blocked Summary
+
+The blocked final preflight summary keeps these states:
+
+- `network_dry_run_blocked=true`
+- `network_dry_run_ready=false`
+- `network_dry_run_authorized=false`
+- `network_dry_run_execution_allowed=false`
+- `human_approval_packet_ready=false`
+- `user_inputs_complete=false`
+- `staging_write_authorized=false`
+- `db_write_authorized=false`
+- `final_human_confirmation=false`
+
+Primary blocking reason:
+
+`missing_user_supplied_real_network_dry_run_inputs`
+
+---
+
+## 4. Missing User Inputs
+
+The final preflight remains blocked until a user supplies:
+
+- `real_target_source`
+- `real_single_target_scope`
+- `source_terms`
+- `license_review`
+- `allowed_use_review`
+- `network_authorization`
+- `external_network_policy`
+- `browser_runtime_policy`
+- `proxy_runtime_policy`
+- `staging_policy`
+- `no_db_write_confirmation`
+- `no_training_confirmation`
+- `no_prediction_confirmation`
+- `final_human_confirmation`
+
+Codex must not fill these values and must not escalate authorization on behalf
+of the user.
+
+---
+
+## 5. Relationship to Previous Phases
+
+- 4.79D handles runtime parameter scaffold
+- 4.80D handles artifact / manifest schema validation
+- 4.81D handles writer path / authorization preflight
+- 4.82D handles staging packet preview
+- 4.83D handles pre-network runbook draft
+- 4.84D handles authorization form template
+- 4.85D handles final readiness checklist
+- 4.86D handles execution plan draft
+- 4.87D handles human approval packet preview
+- 4.88D handles user input requirements closure
+- 4.89D handles blocked final preflight summary
+
+All eleven phases remain non-executing. None equals a real network dry-run.
+
+---
+
+## 6. Recommended Next Phase
+
+Recommended:
+
+`Phase 4.90D: single-target acquisition real-parameter intake template`
+
+Goals:
+
+- still no network
+- still no DB writes
+- still no staging writes
+- only define a user-facing intake template for real source, target, terms, and
+  authorization inputs
+
+Alternative:
+
+`Phase 4.56A: 用户给齐真实 network dry-run 参数后才做 runbook`
+
+---
+
+## 7. Explicit Non-Execution
+
+The following were not executed:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl`
+- `wget`
+- `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- approval packet file write
+- user input closure file write
+- blocked summary file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md
@@ -1,0 +1,172 @@
+# Single-Target Acquisition Network Dry-Run Blocked Final Preflight Summary Template
+
+This document is a Phase 4.89D preview-only blocked final preflight summary for
+a future single-target acquisition network dry-run.
+
+- This is a blocked final preflight summary preview, not an approval document.
+- `network_dry_run_blocked=true`
+- `network_dry_run_ready=false`
+- `network_dry_run_authorized=false`
+- `network_dry_run_execution_allowed=false`
+- `user_inputs_complete=false`
+- Codex must not fill real source, target, terms, or authorization values for
+  the user.
+- Codex must not change this summary from blocked to ready on its own.
+- Phase 4.89D does not write a blocked summary runtime file. It only validates
+  this template and produces a local stdout preview.
+- A real network dry-run must move to a later, separately authorized phase
+  after the user supplies all real parameters.
+
+```yaml
+phase: PHASE4_89D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY
+summary_status: blocked_preview_only
+network_dry_run_blocked: true
+network_dry_run_ready: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+human_approval_packet_ready: false
+user_inputs_complete: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+blocking_summary:
+    primary_reason: missing_user_supplied_real_network_dry_run_inputs
+    cannot_continue_without_user_inputs: true
+    codex_may_not_self_fill_inputs: true
+    codex_may_not_escalate_authorization: true
+    requires_future_separate_phase: true
+
+target:
+    target_source:
+    target_engine_family: titan_discovery
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+    max_targets: 1
+    bulk_scope_allowed: false
+
+missing_user_inputs:
+    - real_target_source
+    - real_single_target_scope
+    - source_terms
+    - license_review
+    - allowed_use_review
+    - network_authorization
+    - external_network_policy
+    - browser_runtime_policy
+    - proxy_runtime_policy
+    - staging_policy
+    - no_db_write_confirmation
+    - no_training_confirmation
+    - no_prediction_confirmation
+    - final_human_confirmation
+
+included_chain:
+    runtime_scaffold: scripts/ops/single_target_acquisition_runtime_scaffold.js
+    staging_schema_validator: scripts/ops/single_target_acquisition_staging_schema_validator.js
+    staging_writer_preflight: scripts/ops/single_target_acquisition_staging_writer_preflight.js
+    staging_packet_preview: scripts/ops/single_target_acquisition_staging_packet_preview.js
+    pre_network_runbook: docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md
+    network_auth_form: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md
+    final_readiness_checklist: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md
+    execution_plan: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md
+    human_approval_packet: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md
+    user_input_closure: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE_TEMPLATE.md
+
+gate_statuses:
+    runtime_scaffold_available: true
+    staging_schema_validator_available: true
+    staging_writer_preflight_available: true
+    staging_packet_preview_available: true
+    pre_network_runbook_available: true
+    network_auth_form_available: true
+    final_readiness_checklist_available: true
+    execution_plan_available: true
+    human_approval_packet_available: true
+    user_input_closure_available: true
+    all_runtime_execution_gates_blocked: true
+    all_write_gates_blocked: true
+    all_authorization_gates_false: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_execute_legacy_titan_discovery: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_user_input_closure_file: false
+    would_write_blocked_summary_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+allowed_next_steps:
+    - remain_blocked
+    - user_provides_real_single_target_network_dry_run_inputs
+    - future_separate_phase_validates_user_inputs
+    - future_separate_phase_reviews_terms_and_authorization
+
+forbidden_next_steps:
+    - codex_self_fills_real_source
+    - codex_self_fills_real_target
+    - codex_self_approves_terms
+    - codex_self_authorizes_network
+    - codex_executes_network_dry_run
+    - codex_writes_staging
+    - codex_writes_db
+    - codex_trains_or_predicts
+```
+
+## Purpose
+
+This template summarizes the blocked state of Phase 4.79D through Phase 4.88D.
+It records that the system is not ready, not authorized, and cannot proceed
+because user-supplied real network dry-run inputs are still missing.
+
+It does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- legacy `titan_discovery` runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- approval packet file writes
+- user input closure file writes
+- blocked summary runtime file writes
+- DB writes
+- training
+- prediction
+
+## Blocked Guardrails
+
+- `summary_status` must remain `blocked_preview_only`
+- `network_dry_run_blocked` must remain `true`
+- `network_dry_run_ready` must remain `false`
+- `network_dry_run_authorized` must remain `false`
+- `network_dry_run_execution_allowed` must remain `false`
+- `user_inputs_complete` must remain `false`
+- every safety `would_*` value must remain `false`
+- every missing user input must remain listed
+
+Codex cannot supply or infer real source, target, terms, license review,
+allowed-use review, network authorization, staging policy, or final human
+confirmation for the user. CLI `yes` values in Phase 4.89D do not authorize
+execution and do not change the blocked status.
+
+Future network dry-run execution must happen in a separate phase with explicit
+user-supplied real parameters, reviewed terms, network authorization, staging
+policy, no-DB/no-training/no-prediction confirmation, and final human approval.

--- a/scripts/ops/single_target_acquisition_network_blocked_final_preflight_summary.js
+++ b/scripts/ops/single_target_acquisition_network_blocked_final_preflight_summary.js
@@ -1,0 +1,644 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    parseApprovalPacketYaml: parseBlockedSummaryYaml,
+} = require('./single_target_acquisition_network_approval_packet_preview');
+const {
+    runValidation: runUserInputClosureValidation,
+} = require('./single_target_acquisition_network_user_input_requirements_closure');
+
+const OUTPUT_PHASE = 'PHASE4.89D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY';
+const TEMPLATE_PHASE = 'PHASE4_89D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY';
+const MODE = 'single-target-acquisition-network-blocked-final-preflight-summary';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition network dry-run blocked final preflight summary execution is not wired in Phase 4.89D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.90D or explicit user-supplied network dry-run parameters';
+const PRIMARY_BLOCKING_REASON = 'missing_user_supplied_real_network_dry_run_inputs';
+
+const REQUIRED_CLI_FIELDS = words(`
+    blocked_summary input_closure approval_packet execution_plan checklist
+    runbook auth_form target_source target_engine_family target_scope_type
+    target_match_id terms_approval network_dry_run_authorization
+    allow_browser_runtime allow_proxy_runtime allow_external_network
+    allow_staging_write final_human_confirmation
+`);
+
+const YES_NO_FIELDS = words(`
+    terms_approval network_dry_run_authorization allow_browser_runtime
+    allow_proxy_runtime allow_external_network allow_staging_write
+    final_human_confirmation
+`);
+
+const REQUIRED_TOP_FIELDS = words(`
+    phase summary_status network_dry_run_blocked network_dry_run_ready
+    network_dry_run_authorized network_dry_run_execution_allowed
+    human_approval_packet_ready user_inputs_complete staging_write_authorized
+    db_write_authorized training_authorized prediction_authorized
+    final_human_confirmation blocking_summary target missing_user_inputs
+    included_chain gate_statuses safety allowed_next_steps forbidden_next_steps
+`);
+
+const BLOCKING_SUMMARY_FIELDS = words(`
+    primary_reason cannot_continue_without_user_inputs
+    codex_may_not_self_fill_inputs codex_may_not_escalate_authorization
+    requires_future_separate_phase
+`);
+
+const TARGET_FIELDS = words(`
+    target_source target_engine_family target_scope_type target_match_id
+    target_league target_season target_date max_targets bulk_scope_allowed
+`);
+
+const SAFETY_FIELDS = words(`
+    would_access_network would_launch_browser would_use_proxy
+    would_execute_engine would_execute_legacy_titan_discovery
+    would_write_staging would_create_staging_directory
+    would_write_source_manifest would_write_packet_file
+    would_write_approval_packet_file would_write_user_input_closure_file
+    would_write_blocked_summary_file would_write_db would_train
+    would_predict would_bulk_harvest
+`);
+
+const TOP_FALSE = {
+    network_dry_run_ready: 'network_dry_run_ready true in template is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true in template is not allowed',
+    human_approval_packet_ready: 'human_approval_packet_ready true in template is not allowed',
+    user_inputs_complete: 'user_inputs_complete true in template is not allowed',
+    staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+    db_write_authorized: 'db_write_authorized true in template is not allowed',
+    training_authorized: 'training_authorized true in template is not allowed',
+    prediction_authorized: 'prediction_authorized true in template is not allowed',
+    final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+};
+
+const REQUIRED_MISSING_USER_INPUTS = [
+    'real_target_source',
+    'real_single_target_scope',
+    'source_terms',
+    'license_review',
+    'allowed_use_review',
+    'network_authorization',
+    'external_network_policy',
+    'browser_runtime_policy',
+    'proxy_runtime_policy',
+    'staging_policy',
+    'no_db_write_confirmation',
+    'no_training_confirmation',
+    'no_prediction_confirmation',
+    'final_human_confirmation',
+];
+
+const EXPECTED_INCLUDED_CHAIN = {
+    runtime_scaffold: 'scripts/ops/single_target_acquisition_runtime_scaffold.js',
+    staging_schema_validator: 'scripts/ops/single_target_acquisition_staging_schema_validator.js',
+    staging_writer_preflight: 'scripts/ops/single_target_acquisition_staging_writer_preflight.js',
+    staging_packet_preview: 'scripts/ops/single_target_acquisition_staging_packet_preview.js',
+    pre_network_runbook: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md',
+    network_auth_form: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md',
+    final_readiness_checklist:
+        'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md',
+    execution_plan: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md',
+    human_approval_packet: 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md',
+    user_input_closure:
+        'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE_TEMPLATE.md',
+};
+
+const GATE_STATUS_FIELDS = words(`
+    runtime_scaffold_available staging_schema_validator_available
+    staging_writer_preflight_available staging_packet_preview_available
+    pre_network_runbook_available network_auth_form_available
+    final_readiness_checklist_available execution_plan_available
+    human_approval_packet_available user_input_closure_available
+    all_runtime_execution_gates_blocked all_write_gates_blocked
+    all_authorization_gates_false
+`);
+
+const REQUIRED_ALLOWED_NEXT_STEPS = words(`
+    remain_blocked user_provides_real_single_target_network_dry_run_inputs
+    future_separate_phase_validates_user_inputs
+    future_separate_phase_reviews_terms_and_authorization
+`);
+
+const REQUIRED_FORBIDDEN_NEXT_STEPS = words(`
+    codex_self_fills_real_source codex_self_fills_real_target
+    codex_self_approves_terms codex_self_authorizes_network
+    codex_executes_network_dry_run codex_writes_staging
+    codex_writes_db codex_trains_or_predicts
+`);
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_blocked_final_preflight_summary.js --blocked-summary <path> --input-closure <path> --approval-packet <path> --execution-plan <path> --checklist <path> --runbook <path> --auth-form <path> --target-source <src> --target-engine-family titan_discovery --target-scope-type match_id --target-match-id <id> --terms-approval no --network-dry-run-authorization no --allow-browser-runtime no --allow-proxy-runtime no --allow-external-network no --allow-staging-write no --final-human-confirmation no',
+        '  node scripts/ops/single_target_acquisition_network_blocked_final_preflight_summary.js --blocked-summary <path> ... --commit',
+        '',
+        'Safety:',
+        '  Phase 4.89D previews a local blocked final preflight summary only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        blocked_summary: '',
+        input_closure: '',
+        approval_packet: '',
+        execution_plan: '',
+        checklist: '',
+        runbook: '',
+        auth_form: '',
+        commit: false,
+        help: false,
+    };
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) throw new Error(`Unknown argument: ${token}`);
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        blocked_final_preflight_summary_preview_only: true,
+        blocked_summary_valid: false,
+        input_closure_valid: false,
+        approval_packet_valid: false,
+        execution_plan_valid: false,
+        readiness_checklist_valid: false,
+        runbook_template_valid: false,
+        auth_form_template_valid: false,
+        network_dry_run_blocked: true,
+        network_dry_run_ready: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        human_approval_packet_ready: false,
+        user_inputs_complete: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        primary_blocking_reason: PRIMARY_BLOCKING_REASON,
+        missing_user_inputs: REQUIRED_MISSING_USER_INPUTS,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_execute_legacy_titan_discovery: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_user_input_closure_file: false,
+        would_write_blocked_summary_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: OUTPUT_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        blocked_summary: args.blocked_summary || null,
+        input_closure: args.input_closure || null,
+        approval_packet: args.approval_packet || null,
+        execution_plan: args.execution_plan || null,
+        checklist: args.checklist || null,
+        runbook: args.runbook || null,
+        auth_form: args.auth_form || null,
+        blocked_summary_found: false,
+        input_closure_found: false,
+        approval_packet_found: false,
+        execution_plan_found: false,
+        checklist_found: false,
+        runbook_found: false,
+        auth_form_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_legacy_titan_discovery_execution',
+            'no_approval_packet_file_writes',
+            'no_user_input_closure_file_writes',
+            'no_blocked_summary_file_writes',
+        ],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function validateRequiredCliFields(args) {
+    return REQUIRED_CLI_FIELDS.flatMap(field => {
+        if (args[field]) return [];
+        if (field === 'blocked_summary') return ['missing blocked summary'];
+        if (field === 'input_closure') return ['missing input closure'];
+        if (field === 'approval_packet') return ['missing approval packet'];
+        if (field === 'execution_plan') return ['missing execution plan'];
+        if (field === 'checklist') return ['missing checklist'];
+        if (field === 'runbook') return ['missing runbook'];
+        if (field === 'auth_form') return ['missing auth form'];
+        return [`missing ${field.replace(/_/g, ' ')} path or value`];
+    });
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = validateRequiredCliFields(args);
+    YES_NO_FIELDS.forEach(field => {
+        if (args[field] !== 'yes' && args[field] !== 'no') {
+            errors.push(`--${field.replace(/_/g, '-')} is required (yes/no)`);
+        }
+    });
+    if (args.target_engine_family && args.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${args.target_engine_family}"`);
+    }
+    if (
+        args.target_scope_type &&
+        args.target_scope_type !== 'match_id' &&
+        args.target_scope_type !== 'league_season_date'
+    ) {
+        errors.push(`unsupported scope type "${args.target_scope_type}"`);
+    }
+    if (args.target_scope_type === 'bulk') errors.push('unsupported scope type bulk');
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function loadBlockedSummaryYaml(args, dependencies) {
+    const targetPath = resolveLocalPath(args.blocked_summary, dependencies.cwd);
+    if (!dependencies.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'blocked-summary-error',
+                blocked_summary_found: false,
+                errors: [`missing blocked summary: ${toRelativePath(targetPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+
+    const yamlText = extractYamlBlock(dependencies.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'blocked-summary-error',
+                blocked_summary_found: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseBlockedSummaryYaml(yamlText), yamlText };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode: 'blocked-summary-error',
+                blocked_summary_found: true,
+                yaml_block_found: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function addMissingNested(root, parentKey, requiredKeys, missingFields) {
+    const value = root[parentKey];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        requiredKeys.forEach(key => missingFields.push(`${parentKey}.${key}`));
+        return;
+    }
+    requiredKeys
+        .filter(key => !Object.prototype.hasOwnProperty.call(value, key))
+        .forEach(key => missingFields.push(`${parentKey}.${key}`));
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_FIELDS.filter(key => !Object.prototype.hasOwnProperty.call(parsedYaml, key));
+    addMissingNested(parsedYaml, 'blocking_summary', BLOCKING_SUMMARY_FIELDS, missingFields);
+    addMissingNested(parsedYaml, 'target', TARGET_FIELDS, missingFields);
+    addMissingNested(parsedYaml, 'included_chain', Object.keys(EXPECTED_INCLUDED_CHAIN), missingFields);
+    addMissingNested(parsedYaml, 'gate_statuses', GATE_STATUS_FIELDS, missingFields);
+    addMissingNested(parsedYaml, 'safety', SAFETY_FIELDS, missingFields);
+    return missingFields;
+}
+
+function ensureArrayContainsAll(root, key, requiredValues, errors, missingMessage) {
+    const value = root[key];
+    if (!Array.isArray(value)) {
+        errors.push(missingMessage || `${key} missing`);
+        return;
+    }
+    requiredValues
+        .filter(requiredValue => !value.includes(requiredValue))
+        .forEach(requiredValue => errors.push(`${key} missing required value "${requiredValue}"`));
+}
+
+function ensureObjectValues(root, parentKey, expectedValues, errors) {
+    const parent = root[parentKey] || {};
+    Object.entries(expectedValues).forEach(([fieldName, expectedValue]) => {
+        if (parent[fieldName] !== expectedValue) {
+            errors.push(`${parentKey}.${fieldName} must be ${expectedValue}`);
+        }
+    });
+}
+
+function validateBlockingSummary(parsedYaml, errors) {
+    const summary = parsedYaml.blocking_summary || {};
+    if (summary.primary_reason !== PRIMARY_BLOCKING_REASON) {
+        errors.push(`primary_reason must be ${PRIMARY_BLOCKING_REASON}`);
+    }
+    words(`
+        cannot_continue_without_user_inputs codex_may_not_self_fill_inputs
+        codex_may_not_escalate_authorization requires_future_separate_phase
+    `).forEach(fieldName => {
+        if (summary[fieldName] !== true) {
+            errors.push(`blocking_summary.${fieldName} must be true`);
+        }
+    });
+}
+
+function validateTargetSection(parsedYaml, errors) {
+    const target = parsedYaml.target || {};
+    if (target.target_engine_family !== 'titan_discovery') {
+        errors.push(`unsupported engine family "${target.target_engine_family}"`);
+    }
+    if (target.target_scope_type === 'bulk') {
+        errors.push('unsupported scope type bulk');
+    }
+    if (target.bulk_scope_allowed !== false) {
+        errors.push('bulk scope allowed must remain false in the Phase 4.89D template');
+    }
+    if (target.max_targets !== 1) {
+        errors.push('max_targets > 1 is not allowed in the Phase 4.89D template');
+    }
+}
+
+function validateSafety(parsedYaml, errors) {
+    const safety = parsedYaml.safety || {};
+    SAFETY_FIELDS.forEach(fieldName => {
+        if (safety[fieldName] !== false) {
+            errors.push(`safety.${fieldName} must remain false`);
+        }
+    });
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) errors.push(`missing required fields: ${missingFields.join(',')}`);
+    if (parsedYaml.phase !== TEMPLATE_PHASE) errors.push(`phase must be ${TEMPLATE_PHASE}`);
+    if (parsedYaml.summary_status !== 'blocked_preview_only') {
+        errors.push('summary_status must remain blocked_preview_only in the Phase 4.89D template');
+    }
+    if (parsedYaml.network_dry_run_blocked !== true) {
+        errors.push('network_dry_run_blocked false in template is not allowed');
+    }
+    Object.entries(TOP_FALSE).forEach(([fieldName, message]) => {
+        if (parsedYaml[fieldName] !== false) errors.push(message);
+    });
+    validateBlockingSummary(parsedYaml, errors);
+    validateTargetSection(parsedYaml, errors);
+    ensureArrayContainsAll(
+        parsedYaml,
+        'missing_user_inputs',
+        REQUIRED_MISSING_USER_INPUTS,
+        errors,
+        'missing_user_inputs missing'
+    );
+    ensureObjectValues(parsedYaml, 'included_chain', EXPECTED_INCLUDED_CHAIN, errors);
+    GATE_STATUS_FIELDS.forEach(fieldName => {
+        if ((parsedYaml.gate_statuses || {})[fieldName] !== true) {
+            errors.push(`gate_statuses.${fieldName} must be true`);
+        }
+    });
+    validateSafety(parsedYaml, errors);
+    ensureArrayContainsAll(parsedYaml, 'allowed_next_steps', REQUIRED_ALLOWED_NEXT_STEPS, errors);
+    ensureArrayContainsAll(parsedYaml, 'forbidden_next_steps', REQUIRED_FORBIDDEN_NEXT_STEPS, errors);
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function validateTargetConsistency(args, parsedYaml, inputClosurePayload) {
+    const target = parsedYaml.target || {};
+    const candidates = [
+        ['blocked_summary.target.target_source', target.target_source, args.target_source],
+        ['blocked_summary.target.target_engine_family', target.target_engine_family, args.target_engine_family],
+        ['blocked_summary.target.target_scope_type', target.target_scope_type, args.target_scope_type],
+        ['blocked_summary.target.target_match_id', target.target_match_id, args.target_match_id],
+        ['blocked_summary.target.target_league', target.target_league, args.target_league],
+        ['blocked_summary.target.target_season', target.target_season, args.target_season],
+        ['blocked_summary.target.target_date', target.target_date, args.target_date],
+    ];
+    const errors = candidates
+        .filter(([, templateValue, cliValue]) => templateValue && templateValue !== cliValue)
+        .map(
+            ([label, templateValue, cliValue]) =>
+                `target mismatch: ${label} "${templateValue}" does not match CLI value "${cliValue}"`
+        );
+    if (inputClosurePayload.errors && inputClosurePayload.errors.some(error => /target mismatch/i.test(error))) {
+        errors.push(...inputClosurePayload.errors);
+    }
+    return errors;
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: OUTPUT_PHASE,
+        mode: MODE,
+        ok: true,
+        blocked_summary: args.blocked_summary,
+        input_closure: args.input_closure,
+        approval_packet: args.approval_packet,
+        execution_plan: args.execution_plan,
+        checklist: args.checklist,
+        runbook: args.runbook,
+        auth_form: args.auth_form,
+        blocked_summary_found: true,
+        input_closure_found: true,
+        approval_packet_found: true,
+        execution_plan_found: true,
+        checklist_found: true,
+        runbook_found: true,
+        auth_form_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        blocked_summary_valid: true,
+        input_closure_valid: true,
+        approval_packet_valid: true,
+        execution_plan_valid: true,
+        readiness_checklist_valid: true,
+        runbook_template_valid: true,
+        auth_form_template_valid: true,
+        errors: [],
+        warnings: [
+            'Phase 4.89D remains blocked-preview-only.',
+            'CLI authorization yes values do not unblock execution in this phase.',
+        ],
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_legacy_titan_discovery_execution',
+            'no_approval_packet_file_writes',
+            'no_user_input_closure_file_writes',
+            'no_blocked_summary_file_writes',
+        ],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const localDeps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const summaryLoad = loadBlockedSummaryYaml(args, localDeps);
+    if (summaryLoad.payload) return summaryLoad.payload;
+
+    const summaryValidation = validateParsedYaml(summaryLoad.parsedYaml);
+    if (!summaryValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'blocked-summary-error',
+            blocked_summary_found: true,
+            yaml_block_found: true,
+            required_fields_present: summaryValidation.missingFields.length === 0,
+            missing_fields: summaryValidation.missingFields,
+            errors: summaryValidation.errors,
+        });
+    }
+
+    const inputClosurePayload = runUserInputClosureValidation(args, localDeps);
+    if (!inputClosurePayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'input-closure-error',
+            blocked_summary_found: true,
+            yaml_block_found: true,
+            blocked_summary_valid: true,
+            errors: inputClosurePayload.errors,
+        });
+    }
+
+    const targetErrors = validateTargetConsistency(args, summaryLoad.parsedYaml, inputClosurePayload);
+    if (targetErrors.length) {
+        return buildFailurePayload(args, {
+            mode: 'target-error',
+            blocked_summary_found: true,
+            input_closure_found: true,
+            approval_packet_found: true,
+            execution_plan_found: true,
+            checklist_found: true,
+            runbook_found: true,
+            auth_form_found: true,
+            yaml_block_found: true,
+            required_fields_present: true,
+            blocked_summary_valid: true,
+            input_closure_valid: true,
+            approval_packet_valid: true,
+            execution_plan_valid: true,
+            readiness_checklist_valid: true,
+            runbook_template_valid: true,
+            auth_form_template_valid: true,
+            errors: targetErrors,
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(payload, io) {
+    io.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (text => process.stdout.write(text)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [error.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    OUTPUT_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_blocked_final_preflight_summary.test.js
+++ b/tests/unit/single_target_acquisition_network_blocked_final_preflight_summary.test.js
@@ -1,0 +1,693 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(
+    PROJECT_ROOT,
+    'scripts/ops/single_target_acquisition_network_blocked_final_preflight_summary.js'
+);
+const BLOCKED_SUMMARY_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md'
+);
+const INPUT_CLOSURE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_USER_INPUT_REQUIREMENTS_CLOSURE_TEMPLATE.md'
+);
+const APPROVAL_PACKET_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_HUMAN_APPROVAL_PACKET_TEMPLATE.md'
+);
+const EXECUTION_PLAN_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md'
+);
+const CHECKLIST_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FINAL_READINESS_CHECKLIST_TEMPLATE.md'
+);
+const RUNBOOK_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_PRE_NETWORK_DRY_RUN_RUNBOOK_TEMPLATE.md'
+);
+const AUTH_FORM_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_FORM_TEMPLATE.md'
+);
+const BLOCKED_SUMMARY_TEXT = fs.readFileSync(BLOCKED_SUMMARY_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        blocked_summary: BLOCKED_SUMMARY_PATH,
+        input_closure: INPUT_CLOSURE_PATH,
+        approval_packet: APPROVAL_PACKET_PATH,
+        execution_plan: EXECUTION_PLAN_PATH,
+        checklist: CHECKLIST_PATH,
+        runbook: RUNBOOK_PATH,
+        auth_form: AUTH_FORM_PATH,
+        target_source: 'fotmob',
+        target_engine_family: 'titan_discovery',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_dry_run_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function buildSummaryTextDependencies(markdownText) {
+    const targetPath = BLOCKED_SUMMARY_PATH;
+    return buildDependencies({
+        existsSync: currentPath => currentPath === targetPath || fs.existsSync(currentPath),
+        readFileSync: (currentPath, encoding) => {
+            if (currentPath === targetPath) return markdownText;
+            return fs.readFileSync(currentPath, encoding);
+        },
+    });
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(
+            `${name} should not be called by single_target_acquisition_network_blocked_final_preflight_summary`
+        );
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) throw new Error(`blocked import: ${request}`);
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(BLOCKED_SUMMARY_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return BLOCKED_SUMMARY_TEXT.replace(searchValue, replaceValue);
+}
+
+function replaceInSection(sectionName, searchValue, replaceValue) {
+    const sectionHeader = `${sectionName}:\n`;
+    const startIndex = BLOCKED_SUMMARY_TEXT.indexOf(sectionHeader);
+    assert.notEqual(startIndex, -1, `missing section ${sectionName}`);
+    const nextSectionMatch = BLOCKED_SUMMARY_TEXT.slice(startIndex + sectionHeader.length).match(/\n[A-Za-z0-9_]+:\n/);
+    const endIndex =
+        nextSectionMatch && typeof nextSectionMatch.index === 'number'
+            ? startIndex + sectionHeader.length + nextSectionMatch.index
+            : BLOCKED_SUMMARY_TEXT.length;
+    const sectionText = BLOCKED_SUMMARY_TEXT.slice(startIndex, endIndex);
+    assert.match(sectionText, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return `${BLOCKED_SUMMARY_TEXT.slice(0, startIndex)}${sectionText.replace(searchValue, replaceValue)}${BLOCKED_SUMMARY_TEXT.slice(endIndex)}`;
+}
+
+function removeLineFromTemplate(line) {
+    return BLOCKED_SUMMARY_TEXT.replace(`${line}\n`, '');
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 blocked summary 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.blocked_summary;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing blocked summary/i);
+});
+
+test('缺 input closure 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.input_closure;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing input closure/i);
+});
+
+test('缺 approval packet 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.approval_packet;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing approval packet/i);
+});
+
+test('缺 execution plan 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.execution_plan;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing execution plan/i);
+});
+
+test('缺 checklist 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.checklist;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing checklist/i);
+});
+
+test('缺 runbook 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.runbook;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing runbook/i);
+});
+
+test('缺 auth form 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.auth_form;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing auth form/i);
+});
+
+test('blocked summary 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildSummaryTextDependencies('# no yaml\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing YAML block/i);
+});
+
+test('blocked summary invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildSummaryTextDependencies('```yaml\nnot yaml\n```\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /invalid YAML/i);
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(
+            removeLineFromTemplate(
+                'phase: PHASE4_89D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing required fields: phase|phase must be/);
+});
+
+test('summary_status 非 blocked_preview_only 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(replaceInTemplate('summary_status: blocked_preview_only', 'summary_status: ready'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /blocked_preview_only/);
+});
+
+test('network_dry_run_blocked=false 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(
+            replaceInTemplate('network_dry_run_blocked: true', 'network_dry_run_blocked: false')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /network_dry_run_blocked false/);
+});
+
+[
+    [
+        'network_dry_run_ready=true 失败',
+        'network_dry_run_ready: false',
+        'network_dry_run_ready: true',
+        /network_dry_run_ready true/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'human_approval_packet_ready=true 失败',
+        'human_approval_packet_ready: false',
+        'human_approval_packet_ready: true',
+        /human_approval_packet_ready true/,
+    ],
+    [
+        'user_inputs_complete=true 失败',
+        'user_inputs_complete: false',
+        'user_inputs_complete: true',
+        /user_inputs_complete true/,
+    ],
+    [
+        'staging_write_authorized=true 失败',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    [
+        'db_write_authorized=true 失败',
+        'db_write_authorized: false',
+        'db_write_authorized: true',
+        /db_write_authorized true/,
+    ],
+    [
+        'training_authorized=true 失败',
+        'training_authorized: false',
+        'training_authorized: true',
+        /training_authorized true/,
+    ],
+    [
+        'prediction_authorized=true 失败',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([name, searchValue, replaceValue, pattern]) => {
+    test(name, () => {
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildSummaryTextDependencies(replaceInTemplate(searchValue, replaceValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+test('missing_user_inputs missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(removeLineFromTemplate('    - real_target_source'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing_user_inputs missing required value|missing_user_inputs missing/);
+});
+
+test('blocking_summary missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(removeLineFromTemplate('blocking_summary:'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /blocking_summary/);
+});
+
+test('primary_reason 非 missing_user_supplied_real_network_dry_run_inputs 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(
+            replaceInTemplate(
+                'primary_reason: missing_user_supplied_real_network_dry_run_inputs',
+                'primary_reason: ready'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /primary_reason/);
+});
+
+test('codex_may_not_self_fill_inputs=false 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(
+            replaceInTemplate('codex_may_not_self_fill_inputs: true', 'codex_may_not_self_fill_inputs: false')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /codex_may_not_self_fill_inputs/);
+});
+
+test('codex_may_not_escalate_authorization=false 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(
+            replaceInTemplate(
+                'codex_may_not_escalate_authorization: true',
+                'codex_may_not_escalate_authorization: false'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /codex_may_not_escalate_authorization/);
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(
+            replaceInSection('target', '    bulk_scope_allowed: false', '    bulk_scope_allowed: true')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /bulk scope allowed/i);
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(replaceInSection('target', '    max_targets: 1', '    max_targets: 2'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+});
+
+test('unsupported engine family 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_engine_family: 'run_production' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported engine family/);
+});
+
+test('unsupported scope type bulk 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs({ target_scope_type: 'bulk' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /unsupported scope type "bulk"|unsupported scope type bulk/);
+});
+
+test('target mismatch 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildSummaryTextDependencies(replaceInSection('target', '    target_source:', '    target_source: other'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /target mismatch/i);
+});
+
+test('valid blocked final preflight summary 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.89D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY');
+    assert.equal(payload.blocked_final_preflight_summary_preview_only, true);
+    assert.equal(payload.blocked_summary_valid, true);
+    assert.equal(payload.input_closure_valid, true);
+    assert.equal(payload.approval_packet_valid, true);
+    assert.equal(payload.execution_plan_valid, true);
+    assert.equal(payload.readiness_checklist_valid, true);
+    assert.equal(payload.runbook_template_valid, true);
+    assert.equal(payload.auth_form_template_valid, true);
+    assert.equal(payload.network_dry_run_blocked, true);
+    assert.equal(payload.network_dry_run_ready, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.human_approval_packet_ready, false);
+    assert.equal(payload.user_inputs_complete, false);
+    assert.equal(payload.primary_blocking_reason, 'missing_user_supplied_real_network_dry_run_inputs');
+    assert.deepEqual(payload.missing_user_inputs, [
+        'real_target_source',
+        'real_single_target_scope',
+        'source_terms',
+        'license_review',
+        'allowed_use_review',
+        'network_authorization',
+        'external_network_policy',
+        'browser_runtime_policy',
+        'proxy_runtime_policy',
+        'staging_policy',
+        'no_db_write_confirmation',
+        'no_training_confirmation',
+        'no_prediction_confirmation',
+        'final_human_confirmation',
+    ]);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_execute_legacy_titan_discovery, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_approval_packet_file, false);
+    assert.equal(payload.would_write_user_input_closure_file, false);
+    assert.equal(payload.would_write_blocked_summary_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('all CLI yes 仍 blocked / inputs incomplete / not authorized', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs({
+            terms_approval: 'yes',
+            network_dry_run_authorization: 'yes',
+            allow_browser_runtime: 'yes',
+            allow_proxy_runtime: 'yes',
+            allow_external_network: 'yes',
+            allow_staging_write: 'yes',
+            final_human_confirmation: 'yes',
+        }),
+        buildDependencies()
+    );
+    assert.equal(payload.ok, true);
+    assert.equal(payload.network_dry_run_blocked, true);
+    assert.equal(payload.user_inputs_complete, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_write_blocked_summary_file, false);
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        [
+            '--blocked-summary',
+            BLOCKED_SUMMARY_PATH,
+            '--input-closure',
+            INPUT_CLOSURE_PATH,
+            '--approval-packet',
+            APPROVAL_PACKET_PATH,
+            '--execution-plan',
+            EXECUTION_PLAN_PATH,
+            '--checklist',
+            CHECKLIST_PATH,
+            '--runbook',
+            RUNBOOK_PATH,
+            '--auth-form',
+            AUTH_FORM_PATH,
+            '--commit',
+        ],
+        buildDependencies()
+    );
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.89D/);
+});
+
+test('Makefile summary preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-blocked-final-preflight-summary',
+            'NETWORK_BLOCKED_PREFLIGHT_NODE=node',
+            `BLOCKED_SUMMARY=${BLOCKED_SUMMARY_PATH}`,
+            `INPUT_CLOSURE=${INPUT_CLOSURE_PATH}`,
+            `APPROVAL_PACKET=${APPROVAL_PACKET_PATH}`,
+            `EXECUTION_PLAN=${EXECUTION_PLAN_PATH}`,
+            `CHECKLIST=${CHECKLIST_PATH}`,
+            `RUNBOOK=${RUNBOOK_PATH}`,
+            `AUTH_FORM=${AUTH_FORM_PATH}`,
+            'TARGET_SOURCE=fotmob',
+            'TARGET_ENGINE_FAMILY=titan_discovery',
+            'TARGET_SCOPE_TYPE=match_id',
+            'TARGET_MATCH_ID=sample-match-001',
+            'TERMS_APPROVAL=no',
+            'NETWORK_DRY_RUN_AUTHORIZATION=no',
+            'ALLOW_BROWSER_RUNTIME=no',
+            'ALLOW_PROXY_RUNTIME=no',
+            'ALLOW_EXTERNAL_NETWORK=no',
+            'ALLOW_STAGING_WRITE=no',
+            'FINAL_HUMAN_CONFIRMATION=no',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.blocked_summary_valid, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-blocked-final-preflight-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.89D/);
+});
+
+[
+    ['不访问网络', 'would_access_network', false],
+    ['不启动 browser', 'would_launch_browser', false],
+    ['不执行 proxy runtime', 'would_use_proxy', false],
+    ['不执行 engine', 'would_execute_engine', false],
+    ['不执行 legacy titan_discovery', 'would_execute_legacy_titan_discovery', false],
+    ['不写 staging', 'would_write_staging', false],
+    ['不创建目录', 'would_create_staging_directory', false],
+    ['不写 source manifest', 'would_write_source_manifest', false],
+    ['不写 packet file', 'would_write_packet_file', false],
+    ['不写 approval packet file', 'would_write_approval_packet_file', false],
+    ['不写 user input closure file', 'would_write_user_input_closure_file', false],
+    ['不写 blocked summary file', 'would_write_blocked_summary_file', false],
+    ['不写 DB', 'would_write_db', false],
+    ['不 spawn child process', 'would_spawn_child_process', false],
+].forEach(([name, field, expected]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], expected);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.89D single-target acquisition network dry-run blocked final preflight summary.

Scope:
- Adds blocked final preflight summary template
- Adds local-only blocked final preflight summary preview validator
- Validates network dry-run remains blocked because user-supplied real inputs are missing
- Validates input closure, approval packet, execution plan, readiness checklist, runbook, and auth form templates remain non-authorized
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.89D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No approval packet file writes
- No user input closure file writes
- No blocked summary file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- preview missing params failed as expected
- valid blocked final preflight summary passed
- all-yes CLI remained blocked / inputs incomplete / not authorized
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed