### PR TITLE
docs(data): add filled-intake review result template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、只预览 blocked final preflight summary + user input closure + human approval packet + execution plan + final readiness checklist + runbook + auth form template 的本地 validator：`make data-single-target-acquisition-network-blocked-final-preflight-summary BLOCKED_SUMMARY=<path> INPUT_CLOSURE=<path> APPROVAL_PACKET=<path> EXECUTION_PLAN=<path> CHECKLIST=<path> RUNBOOK=<path> AUTH_FORM=<path> TARGET_SOURCE=<src> TARGET_ENGINE_FAMILY=titan_discovery TARGET_SCOPE_TYPE=<type> TARGET_MATCH_ID=<id> ...`（Phase 4.89D blocked-preview-only）
 - 不触网、不写文件、不创建目录、不写 DB、只预览 real-parameter intake validation closure template + real-parameter intake template + blocked preflight summary template 的本地 validator：`make data-single-target-acquisition-network-real-parameter-validation-closure-preview VALIDATION_CLOSURE=<path> INTAKE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.91D template-only）
 - 不触网、不写文件、不创建目录、不写 DB、只预览 filled-intake review plan template + real-parameter intake template + validation closure template + blocked preflight summary template 的本地 validator：`make data-single-target-acquisition-network-filled-intake-review-plan-preview REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.92D template-only）
