### PR TITLE
fix(test): stabilize recon league dictionary flow

### DIFF
--- a/docs/_reports/RECON_LEAGUE_DICTIONARY_FLOW_MAIN_CI_HOTFIX.md
+++ b/docs/_reports/RECON_LEAGUE_DICTIONARY_FLOW_MAIN_CI_HOTFIX.md
@@ -1,0 +1,56 @@
+# Recon League Dictionary Flow Main CI Hotfix
+
+## Main CI Failure
+
+- **Run ID**: 25635881128
+- **Job**: Environment / Proxy / Static / Unit Gate
+- **Failed step**: Run Gatekeeper (npm run test:coverage)
+- **Failed test**: Recon League Dictionary Flow > 应支持组合对阵与占位赛程在先回源后通过本地字典候选完成自愈
+- **File**: tests/unit/ReconLeagueDictionaryFlow.test.js:314
+- **Actual**: `'exact'`
+- **Expected**: `'dictionary'`
+
+## Root Cause
+
+测试依赖 `savedMappings` 数组中映射的顺序。但 `Promise.all` 并发
+处理多场比赛，映射持久化顺序取决于异步完成时间，不保证与输入顺序
+一致。
+
+测试中 Match 2（占位赛程 `Winner SF 1 vs Winner SF 2`）的映射处理
+比 Match 1（组合对阵 `Sporting Cp Arsenal vs Barcelona Atletico Madrid`）
+更快完成，因此匹配结果中 `mapping[0].mapping_method === 'exact'`、
+`mapping[1].mapping_method === 'dictionary'`。
+
+测试原来假设 `mapping[0]` 一定是字典匹配，属于不稳定的顺序依赖。
+
+## Fix
+
+不再按数组索引断言，改为按 `match_id` 查找对应映射：
+
+- `'42_20252026_5205814'` → `mapping_method = 'dictionary'`（组合对阵，通过字典解析）
+- `'42_20252026_5205834'` → `mapping_method = 'exact'`（占位赛程，队名完全相等）
+
+## Why This Is Not Lowering Test Quality
+
+- 修改前后覆盖的断言完全相同：两种 mapping_method 各出现一次，
+  各有 confidence=1，各对应正确的 match_id
+- 新写法消除了不稳定的排序假设，使测试在任何异步调度下都可复现
+- 没有修改被测代码逻辑，没有 skip/delete 测试，没有降低覆盖率阈值
+- 没有绕过 gatekeeper
+
+## Validation
+
+- ReconLeagueDictionaryFlow.test.js 3/3 通过（连续 5 次）
+- npm test 48/48 通过
+- npm run test:coverage 通过
+- npm run test:integration 19 pass, 5 skipped, 0 fail
+- eslint / prettier / git diff --check 通过
+
+## Explicit Non-Execution
+
+未执行：coverage 阈值修改、skip/delete 测试、gatekeeper 绕过、DB writes、
+non-SELECT SQL、curl/wget/git clone、外部数据访问、scraping、browser automation、
+proxy runtime、harvest/ingest/backfill、network dry-run、staging write、
+source manifest write、packet file write、runtime file writes、pg_dump/pg_restore、
+model training、real prediction、model artifact loading、Docker volume cleanup、
+force push、git fetch --all、git pull、file deletion

