### PR TITLE
docs(data): add single-target network parameter intake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -821,6 +821,30 @@ AI / Codex 默认禁止：
 
 真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、terms approval、network authorization、runbook / auth form / readiness checklist / execution plan / approval packet / input closure 全部审核通过。
 
+### Phase 4.90D: single-target acquisition network dry-run real-parameter intake template
+
+`data-single-target-acquisition-network-real-parameter-intake-preview` 只允许预览 real-parameter intake template：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 approval packet file
+- 它不得写 blocked summary file
+- 它不得写 real parameter intake file
+- 它不得写 DB
+- real-parameter intake template 不等于真实 network dry-run authorization
+- Codex 不得自行填写真实 source / target / terms / authorization
+- Codex 不得自行把 provided 改成 true
+- 即使 CLI 传入确认参数，Phase 4.90D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-real-parameter-intake-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、terms approval、network authorization、runbook / auth form / readiness checklist / execution plan / approval packet / input closure / blocked preflight 全部审核通过。
+
 Phase 4.55C acquisition architecture rules：
 
 - Codex 不应直接运行 legacy / high-risk acquisition engines，尤其是 `run_production`、`titan_discovery`、`recon_scanner`、`batch_historical_backfill`、`fetch_and_adapt_euro_leagues`、`odds_harvest_pipeline`、`total_war_pipeline`、`titan_marathon`。

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@
         data-single-target-acquisition-network-approval-packet-preview data-single-target-acquisition-network-approval-packet-commit \
         data-single-target-acquisition-network-user-input-closure-preview data-single-target-acquisition-network-user-input-closure-commit \
         data-single-target-acquisition-network-blocked-final-preflight-summary data-single-target-acquisition-network-blocked-final-preflight-commit \
+        data-single-target-acquisition-network-real-parameter-intake-preview data-single-target-acquisition-network-real-parameter-intake-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -87,6 +88,7 @@ NETWORK_EXECUTION_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_APPROVAL_PACKET_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_USER_INPUT_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_BLOCKED_PREFLIGHT_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_REAL_PARAMETER_INTAKE_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -368,6 +370,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-user-input-closure-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_USER_INPUT_CLOSURE=1  # blocked in Phase 4.88D"
 	@echo "  make data-single-target-acquisition-network-blocked-final-preflight-summary BLOCKED_SUMMARY=<path> INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...  # blocked final preflight summary, Phase 4.89D"
 	@echo "  make data-single-target-acquisition-network-blocked-final-preflight-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT=1  # blocked in Phase 4.89D"
+	@echo "  make data-single-target-acquisition-network-real-parameter-intake-preview INTAKE=<path> BLOCKED_SUMMARY=<path>  # real-parameter intake template preview, Phase 4.90D"
+	@echo "  make data-single-target-acquisition-network-real-parameter-intake-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE=1  # blocked in Phase 4.90D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1219,6 +1223,22 @@ data-single-target-acquisition-network-blocked-final-preflight-commit: ## Blocke
 	@echo "BLOCKED: single-target acquisition network dry-run blocked final preflight summary execution is not wired in Phase 4.89D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT=1, this path remains blocked."
 	@echo "  Phase 4.89D previews blocked status only and does not authorize any network dry-run, staging write, blocked summary file write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-real-parameter-intake-preview: ## Preview-only real-parameter intake template validation. Phase 4.90D. No network, no writes, no DB.
