### PR TITLE
docs(data): add single-target parameter validation closure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、只预览 human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-approval-packet-preview APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.87D preview-only）
 - 不触网、不写文件、不创建目录、只预览 user input requirements closure + human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-user-input-closure-preview INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.88D closure-preview-only）
 - 不触网、不写文件、不创建目录、只预览 blocked final preflight summary + user input closure + human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-blocked-final-preflight-summary BLOCKED_SUMMARY=<path> INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.89D blocked-preview-only）
+- 不触网、不写文件、不创建目录、不写 DB、只预览 real-parameter intake validation closure template + real-parameter intake template + blocked preflight summary template 的本地 validator：`make data-single-target-acquisition-network-real-parameter-validation-closure-preview VALIDATION_CLOSURE=<path> INTAKE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.91D template-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -844,6 +845,32 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-real-parameter-intake-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、terms approval、network authorization、runbook / auth form / readiness checklist / execution plan / approval packet / input closure / blocked preflight 全部审核通过。
+
+### Phase 4.91D: single-target acquisition network dry-run real-parameter intake validation closure
+
+`data-single-target-acquisition-network-real-parameter-validation-closure-preview` 只允许预览 real-parameter intake validation closure：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 approval packet file
+- 它不得写 blocked summary file
+- 它不得写 real parameter intake file
+- 它不得写 validation closure file
+- 它不得写 DB
+- real-parameter validation closure 不等于真实 network dry-run authorization
+- Codex 不得自行填写真实 source / target / terms / authorization
+- Codex 不得自行把 validation_passed 改成 true
+- Codex 不得自行把 real_parameter_intake_validated 改成 true
+- 即使 CLI 传入确认参数，Phase 4.91D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-real-parameter-validation-closure-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、再经过独立 validation / terms / authorization review。validation closure 只定义校验规则，不授权任何执行。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@
         data-single-target-acquisition-network-user-input-closure-preview data-single-target-acquisition-network-user-input-closure-commit \
         data-single-target-acquisition-network-blocked-final-preflight-summary data-single-target-acquisition-network-blocked-final-preflight-commit \
         data-single-target-acquisition-network-real-parameter-intake-preview data-single-target-acquisition-network-real-parameter-intake-commit \
+        data-single-target-acquisition-network-real-parameter-validation-closure-preview data-single-target-acquisition-network-real-parameter-validation-closure-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -89,6 +90,7 @@ NETWORK_APPROVAL_PACKET_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_USER_INPUT_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_BLOCKED_PREFLIGHT_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_REAL_PARAMETER_INTAKE_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -372,6 +374,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-blocked-final-preflight-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_BLOCKED_FINAL_PREFLIGHT=1  # blocked in Phase 4.89D"
 	@echo "  make data-single-target-acquisition-network-real-parameter-intake-preview INTAKE=<path> BLOCKED_SUMMARY=<path>  # real-parameter intake template preview, Phase 4.90D"
 	@echo "  make data-single-target-acquisition-network-real-parameter-intake-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE=1  # blocked in Phase 4.90D"
+	@echo "  make data-single-target-acquisition-network-real-parameter-validation-closure-preview VALIDATION_CLOSURE=<path> INTAKE=<path> BLOCKED_SUMMARY=<path>  # validation closure preview, Phase 4.91D"
+	@echo "  make data-single-target-acquisition-network-real-parameter-validation-closure-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE=1  # blocked in Phase 4.91D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1239,6 +1243,23 @@ data-single-target-acquisition-network-real-parameter-intake-commit: ## Blocked 
 	@echo "BLOCKED: single-target acquisition real-parameter intake execution is not wired in Phase 4.90D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE=1, this path remains blocked."
 	@echo "  Phase 4.90D previews the intake template only and does not authorize any network dry-run, staging write, real parameter intake file write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-real-parameter-validation-closure-preview: ## Preview-only real-parameter intake validation closure. Phase 4.91D. No network, no writes, no DB.
+	@if [ -z "$(VALIDATION_CLOSURE)" ] || [ -z "$(INTAKE)" ] || [ -z "$(BLOCKED_SUMMARY)" ]; then \
+		echo "ERROR: provide VALIDATION_CLOSURE=<path>, INTAKE=<path>, and BLOCKED_SUMMARY=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.91D: network real-parameter intake validation closure (template-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE_NODE) scripts/ops/single_target_acquisition_network_real_parameter_intake_validation_closure.js \
+		--validation-closure "$(VALIDATION_CLOSURE)" \
+		--intake "$(INTAKE)" \
+		--blocked-summary "$(BLOCKED_SUMMARY)"
+
+data-single-target-acquisition-network-real-parameter-validation-closure-commit: ## Blocked network real-parameter validation closure gate. Remains not wired in Phase 4.91D.
+	@echo "BLOCKED: single-target acquisition real-parameter intake validation closure execution is not wired in Phase 4.91D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE=1, this path remains blocked."
+	@echo "  Phase 4.91D previews the validation closure template only and does not authorize any network dry-run, staging write, validation closure file write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_PHASE4_91D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_PHASE4_91D.md
@@ -1,0 +1,156 @@
+# Single-Target Acquisition Network Real-Parameter Intake Validation Closure Phase 4.91D
+
+## Executive Summary
+
+Phase 4.91D is the real-parameter intake validation closure stage.
+
+This phase does not access the network, collect data, write DB rows, write
+staging artifacts, write packet files, or write runtime files. Its goal is to
+define how a future phase should validate a user-filled real-parameter intake
+for completeness, safety, and compliance before any single-target acquisition
+network dry-run can be proposed.
+
+## Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_real_parameter_intake_validation_closure.js`
+- `tests/unit/single_target_acquisition_network_real_parameter_intake_validation_closure.test.js`
+- Makefile targets:
+    - `data-single-target-acquisition-network-real-parameter-validation-closure-preview`
+    - `data-single-target-acquisition-network-real-parameter-validation-closure-commit`
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_PHASE4_91D.md`
+
+## Validation Rule Groups
+
+The validation closure defines six rule groups that a future filled intake must
+pass:
+
+1. `real_target_validation` — requires complete target source, engine family,
+   single-target scope (max 1 target), no bulk scope
+2. `source_terms_validation` — requires source homepage, terms, license URLs,
+   allowed-use summary, terms reviewer, terms approval
+3. `network_authorization_validation` — requires explicit network dry-run
+   authorization, external network policy, browser/proxy runtime policy,
+   confirmed single-target (not bulk expansion)
+4. `staging_policy_validation` — requires output root policy, schema validation,
+   source manifest policy, staging write authorization decision
+5. `no_db_training_prediction_validation` — requires confirmed no DB writes, no
+   training, no prediction, no model artifact loading
+6. `final_human_confirmation_validation` — requires confirmed reviewer identity
+   and explicit final human confirmation
+
+## Validation Blocking Reasons
+
+The template lists eight blocking reasons, all active in Phase 4.91D:
+
+- `real_parameters_not_provided`
+- `real_target_not_validated`
+- `source_terms_not_validated`
+- `network_authorization_not_validated`
+- `staging_policy_not_validated`
+- `no_db_training_prediction_policy_not_validated`
+- `final_human_confirmation_not_validated`
+- `future_separate_phase_required`
+
+## Validation Behavior
+
+The validator is local-only and read-only.
+
+It verifies:
+
+- `validation_closure_status=template_only`
+- `real_parameter_intake_validation_ready=false`
+- `real_parameter_intake_validated=false`
+- `real_parameters_provided=false`
+- all `validation_passed=false` across all six rule groups
+- `network_dry_run_authorized=false`
+- `network_dry_run_execution_allowed=false`
+- all `would_*` safety flags remain `false`
+- all Codex constraints remain `true` (Codex may not self-fill)
+- no real source, target, terms, authorization values were provided
+- the Phase 4.90D real-parameter intake template remains valid and unprovided
+- the Phase 4.89D blocked final preflight summary remains valid and blocked
+- no network execution occurs
+- no runtime writes occur
+
+The commit target remains blocked. Phase 4.91D does not write a validation
+closure runtime file and does not authorize staging writes, DB writes,
+training, or prediction.
+
+## Relationship To Previous Phases
+
+- 4.79D parameter scaffold
+- 4.80D schema validation
+- 4.81D writer preflight
+- 4.82D packet preview
+- 4.83D pre-network runbook draft
+- 4.84D authorization form template
+- 4.85D final readiness checklist
+- 4.86D execution plan draft
+- 4.87D human approval packet preview
+- 4.88D user input requirements closure
+- 4.89D blocked final preflight summary
+- 4.90D real-parameter intake template
+- 4.91D real-parameter intake validation closure
+
+All thirteen phases remain pre-execution governance artifacts. None of them is
+a real network dry-run.
+
+## Recommended Next Phase
+
+Recommended next phase:
+
+`Phase 4.92D: single-target acquisition filled-intake review plan template`
+
+- still no network access
+- still no DB writes
+- still no staging writes
+- only defines how a future phase should review a user-filled intake
+
+Alternative:
+
+`Phase 4.56A`, only after the user supplies complete real network dry-run
+parameters and the project returns to runbook preparation.
+
+## Explicit Non-Execution
+
+Phase 4.91D did not execute:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- approval packet file write
+- user input closure file write
+- blocked summary file write
+- real parameter intake file write
+- real parameter validation closure file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion
+- coverage threshold modification
+- skipped tests
+- deleted tests
+- gatekeeper bypass

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md
@@ -1,0 +1,193 @@
+# Single-Target Acquisition Network Dry-Run Real-Parameter Intake Validation Closure Template
+
+This document is a Phase 4.91D template-only validation closure for a future
+user-filled real-parameter intake.
+
+- This is a real-parameter intake validation closure template, not proof that
+  validation has passed.
+- This is not a network dry-run authorization document.
+- `real_parameter_intake_validation_ready=false` by default.
+- `real_parameter_intake_validated=false` by default.
+- `real_parameters_provided=false` by default.
+- Every `validation_passed` field is `false` by default.
+- Codex must not fill real source, target, terms, or authorization values for
+  the user.
+- Codex must not change any `validation_passed` value to `true` on its own.
+- Codex must not authorize network dry-run execution.
+- Phase 4.91D does not write a real parameter validation closure runtime file.
+  It only validates this template and produces a local stdout preview.
+- A real network dry-run must move to a later, separately authorized phase
+  after the user explicitly fills the real parameters and that filled intake is
+  independently reviewed.
+
+```yaml
+phase: PHASE4_91D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE
+validation_closure_status: template_only
+real_parameter_intake_validation_ready: false
+real_parameter_intake_validated: false
+real_parameters_provided: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+validation_rule_groups:
+    real_target_validation:
+        required: true
+        rule_complete: true
+        validation_passed: false
+        requires_target_source: true
+        requires_engine_family_titan_discovery: true
+        requires_single_target_scope: true
+        allows_match_id_scope: true
+        allows_league_season_date_scope: true
+        max_targets: 1
+        bulk_scope_allowed: false
+    source_terms_validation:
+        required: true
+        rule_complete: true
+        validation_passed: false
+        requires_source_homepage_url: true
+        requires_terms_url: true
+        requires_license_url: true
+        requires_allowed_use_summary: true
+        requires_terms_reviewed_by: true
+        requires_terms_approval_yes: true
+    network_authorization_validation:
+        required: true
+        rule_complete: true
+        validation_passed: false
+        requires_network_dry_run_authorization_yes: true
+        requires_allow_external_network_yes_or_explicit_no: true
+        requires_browser_runtime_policy: true
+        requires_proxy_runtime_policy: true
+        requires_no_bulk_expansion_confirmation: true
+    staging_policy_validation:
+        required: true
+        rule_complete: true
+        validation_passed: false
+        requires_output_root_policy: true
+        requires_schema_validation: true
+        requires_source_manifest_policy: true
+        requires_staging_write_authorization_decision: true
+    no_db_training_prediction_validation:
+        required: true
+        rule_complete: true
+        validation_passed: false
+        requires_no_db_write_confirmation: true
+        requires_no_training_confirmation: true
+        requires_no_prediction_confirmation: true
+        requires_no_model_artifact_loading_confirmation: true
+    final_human_confirmation_validation:
+        required: true
+        rule_complete: true
+        validation_passed: false
+        requires_confirmed_by: true
+        requires_final_confirmation_yes: true
+
+validation_blocking_reasons:
+    - real_parameters_not_provided
+    - real_target_not_validated
+    - source_terms_not_validated
+    - network_authorization_not_validated
+    - staging_policy_not_validated
+    - no_db_training_prediction_policy_not_validated
+    - final_human_confirmation_not_validated
+    - future_separate_phase_required
+
+included_artifacts:
+    real_parameter_intake: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md
+    blocked_summary: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md
+
+codex_constraints:
+    codex_may_not_self_fill_real_parameters: true
+    codex_may_not_mark_validation_passed: true
+    codex_may_not_authorize_network: true
+    codex_may_not_enable_execution: true
+    codex_may_not_write_runtime_files: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_execute_legacy_titan_discovery: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_user_input_closure_file: false
+    would_write_blocked_summary_file: false
+    would_write_real_parameter_intake_file: false
+    would_write_real_parameter_validation_closure_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+next_phase_requirements:
+    - user_fills_real_parameter_intake
+    - separate_phase_validates_filled_intake
+    - separate_phase_reviews_terms_and_authorization
+    - separate_phase_confirms_single_target_scope
+    - separate_phase_confirms_no_db_write
+    - separate_phase_confirms_no_training
+    - separate_phase_confirms_no_prediction
+```
+
+## Purpose
+
+This template defines how a later phase should evaluate a user-filled
+real-parameter intake before any single-target acquisition network dry-run can
+be proposed.
+
+It defines validation rules for:
+
+- real target completeness
+- single-target scope validity
+- source terms, license, and allowed-use fields
+- explicit network authorization
+- browser, proxy, and external network policy
+- staging policy
+- no-DB-write confirmation
+- no-training confirmation
+- no-prediction confirmation
+- final human confirmation
+- absence of bulk scope
+- absence of Codex self-filled real parameters
+
+## Guardrails
+
+Even if a future intake is complete, Phase 4.91D does not execute a network
+dry-run. A filled intake must still move through a later, separately authorized
+review phase that checks the filled parameters, terms approval, network
+authorization, staging policy, no-DB/no-training/no-prediction confirmations,
+and final human approval.
+
+This template does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- legacy `titan_discovery` runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- approval packet file writes
+- user input closure file writes
+- blocked summary runtime file writes
+- real parameter intake runtime file writes
+- real parameter validation closure runtime file writes
+- DB writes
+- training
+- prediction
+
+The template must remain `template_only` in Phase 4.91D. Codex cannot supply or
+infer real source, target, terms, license review, allowed-use review, network
+authorization, staging policy, validation pass status, or final human
+confirmation for the user.

--- a/scripts/ops/single_target_acquisition_network_real_parameter_intake_validation_closure.js
+++ b/scripts/ops/single_target_acquisition_network_real_parameter_intake_validation_closure.js
@@ -1,0 +1,573 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    parseIntakeYaml,
+    runValidation: validateRealParameterIntake,
+} = require('./single_target_acquisition_network_real_parameter_intake');
+
+const OUTPUT_PHASE = 'PHASE4.91D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE';
+const TEMPLATE_PHASE = 'PHASE4_91D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE';
+const MODE = 'single-target-acquisition-network-real-parameter-validation-closure-preview';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition real-parameter intake validation closure execution is not wired in Phase 4.91D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.92D or explicit user-filled real parameter intake';
+const REAL_PARAMETER_INTAKE_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md';
+const BLOCKED_SUMMARY_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md';
+
+const VALIDATION_RULE_GROUPS = [
+    'real_target_validation',
+    'source_terms_validation',
+    'network_authorization_validation',
+    'staging_policy_validation',
+    'no_db_training_prediction_validation',
+    'final_human_confirmation_validation',
+];
+
+const VALIDATION_BLOCKING_REASONS = [
+    'real_parameters_not_provided',
+    'real_target_not_validated',
+    'source_terms_not_validated',
+    'network_authorization_not_validated',
+    'staging_policy_not_validated',
+    'no_db_training_prediction_policy_not_validated',
+    'final_human_confirmation_not_validated',
+    'future_separate_phase_required',
+];
+
+const REQUIRED_TOP_FIELDS = words(`
+    phase validation_closure_status real_parameter_intake_validation_ready
+    real_parameter_intake_validated real_parameters_provided
+    network_dry_run_authorized network_dry_run_execution_allowed
+    staging_write_authorized db_write_authorized training_authorized
+    prediction_authorized final_human_confirmation validation_rule_groups
+    validation_blocking_reasons included_artifacts codex_constraints safety
+    next_phase_requirements
+`);
+
+const TOP_FALSE = {
+    real_parameter_intake_validation_ready: 'real_parameter_intake_validation_ready true in template is not allowed',
+    real_parameter_intake_validated: 'real_parameter_intake_validated true in template is not allowed',
+    real_parameters_provided: 'real_parameters_provided true in template is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true in template is not allowed',
+    staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+    db_write_authorized: 'db_write_authorized true in template is not allowed',
+    training_authorized: 'training_authorized true in template is not allowed',
+    prediction_authorized: 'prediction_authorized true in template is not allowed',
+    final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+};
+
+const RULE_GROUP_REQUIREMENTS = {
+    real_target_validation: words(`
+        required rule_complete validation_passed requires_target_source
+        requires_engine_family_titan_discovery requires_single_target_scope
+        allows_match_id_scope allows_league_season_date_scope max_targets
+        bulk_scope_allowed
+    `),
+    source_terms_validation: words(`
+        required rule_complete validation_passed requires_source_homepage_url
+        requires_terms_url requires_license_url requires_allowed_use_summary
+        requires_terms_reviewed_by requires_terms_approval_yes
+    `),
+    network_authorization_validation: words(`
+        required rule_complete validation_passed
+        requires_network_dry_run_authorization_yes
+        requires_allow_external_network_yes_or_explicit_no
+        requires_browser_runtime_policy requires_proxy_runtime_policy
+        requires_no_bulk_expansion_confirmation
+    `),
+    staging_policy_validation: words(`
+        required rule_complete validation_passed requires_output_root_policy
+        requires_schema_validation requires_source_manifest_policy
+        requires_staging_write_authorization_decision
+    `),
+    no_db_training_prediction_validation: words(`
+        required rule_complete validation_passed requires_no_db_write_confirmation
+        requires_no_training_confirmation requires_no_prediction_confirmation
+        requires_no_model_artifact_loading_confirmation
+    `),
+    final_human_confirmation_validation: words(`
+        required rule_complete validation_passed requires_confirmed_by
+        requires_final_confirmation_yes
+    `),
+};
+
+const CODEX_CONSTRAINT_FIELDS = words(`
+    codex_may_not_self_fill_real_parameters
+    codex_may_not_mark_validation_passed
+    codex_may_not_authorize_network
+    codex_may_not_enable_execution
+    codex_may_not_write_runtime_files
+`);
+
+const SAFETY_FIELDS = words(`
+    would_access_network would_launch_browser would_use_proxy
+    would_execute_engine would_execute_legacy_titan_discovery
+    would_write_staging would_create_staging_directory
+    would_write_source_manifest would_write_packet_file
+    would_write_approval_packet_file would_write_user_input_closure_file
+    would_write_blocked_summary_file would_write_real_parameter_intake_file
+    would_write_real_parameter_validation_closure_file
+    would_write_db would_train would_predict would_bulk_harvest
+`);
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_real_parameter_intake_validation_closure.js --validation-closure <path> --intake <path> --blocked-summary <path>',
+        '  node scripts/ops/single_target_acquisition_network_real_parameter_intake_validation_closure.js --validation-closure <path> --intake <path> --blocked-summary <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.91D previews a local real-parameter intake validation closure template only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes, no child processes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        validation_closure: '',
+        intake: '',
+        blocked_summary: '',
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) throw new Error(`Unknown argument: ${token}`);
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        validation_closure_template_only: true,
+        validation_closure_valid: false,
+        real_parameter_intake_valid: false,
+        blocked_summary_valid: false,
+        real_parameter_intake_validation_ready: false,
+        real_parameter_intake_validated: false,
+        real_parameters_provided: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        validation_rule_groups_complete: false,
+        validation_rule_groups_passed: false,
+        validation_blocking_reasons: VALIDATION_BLOCKING_REASONS,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_execute_legacy_titan_discovery: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_user_input_closure_file: false,
+        would_write_blocked_summary_file: false,
+        would_write_real_parameter_intake_file: false,
+        would_write_real_parameter_validation_closure_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: OUTPUT_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        validation_closure: args.validation_closure || null,
+        intake: args.intake || null,
+        blocked_summary: args.blocked_summary || null,
+        validation_closure_found: false,
+        intake_found: false,
+        blocked_summary_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_legacy_titan_discovery_execution',
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+        ],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function validateRequiredCliFields(args) {
+    const errors = [];
+    if (!args.validation_closure) errors.push('missing validation closure');
+    if (!args.intake) errors.push('missing intake');
+    if (!args.blocked_summary) errors.push('missing blocked summary');
+    return errors;
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = validateRequiredCliFields(args);
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function loadYamlFile(args, dependencies, fieldName, missingLabel, mode) {
+    const rawPath = args[fieldName];
+    const targetPath = resolveLocalPath(rawPath, dependencies.cwd);
+    if (!dependencies.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: false,
+                errors: [`missing ${missingLabel}: ${toRelativePath(targetPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+
+    const yamlText = extractYamlBlock(dependencies.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseIntakeYaml(yamlText), yamlText };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function hasOwn(root, key) {
+    return Object.prototype.hasOwnProperty.call(root, key);
+}
+
+function getPath(root, dottedPath) {
+    return dottedPath.split('.').reduce((current, key) => {
+        if (!current || typeof current !== 'object') return undefined;
+        return current[key];
+    }, root);
+}
+
+function addMissingNested(root, parentPath, requiredKeys, missingFields) {
+    const value = getPath(root, parentPath);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        missingFields.push(parentPath);
+        return;
+    }
+    requiredKeys.filter(key => !hasOwn(value, key)).forEach(key => missingFields.push(`${parentPath}.${key}`));
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_FIELDS.filter(key => !hasOwn(parsedYaml, key));
+    VALIDATION_RULE_GROUPS.forEach(groupName => {
+        addMissingNested(
+            parsedYaml,
+            `validation_rule_groups.${groupName}`,
+            RULE_GROUP_REQUIREMENTS[groupName],
+            missingFields
+        );
+    });
+    addMissingNested(parsedYaml, 'included_artifacts', words('real_parameter_intake blocked_summary'), missingFields);
+    addMissingNested(parsedYaml, 'codex_constraints', CODEX_CONSTRAINT_FIELDS, missingFields);
+    addMissingNested(parsedYaml, 'safety', SAFETY_FIELDS, missingFields);
+    return missingFields;
+}
+
+function validateTopLevelFalse(parsedYaml, errors) {
+    Object.entries(TOP_FALSE).forEach(([fieldName, message]) => {
+        if (parsedYaml[fieldName] !== false) errors.push(message);
+    });
+}
+
+function validateRuleGroups(parsedYaml, errors) {
+    const groups = parsedYaml.validation_rule_groups || {};
+    VALIDATION_RULE_GROUPS.forEach(groupName => {
+        const group = groups[groupName];
+        if (!group || typeof group !== 'object' || Array.isArray(group)) {
+            errors.push(`missing validation rule group: ${groupName}`);
+            return;
+        }
+        if (group.required !== true) errors.push(`validation_rule_groups.${groupName}.required must be true`);
+        if (group.rule_complete !== true) {
+            errors.push(`validation_rule_groups.${groupName}.rule_complete must be true`);
+        }
+        if (group.validation_passed !== false) {
+            errors.push(`validation_rule_groups.${groupName}.validation_passed true in template is not allowed`);
+        }
+        RULE_GROUP_REQUIREMENTS[groupName]
+            .filter(fieldName => !['required', 'rule_complete', 'validation_passed'].includes(fieldName))
+            .forEach(fieldName => {
+                if (fieldName === 'max_targets' && group.max_targets !== 1) {
+                    errors.push('max_targets > 1 is not allowed in the Phase 4.91D validation closure template');
+                    return;
+                }
+                if (fieldName === 'bulk_scope_allowed' && group.bulk_scope_allowed !== false) {
+                    errors.push(
+                        'bulk_scope_allowed true is not allowed in the Phase 4.91D validation closure template'
+                    );
+                    return;
+                }
+                if (!['max_targets', 'bulk_scope_allowed'].includes(fieldName) && group[fieldName] !== true) {
+                    errors.push(`validation_rule_groups.${groupName}.${fieldName} must be true`);
+                }
+            });
+    });
+}
+
+function validateBlockingReasons(parsedYaml, errors) {
+    const reasons = parsedYaml.validation_blocking_reasons;
+    if (!Array.isArray(reasons)) {
+        errors.push('missing validation_blocking_reasons');
+        return;
+    }
+    const missing = VALIDATION_BLOCKING_REASONS.filter(reason => !reasons.includes(reason));
+    if (missing.length) errors.push(`missing validation_blocking_reasons: ${missing.join(',')}`);
+}
+
+function validateIncludedArtifacts(parsedYaml, errors) {
+    const included = parsedYaml.included_artifacts || {};
+    if (included.real_parameter_intake !== REAL_PARAMETER_INTAKE_TEMPLATE) {
+        errors.push(`included_artifacts.real_parameter_intake must be ${REAL_PARAMETER_INTAKE_TEMPLATE}`);
+    }
+    if (included.blocked_summary !== BLOCKED_SUMMARY_TEMPLATE) {
+        errors.push(`included_artifacts.blocked_summary must be ${BLOCKED_SUMMARY_TEMPLATE}`);
+    }
+}
+
+function validateCodexConstraints(parsedYaml, errors) {
+    const constraints = parsedYaml.codex_constraints || {};
+    CODEX_CONSTRAINT_FIELDS.forEach(fieldName => {
+        if (constraints[fieldName] !== true) {
+            errors.push(`codex_constraints.${fieldName} false is not allowed`);
+        }
+    });
+}
+
+function validateSafety(parsedYaml, errors) {
+    const safety = parsedYaml.safety || {};
+    SAFETY_FIELDS.forEach(fieldName => {
+        if (safety[fieldName] !== false) {
+            errors.push(`safety.${fieldName} must remain false`);
+        }
+    });
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) errors.push(`missing required fields: ${missingFields.join(',')}`);
+    if (parsedYaml.phase !== TEMPLATE_PHASE) errors.push(`phase must be ${TEMPLATE_PHASE}`);
+    if (parsedYaml.validation_closure_status !== 'template_only') {
+        errors.push('validation_closure_status not template_only');
+    }
+    validateTopLevelFalse(parsedYaml, errors);
+    validateRuleGroups(parsedYaml, errors);
+    validateBlockingReasons(parsedYaml, errors);
+    validateIncludedArtifacts(parsedYaml, errors);
+    validateCodexConstraints(parsedYaml, errors);
+    validateSafety(parsedYaml, errors);
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: OUTPUT_PHASE,
+        mode: MODE,
+        ok: true,
+        validation_closure: args.validation_closure,
+        intake: args.intake,
+        blocked_summary: args.blocked_summary,
+        validation_closure_found: true,
+        intake_found: true,
+        blocked_summary_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        validation_closure_valid: true,
+        real_parameter_intake_valid: true,
+        blocked_summary_valid: true,
+        validation_rule_groups_complete: true,
+        validation_rule_groups_passed: false,
+        errors: [],
+        warnings: [
+            'Phase 4.91D remains template-only.',
+            'Validation closure rules do not authorize network execution in this phase.',
+        ],
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_legacy_titan_discovery_execution',
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+        ],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const localDeps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const closureLoad = loadYamlFile(
+        args,
+        localDeps,
+        'validation_closure',
+        'validation closure',
+        'validation-closure-error'
+    );
+    if (closureLoad.payload) return closureLoad.payload;
+
+    const closureValidation = validateParsedYaml(closureLoad.parsedYaml);
+    if (!closureValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'validation-closure-error',
+            validation_closure_found: true,
+            yaml_block_found: true,
+            required_fields_present: closureValidation.missingFields.length === 0,
+            missing_fields: closureValidation.missingFields,
+            errors: closureValidation.errors,
+        });
+    }
+
+    const intakePayload = validateRealParameterIntake(
+        { intake: args.intake, blocked_summary: args.blocked_summary },
+        localDeps
+    );
+    if (!intakePayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'intake-or-blocked-summary-error',
+            validation_closure_found: true,
+            validation_closure_valid: true,
+            validation_rule_groups_complete: true,
+            yaml_block_found: true,
+            real_parameter_intake_valid: intakePayload.intake_valid === true,
+            blocked_summary_valid: intakePayload.blocked_summary_valid === true,
+            intake_found: intakePayload.intake_found === true,
+            blocked_summary_found: intakePayload.blocked_summary_found === true,
+            errors: intakePayload.errors || ['real parameter intake validation failed'],
+            missing_fields: intakePayload.missing_fields || [],
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(payload, io) {
+    io.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (text => process.stdout.write(text)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [error.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    OUTPUT_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    VALIDATION_RULE_GROUPS,
+    VALIDATION_BLOCKING_REASONS,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_real_parameter_intake_validation_closure.test.js
+++ b/tests/unit/single_target_acquisition_network_real_parameter_intake_validation_closure.test.js
@@ -1,0 +1,579 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(
+    PROJECT_ROOT,
+    'scripts/ops/single_target_acquisition_network_real_parameter_intake_validation_closure.js'
+);
+const VALIDATION_CLOSURE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md'
+);
+const INTAKE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md'
+);
+const BLOCKED_SUMMARY_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md'
+);
+const VALIDATION_CLOSURE_TEXT = fs.readFileSync(VALIDATION_CLOSURE_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        validation_closure: VALIDATION_CLOSURE_PATH,
+        intake: INTAKE_PATH,
+        blocked_summary: BLOCKED_SUMMARY_PATH,
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function buildTextDependencies(markdownText, targetPath = VALIDATION_CLOSURE_PATH) {
+    return buildDependencies({
+        existsSync: currentPath => currentPath === targetPath || fs.existsSync(currentPath),
+        readFileSync: (currentPath, encoding) => {
+            if (currentPath === targetPath) return markdownText;
+            return fs.readFileSync(currentPath, encoding);
+        },
+    });
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(
+            `${name} should not be called by single_target_acquisition_network_real_parameter_intake_validation_closure`
+        );
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+        if (blockedImports.has(request)) throw new Error(`blocked import: ${request}`);
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(VALIDATION_CLOSURE_TEXT, new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return VALIDATION_CLOSURE_TEXT.replace(searchValue, replaceValue);
+}
+
+function removeLineFromTemplate(line) {
+    return VALIDATION_CLOSURE_TEXT.replace(`${line}\n`, '');
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout };
+}
+
+function extractLastJsonObject(stdout) {
+    const trimmed = String(stdout || '').trim();
+    const startIndex = trimmed.lastIndexOf('\n{');
+    const jsonText = startIndex >= 0 ? trimmed.slice(startIndex + 1) : trimmed;
+    return JSON.parse(jsonText);
+}
+
+test('缺 validation closure 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.validation_closure;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing validation closure/i);
+});
+
+test('缺 intake 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.intake;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing intake/i);
+});
+
+test('缺 blocked summary 失败', () => {
+    const gate = loadValidatorFresh();
+    const args = buildArgs();
+    delete args.blocked_summary;
+    const payload = gate.runValidation(args, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing blocked summary/i);
+});
+
+test('validation closure 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('# no yaml\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing YAML block/i);
+});
+
+test('validation closure invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('```yaml\nnot yaml\n```\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /invalid YAML/i);
+});
+
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            removeLineFromTemplate(
+                'phase: PHASE4_91D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing required fields: phase|phase must be/);
+});
+
+test('validation_closure_status 非 template_only 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            replaceInTemplate('validation_closure_status: template_only', 'validation_closure_status: ready')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /validation_closure_status not template_only|template_only/);
+});
+
+[
+    [
+        'real_parameter_intake_validation_ready=true 失败',
+        'real_parameter_intake_validation_ready: false',
+        'real_parameter_intake_validation_ready: true',
+        /real_parameter_intake_validation_ready true/,
+    ],
+    [
+        'real_parameter_intake_validated=true 失败',
+        'real_parameter_intake_validated: false',
+        'real_parameter_intake_validated: true',
+        /real_parameter_intake_validated true/,
+    ],
+    [
+        'real_parameters_provided=true 失败',
+        'real_parameters_provided: false',
+        'real_parameters_provided: true',
+        /real_parameters_provided true/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'staging_write_authorized=true 失败',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    [
+        'db_write_authorized=true 失败',
+        'db_write_authorized: false',
+        'db_write_authorized: true',
+        /db_write_authorized true/,
+    ],
+    [
+        'training_authorized=true 失败',
+        'training_authorized: false',
+        'training_authorized: true',
+        /training_authorized true/,
+    ],
+    [
+        'prediction_authorized=true 失败',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([name, searchValue, replaceValue, pattern]) => {
+    test(name, () => {
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildTextDependencies(replaceInTemplate(searchValue, replaceValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+[
+    'real_target_validation',
+    'source_terms_validation',
+    'network_authorization_validation',
+    'staging_policy_validation',
+    'no_db_training_prediction_validation',
+    'final_human_confirmation_validation',
+].forEach(groupName => {
+    test(`validation_rule_groups.${groupName}.validation_passed=true 失败`, () => {
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildTextDependencies(
+                replaceInTemplate(
+                    `${groupName}:\n        required: true\n        rule_complete: true\n        validation_passed: false`,
+                    `${groupName}:\n        required: true\n        rule_complete: true\n        validation_passed: true`
+                )
+            )
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), new RegExp(`${groupName}\\.validation_passed true`));
+    });
+});
+
+test('codex_may_not_self_fill_real_parameters=false 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            replaceInTemplate(
+                '    codex_may_not_self_fill_real_parameters: true',
+                '    codex_may_not_self_fill_real_parameters: false'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /codex_may_not_self_fill_real_parameters false/);
+});
+
+test('codex_may_not_mark_validation_passed=false 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            replaceInTemplate(
+                '    codex_may_not_mark_validation_passed: true',
+                '    codex_may_not_mark_validation_passed: false'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /codex_may_not_mark_validation_passed false/);
+});
+
+test('validation_blocking_reasons missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('validation_blocking_reasons:', 'validation_blocking_reasons_missing:'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing validation_blocking_reasons|validation_blocking_reasons/);
+});
+
+test('validation rule group missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('    real_target_validation:', '    real_target_validation_missing:'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing validation rule group: real_target_validation/);
+});
+
+test('bulk_scope_allowed=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            replaceInTemplate('        bulk_scope_allowed: false', '        bulk_scope_allowed: true')
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /bulk_scope_allowed true/);
+});
+
+test('max_targets > 1 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('        max_targets: 1', '        max_targets: 2'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /max_targets > 1/);
+});
+
+test('safety would_access_network=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('    would_access_network: false', '    would_access_network: true'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /safety\.would_access_network/);
+});
+
+test('safety would_write_db=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(replaceInTemplate('    would_write_db: false', '    would_write_db: true'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /safety\.would_write_db/);
+});
+
+test('safety would_write_real_parameter_validation_closure_file=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDependencies(
+            replaceInTemplate(
+                '    would_write_real_parameter_validation_closure_file: false',
+                '    would_write_real_parameter_validation_closure_file: true'
+            )
+        )
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /safety\.would_write_real_parameter_validation_closure_file/);
+});
+
+test('valid validation closure preview 成功', () => {
+    const gate = loadValidatorFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    assert.equal(
+        payload.phase,
+        'PHASE4.91D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE'
+    );
+    assert.equal(payload.validation_closure_template_only, true);
+    assert.equal(payload.validation_closure_valid, true);
+    assert.equal(payload.real_parameter_intake_valid, true);
+    assert.equal(payload.blocked_summary_valid, true);
+    assert.equal(payload.real_parameter_intake_validation_ready, false);
+    assert.equal(payload.real_parameter_intake_validated, false);
+    assert.equal(payload.real_parameters_provided, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.validation_rule_groups_complete, true);
+    assert.equal(payload.validation_rule_groups_passed, false);
+    assert.deepEqual(payload.validation_blocking_reasons, [
+        'real_parameters_not_provided',
+        'real_target_not_validated',
+        'source_terms_not_validated',
+        'network_authorization_not_validated',
+        'staging_policy_not_validated',
+        'no_db_training_prediction_policy_not_validated',
+        'final_human_confirmation_not_validated',
+        'future_separate_phase_required',
+    ]);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_execute_engine, false);
+    assert.equal(payload.would_execute_legacy_titan_discovery, false);
+    assert.equal(payload.would_write_staging, false);
+    assert.equal(payload.would_create_staging_directory, false);
+    assert.equal(payload.would_write_source_manifest, false);
+    assert.equal(payload.would_write_packet_file, false);
+    assert.equal(payload.would_write_approval_packet_file, false);
+    assert.equal(payload.would_write_blocked_summary_file, false);
+    assert.equal(payload.would_write_real_parameter_intake_file, false);
+    assert.equal(payload.would_write_real_parameter_validation_closure_file, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const result = runMain(
+        gate,
+        [
+            '--validation-closure',
+            VALIDATION_CLOSURE_PATH,
+            '--intake',
+            INTAKE_PATH,
+            '--blocked-summary',
+            BLOCKED_SUMMARY_PATH,
+            '--commit',
+        ],
+        buildDependencies()
+    );
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.errors.join('\n'), /not wired in Phase 4.91D/);
+});
+
+test('Makefile preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-real-parameter-validation-closure-preview',
+            'NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE_NODE=node',
+            `VALIDATION_CLOSURE=${VALIDATION_CLOSURE_PATH}`,
+            `INTAKE=${INTAKE_PATH}`,
+            `BLOCKED_SUMMARY=${BLOCKED_SUMMARY_PATH}`,
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = extractLastJsonObject(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.validation_closure_valid, true);
+    assert.equal(payload.real_parameter_intake_valid, true);
+    assert.equal(payload.blocked_summary_valid, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-real-parameter-validation-closure-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.91D/);
+});
+
+[
+    ['不访问网络', 'would_access_network', false],
+    ['不启动 browser', 'would_launch_browser', false],
+    ['不执行 proxy runtime', 'would_use_proxy', false],
+    ['不执行 engine', 'would_execute_engine', false],
+    ['不执行 legacy titan_discovery', 'would_execute_legacy_titan_discovery', false],
+    ['不写 staging', 'would_write_staging', false],
+    ['不创建目录', 'would_create_staging_directory', false],
+    ['不写 source manifest', 'would_write_source_manifest', false],
+    ['不写 packet file', 'would_write_packet_file', false],
+    ['不写 approval packet file', 'would_write_approval_packet_file', false],
+    ['不写 blocked summary file', 'would_write_blocked_summary_file', false],
+    ['不写 real parameter intake file', 'would_write_real_parameter_intake_file', false],
+    ['不写 validation closure file', 'would_write_real_parameter_validation_closure_file', false],
+    ['不写 DB', 'would_write_db', false],
+    ['不 spawn child process', 'would_spawn_child_process', false],
+].forEach(([name, field, expected]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadValidatorFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], expected);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.91D single-target acquisition real-parameter intake validation closure.

Scope:
- Adds real-parameter intake validation closure template
- Adds local-only validation closure preview validator
- Defines validation rule groups for future user-filled intake review
- Validates intake remains unprovided and non-authorized
- Validates blocked final preflight summary remains blocked
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.91D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No approval packet file writes
- No user input closure file writes
- No blocked summary file writes
- No real parameter intake file writes
- No real parameter validation closure file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- preview missing params failed as expected
- valid real-parameter validation closure preview passed
- commit gate remained blocked
- unit tests passed (52/52)
- npm test passed (48/48)
- npm run test:coverage passed
- integration tests passed (19 pass, 5 skipped, 0 fail)
- DB row counts unchanged (2/2/2/2/2/2)
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)