--- a/tests/unit/ReconLeagueDictionaryFlow.test.js
+++ b/tests/unit/ReconLeagueDictionaryFlow.test.js
@@ -6,314 +6,357 @@ const assert = require('node:assert');
 const { ReconEngine } = require('../../src/infrastructure/recon/ReconEngine');
 
 describe('Recon League Dictionary Flow', () => {
-  it('应在 runReconMatrix 前预热联赛字典并将短名 h2h 候选洗白后提升为 RECON_LINKED', async () => {
-    const savedMappings = [];
+    it('应在 runReconMatrix 前预热联赛字典并将短名 h2h 候选洗白后提升为 RECON_LINKED', async () => {
+        const savedMappings = [];
 
-    const engine = new ReconEngine({
-      configManager: {
-        getActiveLeagues() {
-          return [
-            { id: 140, name: 'Segunda División', country: 'spain', slug: 'segunda-division', enabled: true }
-          ];
-        }
-      },
-      repository: {
-        async getReconEligibleMatches() {
-          return [
-            {
-              match_id: '140_20252026_4837844',
-              home_team: 'Sporting Gijon',
-              away_team: 'Deportivo La Coruna',
-              league_name: 'Segunda División',
-              season: '2025/2026',
-              pipeline_status: 'harvested',
-              match_date: '2026-04-05T18:00:00.000Z'
-            }
-          ];
-        },
-        async getLeagueDictionaryEntries() {
-          return [
-            {
-              league_id: 140,
-              remote_name: 'Gijon',
-              local_team_id: '9869',
-              local_team_name: 'Sporting Gijon'
+        const engine = new ReconEngine({
+            configManager: {
+                getActiveLeagues() {
+                    return [
+                        {
+                            id: 140,
+                            name: 'Segunda División',
+                            country: 'spain',
+                            slug: 'segunda-division',
+                            enabled: true,
+                        },
+                    ];
+                },
             },
-            {
-              league_id: 140,
-              remote_name: 'Dep La Coruna',
-              local_team_id: '9783',
-              local_team_name: 'Deportivo La Coruna'
-            }
-          ];
-        },
-        async batchSaveOddsPortalMappings(mappings) {
-          savedMappings.push(...mappings);
-          return {
-            success: true,
-            inserted: mappings.length,
-            updated: mappings.length,
-            applied: mappings.length
-          };
-        },
-        async batchUpdateMatchPipelineStatus(matchIds) {
-          return { updated: matchIds.length };
-        },
-        async batchSaveMismatchEvidence() {
-          return { success: true, saved: 0 };
-        }
-      },
-      navigator: {
-        async protocolArchiveExtract() {
-          return {
-            matches: [
-              {
-                hash: '23spHYrm',
-                url: 'https://www.oddsportal.com/football/h2h/gijon-69w4Rb2d/dep-la-coruna-Q51ZzMS6/#23spHYrm',
-                homeTeam: 'Gijon',
-                awayTeam: 'Dep La Coruna',
-                matchDate: '2026-04-05T18:00:00.000Z'
-              }
-            ],
-            pagesScanned: 1,
-            totalCandidates: 1
-          };
-        }
-      },
-      parser: {
-        calculateSimilarity(left, right) {
-          return String(left || '').toLowerCase().trim() === String(right || '').toLowerCase().trim() ? 1 : 0;
-        }
-      },
-      logger: { info() {}, warn() {}, error() {} },
-      baseUrl: 'oddsportal://root'
+            repository: {
+                async getReconEligibleMatches() {
+                    return [
+                        {
+                            match_id: '140_20252026_4837844',
+                            home_team: 'Sporting Gijon',
+                            away_team: 'Deportivo La Coruna',
+                            league_name: 'Segunda División',
+                            season: '2025/2026',
+                            pipeline_status: 'harvested',
+                            match_date: '2026-04-05T18:00:00.000Z',
+                        },
+                    ];
+                },
+                async getLeagueDictionaryEntries() {
+                    return [
+                        {
+                            league_id: 140,
+                            remote_name: 'Gijon',
+                            local_team_id: '9869',
+                            local_team_name: 'Sporting Gijon',
+                        },
+                        {
+                            league_id: 140,
+                            remote_name: 'Dep La Coruna',
+                            local_team_id: '9783',
+                            local_team_name: 'Deportivo La Coruna',
+                        },
+                    ];
+                },
+                async batchSaveOddsPortalMappings(mappings) {
+                    savedMappings.push(...mappings);
+                    return {
+                        success: true,
+                        inserted: mappings.length,
+                        updated: mappings.length,
+                        applied: mappings.length,
+                    };
+                },
+                async batchUpdateMatchPipelineStatus(matchIds) {
+                    return { updated: matchIds.length };
+                },
+                async batchSaveMismatchEvidence() {
+                    return { success: true, saved: 0 };
+                },
+            },
+            navigator: {
+                async protocolArchiveExtract() {
+                    return {
+                        matches: [
+                            {
+                                hash: '23spHYrm',
+                                url: 'https://www.oddsportal.com/football/h2h/gijon-69w4Rb2d/dep-la-coruna-Q51ZzMS6/#23spHYrm',
+                                homeTeam: 'Gijon',
+                                awayTeam: 'Dep La Coruna',
+                                matchDate: '2026-04-05T18:00:00.000Z',
+                            },
+                        ],
+                        pagesScanned: 1,
+                        totalCandidates: 1,
+                    };
+                },
+            },
+            parser: {
+                calculateSimilarity(left, right) {
+                    return String(left || '')
+                        .toLowerCase()
+                        .trim() ===
+                        String(right || '')
+                            .toLowerCase()
+                            .trim()
+                        ? 1
+                        : 0;
+                },
+            },
+            logger: { info() {}, warn() {}, error() {} },
+            baseUrl: 'oddsportal://root',
+        });
+
+        const result = await engine.runReconMatrix({
+            season: '2025-2026',
+            confidenceThreshold: 0.75,
+            concurrency: 1,
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.linked, 1);
+        assert.equal(result.mismatched, 0);
+        assert.equal(savedMappings.length, 1);
+        assert.equal(savedMappings[0].match_id, '140_20252026_4837844');
+        assert.equal(savedMappings[0].oddsportal_hash, '23spHYrm');
+        assert.equal(savedMappings[0].match_confidence, 1);
+        assert.doesNotMatch(savedMappings[0].full_url, /\/h2h\//);
+        assert.match(savedMappings[0].full_url, /-23spHYrm\/$/);
     });
 
-    const result = await engine.runReconMatrix({
-      season: '2025-2026',
-      confidenceThreshold: 0.75,
-      concurrency: 1
+    it('SOURCE_EMPTY 且仅剩 RECON_MISMATCH 时也应先回源一次，再走本地字典自愈', async () => {
+        const savedMappings = [];
+        let navigatorCalls = 0;
+
+        const engine = new ReconEngine({
+            configManager: {
+                getActiveLeagues() {
+                    return [
+                        {
+                            id: 140,
+                            name: 'Segunda División',
+                            country: 'spain',
+                            slug: 'segunda-division',
+                            enabled: true,
+                        },
+                    ];
+                },
+            },
+            repository: {
+                async getReconEligibleMatches() {
+                    return [
+                        {
+                            match_id: '140_20252026_4837532',
+                            home_team: 'Deportivo La Coruna',
+                            away_team: 'Sporting Gijon',
+                            league_name: 'Segunda División',
+                            season: '2025/2026',
+                            pipeline_status: 'RECON_MISMATCH',
+                            match_date: '2026-04-05T18:00:00.000Z',
+                        },
+                    ];
+                },
+                async getLeagueDictionaryEntries() {
+                    return [
+                        {
+                            league_id: 140,
+                            remote_name: 'DEP LA Coruna',
+                            local_team_id: '9783',
+                            local_team_name: 'Deportivo La Coruna',
+                        },
+                        {
+                            league_id: 140,
+                            remote_name: 'Gijon',
+                            local_team_id: '9869',
+                            local_team_name: 'Sporting Gijon',
+                        },
+                    ];
+                },
+                async batchSaveOddsPortalMappings(mappings) {
+                    savedMappings.push(...mappings);
+                    return {
+                        success: true,
+                        inserted: mappings.length,
+                        updated: mappings.length,
+                        applied: mappings.length,
+                    };
+                },
+                async batchUpdateMatchPipelineStatus(matchIds) {
+                    return { updated: matchIds.length };
+                },
+                async batchSaveMismatchEvidence() {
+                    return { success: true, saved: 0 };
+                },
+            },
+            navigator: {
+                async protocolArchiveExtract() {
+                    navigatorCalls++;
+                    return {
+                        matches: [],
+                        pagesScanned: 0,
+                        totalCandidates: 0,
+                        sourceState: 'SOURCE_EMPTY',
+                    };
+                },
+            },
+            parser: {
+                calculateSimilarity(left, right) {
+                    return String(left || '')
+                        .toLowerCase()
+                        .trim() ===
+                        String(right || '')
+                            .toLowerCase()
+                            .trim()
+                        ? 1
+                        : 0;
+                },
+            },
+            logger: { info() {}, warn() {}, error() {} },
+            baseUrl: 'oddsportal://root',
+        });
+
+        const result = await engine.runReconMatrix({
+            season: '2025-2026',
+            confidenceThreshold: 0.75,
+            concurrency: 1,
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.linked, 1);
+        assert.equal(result.mismatched, 0);
+        assert.ok(navigatorCalls >= 1);
+        assert.equal(savedMappings.length, 1);
+        assert.equal(savedMappings[0].mapping_method, 'dictionary');
+        assert.equal(savedMappings[0].match_confidence, 1);
+        assert.match(savedMappings[0].oddsportal_hash, /^~/);
+        assert.match(savedMappings[0].full_url, /^dictionary:\/\/recon\/140\/2025%2F2026\//);
     });
 
-    assert.equal(result.success, true);
-    assert.equal(result.linked, 1);
-    assert.equal(result.mismatched, 0);
-    assert.equal(savedMappings.length, 1);
-    assert.equal(savedMappings[0].match_id, '140_20252026_4837844');
-    assert.equal(savedMappings[0].oddsportal_hash, '23spHYrm');
-    assert.equal(savedMappings[0].match_confidence, 1);
-    assert.doesNotMatch(savedMappings[0].full_url, /\/h2h\//);
-    assert.match(savedMappings[0].full_url, /-23spHYrm\/$/);
-  });
+    it('应支持组合对阵与占位赛程在先回源后通过本地字典候选完成自愈', async () => {
+        const savedMappings = [];
+        let navigatorCalls = 0;
 
-  it('SOURCE_EMPTY 且仅剩 RECON_MISMATCH 时也应先回源一次，再走本地字典自愈', async () => {
-    const savedMappings = [];
-    let navigatorCalls = 0;
-
-    const engine = new ReconEngine({
-      configManager: {
-        getActiveLeagues() {
-          return [
-            { id: 140, name: 'Segunda División', country: 'spain', slug: 'segunda-division', enabled: true }
-          ];
-        }
-      },
-      repository: {
-        async getReconEligibleMatches() {
-          return [
-            {
-              match_id: '140_20252026_4837532',
-              home_team: 'Deportivo La Coruna',
-              away_team: 'Sporting Gijon',
-              league_name: 'Segunda División',
-              season: '2025/2026',
-              pipeline_status: 'RECON_MISMATCH',
-              match_date: '2026-04-05T18:00:00.000Z'
-            }
-          ];
-        },
-        async getLeagueDictionaryEntries() {
-          return [
-            {
-              league_id: 140,
-              remote_name: 'DEP LA Coruna',
-              local_team_id: '9783',
-              local_team_name: 'Deportivo La Coruna'
+        const engine = new ReconEngine({
+            configManager: {
+                getActiveLeagues() {
+                    return [
+                        {
+                            id: 42,
+                            name: 'Champions League',
+                            country: 'europe',
+                            slug: 'champions-league',
+                            enabled: true,
+                        },
+                    ];
+                },
             },
-            {
-              league_id: 140,
-              remote_name: 'Gijon',
-              local_team_id: '9869',
-              local_team_name: 'Sporting Gijon'
-            }
-          ];
-        },
-        async batchSaveOddsPortalMappings(mappings) {
-          savedMappings.push(...mappings);
-          return {
-            success: true,
-            inserted: mappings.length,
-            updated: mappings.length,
-            applied: mappings.length
-          };
-        },
-        async batchUpdateMatchPipelineStatus(matchIds) {
-          return { updated: matchIds.length };
-        },
-        async batchSaveMismatchEvidence() {
-          return { success: true, saved: 0 };
-        }
-      },
-      navigator: {
-        async protocolArchiveExtract() {
-          navigatorCalls++;
-          return {
-            matches: [],
-            pagesScanned: 0,
-            totalCandidates: 0,
-            sourceState: 'SOURCE_EMPTY'
-          };
-        }
-      },
-      parser: {
-        calculateSimilarity(left, right) {
-          return String(left || '').toLowerCase().trim() === String(right || '').toLowerCase().trim() ? 1 : 0;
-        }
-      },
-      logger: { info() {}, warn() {}, error() {} },
-      baseUrl: 'oddsportal://root'
+            repository: {
+                async getReconEligibleMatches() {
+                    return [
+                        {
+                            match_id: '42_20252026_5205814',
+                            home_team: 'Sporting Cp Arsenal',
+                            away_team: 'Barcelona Atletico Madrid',
+                            league_name: 'Champions League',
+                            season: '2025/2026',
+                            pipeline_status: 'RECON_MISMATCH',
+                            match_date: '2026-04-05T18:00:00.000Z',
+                        },
+                        {
+                            match_id: '42_20252026_5205834',
+                            home_team: 'Winner SF 1',
+                            away_team: 'Winner SF 2',
+                            league_name: 'Champions League',
+                            season: '2025/2026',
+                            pipeline_status: 'RECON_MISMATCH',
+                            match_date: '2026-05-10T18:00:00.000Z',
+                        },
+                    ];
+                },
+                async getLeagueDictionaryEntries() {
+                    return [
+                        {
+                            league_id: 42,
+                            remote_name: 'Sporting CP',
+                            local_team_id: '9768',
+                            local_team_name: 'Sporting CP',
+                        },
+                        {
+                            league_id: 42,
+                            remote_name: 'Arsenal',
+                            local_team_id: '9825',
+                            local_team_name: 'Arsenal',
+                        },
+                        {
+                            league_id: 42,
+                            remote_name: 'Barcelona',
+                            local_team_id: '8634',
+                            local_team_name: 'Barcelona',
+                        },
+                        {
+                            league_id: 42,
+                            remote_name: 'ATL Madrid',
+                            local_team_id: '9906',
+                            local_team_name: 'Atletico Madrid',
+                        },
+                    ];
+                },
+                async batchSaveOddsPortalMappings(mappings) {
+                    savedMappings.push(...mappings);
+                    return {
+                        success: true,
+                        inserted: mappings.length,
+                        updated: mappings.length,
+                        applied: mappings.length,
+                    };
+                },
+                async batchUpdateMatchPipelineStatus(matchIds) {
+                    return { updated: matchIds.length };
+                },
+                async batchSaveMismatchEvidence() {
+                    return { success: true, saved: 0 };
+                },
+            },
+            navigator: {
+                async protocolArchiveExtract() {
+                    navigatorCalls++;
+                    return {
+                        matches: [],
+                        pagesScanned: 0,
+                        totalCandidates: 0,
+                        sourceState: 'SOURCE_EMPTY',
+                    };
+                },
+            },
+            parser: {
+                calculateSimilarity(left, right) {
+                    return String(left || '')
+                        .toLowerCase()
+                        .trim() ===
+                        String(right || '')
+                            .toLowerCase()
+                            .trim()
+                        ? 1
+                        : 0;
+                },
+            },
+            logger: { info() {}, warn() {}, error() {} },
+            baseUrl: 'oddsportal://root',
+        });
+
+        const result = await engine.runReconMatrix({
+            season: '2025-2026',
+            confidenceThreshold: 0.75,
+            concurrency: 1,
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.linked, 2);
+        assert.equal(result.mismatched, 0);
+        assert.ok(navigatorCalls >= 1);
+        assert.equal(savedMappings.length, 2);
+        const compositeMapping = savedMappings.find(m => m.match_id === '42_20252026_5205814');
+        const placeholderMapping = savedMappings.find(m => m.match_id === '42_20252026_5205834');
+        assert.ok(compositeMapping, 'composite match mapping exists');
+        assert.equal(compositeMapping.mapping_method, 'dictionary');
+        assert.equal(compositeMapping.match_confidence, 1);
+        assert.ok(placeholderMapping, 'placeholder match mapping exists');
+        assert.equal(placeholderMapping.mapping_method, 'exact');
+        assert.equal(placeholderMapping.match_confidence, 1);
     });
-
-    const result = await engine.runReconMatrix({
-      season: '2025-2026',
-      confidenceThreshold: 0.75,
-      concurrency: 1
-    });
-
-    assert.equal(result.success, true);
-    assert.equal(result.linked, 1);
-    assert.equal(result.mismatched, 0);
-    assert.ok(navigatorCalls >= 1);
-    assert.equal(savedMappings.length, 1);
-    assert.equal(savedMappings[0].mapping_method, 'dictionary');
-    assert.equal(savedMappings[0].match_confidence, 1);
-    assert.match(savedMappings[0].oddsportal_hash, /^~/);
-    assert.match(savedMappings[0].full_url, /^dictionary:\/\/recon\/140\/2025%2F2026\//);
-  });
-
-  it('应支持组合对阵与占位赛程在先回源后通过本地字典候选完成自愈', async () => {
-    const savedMappings = [];
-    let navigatorCalls = 0;
-
-    const engine = new ReconEngine({
-      configManager: {
-        getActiveLeagues() {
-          return [
-            { id: 42, name: 'Champions League', country: 'europe', slug: 'champions-league', enabled: true }
-          ];
-        }
-      },
-      repository: {
-        async getReconEligibleMatches() {
-          return [
-            {
-              match_id: '42_20252026_5205814',
-              home_team: 'Sporting Cp Arsenal',
-              away_team: 'Barcelona Atletico Madrid',
-              league_name: 'Champions League',
-              season: '2025/2026',
-              pipeline_status: 'RECON_MISMATCH',
-              match_date: '2026-04-05T18:00:00.000Z'
-            },
-            {
-              match_id: '42_20252026_5205834',
-              home_team: 'Winner SF 1',
-              away_team: 'Winner SF 2',
-              league_name: 'Champions League',
-              season: '2025/2026',
-              pipeline_status: 'RECON_MISMATCH',
-              match_date: '2026-05-10T18:00:00.000Z'
-            }
-          ];
-        },
-        async getLeagueDictionaryEntries() {
-          return [
-            {
-              league_id: 42,
-              remote_name: 'Sporting CP',
-              local_team_id: '9768',
-              local_team_name: 'Sporting CP'
-            },
-            {
-              league_id: 42,
-              remote_name: 'Arsenal',
-              local_team_id: '9825',
-              local_team_name: 'Arsenal'
-            },
-            {
-              league_id: 42,
-              remote_name: 'Barcelona',
-              local_team_id: '8634',
-              local_team_name: 'Barcelona'
-            },
-            {
-              league_id: 42,
-              remote_name: 'ATL Madrid',
-              local_team_id: '9906',
-              local_team_name: 'Atletico Madrid'
-            }
-          ];
-        },
-        async batchSaveOddsPortalMappings(mappings) {
-          savedMappings.push(...mappings);
-          return {
-            success: true,
-            inserted: mappings.length,
-            updated: mappings.length,
-            applied: mappings.length
-          };
-        },
-        async batchUpdateMatchPipelineStatus(matchIds) {
-          return { updated: matchIds.length };
-        },
-        async batchSaveMismatchEvidence() {
-          return { success: true, saved: 0 };
-        }
-      },
-      navigator: {
-        async protocolArchiveExtract() {
-          navigatorCalls++;
-          return {
-            matches: [],
-            pagesScanned: 0,
-            totalCandidates: 0,
-            sourceState: 'SOURCE_EMPTY'
-          };
-        }
-      },
-      parser: {
-        calculateSimilarity(left, right) {
-          return String(left || '').toLowerCase().trim() === String(right || '').toLowerCase().trim() ? 1 : 0;
-        }
-      },
-      logger: { info() {}, warn() {}, error() {} },
-      baseUrl: 'oddsportal://root'
-    });
-
-    const result = await engine.runReconMatrix({
-      season: '2025-2026',
-      confidenceThreshold: 0.75,
-      concurrency: 1
-    });
-
-    assert.equal(result.success, true);
-    assert.equal(result.linked, 2);
-    assert.equal(result.mismatched, 0);
-    assert.ok(navigatorCalls >= 1);
-    assert.equal(savedMappings.length, 2);
-    assert.equal(savedMappings[0].mapping_method, 'dictionary');
-    assert.equal(savedMappings[0].match_confidence, 1);
-    assert.equal(savedMappings[1].mapping_method, 'exact');
-    assert.equal(savedMappings[1].match_confidence, 1);
-  });
 });


### PR DESCRIPTION
## Summary

Fixes the main push CI failure in ReconLeagueDictionaryFlow.test.js.

Context:
- Main push CI failed after Phase 4.91D merge (run 25635881128)
- Failure was in ReconLeagueDictionaryFlow.test.js:314
- Actual: `'exact'`, Expected: `'dictionary'`
- Root cause: test relied on async-dependent mapping order from `Promise.all`
- The dictionary detection was working correctly; only the test's array-index-based assertions were order-dependent
- Confirmed pre-existing: the test also fails on the parent commit 8b5073b

Fix:
- Replaced index-based assertions (`savedMappings[0]`, `savedMappings[1]`) with match_id-based lookups
- `'42_20252026_5205814'` → `mapping_method: 'dictionary'` (composite matchup via dictionary)
- `'42_20252026_5205834'` → `mapping_method: 'exact'` (placeholder schedule, exact name match)

Safety:
- No coverage threshold changes
- No skipped/deleted tests
- No gatekeeper bypass
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No staging writes
- No packet or runtime file writes
- No pg_dump / pg_restore
- No training
- No prediction execution

Validation:
- ReconLeagueDictionaryFlow.test.js 3/3 passed (5 consecutive runs, stable)
- npm test 48/48 passed
- npm run test:coverage passed
- npm run test:integration 19 pass, 5 skipped, 0 fail
- DB row counts unchanged (2/2/2/2/2/2)
- l1-config residue absent
- docs/_staging_preview not created
- eslint / prettier / git diff --check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)