+- 不触网、不写文件、不创建目录、不写 DB、只预览 filled-intake review result template + review plan template + real-parameter intake template + validation closure template + blocked preflight summary template 的本地 validator：`make data-single-target-acquisition-network-filled-intake-review-result-preview REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.93D template-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -902,6 +903,34 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-filled-intake-review-plan-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、再经过独立 filled-intake review / terms / authorization review。review plan 只定义审阅流程，不授权任何执行。
+
+### Phase 4.93D: single-target acquisition network dry-run filled-intake review result
+
+`data-single-target-acquisition-network-filled-intake-review-result-preview` 只允许预览 filled-intake review result template：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 titan_discovery legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 approval packet file
+- 它不得写 blocked summary file
+- 它不得写 real parameter intake file
+- 它不得写 validation closure file
+- 它不得写 filled-intake review plan file
+- 它不得写 filled-intake review result file
+- 它不得写 DB
+- filled-intake review result template 不等于真实 review result
+- Codex 不得自行填写真实 source / target / terms / authorization
+- Codex 不得自行把 reviewed / passed / accepted 改成 true
+- Codex 不得自行 authorize network dry-run
+- 即使 CLI 传入确认参数，Phase 4.93D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-filled-intake-review-result-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、再经过独立 filled-intake review result / terms / authorization review。review result template 只定义记录格式，不授权任何执行。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@
         data-single-target-acquisition-network-real-parameter-intake-preview data-single-target-acquisition-network-real-parameter-intake-commit \
         data-single-target-acquisition-network-real-parameter-validation-closure-preview data-single-target-acquisition-network-real-parameter-validation-closure-commit \
         data-single-target-acquisition-network-filled-intake-review-plan-preview data-single-target-acquisition-network-filled-intake-review-plan-commit \
+        data-single-target-acquisition-network-filled-intake-review-result-preview data-single-target-acquisition-network-filled-intake-review-result-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -93,6 +94,7 @@ NETWORK_BLOCKED_PREFLIGHT_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_REAL_PARAMETER_INTAKE_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_FILLED_INTAKE_REVIEW_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_FILLED_INTAKE_REVIEW_RESULT_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -380,6 +382,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-real-parameter-validation-closure-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE=1  # blocked in Phase 4.91D"
 	@echo "  make data-single-target-acquisition-network-filled-intake-review-plan-preview REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # review plan preview, Phase 4.92D"
 	@echo "  make data-single-target-acquisition-network-filled-intake-review-plan-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_PLAN=1  # blocked in Phase 4.92D"
+	@echo "  make data-single-target-acquisition-network-filled-intake-review-result-preview REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # review result preview, Phase 4.93D"
+	@echo "  make data-single-target-acquisition-network-filled-intake-review-result-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT=1  # blocked in Phase 4.93D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1282,6 +1286,25 @@ data-single-target-acquisition-network-filled-intake-review-plan-commit: ## Bloc
 	@echo "BLOCKED: single-target acquisition filled-intake review plan execution is not wired in Phase 4.92D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_PLAN=1, this path remains blocked."
 	@echo "  Phase 4.92D previews the filled-intake review plan template only and does not authorize any network dry-run, staging write, filled-intake review file write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-filled-intake-review-result-preview: ## Preview-only filled-intake review result. Phase 4.93D. No network, no writes, no DB.
+	@if [ -z "$(REVIEW_RESULT)" ] || [ -z "$(REVIEW_PLAN)" ] || [ -z "$(INTAKE)" ] || [ -z "$(VALIDATION_CLOSURE)" ] || [ -z "$(BLOCKED_SUMMARY)" ]; then \
+		echo "ERROR: provide REVIEW_RESULT=<path>, REVIEW_PLAN=<path>, INTAKE=<path>, VALIDATION_CLOSURE=<path>, and BLOCKED_SUMMARY=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.93D: network filled-intake review result (template-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_FILLED_INTAKE_REVIEW_RESULT_NODE) scripts/ops/single_target_acquisition_network_filled_intake_review_result.js \
+		--review-result "$(REVIEW_RESULT)" \
+		--review-plan "$(REVIEW_PLAN)" \
+		--intake "$(INTAKE)" \
+		--validation-closure "$(VALIDATION_CLOSURE)" \
+		--blocked-summary "$(BLOCKED_SUMMARY)"
+
+data-single-target-acquisition-network-filled-intake-review-result-commit: ## Blocked network filled-intake review result gate. Remains not wired in Phase 4.93D.
+	@echo "BLOCKED: single-target acquisition filled-intake review result execution is not wired in Phase 4.93D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT=1, this path remains blocked."
+	@echo "  Phase 4.93D previews the filled-intake review result template only and does not authorize any network dry-run, staging write, filled-intake review result file write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT_PHASE4_93D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT_PHASE4_93D.md
@@ -1,0 +1,79 @@
+# Single-Target Acquisition Network Filled-Intake Review Result Phase 4.93D
+
+## Executive Summary
+
+Phase 4.93D is the filled-intake review result template stage.
+
+This phase does not access the network, collect data, write DB rows, write
+staging artifacts, or write packet files. Its goal is to define how a future
+phase should record the review result of a user-filled real-parameter intake
+before any single-target acquisition network dry-run can be proposed.
+
+## Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_filled_intake_review_result.js`
+- `tests/unit/single_target_acquisition_network_filled_intake_review_result.test.js`
+- Makefile targets
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT_PHASE4_93D.md`
+
+## Review Result Sections
+
+- `review_metadata` — reviewer, timestamp, notes, source, result ID, template_only
+- `review_sections.real_target_review`
+- `review_sections.source_terms_review`
+- `review_sections.network_authorization_review`
+- `review_sections.proxy_browser_network_policy_review`
+- `review_sections.staging_policy_review`
+- `review_sections.no_db_training_prediction_review`
+- `review_sections.final_human_confirmation_review`
+- `overall_review_result` — status, accepted, rejected, needs_revision,
+  can_proceed_to_network_dry_run_preparation, blocking_reasons
+
+## Validation Behavior
+
+The validator is local-only and read-only.
+
+It verifies:
+
+- `review_result_status=template_only`
+- `filled_intake_review_result_ready=false`
+- `filled_intake_reviewed=false`
+- `filled_intake_accepted=false`
+- `filled_intake_rejected=false`
+- `filled_intake_needs_revision=false`
+- all `review_sections.*.reviewed=false` (7 sections)
+- all `review_sections.*.passed=false` (7 sections)
+- `overall_review_result.status=not_reviewed`
+- `overall_review_result.accepted=false`
+- `can_proceed_to_network_dry_run_preparation=false`
+- `network_dry_run_authorized=false`
+- `network_dry_run_execution_allowed=false`
+- all `would_*` safety flags remain `false`
+- no network execution
+- no runtime writes
+
+## Relationship To Previous Phases
+
+- 4.79D through 4.93D: fifteen phases of pre-execution governance artifacts
+- None of them is a real network dry-run
+
+## Recommended Next Phase
+
+Recommended: `Phase 4.94D: single-target acquisition authorization handoff checklist template`
+Alternative: `Phase 4.56A` — user supplies complete real parameters first
+
+## Explicit Non-Execution
+
+Phase 4.93D did not execute: DB writes, non-SELECT DB SQL, external download,
+curl/wget/git clone, football/odds data access, scraping, browser automation,
+proxy runtime, harvest, ingest, batch backfill, network dry-run, bulk harvest,
+runtime staging writes/directory creation, source manifest writes, packet file
+writes, approval packet file writes, user input closure file writes, blocked
+summary file writes, real parameter intake file writes, validation closure
+file writes, filled-intake review plan file writes, filled-intake review
+result file writes, pg_dump/pg_restore, training, prediction, model artifact
+loading, Docker volume cleanup, force push, git fetch --all, git pull, file
+deletion, coverage threshold modification, skipped/deleted tests, gatekeeper
+bypass.

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md
@@ -1,0 +1,197 @@
+# Single-Target Acquisition Network Dry-Run Filled-Intake Review Result Template
+
+This document is a Phase 4.93D template-only review result record for a
+future reviewed user-filled real-parameter intake.
+
+- This is a filled-intake review result template, not an actual review result.
+- This is not a network dry-run authorization document.
+- `review_result_status=template_only` by default.
+- `filled_intake_review_result_ready=false` by default.
+- `filled_intake_reviewed=false` by default.
+- `filled_intake_accepted=false` by default.
+- Every `reviewed`, `passed`, and `accepted` field is `false` by default.
+- Codex must not fill real source, target, terms, or authorization values.
+- Codex must not change any `reviewed`/`passed`/`accepted` value to `true`.
+- Codex must not authorize network dry-run execution.
+- Phase 4.93D does not write a filled-intake review result runtime file. It
+  only validates this template and produces a local stdout preview.
+- A real network dry-run must move to a later, separately authorized phase
+  after the user explicitly fills the real parameters, the filled intake is
+  reviewed, and review results are recorded.
+
+```yaml
+phase: PHASE4_93D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT
+review_result_status: template_only
+filled_intake_review_result_ready: false
+filled_intake_reviewed: false
+filled_intake_accepted: false
+filled_intake_rejected: false
+filled_intake_needs_revision: false
+real_parameters_provided: false
+real_parameter_intake_validated: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+included_artifacts:
+    filled_intake_review_plan: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md
+    real_parameter_intake: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md
+    validation_closure: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md
+    blocked_summary: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md
+
+review_metadata:
+    reviewer:
+    reviewed_at:
+    review_notes:
+    source_of_filled_intake:
+    review_result_id:
+    template_only: true
+
+review_sections:
+    real_target_review:
+        reviewed: false
+        passed: false
+        result: not_reviewed
+        blocking_reason: real_target_not_reviewed
+        reviewer_notes:
+    source_terms_review:
+        reviewed: false
+        passed: false
+        result: not_reviewed
+        blocking_reason: source_terms_not_reviewed
+        reviewer_notes:
+    network_authorization_review:
+        reviewed: false
+        passed: false
+        result: not_reviewed
+        blocking_reason: network_authorization_not_reviewed
+        reviewer_notes:
+    proxy_browser_network_policy_review:
+        reviewed: false
+        passed: false
+        result: not_reviewed
+        blocking_reason: proxy_browser_network_policy_not_reviewed
+        reviewer_notes:
+    staging_policy_review:
+        reviewed: false
+        passed: false
+        result: not_reviewed
+        blocking_reason: staging_policy_not_reviewed
+        reviewer_notes:
+    no_db_training_prediction_review:
+        reviewed: false
+        passed: false
+        result: not_reviewed
+        blocking_reason: no_db_training_prediction_policy_not_reviewed
+        reviewer_notes:
+    final_human_confirmation_review:
+        reviewed: false
+        passed: false
+        result: not_reviewed
+        blocking_reason: final_human_confirmation_not_reviewed
+        reviewer_notes:
+
+overall_review_result:
+    status: not_reviewed
+    accepted: false
+    rejected: false
+    needs_revision: false
+    can_proceed_to_network_dry_run_preparation: false
+    requires_future_separate_phase: true
+    blocking_reasons:
+        - filled_intake_not_provided
+        - filled_intake_not_reviewed
+        - review_result_template_only
+        - future_separate_phase_required
+
+codex_constraints:
+    codex_may_not_self_fill_real_parameters: true
+    codex_may_not_mark_reviewed: true
+    codex_may_not_mark_passed: true
+    codex_may_not_accept_filled_intake: true
+    codex_may_not_authorize_network: true
+    codex_may_not_enable_execution: true
+    codex_may_not_write_runtime_files: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_execute_legacy_titan_discovery: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_user_input_closure_file: false
+    would_write_blocked_summary_file: false
+    would_write_real_parameter_intake_file: false
+    would_write_real_parameter_validation_closure_file: false
+    would_write_filled_intake_review_file: false
+    would_write_filled_intake_review_result_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+next_phase_requirements:
+    - user_supplies_filled_real_parameter_intake
+    - separate_phase_reviews_filled_intake
+    - separate_phase_records_review_result
+    - separate_phase_keeps_network_execution_blocked_until_explicit_authorization
+    - separate_phase_confirms_no_db_write
+    - separate_phase_confirms_no_training
+    - separate_phase_confirms_no_prediction
+```
+
+## Purpose
+
+This template defines how a future phase should record the review result of a
+user-filled real-parameter intake before any single-target acquisition network
+dry-run can be proposed.
+
+It defines:
+
+- Review metadata fields (reviewer, timestamp, notes)
+- Seven review sections, each with `reviewed`, `passed`, `result`, and
+  `blocking_reason` fields
+- An overall review result with `status`, `accepted`, `rejected`,
+  `needs_revision`, and `can_proceed_to_network_dry_run_preparation` fields
+- Blocking reasons that prevent network dry-run execution
+- Codex constraints that prohibit self-review, self-accept, and
+  self-authorization
+
+## Guardrails
+
+Even if a future review result shows all sections passed, Phase 4.93D does not
+execute a network dry-run. A completed review result must still move through a
+later, separately authorized phase for final handoff and authorization.
+
+This template does not permit:
+
+- network access
+- browser launch
+- proxy runtime execution
+- legacy `titan_discovery` runtime execution
+- acquisition engine execution
+- staging writes
+- source manifest writes
+- packet file writes
+- approval packet file writes
+- user input closure file writes
+- blocked summary runtime file writes
+- real parameter intake runtime file writes
+- real parameter validation closure runtime file writes
+- filled-intake review plan runtime file writes
+- filled-intake review result runtime file writes
+- DB writes
+- training
+- prediction
+
+The template must remain `template_only` in Phase 4.93D. Codex cannot supply or
+infer review results, acceptance decisions, or authorizations for the user.

--- a/scripts/ops/single_target_acquisition_network_filled_intake_review_result.js
+++ b/scripts/ops/single_target_acquisition_network_filled_intake_review_result.js
@@ -1,0 +1,606 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    parseIntakeYaml,
+    runValidation: validateRealParameterIntake,
+} = require('./single_target_acquisition_network_real_parameter_intake');
+const {
+    runValidation: validateValidationClosure,
+} = require('./single_target_acquisition_network_real_parameter_intake_validation_closure');
+const { runValidation: validateReviewPlan } = require('./single_target_acquisition_network_filled_intake_review_plan');
+
+const OUTPUT_PHASE = 'PHASE4.93D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT';
+const TEMPLATE_PHASE = 'PHASE4_93D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT';
+const MODE = 'single-target-acquisition-network-filled-intake-review-result-preview';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition filled-intake review result execution is not wired in Phase 4.93D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.94D or explicit user-filled real parameter intake';
+const REVIEW_PLAN_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md';
+const INTAKE_TEMPLATE = 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md';
+const VALIDATION_CLOSURE_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md';
+const BLOCKED_SUMMARY_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md';
+
+const REVIEW_SECTIONS = [
+    'real_target_review',
+    'source_terms_review',
+    'network_authorization_review',
+    'proxy_browser_network_policy_review',
+    'staging_policy_review',
+    'no_db_training_prediction_review',
+    'final_human_confirmation_review',
+];
+
+const REVIEW_BLOCKING_REASONS = [
+    'filled_intake_not_provided',
+    'filled_intake_not_reviewed',
+    'review_result_template_only',
+    'future_separate_phase_required',
+];
+
+const SECTION_FIELDS = words(`
+    reviewed passed result blocking_reason reviewer_notes
+`);
+
+const OVERALL_FIELDS = words(`
+    status accepted rejected needs_revision
+    can_proceed_to_network_dry_run_preparation
+    requires_future_separate_phase blocking_reasons
+`);
+
+const REQUIRED_TOP_FIELDS = words(`
+    phase review_result_status filled_intake_review_result_ready
+    filled_intake_reviewed filled_intake_accepted filled_intake_rejected
+    filled_intake_needs_revision real_parameters_provided
+    real_parameter_intake_validated network_dry_run_authorized
+    network_dry_run_execution_allowed staging_write_authorized
+    db_write_authorized training_authorized prediction_authorized
+    final_human_confirmation review_metadata review_sections
+    overall_review_result included_artifacts codex_constraints safety
+    next_phase_requirements
+`);
+
+const TOP_FALSE = {
+    filled_intake_review_result_ready: 'filled_intake_review_result_ready true in template is not allowed',
+    filled_intake_reviewed: 'filled_intake_reviewed true in template is not allowed',
+    filled_intake_accepted: 'filled_intake_accepted true in template is not allowed',
+    filled_intake_rejected: 'filled_intake_rejected true in template is not allowed',
+    filled_intake_needs_revision: 'filled_intake_needs_revision true in template is not allowed',
+    real_parameters_provided: 'real_parameters_provided true in template is not allowed',
+    real_parameter_intake_validated: 'real_parameter_intake_validated true in template is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true in template is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true in template is not allowed',
+    staging_write_authorized: 'staging_write_authorized true in template is not allowed',
+    db_write_authorized: 'db_write_authorized true in template is not allowed',
+    training_authorized: 'training_authorized true in template is not allowed',
+    prediction_authorized: 'prediction_authorized true in template is not allowed',
+    final_human_confirmation: 'final_human_confirmation true in template is not allowed',
+};
+
+const CODEX_CONSTRAINT_FIELDS = words(`
+    codex_may_not_self_fill_real_parameters codex_may_not_mark_reviewed
+    codex_may_not_mark_passed codex_may_not_accept_filled_intake
+    codex_may_not_authorize_network codex_may_not_enable_execution
+    codex_may_not_write_runtime_files
+`);
+
+const SAFETY_FIELDS = words(`
+    would_access_network would_launch_browser would_use_proxy
+    would_execute_engine would_execute_legacy_titan_discovery
+    would_write_staging would_create_staging_directory
+    would_write_source_manifest would_write_packet_file
+    would_write_approval_packet_file would_write_user_input_closure_file
+    would_write_blocked_summary_file would_write_real_parameter_intake_file
+    would_write_real_parameter_validation_closure_file
+    would_write_filled_intake_review_file
+    would_write_filled_intake_review_result_file
+    would_write_db would_train would_predict would_bulk_harvest
+`);
+
+function words(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_filled_intake_review_result.js --review-result <path> --review-plan <path> --intake <path> --validation-closure <path> --blocked-summary <path>',
+        '  node scripts/ops/single_target_acquisition_network_filled_intake_review_result.js --review-result <path> --review-plan <path> --intake <path> --validation-closure <path> --blocked-summary <path> --commit',
+        '',
+        'Safety: Phase 4.93D previews a local filled-intake review result template only.',
+        '  No network, no browser, no proxy runtime, no engine execution, no DB, no file writes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        review_result: '',
+        review_plan: '',
+        intake: '',
+        validation_closure: '',
+        blocked_summary: '',
+        commit: false,
+        help: false,
+    };
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) throw new Error('Unknown argument: ' + token);
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error('Unknown argument: ' + token);
+        }
+    }
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        filled_intake_review_result_template_only: true,
+        review_result_valid: false,
+        review_plan_valid: false,
+        real_parameter_intake_valid: false,
+        validation_closure_valid: false,
+        blocked_summary_valid: false,
+        filled_intake_review_result_ready: false,
+        filled_intake_reviewed: false,
+        filled_intake_accepted: false,
+        filled_intake_rejected: false,
+        filled_intake_needs_revision: false,
+        real_parameters_provided: false,
+        real_parameter_intake_validated: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        review_sections_complete: false,
+        review_sections_passed: false,
+        overall_review_status: 'not_reviewed',
+        can_proceed_to_network_dry_run_preparation: false,
+        review_blocking_reasons: REVIEW_BLOCKING_REASONS,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_execute_legacy_titan_discovery: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_user_input_closure_file: false,
+        would_write_blocked_summary_file: false,
+        would_write_real_parameter_intake_file: false,
+        would_write_real_parameter_validation_closure_file: false,
+        would_write_filled_intake_review_file: false,
+        would_write_filled_intake_review_result_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: OUTPUT_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        review_result: args.review_result || null,
+        review_plan: args.review_plan || null,
+        intake: args.intake || null,
+        validation_closure: args.validation_closure || null,
+        blocked_summary: args.blocked_summary || null,
+        review_result_found: false,
+        review_plan_found: false,
+        intake_found: false,
+        validation_closure_found: false,
+        blocked_summary_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+            'no_filled_intake_review_file_writes',
+            'no_filled_intake_review_result_file_writes',
+            'no_legacy_titan_discovery_execution',
+        ],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function validateRequiredCliFields(args) {
+    const errors = [];
+    if (!args.review_result) errors.push('missing review result');
+    if (!args.review_plan) errors.push('missing review plan');
+    if (!args.intake) errors.push('missing intake');
+    if (!args.validation_closure) errors.push('missing validation closure');
+    if (!args.blocked_summary) errors.push('missing blocked summary');
+    return errors;
+}
+
+function validateCliArgsOrPayload(args) {
+    const errs = validateRequiredCliFields(args);
+    return errs.length ? buildFailurePayload(args, { mode: 'argument-error', errors: errs }) : null;
+}
+
+function loadYamlFile(args, deps, fieldName, missingLabel, mode) {
+    const targetPath = resolveLocalPath(args[fieldName], deps.cwd);
+    if (!deps.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: false,
+                errors: ['missing ' + missingLabel + ': ' + toRelativePath(targetPath, deps.cwd)],
+            }),
+        };
+    }
+    const yamlText = extractYamlBlock(deps.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+    try {
+        return { parsedYaml: parseIntakeYaml(yamlText), yamlText };
+    } catch (e) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: true,
+                errors: ['invalid YAML: ' + e.message],
+            }),
+        };
+    }
+}
+
+function hasOwn(root, key) {
+    return Object.prototype.hasOwnProperty.call(root, key);
+}
+
+function getPath(root, dottedPath) {
+    return dottedPath.split('.').reduce((c, k) => {
+        if (!c || typeof c !== 'object') return undefined;
+        return c[k];
+    }, root);
+}
+
+function addMissingNested(root, parentPath, requiredKeys, missingFields) {
+    const value = getPath(root, parentPath);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        missingFields.push(parentPath);
+        return;
+    }
+    requiredKeys.filter(k => !hasOwn(value, k)).forEach(k => missingFields.push(parentPath + '.' + k));
+}
+
+function findMissingFields(parsedYaml) {
+    const mf = REQUIRED_TOP_FIELDS.filter(k => !hasOwn(parsedYaml, k));
+    REVIEW_SECTIONS.forEach(s => addMissingNested(parsedYaml, 'review_sections.' + s, SECTION_FIELDS, mf));
+    addMissingNested(
+        parsedYaml,
+        'review_metadata',
+        words('reviewer reviewed_at review_notes source_of_filled_intake review_result_id template_only'),
+        mf
+    );
+    addMissingNested(parsedYaml, 'overall_review_result', OVERALL_FIELDS, mf);
+    addMissingNested(
+        parsedYaml,
+        'included_artifacts',
+        words('filled_intake_review_plan real_parameter_intake validation_closure blocked_summary'),
+        mf
+    );
+    addMissingNested(parsedYaml, 'codex_constraints', CODEX_CONSTRAINT_FIELDS, mf);
+    addMissingNested(parsedYaml, 'safety', SAFETY_FIELDS, mf);
+    return mf;
+}
+
+function validateTopLevelFalse(parsedYaml, errors) {
+    Object.entries(TOP_FALSE).forEach(([k, msg]) => {
+        if (parsedYaml[k] !== false) errors.push(msg);
+    });
+}
+
+function validateReviewSections(parsedYaml, errors) {
+    const sections = parsedYaml.review_sections || {};
+    REVIEW_SECTIONS.forEach(name => {
+        const s = sections[name];
+        if (!s || typeof s !== 'object' || Array.isArray(s)) {
+            errors.push('missing review_sections.' + name);
+            return;
+        }
+        if (s.reviewed !== false) errors.push('review_sections.' + name + '.reviewed true in template is not allowed');
+        if (s.passed !== false) errors.push('review_sections.' + name + '.passed true in template is not allowed');
+        if (s.result !== 'not_reviewed') {
+            errors.push('review_sections.' + name + '.result must be not_reviewed in template');
+        }
+    });
+}
+
+function validateOverallResult(parsedYaml, errors) {
+    const overall = parsedYaml.overall_review_result || {};
+    if (overall.status !== 'not_reviewed') errors.push('overall_review_result.status must be not_reviewed in template');
+    if (overall.accepted !== false) errors.push('overall_review_result.accepted true in template is not allowed');
+    if (overall.can_proceed_to_network_dry_run_preparation !== false) {
+        errors.push('overall_review_result.can_proceed_to_network_dry_run_preparation true in template is not allowed');
+    }
+    if (overall.requires_future_separate_phase !== true) {
+        errors.push('overall_review_result.requires_future_separate_phase must be true in template');
+    }
+    if (!Array.isArray(overall.blocking_reasons)) {
+        errors.push('missing overall_review_result.blocking_reasons');
+        return;
+    }
+    const missing = REVIEW_BLOCKING_REASONS.filter(r => !overall.blocking_reasons.includes(r));
+    if (missing.length) errors.push('missing overall_review_result.blocking_reasons: ' + missing.join(','));
+}
+
+function validateIncludedArtifacts(parsedYaml, errors) {
+    const inc = parsedYaml.included_artifacts || {};
+    if (inc.filled_intake_review_plan !== REVIEW_PLAN_TEMPLATE) {
+        errors.push('included_artifacts.filled_intake_review_plan must be ' + REVIEW_PLAN_TEMPLATE);
+    }
+    if (inc.real_parameter_intake !== INTAKE_TEMPLATE) {
+        errors.push('included_artifacts.real_parameter_intake must be ' + INTAKE_TEMPLATE);
+    }
+    if (inc.validation_closure !== VALIDATION_CLOSURE_TEMPLATE) {
+        errors.push('included_artifacts.validation_closure must be ' + VALIDATION_CLOSURE_TEMPLATE);
+    }
+    if (inc.blocked_summary !== BLOCKED_SUMMARY_TEMPLATE) {
+        errors.push('included_artifacts.blocked_summary must be ' + BLOCKED_SUMMARY_TEMPLATE);
+    }
+}
+
+function validateCodexConstraints(parsedYaml, errors) {
+    const cc = parsedYaml.codex_constraints || {};
+    CODEX_CONSTRAINT_FIELDS.forEach(f => {
+        if (cc[f] !== true) errors.push('codex_constraints.' + f + ' false is not allowed');
+    });
+}
+
+function validateSafety(parsedYaml, errors) {
+    const s = parsedYaml.safety || {};
+    SAFETY_FIELDS.forEach(f => {
+        if (s[f] !== false) errors.push('safety.' + f + ' must remain false');
+    });
+}
+
+function validateReviewMetadata(parsedYaml, errors) {
+    const meta = parsedYaml.review_metadata || {};
+    if (meta.template_only !== true) errors.push('review_metadata.template_only must be true in template');
+    if (meta.reviewer) errors.push('review_metadata.reviewer must be empty in template');
+    if (meta.reviewed_at) errors.push('review_metadata.reviewed_at must be empty in template');
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const mf = findMissingFields(parsedYaml);
+    if (mf.length) errors.push('missing required fields: ' + mf.join(','));
+    if (parsedYaml.phase !== TEMPLATE_PHASE) errors.push('phase must be ' + TEMPLATE_PHASE);
+    if (parsedYaml.review_result_status !== 'template_only') errors.push('review_result_status not template_only');
+    validateTopLevelFalse(parsedYaml, errors);
+    validateReviewMetadata(parsedYaml, errors);
+    validateReviewSections(parsedYaml, errors);
+    validateOverallResult(parsedYaml, errors);
+    validateIncludedArtifacts(parsedYaml, errors);
+    validateCodexConstraints(parsedYaml, errors);
+    validateSafety(parsedYaml, errors);
+    return { ok: errors.length === 0, missingFields: mf, errors };
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: OUTPUT_PHASE,
+        mode: MODE,
+        ok: true,
+        review_result: args.review_result,
+        review_plan: args.review_plan,
+        intake: args.intake,
+        validation_closure: args.validation_closure,
+        blocked_summary: args.blocked_summary,
+        review_result_found: true,
+        review_plan_found: true,
+        intake_found: true,
+        validation_closure_found: true,
+        blocked_summary_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        review_result_valid: true,
+        review_plan_valid: true,
+        real_parameter_intake_valid: true,
+        validation_closure_valid: true,
+        blocked_summary_valid: true,
+        review_sections_complete: true,
+        review_sections_passed: false,
+        overall_review_status: 'not_reviewed',
+        can_proceed_to_network_dry_run_preparation: false,
+        errors: [],
+        warnings: [
+            'Phase 4.93D remains template-only.',
+            'Filled-intake review result does not authorize network execution in this phase.',
+        ],
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+            'no_filled_intake_review_file_writes',
+            'no_filled_intake_review_result_file_writes',
+            'no_legacy_titan_discovery_execution',
+        ],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const deps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+
+    const cliP = validateCliArgsOrPayload(args);
+    if (cliP) return cliP;
+
+    const rrLoad = loadYamlFile(args, deps, 'review_result', 'review result', 'review-result-error');
+    if (rrLoad.payload) return rrLoad.payload;
+
+    const rrValidation = validateParsedYaml(rrLoad.parsedYaml);
+    if (!rrValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'review-result-error',
+            review_result_found: true,
+            yaml_block_found: true,
+            required_fields_present: rrValidation.missingFields.length === 0,
+            missing_fields: rrValidation.missingFields,
+            errors: rrValidation.errors,
+        });
+    }
+
+    const intakeP = validateRealParameterIntake({ intake: args.intake, blocked_summary: args.blocked_summary }, deps);
+    if (!intakeP.ok) {
+        return buildFailurePayload(args, {
+            mode: 'intake-error',
+            review_result_found: true,
+            review_result_valid: true,
+            yaml_block_found: true,
+            errors: intakeP.errors || ['intake validation failed'],
+        });
+    }
+
+    const closureP = validateValidationClosure(
+        { validation_closure: args.validation_closure, intake: args.intake, blocked_summary: args.blocked_summary },
+        deps
+    );
+    if (!closureP.ok) {
+        return buildFailurePayload(args, {
+            mode: 'closure-error',
+            review_result_found: true,
+            review_result_valid: true,
+            real_parameter_intake_valid: true,
+            yaml_block_found: true,
+            errors: closureP.errors || ['closure validation failed'],
+        });
+    }
+
+    const planP = validateReviewPlan(
+        {
+            review_plan: args.review_plan,
+            intake: args.intake,
+            validation_closure: args.validation_closure,
+            blocked_summary: args.blocked_summary,
+        },
+        deps
+    );
+    if (!planP.ok) {
+        return buildFailurePayload(args, {
+            mode: 'plan-error',
+            review_result_found: true,
+            review_result_valid: true,
+            real_parameter_intake_valid: true,
+            validation_closure_valid: true,
+            yaml_block_found: true,
+            errors: planP.errors || ['review plan validation failed'],
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(payload, io) {
+    io.stdout(JSON.stringify(payload, null, 2) + '\n');
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (t => process.stdout.write(t)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(usage() + '\n');
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const p = runValidation(args, dependencies);
+        writePayload(p, output);
+        return p.ok ? 0 : 1;
+    } catch (e) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [e.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    OUTPUT_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    REVIEW_SECTIONS,
+    REVIEW_BLOCKING_REASONS,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_filled_intake_review_result.test.js
+++ b/tests/unit/single_target_acquisition_network_filled_intake_review_result.test.js
@@ -1,0 +1,609 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(
+    PROJECT_ROOT,
+    'scripts/ops/single_target_acquisition_network_filled_intake_review_result.js'
+);
+const REVIEW_RESULT_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md'
+);
+const REVIEW_PLAN_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md'
+);
+const INTAKE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md'
+);
+const VALIDATION_CLOSURE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md'
+);
+const BLOCKED_SUMMARY_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md'
+);
+const REVIEW_RESULT_TEXT = fs.readFileSync(REVIEW_RESULT_PATH, 'utf8');
+
+function loadValidatorFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        review_result: REVIEW_RESULT_PATH,
+        review_plan: REVIEW_PLAN_PATH,
+        intake: INTAKE_PATH,
+        validation_closure: VALIDATION_CLOSURE_PATH,
+        blocked_summary: BLOCKED_SUMMARY_PATH,
+        ...overrides,
+    };
+}
+
+function buildDeps(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: p => fs.existsSync(p),
+        readFileSync: (p, e) => fs.readFileSync(p, e),
+        ...overrides,
+    };
+}
+
+function buildTextDeps(markdownText, targetPath = REVIEW_RESULT_PATH) {
+    return buildDeps({
+        existsSync: p => p === targetPath || fs.existsSync(p),
+        readFileSync: (p, e) => {
+            if (p === targetPath) return markdownText;
+            return fs.readFileSync(p, e);
+        },
+    });
+}
+
+function installGuards(t) {
+    const orig = {
+        http: http.request,
+        https: https.request,
+        fetch: global.fetch,
+        spawn: childProcess.spawn,
+        exec: childProcess.exec,
+        execFile: childProcess.execFile,
+        writeFile: fs.writeFile,
+        writeFileSync: fs.writeFileSync,
+        createWriteStream: fs.createWriteStream,
+        mkdir: fs.mkdir,
+        mkdirSync: fs.mkdirSync,
+        net: net.connect,
+        load: Module._load,
+    };
+    const fail = n => () => {
+        throw new Error(n + ' should not be called');
+    };
+    http.request = fail('http');
+    https.request = fail('https');
+    global.fetch = fail('fetch');
+    childProcess.spawn = fail('spawn');
+    childProcess.exec = fail('exec');
+    childProcess.execFile = fail('execFile');
+    fs.writeFile = fail('writeFile');
+    fs.writeFileSync = fail('writeFileSync');
+    fs.createWriteStream = fail('createWriteStream');
+    fs.mkdir = fail('mkdir');
+    fs.mkdirSync = fail('mkdirSync');
+    net.connect = fail('net');
+    Module._load = function p(r, parent, isMain) {
+        if (
+            new Set([
+                'http',
+                'node:http',
+                'https',
+                'node:https',
+                'child_process',
+                'node:child_process',
+                'pg',
+                'redis',
+                'ioredis',
+                'playwright',
+                'playwright-core',
+            ]).has(r)
+        ) {
+            throw new Error('blocked: ' + r);
+        }
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(r)) throw new Error('blocked: ' + r);
+        return orig.load.call(this, r, parent, isMain);
+    };
+    t.after(() => {
+        Object.assign(http, { request: orig.http });
+        Object.assign(https, { request: orig.https });
+        global.fetch = orig.fetch;
+        Object.assign(childProcess, { spawn: orig.spawn, exec: orig.exec, execFile: orig.execFile });
+        Object.assign(fs, {
+            writeFile: orig.writeFile,
+            writeFileSync: orig.writeFileSync,
+            createWriteStream: orig.createWriteStream,
+            mkdir: orig.mkdir,
+            mkdirSync: orig.mkdirSync,
+        });
+        net.connect = orig.net;
+        Module._load = orig.load;
+    });
+}
+
+function replaceInTemplate(s, r) {
+    assert.match(REVIEW_RESULT_TEXT, new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return REVIEW_RESULT_TEXT.replace(s, r);
+}
+function removeLine(l) {
+    return REVIEW_RESULT_TEXT.replace(l + '\n', '');
+}
+
+function runMain(gate, argv, deps = buildDeps()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: t => {
+                stdout += t;
+            },
+        },
+        deps
+    );
+    return { status, stdout };
+}
+
+function extractLastJsonObject(stdout) {
+    const t = String(stdout || '').trim();
+    const i = t.lastIndexOf('\n{');
+    return JSON.parse(i >= 0 ? t.slice(i + 1) : t);
+}
+
+// 1-5: missing files
+['review_result', 'review_plan', 'intake', 'validation_closure', 'blocked_summary'].forEach(f => {
+    const label = f.replace(/_/g, ' ');
+    test('缺 ' + label + ' 失败', () => {
+        const gate = loadValidatorFresh();
+        const args = buildArgs();
+        delete args[f];
+        const p = gate.runValidation(args, buildDeps());
+        assert.equal(p.ok, false);
+        assert.match(p.errors.join('\n'), new RegExp('missing ' + label, 'i'));
+    });
+});
+
+// 6-7: YAML issues
+test('review result 缺 YAML block 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(buildArgs(), buildTextDeps('# no yaml\n'));
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing YAML block/i);
+});
+test('review result invalid YAML 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(buildArgs(), buildTextDeps('```yaml\nnot yaml\n```\n'));
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /invalid YAML/i);
+});
+
+// 8: missing phase
+test('missing phase 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(
+            removeLine('phase: PHASE4_93D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT')
+        )
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing required fields: phase|phase must be/);
+});
+
+// 9: review_result_status non-template_only
+test('review_result_status 非 template_only 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('review_result_status: template_only', 'review_result_status: ready'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /review_result_status not template_only/);
+});
+
+// 10-16: top-level false fields
+[
+    [
+        'filled_intake_review_result_ready=true',
+        'filled_intake_review_result_ready: false',
+        'filled_intake_review_result_ready: true',
+        /filled_intake_review_result_ready true/,
+    ],
+    [
+        'filled_intake_reviewed=true',
+        'filled_intake_reviewed: false',
+        'filled_intake_reviewed: true',
+        /filled_intake_reviewed true/,
+    ],
+    [
+        'filled_intake_accepted=true',
+        'filled_intake_accepted: false',
+        'filled_intake_accepted: true',
+        /filled_intake_accepted true/,
+    ],
+    [
+        'filled_intake_rejected=true',
+        'filled_intake_rejected: false',
+        'filled_intake_rejected: true',
+        /filled_intake_rejected true/,
+    ],
+    [
+        'filled_intake_needs_revision=true',
+        'filled_intake_needs_revision: false',
+        'filled_intake_needs_revision: true',
+        /filled_intake_needs_revision true/,
+    ],
+    [
+        'real_parameters_provided=true',
+        'real_parameters_provided: false',
+        'real_parameters_provided: true',
+        /real_parameters_provided true/,
+    ],
+    [
+        'real_parameter_intake_validated=true',
+        'real_parameter_intake_validated: false',
+        'real_parameter_intake_validated: true',
+        /real_parameter_intake_validated true/,
+    ],
+].forEach(([n, s, r, p]) => {
+    test(n + ' 失败', () => {
+        const gate = loadValidatorFresh();
+        const pl = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(s, r)));
+        assert.equal(pl.ok, false);
+        assert.match(pl.errors.join('\n'), p);
+    });
+});
+
+// 17-30: review_sections.*.reviewed/passed=true
+const SECTION_NAMES = [
+    'real_target_review',
+    'source_terms_review',
+    'network_authorization_review',
+    'proxy_browser_network_policy_review',
+    'staging_policy_review',
+    'no_db_training_prediction_review',
+    'final_human_confirmation_review',
+];
+SECTION_NAMES.forEach(name => {
+    test('review_sections.' + name + '.reviewed=true 失败', () => {
+        const gate = loadValidatorFresh();
+        const t = REVIEW_RESULT_TEXT.replace(
+            new RegExp('(' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ':[\\s\\S]*?reviewed: )false'),
+            '$1true'
+        );
+        assert.ok(t !== REVIEW_RESULT_TEXT, 'template should be modified');
+        const p = gate.runValidation(buildArgs(), buildTextDeps(t));
+        assert.equal(p.ok, false);
+        assert.match(p.errors.join('\n'), new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\.reviewed true'));
+    });
+    test('review_sections.' + name + '.passed=true 失败', () => {
+        const gate = loadValidatorFresh();
+        const t = REVIEW_RESULT_TEXT.replace(
+            new RegExp('(' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ':[\\s\\S]*?passed: )false'),
+            '$1true'
+        );
+        assert.ok(t !== REVIEW_RESULT_TEXT, 'template should be modified');
+        const p = gate.runValidation(buildArgs(), buildTextDeps(t));
+        assert.equal(p.ok, false);
+        assert.match(p.errors.join('\n'), new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\.passed true'));
+    });
+});
+
+// 31-33: overall_review_result
+test('overall_review_result.status 不是 not_reviewed 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('status: not_reviewed', 'status: accepted'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /overall_review_result\.status/);
+});
+test('overall_review_result.accepted=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('    accepted: false', '    accepted: true'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /overall_review_result\.accepted true/);
+});
+test('overall_review_result.can_proceed_to_network_dry_run_preparation=true 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(
+            replaceInTemplate(
+                'can_proceed_to_network_dry_run_preparation: false',
+                'can_proceed_to_network_dry_run_preparation: true'
+            )
+        )
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /can_proceed_to_network_dry_run_preparation true/);
+});
+
+// 34-40: authorization flags
+[
+    [
+        'network_dry_run_authorized=true',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'staging_write_authorized=true',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    ['db_write_authorized=true', 'db_write_authorized: false', 'db_write_authorized: true', /db_write_authorized true/],
+    ['training_authorized=true', 'training_authorized: false', 'training_authorized: true', /training_authorized true/],
+    [
+        'prediction_authorized=true',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([n, s, r, p]) => {
+    test(n + ' 失败', () => {
+        const gate = loadValidatorFresh();
+        const pl = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(s, r)));
+        assert.equal(pl.ok, false);
+        assert.match(pl.errors.join('\n'), p);
+    });
+});
+
+// 41-44: codex constraints
+[
+    [
+        'codex_may_not_self_fill_real_parameters=false',
+        'codex_may_not_self_fill_real_parameters: true',
+        'codex_may_not_self_fill_real_parameters: false',
+        /codex_may_not_self_fill_real_parameters false/,
+    ],
+    [
+        'codex_may_not_mark_reviewed=false',
+        'codex_may_not_mark_reviewed: true',
+        'codex_may_not_mark_reviewed: false',
+        /codex_may_not_mark_reviewed false/,
+    ],
+    [
+        'codex_may_not_mark_passed=false',
+        'codex_may_not_mark_passed: true',
+        'codex_may_not_mark_passed: false',
+        /codex_may_not_mark_passed false/,
+    ],
+    [
+        'codex_may_not_accept_filled_intake=false',
+        'codex_may_not_accept_filled_intake: true',
+        'codex_may_not_accept_filled_intake: false',
+        /codex_may_not_accept_filled_intake false/,
+    ],
+].forEach(([n, s, r, p]) => {
+    test(n + ' 失败', () => {
+        const gate = loadValidatorFresh();
+        const pl = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(s, r)));
+        assert.equal(pl.ok, false);
+        assert.match(pl.errors.join('\n'), p);
+    });
+});
+
+// 45: missing review_sections
+test('review_sections missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('review_sections:', 'review_sections_missing:'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing required fields.*review_sections/);
+});
+
+// 46: missing blocking_reasons
+test('overall_review_result.blocking_reasons missing 失败', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('blocking_reasons:', 'blocking_reasons_missing:'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing overall_review_result\.blocking_reasons/);
+});
+
+// 49-51: safety would_*
+['would_access_network', 'would_write_db', 'would_write_filled_intake_review_result_file'].forEach(f => {
+    test('safety ' + f + '=true 失败', () => {
+        const gate = loadValidatorFresh();
+        const p = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(f + ': false', f + ': true')));
+        assert.equal(p.ok, false);
+        assert.match(p.errors.join('\n'), new RegExp('safety\\.' + f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    });
+});
+
+// 52: valid preview
+test('valid filled-intake review result preview 成功', () => {
+    const gate = loadValidatorFresh();
+    const p = gate.runValidation(buildArgs(), buildDeps());
+    assert.equal(p.ok, true);
+    assert.equal(p.phase, 'PHASE4.93D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT');
+    assert.equal(p.filled_intake_review_result_template_only, true);
+    assert.equal(p.review_result_valid, true);
+    assert.equal(p.review_plan_valid, true);
+    assert.equal(p.real_parameter_intake_valid, true);
+    assert.equal(p.validation_closure_valid, true);
+    assert.equal(p.blocked_summary_valid, true);
+    assert.equal(p.filled_intake_review_result_ready, false);
+    assert.equal(p.filled_intake_reviewed, false);
+    assert.equal(p.filled_intake_accepted, false);
+    assert.equal(p.filled_intake_rejected, false);
+    assert.equal(p.filled_intake_needs_revision, false);
+    assert.equal(p.real_parameters_provided, false);
+    assert.equal(p.real_parameter_intake_validated, false);
+    assert.equal(p.network_dry_run_authorized, false);
+    assert.equal(p.network_dry_run_execution_allowed, false);
+    assert.equal(p.review_sections_complete, true);
+    assert.equal(p.review_sections_passed, false);
+    assert.equal(p.overall_review_status, 'not_reviewed');
+    assert.equal(p.can_proceed_to_network_dry_run_preparation, false);
+    assert.deepEqual(p.review_blocking_reasons, [
+        'filled_intake_not_provided',
+        'filled_intake_not_reviewed',
+        'review_result_template_only',
+        'future_separate_phase_required',
+    ]);
+    for (const f of [
+        'would_access_network',
+        'would_launch_browser',
+        'would_use_proxy',
+        'would_execute_engine',
+        'would_execute_legacy_titan_discovery',
+        'would_write_staging',
+        'would_create_staging_directory',
+        'would_write_source_manifest',
+        'would_write_packet_file',
+        'would_write_approval_packet_file',
+        'would_write_blocked_summary_file',
+        'would_write_real_parameter_intake_file',
+        'would_write_real_parameter_validation_closure_file',
+        'would_write_filled_intake_review_file',
+        'would_write_filled_intake_review_result_file',
+        'would_write_db',
+        'would_train',
+        'would_predict',
+        'would_spawn_child_process',
+    ]) {
+        assert.equal(p[f], false, f + ' should be false');
+    }
+    assert.equal(p.commit_gate, 'blocked');
+});
+
+// 53: --commit blocked
+test('--commit blocked', () => {
+    const gate = loadValidatorFresh();
+    const r = runMain(
+        gate,
+        [
+            '--review-result',
+            REVIEW_RESULT_PATH,
+            '--review-plan',
+            REVIEW_PLAN_PATH,
+            '--intake',
+            INTAKE_PATH,
+            '--validation-closure',
+            VALIDATION_CLOSURE_PATH,
+            '--blocked-summary',
+            BLOCKED_SUMMARY_PATH,
+            '--commit',
+        ],
+        buildDeps()
+    );
+    assert.equal(r.status, 1);
+    assert.match(JSON.parse(r.stdout).errors.join('\n'), /not wired in Phase 4.93D/);
+});
+
+// 54-55: Makefile
+test('Makefile preview 成功', () => {
+    const r = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-filled-intake-review-result-preview',
+            'NETWORK_FILLED_INTAKE_REVIEW_RESULT_NODE=node',
+            'REVIEW_RESULT=' + REVIEW_RESULT_PATH,
+            'REVIEW_PLAN=' + REVIEW_PLAN_PATH,
+            'INTAKE=' + INTAKE_PATH,
+            'VALIDATION_CLOSURE=' + VALIDATION_CLOSURE_PATH,
+            'BLOCKED_SUMMARY=' + BLOCKED_SUMMARY_PATH,
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(r.status, 0, r.stderr);
+    const p = extractLastJsonObject(r.stdout);
+    assert.equal(p.ok, true);
+    assert.equal(p.review_result_valid, true);
+});
+test('Makefile commit blocked', () => {
+    const r = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-filled-intake-review-result-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout, /not wired in Phase 4.93D/);
+});
+
+// 56-72: safety guard tests
+[
+    ['不访问网络', 'would_access_network'],
+    ['不启动 browser', 'would_launch_browser'],
+    ['不执行 proxy runtime', 'would_use_proxy'],
+    ['不执行 engine', 'would_execute_engine'],
+    ['不执行 legacy titan_discovery', 'would_execute_legacy_titan_discovery'],
+    ['不写 staging', 'would_write_staging'],
+    ['不创建目录', 'would_create_staging_directory'],
+    ['不写 source manifest', 'would_write_source_manifest'],
+    ['不写 packet file', 'would_write_packet_file'],
+    ['不写 approval packet file', 'would_write_approval_packet_file'],
+    ['不写 blocked summary file', 'would_write_blocked_summary_file'],
+    ['不写 real parameter intake file', 'would_write_real_parameter_intake_file'],
+    ['不写 validation closure file', 'would_write_real_parameter_validation_closure_file'],
+    ['不写 filled-intake review plan file', 'would_write_filled_intake_review_file'],
+    ['不写 filled-intake review result file', 'would_write_filled_intake_review_result_file'],
+    ['不写 DB', 'would_write_db'],
+    ['不 spawn child process', 'would_spawn_child_process'],
+].forEach(([n, f]) => {
+    test(n, t => {
+        installGuards(t);
+        const gate = loadValidatorFresh();
+        const p = gate.runValidation(buildArgs(), buildDeps());
+        assert.equal(p.ok, true);
+        assert.equal(p[f], false);
+    });
+});
+
+// source audit
+test('source audit: 不 import forbidden modules', () => {
+    const src = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(src));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(src));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(src));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(src));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(src));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(src));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(src));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(src));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.93D single-target acquisition filled-intake review result template.

Scope:
- Adds filled-intake review result template
- Adds local-only review result preview validator
- Defines future review result sections for recording intake review outcomes
- Validates review result remains template-only, not reviewed, not accepted
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests (71 tests)
- Updates AGENTS.md
- Adds Phase 4.93D report

Safety:
- No DB writes, No external downloads, No football/odds data access
- No scraping, No browser automation, No proxy runtime execution
- No harvest/ingest, No network dry-run execution
- No runtime staging writes/directory creation, No source manifest writes
- No packet/approval/closure/summary/runtime file writes
- No pg_dump/pg_restore, No training, No prediction, No model artifact loading

Validation:
- preview missing params failed as expected
- valid review result preview passed (ok: true)
- commit gate remained blocked even with CONFIRM=1
- unit tests 71/71 passed
- npm test 48/48 passed
- DB row counts unchanged (2/2/2/2/2/2)
- l1-config residue absent, staging preview not created
- eslint / prettier / git diff --check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)