+	@if [ -z "$(INTAKE)" ] || [ -z "$(BLOCKED_SUMMARY)" ]; then \
+		echo "ERROR: provide INTAKE=<path> and BLOCKED_SUMMARY=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.90D: network real-parameter intake template (template-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_REAL_PARAMETER_INTAKE_NODE) scripts/ops/single_target_acquisition_network_real_parameter_intake.js \
+		--intake "$(INTAKE)" \
+		--blocked-summary "$(BLOCKED_SUMMARY)"
+
+data-single-target-acquisition-network-real-parameter-intake-commit: ## Blocked network real-parameter intake gate. Remains not wired in Phase 4.90D.
+	@echo "BLOCKED: single-target acquisition real-parameter intake execution is not wired in Phase 4.90D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE=1, this path remains blocked."
+	@echo "  Phase 4.90D previews the intake template only and does not authorize any network dry-run, staging write, real parameter intake file write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE_PHASE4_90D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE_PHASE4_90D.md
@@ -1,0 +1,123 @@
+# Single-Target Acquisition Network Real-Parameter Intake Phase 4.90D
+
+## Executive Summary
+
+Phase 4.90D is the network dry-run real-parameter intake template stage.
+
+This phase does not access the network, collect data, write DB rows, write
+staging artifacts, or write packet files. Its goal is to create the template a
+future user can fill with real source, target, terms, and authorization values
+before any single-target acquisition network dry-run can be proposed.
+
+## Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_real_parameter_intake.js`
+- `tests/unit/single_target_acquisition_network_real_parameter_intake.test.js`
+- Makefile targets:
+    - `data-single-target-acquisition-network-real-parameter-intake-preview`
+    - `data-single-target-acquisition-network-real-parameter-intake-commit`
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE_PHASE4_90D.md`
+
+## Required Real Parameter Groups
+
+- `real_target`
+- `source_terms`
+- `network_authorization`
+- `proxy_browser_network_policy`
+- `staging_policy`
+- `no_db_training_prediction_policy`
+- `final_human_confirmation`
+
+## Validation Behavior
+
+The validator is local-only and read-only.
+
+It verifies:
+
+- `intake_status=template_only`
+- `real_parameters_provided=false`
+- all `provided=false`
+- `network_dry_run_authorized=false`
+- `network_dry_run_execution_allowed=false`
+- all `would_*` values remain `false`
+- no real source, target, terms, policy, or confirmation values were self-filled
+- the Phase 4.89D blocked final preflight summary remains valid and blocked
+- no network execution occurs
+- no runtime writes occur
+
+The commit target remains blocked. Phase 4.90D does not write a real parameter
+intake runtime file and does not authorize staging writes or DB writes.
+
+## Relationship To Previous Phases
+
+- 4.79D parameter scaffold
+- 4.80D schema validation
+- 4.81D writer preflight
+- 4.82D packet preview
+- 4.83D pre-network runbook draft
+- 4.84D authorization form template
+- 4.85D final readiness checklist
+- 4.86D execution plan draft
+- 4.87D human approval packet preview
+- 4.88D user input requirements closure
+- 4.89D blocked final preflight summary
+- 4.90D real-parameter intake template
+
+All twelve phases remain pre-execution governance artifacts. None of them is a
+real network dry-run.
+
+## Recommended Next Phase
+
+Recommended next phase:
+
+`Phase 4.91D: single-target acquisition real-parameter intake validation closure`
+
+- still no network access
+- still no DB writes
+- still no staging writes
+- only defines how a future user-filled intake would be validated for
+  completeness
+
+Alternative:
+
+`Phase 4.56A`, only after the user supplies complete real network dry-run
+parameters and the project returns to runbook preparation.
+
+## Explicit Non-Execution
+
+Phase 4.90D did not execute:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- approval packet file write
+- user input closure file write
+- blocked summary file write
+- real parameter intake file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md
@@ -1,0 +1,254 @@
+# Single-Target Acquisition Network Dry-Run Real-Parameter Intake Template
+
+This document is a Phase 4.90D template-only intake form for a future
+single-target acquisition network dry-run.
+
+- This is a real-parameter intake template, not an authorization document.
+- `real_parameters_provided=false` by default.
+- Every `provided` field is `false` by default.
+- `network_dry_run_authorized=false` by default.
+- `network_dry_run_execution_allowed=false` by default.
+- Codex must not fill real source, target, terms, or authorization values for
+  the user.
+- Codex must not change any `provided` value to `true` on its own.
+- Phase 4.90D does not write a real parameter intake runtime file. It only
+  validates this template and produces a local stdout preview.
+- A real network dry-run must move to a later, separately authorized phase
+  after the user explicitly fills the real parameters.
+
+```yaml
+phase: PHASE4_90D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE
+intake_status: template_only
+real_parameters_provided: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+real_target:
+    target_source:
+        required: true
+        provided: false
+        value:
+    target_engine_family:
+        required: true
+        provided: false
+        value: titan_discovery
+    target_scope_type:
+        required: true
+        provided: false
+        value:
+        allowed_values:
+            - match_id
+            - league_season_date
+    target_match_id:
+        required_when_scope_type: match_id
+        provided: false
+        value:
+    target_league:
+        required_when_scope_type: league_season_date
+        provided: false
+        value:
+    target_season:
+        required_when_scope_type: league_season_date
+        provided: false
+        value:
+    target_date:
+        required_when_scope_type: league_season_date
+        provided: false
+        value:
+    max_targets: 1
+    bulk_scope_allowed: false
+
+source_terms:
+    source_homepage_url:
+        required: true
+        provided: false
+        value:
+    terms_url:
+        required: true
+        provided: false
+        value:
+    license_url:
+        required: true
+        provided: false
+        value:
+    allowed_use_summary:
+        required: true
+        provided: false
+        value:
+    terms_reviewed_by:
+        required: true
+        provided: false
+        value:
+    terms_approval:
+        required: true
+        provided: false
+        value: no
+
+network_authorization:
+    network_dry_run_authorization:
+        required: true
+        provided: false
+        value: no
+    allow_external_network:
+        required: true
+        provided: false
+        value: no
+    allow_browser_runtime:
+        required: true
+        provided: false
+        value: no
+    allow_proxy_runtime:
+        required: true
+        provided: false
+        value: no
+    allow_staging_write:
+        required: true
+        provided: false
+        value: no
+
+proxy_browser_network_policy:
+    proxy_policy:
+        required: true
+        provided: false
+        value:
+    browser_policy:
+        required: true
+        provided: false
+        value:
+    rate_limit_policy:
+        required: true
+        provided: false
+        value:
+    retry_policy:
+        required: true
+        provided: false
+        value:
+    user_agent_policy:
+        required: true
+        provided: false
+        value:
+    no_login_paywall_bypass_confirmation:
+        required: true
+        provided: false
+        value: no
+    no_anti_bot_bypass_confirmation:
+        required: true
+        provided: false
+        value: no
+    no_bulk_expansion_confirmation:
+        required: true
+        provided: false
+        value: no
+
+staging_policy:
+    output_root:
+        required: true
+        provided: false
+        value:
+        allowed_prefix: docs/_staging_preview/acquisition/single_target
+    schema_validation_required: true
+    source_manifest_required: true
+    staging_write_authorized:
+        required: true
+        provided: false
+        value: no
+
+no_db_training_prediction_policy:
+    no_db_write_confirmation:
+        required: true
+        provided: false
+        value: no
+    no_training_confirmation:
+        required: true
+        provided: false
+        value: no
+    no_prediction_confirmation:
+        required: true
+        provided: false
+        value: no
+    no_model_artifact_loading_confirmation:
+        required: true
+        provided: false
+        value: no
+
+final_human_confirmation:
+    required: true
+    provided: false
+    confirmed_by:
+    value: no
+
+included_blocked_preflight:
+    blocked_summary: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md
+    primary_blocking_reason: missing_user_supplied_real_network_dry_run_inputs
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_execute_legacy_titan_discovery: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_user_input_closure_file: false
+    would_write_blocked_summary_file: false
+    would_write_real_parameter_intake_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+```
+
+## Purpose
+
+This template is the intake shape a user must fill in a later phase before a
+real single-target acquisition network dry-run can even be proposed.
+
+It collects:
+
+- real target source
+- real single-target scope
+- source homepage URL, terms URL, and license URL
+- allowed-use summary and terms approval
+- network dry-run authorization
+- external network, browser runtime, and proxy runtime policy
+- staging policy
+- no-DB-write confirmation
+- no-training confirmation
+- no-prediction confirmation
+- final human confirmation
+
+## Guardrails
+
+This template does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- legacy `titan_discovery` runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- approval packet file writes
+- user input closure file writes
+- blocked summary runtime file writes
+- real parameter intake runtime file writes
+- DB writes
+- training
+- prediction
+
+The template must remain `template_only` in Phase 4.90D. Codex cannot supply or
+infer real source, target, terms, license review, allowed-use review, network
+authorization, staging policy, or final human confirmation for the user.
+
+Future network dry-run execution must happen in a separate phase with explicit
+user-supplied real parameters, reviewed terms, network authorization, staging
+policy, no-DB/no-training/no-prediction confirmation, and final human approval.

--- a/scripts/ops/single_target_acquisition_network_real_parameter_intake.js
+++ b/scripts/ops/single_target_acquisition_network_real_parameter_intake.js
@@ -1,0 +1,679 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    validateParsedYaml: validateBlockedSummaryYaml,
+} = require('./single_target_acquisition_network_blocked_final_preflight_summary');
+
+const OUTPUT_PHASE = 'PHASE4.90D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE';
+const TEMPLATE_PHASE = 'PHASE4_90D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE';
+const MODE = 'single-target-acquisition-network-real-parameter-intake-preview';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition real-parameter intake execution is not wired in Phase 4.90D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.91D or explicit user-supplied real network dry-run parameters';
+const BLOCKED_SUMMARY_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md';
+const PRIMARY_BLOCKING_REASON = 'missing_user_supplied_real_network_dry_run_inputs';
+
+const MISSING_PARAMETER_GROUPS = [
+    'real_target',
+    'source_terms',
+    'network_authorization',
+    'proxy_browser_network_policy',
+    'staging_policy',
+    'no_db_training_prediction_policy',
+    'final_human_confirmation',
+];
+
+const REQUIRED_TOP_FIELDS = words(`
+    phase intake_status real_parameters_provided network_dry_run_authorized
+    network_dry_run_execution_allowed staging_write_authorized
+    db_write_authorized training_authorized prediction_authorized
+    final_human_confirmation real_target source_terms network_authorization
+    proxy_browser_network_policy staging_policy no_db_training_prediction_policy
+    included_blocked_preflight safety
+`);
+
+const TOP_FALSE = {
+    real_parameters_provided: 'real_parameters_provided true in template is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true in template is not allowed',
+    staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+    db_write_authorized: 'db_write_authorized true in template is not allowed',
+    training_authorized: 'training_authorized true in template is not allowed',
+    prediction_authorized: 'prediction_authorized true in template is not allowed',
+    final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+};
+
+const SAFETY_FIELDS = words(`
+    would_access_network would_launch_browser would_use_proxy
+    would_execute_engine would_execute_legacy_titan_discovery
+    would_write_staging would_create_staging_directory
+    would_write_source_manifest would_write_packet_file
+    would_write_approval_packet_file would_write_user_input_closure_file
+    would_write_blocked_summary_file would_write_real_parameter_intake_file
+    would_write_db would_train would_predict would_bulk_harvest
+`);
+
+const FIELD_OBJECT_REQUIREMENTS = {
+    real_target: {
+        target_source: words('required provided value'),
+        target_engine_family: words('required provided value'),
+        target_scope_type: words('required provided value allowed_values'),
+        target_match_id: words('required_when_scope_type provided value'),
+        target_league: words('required_when_scope_type provided value'),
+        target_season: words('required_when_scope_type provided value'),
+        target_date: words('required_when_scope_type provided value'),
+    },
+    source_terms: {
+        source_homepage_url: words('required provided value'),
+        terms_url: words('required provided value'),
+        license_url: words('required provided value'),
+        allowed_use_summary: words('required provided value'),
+        terms_reviewed_by: words('required provided value'),
+        terms_approval: words('required provided value'),
+    },
+    network_authorization: {
+        network_dry_run_authorization: words('required provided value'),
+        allow_external_network: words('required provided value'),
+        allow_browser_runtime: words('required provided value'),
+        allow_proxy_runtime: words('required provided value'),
+        allow_staging_write: words('required provided value'),
+    },
+    proxy_browser_network_policy: {
+        proxy_policy: words('required provided value'),
+        browser_policy: words('required provided value'),
+        rate_limit_policy: words('required provided value'),
+        retry_policy: words('required provided value'),
+        user_agent_policy: words('required provided value'),
+        no_login_paywall_bypass_confirmation: words('required provided value'),
+        no_anti_bot_bypass_confirmation: words('required provided value'),
+        no_bulk_expansion_confirmation: words('required provided value'),
+    },
+    staging_policy: {
+        output_root: words('required provided value allowed_prefix'),
+        staging_write_authorized: words('required provided value'),
+    },
+    no_db_training_prediction_policy: {
+        no_db_write_confirmation: words('required provided value'),
+        no_training_confirmation: words('required provided value'),
+        no_prediction_confirmation: words('required provided value'),
+        no_model_artifact_loading_confirmation: words('required provided value'),
+    },
+};
+
+const FINAL_CONFIRMATION_FIELDS = words('required provided confirmed_by value');
+
+const DEFAULT_NO_VALUE_PATHS = words(`
+    source_terms.terms_approval
+    network_authorization.network_dry_run_authorization
+    network_authorization.allow_external_network
+    network_authorization.allow_browser_runtime
+    network_authorization.allow_proxy_runtime
+    network_authorization.allow_staging_write
+    proxy_browser_network_policy.no_login_paywall_bypass_confirmation
+    proxy_browser_network_policy.no_anti_bot_bypass_confirmation
+    proxy_browser_network_policy.no_bulk_expansion_confirmation
+    staging_policy.staging_write_authorized
+    no_db_training_prediction_policy.no_db_write_confirmation
+    no_db_training_prediction_policy.no_training_confirmation
+    no_db_training_prediction_policy.no_prediction_confirmation
+    no_db_training_prediction_policy.no_model_artifact_loading_confirmation
+`);
+
+const EMPTY_REAL_VALUE_PATHS = words(`
+    real_target.target_source
+    real_target.target_scope_type
+    real_target.target_match_id
+    real_target.target_league
+    real_target.target_season
+    real_target.target_date
+    source_terms.source_homepage_url
+    source_terms.terms_url
+    source_terms.license_url
+    source_terms.allowed_use_summary
+    source_terms.terms_reviewed_by
+    proxy_browser_network_policy.proxy_policy
+    proxy_browser_network_policy.browser_policy
+    proxy_browser_network_policy.rate_limit_policy
+    proxy_browser_network_policy.retry_policy
+    proxy_browser_network_policy.user_agent_policy
+    staging_policy.output_root
+`);
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_real_parameter_intake.js --intake <path> --blocked-summary <path>',
+        '  node scripts/ops/single_target_acquisition_network_real_parameter_intake.js --intake <path> --blocked-summary <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.90D previews a local real-parameter intake template only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        intake: '',
+        blocked_summary: '',
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) throw new Error(`Unknown argument: ${token}`);
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        real_parameter_intake_template_only: true,
+        intake_valid: false,
+        blocked_summary_valid: false,
+        real_parameters_provided: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        missing_parameter_groups: MISSING_PARAMETER_GROUPS,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_execute_legacy_titan_discovery: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_user_input_closure_file: false,
+        would_write_blocked_summary_file: false,
+        would_write_real_parameter_intake_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: OUTPUT_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        intake: args.intake || null,
+        blocked_summary: args.blocked_summary || null,
+        intake_found: false,
+        blocked_summary_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_legacy_titan_discovery_execution',
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+        ],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function parseScalar(rawValue) {
+    const value = String(rawValue || '').trim();
+    if (value === '') return null;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    if (/^-?\d+$/.test(value)) return Number(value);
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+
+function getNextContainerType(lines, currentIndex, currentIndent) {
+    for (let index = currentIndex + 1; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (!line.trim() || line.trim().startsWith('#')) continue;
+        const indent = line.match(/^ */)[0].length;
+        if (indent <= currentIndent) return false;
+        return line.trim().startsWith('- ') ? 'list' : 'object';
+    }
+    return false;
+}
+
+function assignParsedValue(parent, key, value) {
+    if (
+        parent &&
+        Object.prototype.hasOwnProperty.call(parent, key) &&
+        key === 'final_human_confirmation' &&
+        typeof parent[key] === 'boolean' &&
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+    ) {
+        parent.final_human_confirmation_details = value;
+        return;
+    }
+    parent[key] = value;
+}
+
+function parseIntakeYaml(yamlText) {
+    const root = {};
+    const stack = [{ indent: -1, value: root }];
+    const lines = String(yamlText || '').split(/\r?\n/);
+
+    lines.forEach((rawLine, lineIndex) => {
+        if (!rawLine.trim() || rawLine.trim().startsWith('#')) return;
+        const indent = rawLine.match(/^ */)[0].length;
+        const trimmed = rawLine.trim();
+
+        while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop();
+        const parent = stack[stack.length - 1].value;
+
+        if (trimmed.startsWith('- ')) {
+            if (!Array.isArray(parent)) throw new Error(`unsupported YAML list line: ${trimmed}`);
+            parent.push(parseScalar(trimmed.slice(2)));
+            return;
+        }
+
+        const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+        if (!match) throw new Error(`unsupported YAML line: ${trimmed}`);
+        const key = match[1];
+        const valueText = match[2].trim();
+
+        if (valueText !== '') {
+            assignParsedValue(parent, key, parseScalar(valueText));
+            return;
+        }
+
+        const nextContainerType = getNextContainerType(lines, lineIndex, indent);
+        if (!nextContainerType) {
+            assignParsedValue(parent, key, null);
+            return;
+        }
+        const container = nextContainerType === 'list' ? [] : {};
+        assignParsedValue(parent, key, container);
+        stack.push({ indent, value: container });
+    });
+
+    return root;
+}
+
+function validateRequiredCliFields(args) {
+    const errors = [];
+    if (!args.intake) errors.push('missing intake');
+    if (!args.blocked_summary) errors.push('missing blocked summary');
+    return errors;
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = validateRequiredCliFields(args);
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function loadYamlFile(args, dependencies, fieldName, missingLabel, mode) {
+    const rawPath = args[fieldName];
+    const targetPath = resolveLocalPath(rawPath, dependencies.cwd);
+    if (!dependencies.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: false,
+                errors: [`missing ${missingLabel}: ${toRelativePath(targetPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+
+    const yamlText = extractYamlBlock(dependencies.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseIntakeYaml(yamlText), yamlText };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function hasOwn(root, key) {
+    return Object.prototype.hasOwnProperty.call(root, key);
+}
+
+function addMissingNested(root, parentPath, requiredKeys, missingFields) {
+    const value = getPath(root, parentPath);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        requiredKeys.forEach(key => missingFields.push(`${parentPath}.${key}`));
+        return;
+    }
+    requiredKeys.filter(key => !hasOwn(value, key)).forEach(key => missingFields.push(`${parentPath}.${key}`));
+}
+
+function getPath(root, dottedPath) {
+    return dottedPath.split('.').reduce((current, key) => {
+        if (!current || typeof current !== 'object') return undefined;
+        return current[key];
+    }, root);
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_FIELDS.filter(key => !hasOwn(parsedYaml, key));
+    if (!hasOwn(parsedYaml, 'final_human_confirmation_details')) {
+        missingFields.push('final_human_confirmation.provided');
+    }
+    Object.entries(FIELD_OBJECT_REQUIREMENTS).forEach(([sectionName, fieldRequirements]) => {
+        Object.entries(fieldRequirements).forEach(([fieldName, requiredKeys]) => {
+            addMissingNested(parsedYaml, `${sectionName}.${fieldName}`, requiredKeys, missingFields);
+        });
+    });
+    addMissingNested(parsedYaml, 'final_human_confirmation_details', FINAL_CONFIRMATION_FIELDS, missingFields);
+    addMissingNested(
+        parsedYaml,
+        'included_blocked_preflight',
+        words('blocked_summary primary_blocking_reason'),
+        missingFields
+    );
+    addMissingNested(parsedYaml, 'safety', SAFETY_FIELDS, missingFields);
+    ['max_targets', 'bulk_scope_allowed'].forEach(fieldName => {
+        if (!hasOwn(parsedYaml.real_target || {}, fieldName)) missingFields.push(`real_target.${fieldName}`);
+    });
+    ['schema_validation_required', 'source_manifest_required'].forEach(fieldName => {
+        if (!hasOwn(parsedYaml.staging_policy || {}, fieldName)) missingFields.push(`staging_policy.${fieldName}`);
+    });
+    return missingFields;
+}
+
+function isEmptyValue(value) {
+    return value === null || typeof value === 'undefined' || value === '';
+}
+
+function validateProvidedFields(parsedYaml, errors) {
+    Object.entries(FIELD_OBJECT_REQUIREMENTS).forEach(([sectionName, fieldRequirements]) => {
+        Object.keys(fieldRequirements).forEach(fieldName => {
+            const fieldPath = `${sectionName}.${fieldName}`;
+            const field = getPath(parsedYaml, fieldPath);
+            if (!field || typeof field !== 'object' || Array.isArray(field)) return;
+            if (field.provided !== false) {
+                errors.push(`${fieldPath}.provided true in template is not allowed`);
+            }
+        });
+    });
+    const finalConfirmation = parsedYaml.final_human_confirmation_details || {};
+    if (finalConfirmation.provided !== false) {
+        errors.push('final_human_confirmation.provided true in template is not allowed');
+    }
+}
+
+function validateDefaultValues(parsedYaml, errors) {
+    EMPTY_REAL_VALUE_PATHS.forEach(fieldPath => {
+        const value = getPath(parsedYaml, `${fieldPath}.value`);
+        if (!isEmptyValue(value)) {
+            errors.push(`Codex self-filled real parameter: ${fieldPath}.value must remain empty`);
+        }
+    });
+
+    DEFAULT_NO_VALUE_PATHS.forEach(fieldPath => {
+        const value = getPath(parsedYaml, `${fieldPath}.value`);
+        if (value !== 'no') errors.push(`${fieldPath}.value must remain no`);
+    });
+
+    const engine = getPath(parsedYaml, 'real_target.target_engine_family');
+    if (!engine || engine.value !== 'titan_discovery') {
+        errors.push(`target_engine_family not titan_discovery: ${engine ? engine.value : 'missing'}`);
+    }
+    if (engine && engine.provided !== false) {
+        errors.push('real_target.target_engine_family.provided true in template is not allowed');
+    }
+
+    const allowedValues = getPath(parsedYaml, 'real_target.target_scope_type.allowed_values');
+    if (
+        !Array.isArray(allowedValues) ||
+        !allowedValues.includes('match_id') ||
+        !allowedValues.includes('league_season_date')
+    ) {
+        errors.push('real_target.target_scope_type.allowed_values must include match_id and league_season_date');
+    }
+
+    const finalConfirmation = parsedYaml.final_human_confirmation_details || {};
+    if (!isEmptyValue(finalConfirmation.confirmed_by)) {
+        errors.push('Codex self-filled real parameter: final_human_confirmation.confirmed_by must remain empty');
+    }
+    if (finalConfirmation.value !== 'no') {
+        errors.push('final_human_confirmation.value must remain no');
+    }
+}
+
+function validateSafety(parsedYaml, errors) {
+    const safety = parsedYaml.safety || {};
+    SAFETY_FIELDS.forEach(fieldName => {
+        if (safety[fieldName] !== false) {
+            errors.push(`safety.${fieldName} must remain false`);
+        }
+    });
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) errors.push(`missing required fields: ${missingFields.join(',')}`);
+    if (parsedYaml.phase !== TEMPLATE_PHASE) errors.push(`phase must be ${TEMPLATE_PHASE}`);
+    if (parsedYaml.intake_status !== 'template_only') {
+        errors.push('intake_status must remain template_only in the Phase 4.90D template');
+    }
+    Object.entries(TOP_FALSE).forEach(([fieldName, message]) => {
+        if (parsedYaml[fieldName] !== false) errors.push(message);
+    });
+    validateProvidedFields(parsedYaml, errors);
+    validateDefaultValues(parsedYaml, errors);
+    if ((parsedYaml.real_target || {}).bulk_scope_allowed !== false) {
+        errors.push('bulk_scope_allowed true is not allowed in the Phase 4.90D template');
+    }
+    if ((parsedYaml.real_target || {}).max_targets !== 1) {
+        errors.push('max_targets > 1 is not allowed in the Phase 4.90D template');
+    }
+    if ((parsedYaml.staging_policy || {}).schema_validation_required !== true) {
+        errors.push('staging_policy.schema_validation_required must be true');
+    }
+    if ((parsedYaml.staging_policy || {}).source_manifest_required !== true) {
+        errors.push('staging_policy.source_manifest_required must be true');
+    }
+    const included = parsedYaml.included_blocked_preflight || {};
+    if (included.blocked_summary !== BLOCKED_SUMMARY_TEMPLATE) {
+        errors.push(`included_blocked_preflight.blocked_summary must be ${BLOCKED_SUMMARY_TEMPLATE}`);
+    }
+    if (included.primary_blocking_reason !== PRIMARY_BLOCKING_REASON) {
+        errors.push(`included_blocked_preflight.primary_blocking_reason must be ${PRIMARY_BLOCKING_REASON}`);
+    }
+    validateSafety(parsedYaml, errors);
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: OUTPUT_PHASE,
+        mode: MODE,
+        ok: true,
+        intake: args.intake,
+        blocked_summary: args.blocked_summary,
+        intake_found: true,
+        blocked_summary_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        intake_valid: true,
+        blocked_summary_valid: true,
+        errors: [],
+        warnings: [
+            'Phase 4.90D remains template-only.',
+            'Real parameters remain unprovided and do not authorize network execution in this phase.',
+        ],
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_legacy_titan_discovery_execution',
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+        ],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const localDeps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const intakeLoad = loadYamlFile(args, localDeps, 'intake', 'intake', 'intake-error');
+    if (intakeLoad.payload) return intakeLoad.payload;
+
+    const intakeValidation = validateParsedYaml(intakeLoad.parsedYaml);
+    if (!intakeValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'intake-error',
+            intake_found: true,
+            yaml_block_found: true,
+            required_fields_present: intakeValidation.missingFields.length === 0,
+            missing_fields: intakeValidation.missingFields,
+            errors: intakeValidation.errors,
+        });
+    }
+
+    const blockedLoad = loadYamlFile(args, localDeps, 'blocked_summary', 'blocked summary', 'blocked-summary-error');
+    if (blockedLoad.payload) {
+        return {
+            ...blockedLoad.payload,
+            intake_found: true,
+            intake_valid: true,
+        };
+    }
+
+    const blockedValidation = validateBlockedSummaryYaml(blockedLoad.parsedYaml);
+    if (!blockedValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'blocked-summary-error',
+            intake_found: true,
+            blocked_summary_found: true,
+            yaml_block_found: true,
+            intake_valid: true,
+            errors: blockedValidation.errors,
+            missing_fields: blockedValidation.missingFields || [],
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(payload, io) {
+    io.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (text => process.stdout.write(text)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [error.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    OUTPUT_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    parseArgs,
+    parseIntakeYaml,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_real_parameter_intake.test.js
+++ b/tests/unit/single_target_acquisition_network_real_parameter_intake.test.js
@@ -1,0 +1,527 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/single_target_acquisition_network_real_parameter_intake.js');
+const INTAKE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md'
+);
+const BLOCKED_SUMMARY_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md'
+);
+const INTAKE_TEXT = fs.readFileSync(INTAKE_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        intake: INTAKE_PATH,
+        blocked_summary: BLOCKED_SUMMARY_PATH,
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function buildTextDependencies(markdownText, targetPath = INTAKE_PATH) {
+    return buildDependencies({
+        existsSync: currentPath => currentPath === targetPath || fs.existsSync(currentPath),
+        readFileSync: (currentPath, encoding) => {
+            if (currentPath === targetPath) return markdownText;
+            return fs.readFileSync(currentPath, encoding);
+        },
+    });
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by single_target_acquisition_network_real_parameter_intake`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) throw new Error(`blocked import: ${request}`);
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(INTAKE_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return INTAKE_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return INTAKE_TEXT.replace(`${line}\n`, '');
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 intake 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.intake;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing intake/i);
+});
+
+test('缺 blocked summary 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.blocked_summary;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing blocked summary/i);
+});
+
+test('intake 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('# no yaml\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing YAML block/i);
+});
+
+test('intake invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('```yaml\nnot yaml\n```\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /invalid YAML/i);
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            removeLineFromTemplate('phase: PHASE4_90D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing required fields: phase|phase must be/);
+});
+
+test('intake_status 非 template_only 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('intake_status: template_only', 'intake_status: ready'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /template_only/);
+});
+
+[
+    [
+        'real_parameters_provided=true 失败',
+        'real_parameters_provided: false',
+        'real_parameters_provided: true',
+        /real_parameters_provided true/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'staging_write_authorized=true 失败',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    [
+        'db_write_authorized=true 失败',
+        'db_write_authorized: false',
+        'db_write_authorized: true',
+        /db_write_authorized true/,
+    ],
+    [
+        'training_authorized=true 失败',
+        'training_authorized: false',
+        'training_authorized: true',
+        /training_authorized true/,
+    ],
+    [
+        'prediction_authorized=true 失败',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([name, searchValue, replaceValue, pattern]) => {
+    test(name, () => {
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildTextDependencies(replaceInTemplate(searchValue, replaceValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+[
+    [
+        'real_target.target_source.provided=true 失败',
+        'target_source:\n        required: true\n        provided: false',
+        'target_source:\n        required: true\n        provided: true',
+        /real_target\.target_source\.provided true/,
+    ],
+    [
+        'real_target.target_scope_type.provided=true 失败',
+        'target_scope_type:\n        required: true\n        provided: false',
+        'target_scope_type:\n        required: true\n        provided: true',
+        /real_target\.target_scope_type\.provided true/,
+    ],
+    [
+        'source_terms.terms_url.provided=true 失败',
+        'terms_url:\n        required: true\n        provided: false',
+        'terms_url:\n        required: true\n        provided: true',
+        /source_terms\.terms_url\.provided true/,
+    ],
+    [
+        'network_authorization.network_dry_run_authorization.provided=true 失败',
+        'network_dry_run_authorization:\n        required: true\n        provided: false',
+        'network_dry_run_authorization:\n        required: true\n        provided: true',
+        /network_authorization\.network_dry_run_authorization\.provided true/,
+    ],
+    [
+        'proxy_browser_network_policy.proxy_policy.provided=true 失败',
+        'proxy_policy:\n        required: true\n        provided: false',
+        'proxy_policy:\n        required: true\n        provided: true',
+        /proxy_browser_network_policy\.proxy_policy\.provided true/,
+    ],
+    [
+        'staging_policy.output_root.provided=true 失败',
+        'output_root:\n        required: true\n        provided: false',
+        'output_root:\n        required: true\n        provided: true',
+        /staging_policy\.output_root\.provided true/,
+    ],
+    [
+        'no_db_training_prediction_policy.no_db_write_confirmation.provided=true 失败',
+        'no_db_write_confirmation:\n        required: true\n        provided: false',
+        'no_db_write_confirmation:\n        required: true\n        provided: true',
+        /no_db_training_prediction_policy\.no_db_write_confirmation\.provided true/,
+    ],
+    [
+        'final_human_confirmation.provided=true 失败',
+        'final_human_confirmation:\n    required: true\n    provided: false',
+        'final_human_confirmation:\n    required: true\n    provided: true',
+        /final_human_confirmation\.provided true/,
+    ],
+].forEach(([name, searchValue, replaceValue, pattern]) => {
+    test(name, () => {
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildTextDependencies(replaceInTemplate(searchValue, replaceValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('    bulk_scope_allowed: false', '    bulk_scope_allowed: true'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /bulk_scope_allowed true|bulk scope/i);
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('    max_targets: 1', '    max_targets: 2'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+});
+
+test('target_engine_family 不是 titan_discovery 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('        value: titan_discovery', '        value: run_production'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /target_engine_family not titan_discovery/);
+});
+
+test('safety would_access_network=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('    would_access_network: false', '    would_access_network: true'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /safety\.would_access_network/);
+});
+
+test('safety would_write_db=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('    would_write_db: false', '    would_write_db: true'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /safety\.would_write_db/);
+});
+
+test('safety would_write_real_parameter_intake_file=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            replaceInTemplate(
+                '    would_write_real_parameter_intake_file: false',
+                '    would_write_real_parameter_intake_file: true'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /safety\.would_write_real_parameter_intake_file/);
+});
+
+test('Codex self-filled real parameter 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('        value:\n', '        value: fotmob\n'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /Codex self-filled real parameter/);
+});
+
+test('valid intake preview 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.90D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE');
+    assert.equal(payload.real_parameter_intake_template_only, true);
+    assert.equal(payload.intake_valid, true);
+    assert.equal(payload.blocked_summary_valid, true);
+    assert.equal(payload.real_parameters_provided, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.deepEqual(payload.missing_parameter_groups, [
+        'real_target',
+        'source_terms',
+        'network_authorization',
+        'proxy_browser_network_policy',
+        'staging_policy',
+        'no_db_training_prediction_policy',
+        'final_human_confirmation',
+    ]);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_execute_legacy_titan_discovery, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_approval_packet_file, false);
+    assert.equal(payload.would_write_blocked_summary_file, false);
+    assert.equal(payload.would_write_real_parameter_intake_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        ['--intake', INTAKE_PATH, '--blocked-summary', BLOCKED_SUMMARY_PATH, '--commit'],
+        buildDependencies()
+    );
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.90D/);
+});
+
+test('Makefile preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-real-parameter-intake-preview',
+            'NETWORK_REAL_PARAMETER_INTAKE_NODE=node',
+            `INTAKE=${INTAKE_PATH}`,
+            `BLOCKED_SUMMARY=${BLOCKED_SUMMARY_PATH}`,
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.intake_valid, true);
+    assert.equal(payload.blocked_summary_valid, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-real-parameter-intake-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.90D/);
+});
+
+[
+    ['不访问网络', 'would_access_network', false],
+    ['不启动 browser', 'would_launch_browser', false],
+    ['不执行 proxy runtime', 'would_use_proxy', false],
+    ['不执行 engine', 'would_execute_engine', false],
+    ['不执行 legacy titan_discovery', 'would_execute_legacy_titan_discovery', false],
+    ['不写 staging', 'would_write_staging', false],
+    ['不创建目录', 'would_create_staging_directory', false],
+    ['不写 source manifest', 'would_write_source_manifest', false],
+    ['不写 packet file', 'would_write_packet_file', false],
+    ['不写 approval packet file', 'would_write_approval_packet_file', false],
+    ['不写 blocked summary file', 'would_write_blocked_summary_file', false],
+    ['不写 real parameter intake file', 'would_write_real_parameter_intake_file', false],
+    ['不写 DB', 'would_write_db', false],
+    ['不 spawn child process', 'would_spawn_child_process', false],
+].forEach(([name, field, expected]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], expected);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.90D single-target acquisition network dry-run real-parameter intake template.

Scope:
- Adds real-parameter intake template
- Adds local-only real-parameter intake preview validator
- Validates real parameters remain unprovided and non-authorized
- Validates blocked final preflight summary remains blocked
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.90D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No approval packet file writes
- No user input closure file writes
- No blocked summary file writes
- No real parameter intake file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- preview missing params failed as expected
- valid real-parameter intake preview passed
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed