### PR TITLE
docs(data): add authorization handoff checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ AI / Codex 默认只能执行：
 - 不触网、不写文件、不创建目录、不写 DB、只预览 real-parameter intake validation closure template + real-parameter intake template + blocked preflight summary template 的本地 validator：`make data-single-target-acquisition-network-real-parameter-validation-closure-preview VALIDATION_CLOSURE=<path> INTAKE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.91D template-only）
 - 不触网、不写文件、不创建目录、不写 DB、只预览 filled-intake review plan template + real-parameter intake template + validation closure template + blocked preflight summary template 的本地 validator：`make data-single-target-acquisition-network-filled-intake-review-plan-preview REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.92D template-only）
 - 不触网、不写文件、不创建目录、不写 DB、只预览 filled-intake review result template + review plan template + real-parameter intake template + validation closure template + blocked preflight summary template 的本地 validator：`make data-single-target-acquisition-network-filled-intake-review-result-preview REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.93D template-only）
+- 不触网、不写文件、不创建目录、不写 DB、只预览 authorization handoff checklist template + review result + review plan + intake + validation closure + blocked summary 的本地 validator：`make data-single-target-acquisition-network-authorization-handoff-checklist-preview HANDOFF_CHECKLIST=<path> REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>`（Phase 4.94D template-only）
 - 只读本地 approval form 模板、不读 DB、不写 DB、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-small-write-runbook-validate APPROVAL_FORM=<local md>`
 - 只读本地 packet file creation authorization 模板、不读 DB、不写 DB、不创建目录、不写 packet 文件、不执行 `pg_dump` / `pg_restore` 的 `make data-football-data-packet-file-auth-validate AUTH_FORM=<local md>`
 - 用户明确授权且只读本地 CSV、不写 DB、不训练、不预测的 `make data-finished-csv-dry-run SAMPLE_CSV=<local csv>`
@@ -931,6 +932,22 @@ AI / Codex 默认禁止：
 `data-single-target-acquisition-network-filled-intake-review-result-commit` 当前 blocked。
 
 真实 network dry-run 必须后续单独阶段、用户明确给齐真实参数、再经过独立 filled-intake review result / terms / authorization review。review result template 只定义记录格式，不授权任何执行。
+
+### Phase 4.94D: single-target acquisition network dry-run authorization handoff checklist
+
+`data-single-target-acquisition-network-authorization-handoff-checklist-preview` 只允许预览 authorization handoff checklist template：
+
+- 它不得触网/启动 browser/执行 proxy runtime/运行 legacy runtime
+- 它不得写 staging/source manifest/packet/approval/closure/runtime 文件
+- 它不得写 DB
+- authorization handoff checklist 不等于真实 authorization
+- Codex 不得自行把 checked/passed/completed/ready 改成 true
+- Codex 不得自行 authorize network dry-run
+- 即使 CLI 传入确认参数，Phase 4.94D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-authorization-handoff-checklist-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独 authorization 阶段。
 
 Phase 4.55C acquisition architecture rules：
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@
         data-single-target-acquisition-network-real-parameter-validation-closure-preview data-single-target-acquisition-network-real-parameter-validation-closure-commit \
         data-single-target-acquisition-network-filled-intake-review-plan-preview data-single-target-acquisition-network-filled-intake-review-plan-commit \
         data-single-target-acquisition-network-filled-intake-review-result-preview data-single-target-acquisition-network-filled-intake-review-result-commit \
+        data-single-target-acquisition-network-authorization-handoff-checklist-preview data-single-target-acquisition-network-authorization-handoff-checklist-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -95,6 +96,7 @@ NETWORK_REAL_PARAMETER_INTAKE_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_FILLED_INTAKE_REVIEW_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_FILLED_INTAKE_REVIEW_RESULT_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -384,6 +386,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-filled-intake-review-plan-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_PLAN=1  # blocked in Phase 4.92D"
 	@echo "  make data-single-target-acquisition-network-filled-intake-review-result-preview REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # review result preview, Phase 4.93D"
 	@echo "  make data-single-target-acquisition-network-filled-intake-review-result-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT=1  # blocked in Phase 4.93D"
+	@echo "  make data-single-target-acquisition-network-authorization-handoff-checklist-preview HANDOFF_CHECKLIST=<path> REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # handoff preview, Phase 4.94D"
+	@echo "  make data-single-target-acquisition-network-authorization-handoff-checklist-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST=1  # blocked in Phase 4.94D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1305,6 +1309,26 @@ data-single-target-acquisition-network-filled-intake-review-result-commit: ## Bl
 	@echo "BLOCKED: single-target acquisition filled-intake review result execution is not wired in Phase 4.93D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT=1, this path remains blocked."
 	@echo "  Phase 4.93D previews the filled-intake review result template only and does not authorize any network dry-run, staging write, filled-intake review result file write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-authorization-handoff-checklist-preview: ## Preview-only authorization handoff checklist. Phase 4.94D. No network, no writes, no DB.
+	@if [ -z "$(HANDOFF_CHECKLIST)" ] || [ -z "$(REVIEW_RESULT)" ] || [ -z "$(REVIEW_PLAN)" ] || [ -z "$(INTAKE)" ] || [ -z "$(VALIDATION_CLOSURE)" ] || [ -z "$(BLOCKED_SUMMARY)" ]; then \
+		echo "ERROR: provide HANDOFF_CHECKLIST=<path>, REVIEW_RESULT=<path>, REVIEW_PLAN=<path>, INTAKE=<path>, VALIDATION_CLOSURE=<path>, and BLOCKED_SUMMARY=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.94D: network authorization handoff checklist (template-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_NODE) scripts/ops/single_target_acquisition_network_authorization_handoff_checklist.js \
+		--handoff-checklist "$(HANDOFF_CHECKLIST)" \
+		--review-result "$(REVIEW_RESULT)" \
+		--review-plan "$(REVIEW_PLAN)" \
+		--intake "$(INTAKE)" \
+		--validation-closure "$(VALIDATION_CLOSURE)" \
+		--blocked-summary "$(BLOCKED_SUMMARY)"
+
+data-single-target-acquisition-network-authorization-handoff-checklist-commit: ## Blocked authorization handoff checklist gate. Remains not wired in Phase 4.94D.
+	@echo "BLOCKED: single-target acquisition authorization handoff checklist execution is not wired in Phase 4.94D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST=1, this path remains blocked."
+	@echo "  Phase 4.94D previews the authorization handoff checklist template only and does not authorize any network dry-run, staging write, authorization handoff checklist file write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_PHASE4_94D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_PHASE4_94D.md
@@ -1,0 +1,54 @@
+# Single-Target Acquisition Network Authorization Handoff Checklist Phase 4.94D
+
+## Executive Summary
+
+Phase 4.94D is the authorization handoff checklist template stage. No network
+access, no data collection, no DB writes, no staging, no packet files. The goal
+is to define the checklist for transitioning from filled-intake review result
+to a future network authorization phase.
+
+## Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_authorization_handoff_checklist.js`
+- `tests/unit/single_target_acquisition_network_authorization_handoff_checklist.test.js`
+- Makefile targets, AGENTS.md update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_PHASE4_94D.md`
+
+## Handoff Sections
+
+8 sections: filled_intake_review_result_check, real_parameter_integrity_check,
+source_terms_and_allowed_use_check, network_authorization_check,
+proxy_browser_network_policy_check, staging_policy_check,
+no_db_training_prediction_check, final_human_confirmation_check
+
+## Authorization Boundary
+
+- `handoff_checklist_is_not_authorization=true`
+- `future_authorization_phase_required=true`
+- Codex may not authorize network, enable execution, convert handoff to runbook,
+  self-approve terms, or self-accept review result
+
+## Validation
+
+Local-only, read-only. Verifies template_only status, all checked/passed=false,
+handoff not authorization, network not authorized, all would_* false.
+
+## Relationship
+
+4.79D through 4.94D: sixteen phases of pre-execution governance artifacts.
+None is a real network dry-run.
+
+## Next Phase
+
+Phase 4.95D: network authorization decision template, or Phase 4.56A with
+user-supplied real parameters.
+
+## Explicit Non-Execution
+
+Phase 4.94D did not execute: DB writes, non-SELECT SQL, external downloads,
+data access, scraping, browser automation, proxy runtime, harvest/ingest,
+network dry-run, staging writes, packet/approval/closure/runtime file writes,
+pg_dump/pg_restore, training, prediction, model artifact loading, Docker
+cleanup, force push, git fetch --all, git pull, file deletion, coverage
+threshold changes, skipped/deleted tests, gatekeeper bypass.

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST_TEMPLATE.md
@@ -1,0 +1,175 @@
+# Single-Target Acquisition Network Dry-Run Authorization Handoff Checklist Template
+
+This document is a Phase 4.94D template-only authorization handoff checklist.
+
+- This is an authorization handoff checklist template, not authorization itself.
+- `handoff_checklist_status=template_only` by default.
+- `authorization_handoff_ready=false` by default.
+- `authorization_handoff_completed=false` by default.
+- Every `checked`, `passed`, `completed`, `ready` field is `false` by default.
+- Codex must not change any `checked`/`passed`/`completed`/`ready` to `true`.
+- Codex must not authorize network dry-run execution.
+- Phase 4.94D does not write an authorization handoff checklist runtime file.
+  It only validates this template and produces a local stdout preview.
+- A real network dry-run must enter a separate, later authorization phase.
+
+```yaml
+phase: PHASE4_94D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST
+handoff_checklist_status: template_only
+authorization_handoff_ready: false
+authorization_handoff_completed: false
+filled_intake_review_result_ready: false
+filled_intake_reviewed: false
+filled_intake_accepted: false
+can_proceed_to_network_dry_run_preparation: false
+real_parameters_provided: false
+real_parameter_intake_validated: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+included_artifacts:
+    filled_intake_review_result: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md
+    filled_intake_review_plan: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md
+    real_parameter_intake: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md
+    validation_closure: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md
+    blocked_summary: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md
+
+handoff_sections:
+    filled_intake_review_result_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: filled_intake_review_result_not_accepted
+    real_parameter_integrity_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: real_parameters_not_validated
+    source_terms_and_allowed_use_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: source_terms_not_approved
+    network_authorization_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: network_dry_run_not_authorized
+    proxy_browser_network_policy_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: proxy_browser_network_policy_not_approved
+    staging_policy_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: staging_policy_not_approved
+    no_db_training_prediction_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: no_db_training_prediction_policy_not_confirmed
+    final_human_confirmation_check:
+        required: true
+        checked: false
+        passed: false
+        blocking_reason: final_human_confirmation_missing
+
+handoff_blocking_reasons:
+    - handoff_checklist_template_only
+    - filled_intake_review_result_not_accepted
+    - real_parameters_not_validated
+    - source_terms_not_approved
+    - network_dry_run_not_authorized
+    - proxy_browser_network_policy_not_approved
+    - staging_policy_not_approved
+    - no_db_training_prediction_policy_not_confirmed
+    - final_human_confirmation_missing
+    - future_separate_authorization_phase_required
+
+authorization_boundary:
+    handoff_checklist_is_not_authorization: true
+    future_authorization_phase_required: true
+    codex_may_not_authorize_network: true
+    codex_may_not_enable_execution: true
+    codex_may_not_convert_handoff_to_runbook: true
+    codex_may_not_self_approve_terms: true
+    codex_may_not_self_accept_review_result: true
+
+codex_constraints:
+    codex_may_not_self_fill_real_parameters: true
+    codex_may_not_mark_checked: true
+    codex_may_not_mark_passed: true
+    codex_may_not_complete_handoff: true
+    codex_may_not_authorize_network: true
+    codex_may_not_enable_execution: true
+    codex_may_not_write_runtime_files: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_execute_legacy_titan_discovery: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_user_input_closure_file: false
+    would_write_blocked_summary_file: false
+    would_write_real_parameter_intake_file: false
+    would_write_real_parameter_validation_closure_file: false
+    would_write_filled_intake_review_file: false
+    would_write_filled_intake_review_result_file: false
+    would_write_authorization_handoff_checklist_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+
+next_phase_requirements:
+    - user_supplies_filled_real_parameter_intake
+    - separate_phase_reviews_filled_intake
+    - separate_phase_records_review_result
+    - separate_phase_checks_authorization_handoff
+    - separate_phase_records_handoff_result
+    - separate_phase_still_requires_explicit_network_authorization
+    - separate_phase_confirms_no_db_write
+    - separate_phase_confirms_no_training
+    - separate_phase_confirms_no_prediction
+```
+
+## Purpose
+
+This template defines the handoff checklist that a future phase should verify
+before transitioning from a filled-intake review result to a network
+dry-run authorization phase.
+
+It defines:
+
+- Eight handoff sections covering review result acceptance, parameter integrity,
+  source terms, network authorization, proxy/browser/network policy, staging
+  policy, no-DB/no-training/no-prediction confirmation, and final human
+  confirmation
+- Blocking reasons that prevent handoff
+- An authorization boundary explicitly stating the checklist is not
+  authorization itself
+- Codex constraints prohibiting self-authorization
+
+## Guardrails
+
+Even if a future handoff checklist shows all sections passed, Phase 4.94D does
+not execute a network dry-run. A completed handoff must still move through a
+separate, later authorization phase.
+
+This template does not permit: network access, browser launch, proxy runtime,
+legacy runtime execution, engine execution, staging writes, source manifest
+writes, packet/approval/closure/runtime file writes, DB writes, training, or
+prediction. The template must remain `template_only` in Phase 4.94D.

--- a/scripts/ops/single_target_acquisition_network_authorization_handoff_checklist.js
+++ b/scripts/ops/single_target_acquisition_network_authorization_handoff_checklist.js
@@ -1,0 +1,607 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const {
+    parseIntakeYaml,
+    runValidation: validateRealParameterIntake,
+} = require('./single_target_acquisition_network_real_parameter_intake');
+const {
+    runValidation: validateValidationClosure,
+} = require('./single_target_acquisition_network_real_parameter_intake_validation_closure');
+const { runValidation: validateReviewPlan } = require('./single_target_acquisition_network_filled_intake_review_plan');
+const {
+    runValidation: validateReviewResult,
+} = require('./single_target_acquisition_network_filled_intake_review_result');
+
+const OUTPUT_PHASE = 'PHASE4.94D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST';
+const TEMPLATE_PHASE = 'PHASE4_94D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST';
+const MODE = 'single-target-acquisition-network-authorization-handoff-checklist-preview';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition authorization handoff checklist execution is not wired in Phase 4.94D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.95D or explicit user-filled real parameter intake';
+const REVIEW_RESULT_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md';
+const REVIEW_PLAN_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md';
+const INTAKE_TEMPLATE = 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md';
+const VALIDATION_CLOSURE_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md';
+const BLOCKED_SUMMARY_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md';
+
+const HANDOFF_SECTIONS = [
+    'filled_intake_review_result_check',
+    'real_parameter_integrity_check',
+    'source_terms_and_allowed_use_check',
+    'network_authorization_check',
+    'proxy_browser_network_policy_check',
+    'staging_policy_check',
+    'no_db_training_prediction_check',
+    'final_human_confirmation_check',
+];
+
+const HANDOFF_BLOCKING_REASONS = [
+    'handoff_checklist_template_only',
+    'filled_intake_review_result_not_accepted',
+    'real_parameters_not_validated',
+    'source_terms_not_approved',
+    'network_dry_run_not_authorized',
+    'proxy_browser_network_policy_not_approved',
+    'staging_policy_not_approved',
+    'no_db_training_prediction_policy_not_confirmed',
+    'final_human_confirmation_missing',
+    'future_separate_authorization_phase_required',
+];
+
+const SECTION_FIELDS = w('required checked passed blocking_reason');
+const AUTH_BOUNDARY_FIELDS = w(
+    'handoff_checklist_is_not_authorization future_authorization_phase_required codex_may_not_authorize_network codex_may_not_enable_execution codex_may_not_convert_handoff_to_runbook codex_may_not_self_approve_terms codex_may_not_self_accept_review_result'
+);
+
+const REQUIRED_TOP = w(
+    'phase handoff_checklist_status authorization_handoff_ready authorization_handoff_completed filled_intake_review_result_ready filled_intake_reviewed filled_intake_accepted can_proceed_to_network_dry_run_preparation real_parameters_provided real_parameter_intake_validated network_dry_run_authorized network_dry_run_execution_allowed staging_write_authorized db_write_authorized training_authorized prediction_authorized final_human_confirmation handoff_sections handoff_blocking_reasons authorization_boundary included_artifacts codex_constraints safety next_phase_requirements'
+);
+
+const TOP_FALSE = {
+    authorization_handoff_ready: 'authorization_handoff_ready true is not allowed',
+    authorization_handoff_completed: 'authorization_handoff_completed true is not allowed',
+    filled_intake_review_result_ready: 'filled_intake_review_result_ready true is not allowed',
+    filled_intake_reviewed: 'filled_intake_reviewed true is not allowed',
+    filled_intake_accepted: 'filled_intake_accepted true is not allowed',
+    can_proceed_to_network_dry_run_preparation: 'can_proceed_to_network_dry_run_preparation true is not allowed',
+    real_parameters_provided: 'real_parameters_provided true is not allowed',
+    real_parameter_intake_validated: 'real_parameter_intake_validated true is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true is not allowed',
+    staging_write_authorized: 'staging_write_authorized true is not allowed',
+    db_write_authorized: 'db_write_authorized true is not allowed',
+    training_authorized: 'training_authorized true is not allowed',
+    prediction_authorized: 'prediction_authorized true is not allowed',
+    final_human_confirmation: 'final_human_confirmation true is not allowed',
+};
+
+const CODEX_FIELDS = w(
+    'codex_may_not_self_fill_real_parameters codex_may_not_mark_checked codex_may_not_mark_passed codex_may_not_complete_handoff codex_may_not_authorize_network codex_may_not_enable_execution codex_may_not_write_runtime_files'
+);
+
+const SAFETY_FIELDS = w(
+    'would_access_network would_launch_browser would_use_proxy would_execute_engine would_execute_legacy_titan_discovery would_write_staging would_create_staging_directory would_write_source_manifest would_write_packet_file would_write_approval_packet_file would_write_user_input_closure_file would_write_blocked_summary_file would_write_real_parameter_intake_file would_write_real_parameter_validation_closure_file would_write_filled_intake_review_file would_write_filled_intake_review_result_file would_write_authorization_handoff_checklist_file would_write_db would_train would_predict would_bulk_harvest'
+);
+
+function w(t) {
+    return t.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_authorization_handoff_checklist.js --handoff-checklist <path> --review-result <path> --review-plan <path> --intake <path> --validation-closure <path> --blocked-summary <path>',
+        '',
+        'Safety: Phase 4.94D previews a local authorization handoff checklist template only. No network, no writes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const a = {
+        handoff_checklist: '',
+        review_result: '',
+        review_plan: '',
+        intake: '',
+        validation_closure: '',
+        blocked_summary: '',
+        commit: false,
+        help: false,
+    };
+    for (let i = 0; i < argv.length; i += 1) {
+        const t = argv[i];
+        if (t === '--commit') {
+            a.commit = true;
+            continue;
+        }
+        if (t === '--help' || t === '-h') {
+            a.help = true;
+            continue;
+        }
+        if (!t.startsWith('--')) throw new Error('Unknown: ' + t);
+        const eq = t.indexOf('=');
+        if (eq !== -1) {
+            a[t.slice(2, eq).replace(/-/g, '_')] = t.slice(eq + 1);
+        } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+            a[t.slice(2).replace(/-/g, '_')] = String(argv[i + 1] || '');
+            i += 1;
+        } else {
+            throw new Error('Unknown: ' + t);
+        }
+    }
+    return a;
+}
+
+function buildSafetyFlags() {
+    return {
+        authorization_handoff_checklist_template_only: true,
+        handoff_checklist_valid: false,
+        review_result_valid: false,
+        review_plan_valid: false,
+        real_parameter_intake_valid: false,
+        validation_closure_valid: false,
+        blocked_summary_valid: false,
+        authorization_handoff_ready: false,
+        authorization_handoff_completed: false,
+        filled_intake_review_result_ready: false,
+        filled_intake_reviewed: false,
+        filled_intake_accepted: false,
+        can_proceed_to_network_dry_run_preparation: false,
+        real_parameters_provided: false,
+        real_parameter_intake_validated: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        handoff_sections_complete: false,
+        handoff_sections_passed: false,
+        handoff_checklist_is_not_authorization: true,
+        future_authorization_phase_required: true,
+        handoff_blocking_reasons: HANDOFF_BLOCKING_REASONS,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_execute_legacy_titan_discovery: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_user_input_closure_file: false,
+        would_write_blocked_summary_file: false,
+        would_write_real_parameter_intake_file: false,
+        would_write_real_parameter_validation_closure_file: false,
+        would_write_filled_intake_review_file: false,
+        would_write_filled_intake_review_result_file: false,
+        would_write_authorization_handoff_checklist_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: OUTPUT_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        handoff_checklist: args.handoff_checklist || null,
+        review_result: args.review_result || null,
+        review_plan: args.review_plan || null,
+        intake: args.intake || null,
+        validation_closure: args.validation_closure || null,
+        blocked_summary: args.blocked_summary || null,
+        handoff_checklist_found: false,
+        review_result_found: false,
+        review_plan_found: false,
+        intake_found: false,
+        validation_closure_found: false,
+        blocked_summary_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+            'no_filled_intake_review_file_writes',
+            'no_filled_intake_review_result_file_writes',
+            'no_authorization_handoff_checklist_file_writes',
+            'no_legacy_titan_discovery_execution',
+        ],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveLocalPath(r, cwd) {
+    if (!r) return '';
+    return path.isAbsolute(r) ? path.resolve(r) : path.resolve(cwd, r);
+}
+function toRelativePath(a, cwd) {
+    if (!a) return '';
+    return path.relative(cwd, a) || '.';
+}
+
+function validateRequiredCliFields(args) {
+    const e = [];
+    if (!args.handoff_checklist) e.push('missing handoff checklist');
+    if (!args.review_result) e.push('missing review result');
+    if (!args.review_plan) e.push('missing review plan');
+    if (!args.intake) e.push('missing intake');
+    if (!args.validation_closure) e.push('missing validation closure');
+    if (!args.blocked_summary) e.push('missing blocked summary');
+    return e;
+}
+function validateCliArgsOrPayload(args) {
+    const e = validateRequiredCliFields(args);
+    return e.length ? buildFailurePayload(args, { mode: 'argument-error', errors: e }) : null;
+}
+
+function loadYamlFile(args, deps, fieldName, missingLabel, mode) {
+    const tp = resolveLocalPath(args[fieldName], deps.cwd);
+    if (!deps.existsSync(tp)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: false,
+                errors: ['missing ' + missingLabel + ': ' + toRelativePath(tp, deps.cwd)],
+            }),
+        };
+    }
+    const yt = extractYamlBlock(deps.readFileSync(tp, 'utf8'));
+    if (!yt) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+    try {
+        return { parsedYaml: parseIntakeYaml(yt), yamlText: yt };
+    } catch (e) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: true,
+                errors: ['invalid YAML: ' + e.message],
+            }),
+        };
+    }
+}
+
+function hasOwn(root, key) {
+    return Object.prototype.hasOwnProperty.call(root, key);
+}
+function gp(root, dp) {
+    return dp.split('.').reduce((c, k) => {
+        if (!c || typeof c !== 'object') return undefined;
+        return c[k];
+    }, root);
+}
+function addMissing(root, pp, rk, mf) {
+    const v = gp(root, pp);
+    if (!v || typeof v !== 'object' || Array.isArray(v)) {
+        mf.push(pp);
+        return;
+    }
+    rk.filter(k => !hasOwn(v, k)).forEach(k => mf.push(pp + '.' + k));
+}
+
+function findMissingFields(py) {
+    const mf = REQUIRED_TOP.filter(k => !hasOwn(py, k));
+    HANDOFF_SECTIONS.forEach(s => addMissing(py, 'handoff_sections.' + s, SECTION_FIELDS, mf));
+    addMissing(py, 'authorization_boundary', AUTH_BOUNDARY_FIELDS, mf);
+    addMissing(
+        py,
+        'included_artifacts',
+        w(
+            'filled_intake_review_result filled_intake_review_plan real_parameter_intake validation_closure blocked_summary'
+        ),
+        mf
+    );
+    addMissing(py, 'codex_constraints', CODEX_FIELDS, mf);
+    addMissing(py, 'safety', SAFETY_FIELDS, mf);
+    return mf;
+}
+
+function validateTopLevelFalse(py, errors) {
+    Object.entries(TOP_FALSE).forEach(([k, msg]) => {
+        if (py[k] !== false) errors.push(msg);
+    });
+}
+
+function validateHandoffSections(py, errors) {
+    const sec = py.handoff_sections || {};
+    HANDOFF_SECTIONS.forEach(name => {
+        const s = sec[name];
+        if (!s || typeof s !== 'object' || Array.isArray(s)) {
+            errors.push('missing handoff_sections.' + name);
+            return;
+        }
+        if (s.checked !== false) errors.push('handoff_sections.' + name + '.checked true in template is not allowed');
+        if (s.passed !== false) errors.push('handoff_sections.' + name + '.passed true in template is not allowed');
+        if (s.required !== true) errors.push('handoff_sections.' + name + '.required must be true');
+    });
+}
+
+function validateAuthorizationBoundary(py, errors) {
+    const ab = py.authorization_boundary || {};
+    AUTH_BOUNDARY_FIELDS.forEach(f => {
+        if (ab[f] !== true) errors.push('authorization_boundary.' + f + ' must be true');
+    });
+}
+
+function validateBlockingReasons(py, errors) {
+    const br = py.handoff_blocking_reasons;
+    if (!Array.isArray(br)) {
+        errors.push('missing handoff_blocking_reasons');
+        return;
+    }
+    const m = HANDOFF_BLOCKING_REASONS.filter(r => !br.includes(r));
+    if (m.length) errors.push('missing handoff_blocking_reasons: ' + m.join(','));
+}
+
+function validateIncludedArtifacts(py, errors) {
+    const inc = py.included_artifacts || {};
+    if (inc.filled_intake_review_result !== REVIEW_RESULT_TEMPLATE) {
+        errors.push('included_artifacts.filled_intake_review_result must be ' + REVIEW_RESULT_TEMPLATE);
+    }
+    if (inc.filled_intake_review_plan !== REVIEW_PLAN_TEMPLATE) {
+        errors.push('included_artifacts.filled_intake_review_plan must be ' + REVIEW_PLAN_TEMPLATE);
+    }
+    if (inc.real_parameter_intake !== INTAKE_TEMPLATE) {
+        errors.push('included_artifacts.real_parameter_intake must be ' + INTAKE_TEMPLATE);
+    }
+    if (inc.validation_closure !== VALIDATION_CLOSURE_TEMPLATE) {
+        errors.push('included_artifacts.validation_closure must be ' + VALIDATION_CLOSURE_TEMPLATE);
+    }
+    if (inc.blocked_summary !== BLOCKED_SUMMARY_TEMPLATE) {
+        errors.push('included_artifacts.blocked_summary must be ' + BLOCKED_SUMMARY_TEMPLATE);
+    }
+}
+
+function validateCodexConstraints(py, errors) {
+    const cc = py.codex_constraints || {};
+    CODEX_FIELDS.forEach(f => {
+        if (cc[f] !== true) errors.push('codex_constraints.' + f + ' false is not allowed');
+    });
+}
+function validateSafety(py, errors) {
+    const s = py.safety || {};
+    SAFETY_FIELDS.forEach(f => {
+        if (s[f] !== false) errors.push('safety.' + f + ' must remain false');
+    });
+}
+
+function validateParsedYaml(py) {
+    const errors = [];
+    const mf = findMissingFields(py);
+    if (mf.length) errors.push('missing required fields: ' + mf.join(','));
+    if (py.phase !== TEMPLATE_PHASE) errors.push('phase must be ' + TEMPLATE_PHASE);
+    if (py.handoff_checklist_status !== 'template_only') errors.push('handoff_checklist_status not template_only');
+    validateTopLevelFalse(py, errors);
+    validateHandoffSections(py, errors);
+    validateAuthorizationBoundary(py, errors);
+    validateBlockingReasons(py, errors);
+    validateIncludedArtifacts(py, errors);
+    validateCodexConstraints(py, errors);
+    validateSafety(py, errors);
+    return { ok: errors.length === 0, missingFields: mf, errors };
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: OUTPUT_PHASE,
+        mode: MODE,
+        ok: true,
+        handoff_checklist: args.handoff_checklist,
+        review_result: args.review_result,
+        review_plan: args.review_plan,
+        intake: args.intake,
+        validation_closure: args.validation_closure,
+        blocked_summary: args.blocked_summary,
+        handoff_checklist_found: true,
+        review_result_found: true,
+        review_plan_found: true,
+        intake_found: true,
+        validation_closure_found: true,
+        blocked_summary_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        handoff_checklist_valid: true,
+        review_result_valid: true,
+        review_plan_valid: true,
+        real_parameter_intake_valid: true,
+        validation_closure_valid: true,
+        blocked_summary_valid: true,
+        handoff_sections_complete: true,
+        handoff_sections_passed: false,
+        handoff_checklist_is_not_authorization: true,
+        future_authorization_phase_required: true,
+        errors: [],
+        warnings: ['Phase 4.94D remains template-only.', 'Handoff checklist does not constitute authorization.'],
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+            'no_filled_intake_review_file_writes',
+            'no_filled_intake_review_result_file_writes',
+            'no_authorization_handoff_checklist_file_writes',
+            'no_legacy_titan_discovery_execution',
+        ],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const deps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+    const cliP = validateCliArgsOrPayload(args);
+    if (cliP) return cliP;
+
+    const hcLoad = loadYamlFile(args, deps, 'handoff_checklist', 'handoff checklist', 'handoff-checklist-error');
+    if (hcLoad.payload) return hcLoad.payload;
+
+    const hcValidation = validateParsedYaml(hcLoad.parsedYaml);
+    if (!hcValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'handoff-checklist-error',
+            handoff_checklist_found: true,
+            yaml_block_found: true,
+            required_fields_present: hcValidation.missingFields.length === 0,
+            missing_fields: hcValidation.missingFields,
+            errors: hcValidation.errors,
+        });
+    }
+
+    const intakeP = validateRealParameterIntake({ intake: args.intake, blocked_summary: args.blocked_summary }, deps);
+    if (!intakeP.ok) {
+        return buildFailurePayload(args, {
+            mode: 'intake-error',
+            handoff_checklist_found: true,
+            handoff_checklist_valid: true,
+            yaml_block_found: true,
+            errors: intakeP.errors || ['intake validation failed'],
+        });
+    }
+
+    const closureP = validateValidationClosure(
+        { validation_closure: args.validation_closure, intake: args.intake, blocked_summary: args.blocked_summary },
+        deps
+    );
+    if (!closureP.ok) {
+        return buildFailurePayload(args, {
+            mode: 'closure-error',
+            handoff_checklist_found: true,
+            handoff_checklist_valid: true,
+            real_parameter_intake_valid: true,
+            yaml_block_found: true,
+            errors: closureP.errors || ['closure failed'],
+        });
+    }
+
+    const planP = validateReviewPlan(
+        {
+            review_plan: args.review_plan,
+            intake: args.intake,
+            validation_closure: args.validation_closure,
+            blocked_summary: args.blocked_summary,
+        },
+        deps
+    );
+    if (!planP.ok) {
+        return buildFailurePayload(args, {
+            mode: 'plan-error',
+            handoff_checklist_found: true,
+            handoff_checklist_valid: true,
+            real_parameter_intake_valid: true,
+            validation_closure_valid: true,
+            yaml_block_found: true,
+            errors: planP.errors || ['plan failed'],
+        });
+    }
+
+    const resultP = validateReviewResult(
+        {
+            review_result: args.review_result,
+            review_plan: args.review_plan,
+            intake: args.intake,
+            validation_closure: args.validation_closure,
+            blocked_summary: args.blocked_summary,
+        },
+        deps
+    );
+    if (!resultP.ok) {
+        return buildFailurePayload(args, {
+            mode: 'result-error',
+            handoff_checklist_found: true,
+            handoff_checklist_valid: true,
+            real_parameter_intake_valid: true,
+            validation_closure_valid: true,
+            review_plan_valid: true,
+            yaml_block_found: true,
+            errors: resultP.errors || ['result failed'],
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(p, io) {
+    io.stdout(JSON.stringify(p, null, 2) + '\n');
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (t => process.stdout.write(t)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(usage() + '\n');
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const p = runValidation(args, dependencies);
+        writePayload(p, output);
+        return p.ok ? 0 : 1;
+    } catch (e) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [e.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    OUTPUT_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    HANDOFF_SECTIONS,
+    HANDOFF_BLOCKING_REASONS,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_authorization_handoff_checklist.test.js
+++ b/tests/unit/single_target_acquisition_network_authorization_handoff_checklist.test.js
@@ -1,0 +1,607 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(
+    PROJECT_ROOT,
+    'scripts/ops/single_target_acquisition_network_authorization_handoff_checklist.js'
+);
+const HC_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST_TEMPLATE.md'
+);
+const RR_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md'
+);
+const RP_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md'
+);
+const INTAKE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md'
+);
+const VC_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md'
+);
+const BS_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md'
+);
+const HC_TEXT = fs.readFileSync(HC_PATH, 'utf8');
+
+function loadFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+function buildArgs(o = {}) {
+    return {
+        handoff_checklist: HC_PATH,
+        review_result: RR_PATH,
+        review_plan: RP_PATH,
+        intake: INTAKE_PATH,
+        validation_closure: VC_PATH,
+        blocked_summary: BS_PATH,
+        ...o,
+    };
+}
+function buildDeps(o = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: p => fs.existsSync(p),
+        readFileSync: (p, e) => fs.readFileSync(p, e),
+        ...o,
+    };
+}
+function buildTextDeps(text, tp = HC_PATH) {
+    return buildDeps({
+        existsSync: p => p === tp || fs.existsSync(p),
+        readFileSync: (p, e) => {
+            if (p === tp) return text;
+            return fs.readFileSync(p, e);
+        },
+    });
+}
+
+function installGuards(t) {
+    const orig = {
+        http: http.request,
+        https: https.request,
+        fetch: global.fetch,
+        spawn: childProcess.spawn,
+        exec: childProcess.exec,
+        execFile: childProcess.execFile,
+        writeFile: fs.writeFile,
+        writeFileSync: fs.writeFileSync,
+        createWriteStream: fs.createWriteStream,
+        mkdir: fs.mkdir,
+        mkdirSync: fs.mkdirSync,
+        net: net.connect,
+        load: Module._load,
+    };
+    const fail = n => () => {
+        throw new Error(n + ' should not be called');
+    };
+    http.request = fail('http');
+    https.request = fail('https');
+    global.fetch = fail('fetch');
+    childProcess.spawn = fail('spawn');
+    childProcess.exec = fail('exec');
+    childProcess.execFile = fail('execFile');
+    fs.writeFile = fail('writeFile');
+    fs.writeFileSync = fail('writeFileSync');
+    fs.createWriteStream = fail('createWriteStream');
+    fs.mkdir = fail('mkdir');
+    fs.mkdirSync = fail('mkdirSync');
+    net.connect = fail('net');
+    Module._load = function p(r, parent, isMain) {
+        if (
+            new Set([
+                'http',
+                'node:http',
+                'https',
+                'node:https',
+                'child_process',
+                'node:child_process',
+                'pg',
+                'redis',
+                'ioredis',
+                'playwright',
+                'playwright-core',
+            ]).has(r)
+        ) {
+            throw new Error('blocked: ' + r);
+        }
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(r)) throw new Error('blocked: ' + r);
+        return orig.load.call(this, r, parent, isMain);
+    };
+    t.after(() => {
+        Object.assign(http, { request: orig.http });
+        Object.assign(https, { request: orig.https });
+        global.fetch = orig.fetch;
+        Object.assign(childProcess, { spawn: orig.spawn, exec: orig.exec, execFile: orig.execFile });
+        Object.assign(fs, {
+            writeFile: orig.writeFile,
+            writeFileSync: orig.writeFileSync,
+            createWriteStream: orig.createWriteStream,
+            mkdir: orig.mkdir,
+            mkdirSync: orig.mkdirSync,
+        });
+        net.connect = orig.net;
+        Module._load = orig.load;
+    });
+}
+
+function replaceInTemplate(s, r) {
+    assert.match(HC_TEXT, new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    return HC_TEXT.replace(s, r);
+}
+function removeLine(l) {
+    return HC_TEXT.replace(l + '\n', '');
+}
+function runMain(gate, argv, deps = buildDeps()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: t => {
+                stdout += t;
+            },
+        },
+        deps
+    );
+    return { status, stdout };
+}
+function extractJson(out) {
+    const t = String(out || '').trim();
+    const i = t.lastIndexOf('\n{');
+    return JSON.parse(i >= 0 ? t.slice(i + 1) : t);
+}
+
+// 1-6: missing files
+['handoff_checklist', 'review_result', 'review_plan', 'intake', 'validation_closure', 'blocked_summary'].forEach(f => {
+    const label = f.replace(/_/g, ' ');
+    test('缺 ' + label + ' 失败', () => {
+        const gate = loadFresh();
+        const args = buildArgs();
+        delete args[f];
+        const p = gate.runValidation(args, buildDeps());
+        assert.equal(p.ok, false);
+        assert.match(p.errors.join('\n'), new RegExp('missing ' + label, 'i'));
+    });
+});
+
+// 7-8: YAML
+test('handoff checklist 缺 YAML block 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(buildArgs(), buildTextDeps('# no yaml\n'));
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing YAML block/i);
+});
+test('handoff checklist invalid YAML 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(buildArgs(), buildTextDeps('```yaml\nnot yaml\n```\n'));
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /invalid YAML/i);
+});
+
+// 9: missing phase
+test('missing phase 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(
+            removeLine('phase: PHASE4_94D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST')
+        )
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing required fields: phase|phase must be/);
+});
+
+// 10: handoff_checklist_status
+test('handoff_checklist_status 非 template_only 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('handoff_checklist_status: template_only', 'handoff_checklist_status: ready'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /handoff_checklist_status not template_only/);
+});
+
+// 11-18: top-level false fields
+[
+    [
+        'authorization_handoff_ready=true',
+        'authorization_handoff_ready: false',
+        'authorization_handoff_ready: true',
+        /authorization_handoff_ready true/,
+    ],
+    [
+        'authorization_handoff_completed=true',
+        'authorization_handoff_completed: false',
+        'authorization_handoff_completed: true',
+        /authorization_handoff_completed true/,
+    ],
+    [
+        'filled_intake_review_result_ready=true',
+        'filled_intake_review_result_ready: false',
+        'filled_intake_review_result_ready: true',
+        /filled_intake_review_result_ready true/,
+    ],
+    [
+        'filled_intake_reviewed=true',
+        'filled_intake_reviewed: false',
+        'filled_intake_reviewed: true',
+        /filled_intake_reviewed true/,
+    ],
+    [
+        'filled_intake_accepted=true',
+        'filled_intake_accepted: false',
+        'filled_intake_accepted: true',
+        /filled_intake_accepted true/,
+    ],
+    [
+        'can_proceed_to_network_dry_run_preparation=true',
+        'can_proceed_to_network_dry_run_preparation: false',
+        'can_proceed_to_network_dry_run_preparation: true',
+        /can_proceed_to_network_dry_run_preparation true/,
+    ],
+    [
+        'real_parameters_provided=true',
+        'real_parameters_provided: false',
+        'real_parameters_provided: true',
+        /real_parameters_provided true/,
+    ],
+    [
+        'real_parameter_intake_validated=true',
+        'real_parameter_intake_validated: false',
+        'real_parameter_intake_validated: true',
+        /real_parameter_intake_validated true/,
+    ],
+].forEach(([n, s, r, p]) => {
+    test(n + ' 失败', () => {
+        const gate = loadFresh();
+        const pl = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(s, r)));
+        assert.equal(pl.ok, false);
+        assert.match(pl.errors.join('\n'), p);
+    });
+});
+
+// 19-34: handoff_sections.*.checked/passed=true
+const SEC_NAMES = [
+    'filled_intake_review_result_check',
+    'real_parameter_integrity_check',
+    'source_terms_and_allowed_use_check',
+    'network_authorization_check',
+    'proxy_browser_network_policy_check',
+    'staging_policy_check',
+    'no_db_training_prediction_check',
+    'final_human_confirmation_check',
+];
+SEC_NAMES.forEach(name => {
+    ['checked', 'passed'].forEach(field => {
+        test('handoff_sections.' + name + '.' + field + '=true 失败', () => {
+            const gate = loadFresh();
+            const t = HC_TEXT.replace(
+                new RegExp('(' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ':[\\s\\S]*?' + field + ': )false'),
+                '$1true'
+            );
+            assert.ok(t !== HC_TEXT, 'template should be modified');
+            const p = gate.runValidation(buildArgs(), buildTextDeps(t));
+            assert.equal(p.ok, false);
+            assert.match(
+                p.errors.join('\n'),
+                new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\.' + field + ' true')
+            );
+        });
+    });
+});
+
+// 35-41: authorization flags
+[
+    [
+        'network_dry_run_authorized=true',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'staging_write_authorized=true',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    ['db_write_authorized=true', 'db_write_authorized: false', 'db_write_authorized: true', /db_write_authorized true/],
+    ['training_authorized=true', 'training_authorized: false', 'training_authorized: true', /training_authorized true/],
+    [
+        'prediction_authorized=true',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+].forEach(([n, s, r, p]) => {
+    test(n + ' 失败', () => {
+        const gate = loadFresh();
+        const pl = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(s, r)));
+        assert.equal(pl.ok, false);
+        assert.match(pl.errors.join('\n'), p);
+    });
+});
+
+// 42-43: authorization_boundary flags
+test('handoff_checklist_is_not_authorization=false 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(
+            replaceInTemplate(
+                'handoff_checklist_is_not_authorization: true',
+                'handoff_checklist_is_not_authorization: false'
+            )
+        )
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /handoff_checklist_is_not_authorization/);
+});
+test('future_authorization_phase_required=false 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(
+            replaceInTemplate('future_authorization_phase_required: true', 'future_authorization_phase_required: false')
+        )
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /future_authorization_phase_required/);
+});
+
+// 44-47: codex constraints
+[
+    [
+        'codex_may_not_mark_checked=false',
+        'codex_may_not_mark_checked: true',
+        'codex_may_not_mark_checked: false',
+        /codex_may_not_mark_checked false/,
+    ],
+    [
+        'codex_may_not_mark_passed=false',
+        'codex_may_not_mark_passed: true',
+        'codex_may_not_mark_passed: false',
+        /codex_may_not_mark_passed false/,
+    ],
+    [
+        'codex_may_not_complete_handoff=false',
+        'codex_may_not_complete_handoff: true',
+        'codex_may_not_complete_handoff: false',
+        /codex_may_not_complete_handoff false/,
+    ],
+    [
+        'codex_may_not_authorize_network=false',
+        'codex_may_not_authorize_network: true',
+        'codex_may_not_authorize_network: false',
+        /codex_may_not_authorize_network/,
+    ],
+].forEach(([n, s, r, p]) => {
+    test(n + ' 失败', () => {
+        const gate = loadFresh();
+        const pl = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(s, r)));
+        assert.equal(pl.ok, false);
+        assert.match(pl.errors.join('\n'), p);
+    });
+});
+
+// 48-49: missing sections
+test('handoff_sections missing 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('handoff_sections:', 'handoff_sections_missing:'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing required fields.*handoff_sections/);
+});
+test('handoff_blocking_reasons missing 失败', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInTemplate('handoff_blocking_reasons:', 'handoff_blocking_reasons_missing:'))
+    );
+    assert.equal(p.ok, false);
+    assert.match(p.errors.join('\n'), /missing handoff_blocking_reasons/);
+});
+
+// 52-54: safety would_*
+['would_access_network', 'would_write_db', 'would_write_authorization_handoff_checklist_file'].forEach(f => {
+    test('safety ' + f + '=true 失败', () => {
+        const gate = loadFresh();
+        const p = gate.runValidation(buildArgs(), buildTextDeps(replaceInTemplate(f + ': false', f + ': true')));
+        assert.equal(p.ok, false);
+        assert.match(p.errors.join('\n'), new RegExp('safety\\.' + f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    });
+});
+
+// 55: valid preview
+test('valid authorization handoff checklist preview 成功', () => {
+    const gate = loadFresh();
+    const p = gate.runValidation(buildArgs(), buildDeps());
+    assert.equal(p.ok, true);
+    assert.equal(p.phase, 'PHASE4.94D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST');
+    assert.equal(p.authorization_handoff_checklist_template_only, true);
+    assert.equal(p.handoff_checklist_valid, true);
+    assert.equal(p.review_result_valid, true);
+    assert.equal(p.review_plan_valid, true);
+    assert.equal(p.real_parameter_intake_valid, true);
+    assert.equal(p.validation_closure_valid, true);
+    assert.equal(p.blocked_summary_valid, true);
+    assert.equal(p.authorization_handoff_ready, false);
+    assert.equal(p.authorization_handoff_completed, false);
+    assert.equal(p.filled_intake_accepted, false);
+    assert.equal(p.can_proceed_to_network_dry_run_preparation, false);
+    assert.equal(p.network_dry_run_authorized, false);
+    assert.equal(p.network_dry_run_execution_allowed, false);
+    assert.equal(p.handoff_sections_complete, true);
+    assert.equal(p.handoff_sections_passed, false);
+    assert.equal(p.handoff_checklist_is_not_authorization, true);
+    assert.equal(p.future_authorization_phase_required, true);
+    assert.deepEqual(p.handoff_blocking_reasons, [
+        'handoff_checklist_template_only',
+        'filled_intake_review_result_not_accepted',
+        'real_parameters_not_validated',
+        'source_terms_not_approved',
+        'network_dry_run_not_authorized',
+        'proxy_browser_network_policy_not_approved',
+        'staging_policy_not_approved',
+        'no_db_training_prediction_policy_not_confirmed',
+        'final_human_confirmation_missing',
+        'future_separate_authorization_phase_required',
+    ]);
+    for (const f of [
+        'would_access_network',
+        'would_launch_browser',
+        'would_use_proxy',
+        'would_execute_engine',
+        'would_execute_legacy_titan_discovery',
+        'would_write_staging',
+        'would_create_staging_directory',
+        'would_write_source_manifest',
+        'would_write_packet_file',
+        'would_write_approval_packet_file',
+        'would_write_blocked_summary_file',
+        'would_write_real_parameter_intake_file',
+        'would_write_real_parameter_validation_closure_file',
+        'would_write_filled_intake_review_file',
+        'would_write_filled_intake_review_result_file',
+        'would_write_authorization_handoff_checklist_file',
+        'would_write_db',
+        'would_train',
+        'would_predict',
+        'would_spawn_child_process',
+    ]) {
+        assert.equal(p[f], false, f);
+    }
+    assert.equal(p.commit_gate, 'blocked');
+});
+
+// 56: --commit blocked
+test('--commit blocked', () => {
+    const gate = loadFresh();
+    const r = runMain(
+        gate,
+        [
+            '--handoff-checklist',
+            HC_PATH,
+            '--review-result',
+            RR_PATH,
+            '--review-plan',
+            RP_PATH,
+            '--intake',
+            INTAKE_PATH,
+            '--validation-closure',
+            VC_PATH,
+            '--blocked-summary',
+            BS_PATH,
+            '--commit',
+        ],
+        buildDeps()
+    );
+    assert.equal(r.status, 1);
+    assert.match(JSON.parse(r.stdout).errors.join('\n'), /not wired in Phase 4.94D/);
+});
+
+// 57-58: Makefile
+test('Makefile preview 成功', () => {
+    const r = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-authorization-handoff-checklist-preview',
+            'NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_NODE=node',
+            'HANDOFF_CHECKLIST=' + HC_PATH,
+            'REVIEW_RESULT=' + RR_PATH,
+            'REVIEW_PLAN=' + RP_PATH,
+            'INTAKE=' + INTAKE_PATH,
+            'VALIDATION_CLOSURE=' + VC_PATH,
+            'BLOCKED_SUMMARY=' + BS_PATH,
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(extractJson(r.stdout).ok, true);
+});
+test('Makefile commit blocked', () => {
+    const r = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-authorization-handoff-checklist-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout, /not wired in Phase 4.94D/);
+});
+
+// 59-76: safety guard tests
+[
+    ['不访问网络', 'would_access_network'],
+    ['不启动 browser', 'would_launch_browser'],
+    ['不执行 proxy runtime', 'would_use_proxy'],
+    ['不执行 engine', 'would_execute_engine'],
+    ['不执行 legacy titan_discovery', 'would_execute_legacy_titan_discovery'],
+    ['不写 staging', 'would_write_staging'],
+    ['不创建目录', 'would_create_staging_directory'],
+    ['不写 source manifest', 'would_write_source_manifest'],
+    ['不写 packet file', 'would_write_packet_file'],
+    ['不写 approval packet file', 'would_write_approval_packet_file'],
+    ['不写 blocked summary file', 'would_write_blocked_summary_file'],
+    ['不写 real parameter intake file', 'would_write_real_parameter_intake_file'],
+    ['不写 validation closure file', 'would_write_real_parameter_validation_closure_file'],
+    ['不写 filled-intake review plan file', 'would_write_filled_intake_review_file'],
+    ['不写 filled-intake review result file', 'would_write_filled_intake_review_result_file'],
+    ['不写 authorization handoff checklist file', 'would_write_authorization_handoff_checklist_file'],
+    ['不写 DB', 'would_write_db'],
+    ['不 spawn child process', 'would_spawn_child_process'],
+].forEach(([n, f]) => {
+    test(n, t => {
+        installGuards(t);
+        const gate = loadFresh();
+        const p = gate.runValidation(buildArgs(), buildDeps());
+        assert.equal(p.ok, true);
+        assert.equal(p[f], false);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const src = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(src));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(src));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(src));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(src));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(src));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(src));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(src));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(src));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.94D single-target acquisition authorization handoff checklist template.

Scope:
- Adds authorization handoff checklist template (8 handoff sections + authorization boundary)
- Adds local-only handoff checklist preview validator
- Validates handoff remains template-only, incomplete, non-authorized
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests (75 tests)
- Updates AGENTS.md
- Adds Phase 4.94D report

Safety: No DB writes, external downloads, data access, scraping, browser automation, proxy runtime, harvest/ingest, network dry-run, staging writes, packet/approval/closure/runtime file writes, pg_dump, training, prediction, model artifact loading.

Validation: preview OK, commit blocked, 75/75 tests passed, npm test 48/48 passed, DB 2/2/2/2/2/2 unchanged, eslint/prettier/git diff passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)