### PR TITLE
docs(data): add network authorization decision template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -949,6 +949,38 @@ AI / Codex 默认禁止：
 
 真实 network dry-run 必须后续单独 authorization 阶段。
 
+### Phase 4.95D: single-target acquisition network dry-run authorization decision
+
+`data-single-target-acquisition-network-authorization-decision-preview` 只允许预览 network authorization decision template：
+
+- 它不得触网
+- 它不得启动 browser
+- 它不得执行 proxy runtime
+- 它不得运行 `titan_discovery` legacy runtime
+- 它不得写 staging
+- 它不得写 source manifest
+- 它不得写 packet file
+- 它不得写 approval packet file
+- 它不得写 blocked summary file
+- 它不得写 real parameter intake file
+- 它不得写 validation closure file
+- 它不得写 filled-intake review plan file
+- 它不得写 filled-intake review result file
+- 它不得写 authorization handoff checklist file
+- 它不得写 network authorization decision file
+- 它不得写 DB
+- network authorization decision template 不等于真实 authorization
+- network authorization decision 也不等于 network dry-run execution
+- Codex 不得自行填写真实 source / target / terms / authorization
+- Codex 不得自行把 `authorization_decision` 改成 authorized
+- Codex 不得自行把 `network_dry_run_authorized` 改成 true
+- Codex 不得自行把 `network_dry_run_execution_allowed` 改成 true
+- 即使 CLI 传入确认参数，Phase 4.95D 也不触网、不写文件、不写 DB
+
+`data-single-target-acquisition-network-authorization-decision-commit` 当前 blocked。
+
+真实 network dry-run 必须后续单独 execution preparation / final confirmation 阶段。
+
 Phase 4.55C acquisition architecture rules：
 
 - Codex 不应直接运行 legacy / high-risk acquisition engines，尤其是 `run_production`、`titan_discovery`、`recon_scanner`、`batch_historical_backfill`、`fetch_and_adapt_euro_leagues`、`odds_harvest_pipeline`、`total_war_pipeline`、`titan_marathon`。

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@
         data-single-target-acquisition-network-filled-intake-review-plan-preview data-single-target-acquisition-network-filled-intake-review-plan-commit \
         data-single-target-acquisition-network-filled-intake-review-result-preview data-single-target-acquisition-network-filled-intake-review-result-commit \
         data-single-target-acquisition-network-authorization-handoff-checklist-preview data-single-target-acquisition-network-authorization-handoff-checklist-commit \
+        data-single-target-acquisition-network-authorization-decision-preview data-single-target-acquisition-network-authorization-decision-commit \
         data-real-source-audit data-real-finished-csv-dry-run data-real-finished-csv-commit \
         data-football-data-csv-dry-run data-football-data-csv-commit \
         data-football-data-db-write-preflight data-football-data-db-write-commit \
@@ -97,6 +98,7 @@ NETWORK_REAL_PARAMETER_VALIDATION_CLOSURE_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_FILLED_INTAKE_REVIEW_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_FILLED_INTAKE_REVIEW_RESULT_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
+NETWORK_AUTHORIZATION_DECISION_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -388,6 +390,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-filled-intake-review-result-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_FILLED_INTAKE_REVIEW_RESULT=1  # blocked in Phase 4.93D"
 	@echo "  make data-single-target-acquisition-network-authorization-handoff-checklist-preview HANDOFF_CHECKLIST=<path> REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # handoff preview, Phase 4.94D"
 	@echo "  make data-single-target-acquisition-network-authorization-handoff-checklist-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST=1  # blocked in Phase 4.94D"
+	@echo "  make data-single-target-acquisition-network-authorization-decision-preview AUTHORIZATION_DECISION=<path> HANDOFF_CHECKLIST=<path> REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # authorization decision preview, Phase 4.95D"
+	@echo "  make data-single-target-acquisition-network-authorization-decision-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION=1  # blocked in Phase 4.95D"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -1329,6 +1333,27 @@ data-single-target-acquisition-network-authorization-handoff-checklist-commit: #
 	@echo "BLOCKED: single-target acquisition authorization handoff checklist execution is not wired in Phase 4.94D."
 	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST=1, this path remains blocked."
 	@echo "  Phase 4.94D previews the authorization handoff checklist template only and does not authorize any network dry-run, staging write, authorization handoff checklist file write, or DB write."
+	@exit 1
+
+data-single-target-acquisition-network-authorization-decision-preview: ## Preview-only network authorization decision. Phase 4.95D. No network, no writes, no DB.
+	@if [ -z "$(AUTHORIZATION_DECISION)" ] || [ -z "$(HANDOFF_CHECKLIST)" ] || [ -z "$(REVIEW_RESULT)" ] || [ -z "$(REVIEW_PLAN)" ] || [ -z "$(INTAKE)" ] || [ -z "$(VALIDATION_CLOSURE)" ] || [ -z "$(BLOCKED_SUMMARY)" ]; then \
+		echo "ERROR: provide AUTHORIZATION_DECISION=<path>, HANDOFF_CHECKLIST=<path>, REVIEW_RESULT=<path>, REVIEW_PLAN=<path>, INTAKE=<path>, VALIDATION_CLOSURE=<path>, and BLOCKED_SUMMARY=<path>"; \
+		exit 1; \
+	fi
+	@echo "Phase 4.95D: network authorization decision (template-only, local-only, no writes, no network, no DB)"
+	$(NETWORK_AUTHORIZATION_DECISION_NODE) scripts/ops/single_target_acquisition_network_authorization_decision.js \
+		--authorization-decision "$(AUTHORIZATION_DECISION)" \
+		--handoff-checklist "$(HANDOFF_CHECKLIST)" \
+		--review-result "$(REVIEW_RESULT)" \
+		--review-plan "$(REVIEW_PLAN)" \
+		--intake "$(INTAKE)" \
+		--validation-closure "$(VALIDATION_CLOSURE)" \
+		--blocked-summary "$(BLOCKED_SUMMARY)"
+
+data-single-target-acquisition-network-authorization-decision-commit: ## Blocked network authorization decision gate. Remains not wired in Phase 4.95D.
+	@echo "BLOCKED: single-target acquisition network authorization decision execution is not wired in Phase 4.95D."
+	@echo "  Even with CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION=1, this path remains blocked."
+	@echo "  Phase 4.95D previews the authorization decision template only and does not authorize any network dry-run, staging write, network authorization decision file write, or DB write."
 	@exit 1
 
 data-finished-csv-dry-run: ## Run local finished CSV sample import preview. Requires SAMPLE_CSV.

--- a/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION_PHASE4_95D.md
+++ b/docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION_PHASE4_95D.md
@@ -1,0 +1,131 @@
+# Single-Target Acquisition Network Authorization Decision Phase 4.95D
+
+## Executive Summary
+
+Phase 4.95D is the network authorization decision template stage. It does not
+access the network, collect data, write DB rows, write staging artifacts, or
+write packet files. The goal is to define how a future phase should record the
+final decision for a single-target network dry-run authorization.
+
+## Implemented Files
+
+- `docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION_TEMPLATE.md`
+- `scripts/ops/single_target_acquisition_network_authorization_decision.js`
+- `tests/unit/single_target_acquisition_network_authorization_decision.test.js`
+- Makefile targets:
+  `data-single-target-acquisition-network-authorization-decision-preview` and
+  `data-single-target-acquisition-network-authorization-decision-commit`
+- `AGENTS.md` update
+- `docs/_reports/SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION_PHASE4_95D.md`
+
+## Decision Sections
+
+- `scope_decision`
+- `source_terms_decision`
+- `network_runtime_decision`
+- `staging_decision`
+- `db_training_prediction_decision`
+- `final_human_decision`
+
+## Authorization Boundaries
+
+- Authorization decision template is not authorization.
+- Authorization decision is not execution.
+- Future execution preparation phase required.
+- Future final confirmation required.
+- Codex may not authorize network.
+- Codex may not enable execution.
+- Codex may not self-approve terms.
+- Codex may not self-accept handoff.
+
+## Validation Behavior
+
+The validator is local-only and read-only. It verifies
+`authorization_decision_status=template_only`,
+`authorization_decision=not_authorized`,
+`network_authorization_decision_ready=false`,
+`network_authorization_decision_recorded=false`,
+`network_dry_run_authorized=false`, and
+`network_dry_run_execution_allowed=false`.
+
+It also verifies all `decision_sections.*.decision=not_authorized`, all runtime
+allow flags remain `false`, all `would_*` safety flags remain `false`, no
+network execution is allowed, and no runtime writes are allowed.
+
+## Relationship To Previous Phases
+
+- 4.79D: parameter scaffold
+- 4.80D: schema validation
+- 4.81D: writer preflight
+- 4.82D: packet preview
+- 4.83D: pre-network runbook draft
+- 4.84D: authorization form template
+- 4.85D: final readiness checklist
+- 4.86D: execution plan draft
+- 4.87D: human approval packet preview
+- 4.88D: user input requirements closure
+- 4.89D: blocked final preflight summary
+- 4.90D: real-parameter intake template
+- 4.91D: real-parameter intake validation closure
+- 4.92D: filled-intake review plan template
+- 4.93D: filled-intake review result template
+- 4.94D: authorization handoff checklist template
+- 4.95D: network authorization decision template
+
+All seventeen artifacts are pre-execution governance artifacts. None is a real
+network dry-run.
+
+## Recommended Next Phase
+
+Recommended: Phase 4.96D, single-target acquisition network execution
+preparation template. It should still avoid network access, DB writes, and
+staging writes, and should only define how future execution would be prepared
+after a separate authorization decision passes.
+
+Alternative: Phase 4.56A only after the user supplies complete real network
+dry-run parameters for a runbook.
+
+## Explicit Non-Execution
+
+Phase 4.95D did not execute:
+
+- DB writes
+- non-SELECT DB SQL
+- external download
+- `curl` / `wget` / `git clone`
+- external football data access
+- external odds data access
+- scraping
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- bulk harvest
+- runtime staging artifact write
+- runtime staging directory creation
+- runtime source manifest write
+- packet file write
+- approval packet file write
+- user input closure file write
+- blocked summary file write
+- real parameter intake file write
+- real parameter validation closure file write
+- filled-intake review plan file write
+- filled-intake review result file write
+- authorization handoff checklist file write
+- network authorization decision file write
+- `pg_dump`
+- `pg_restore`
+- model training
+- real prediction
+- model artifact loading
+- Docker volume cleanup
+- force push
+- `git fetch --all`
+- `git pull`
+- file deletion
+
+It also did not modify coverage thresholds, skip tests, delete tests, or bypass
+gatekeeper behavior.

--- a/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION_TEMPLATE.md
+++ b/docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION_TEMPLATE.md
@@ -1,0 +1,223 @@
+# Single-Target Acquisition Network Dry-Run Authorization Decision Template
+
+This document is a Phase 4.95D template-only network authorization decision
+record.
+
+- This is a network authorization decision template, not authorization itself.
+- `authorization_decision_status=template_only` by default.
+- `authorization_decision=not_authorized` by default.
+- `network_authorization_decision_ready=false` by default.
+- `network_authorization_decision_recorded=false` by default.
+- `network_dry_run_authorized=false` by default.
+- `network_dry_run_execution_allowed=false` by default.
+- Every `decision_sections.*.reviewed` field is `false` by default.
+- Every `decision_sections.*.decision` field is `not_authorized` by default.
+- Codex must not change `authorization_decision` to `authorized` or
+  `conditionally_authorized_for_future_preparation`.
+- Codex must not change `network_dry_run_authorized` to `true`.
+- Codex must not change `network_dry_run_execution_allowed` to `true`.
+- Phase 4.95D does not write a network authorization decision runtime file.
+  It only validates this template and produces a local stdout preview.
+- A real network dry-run must enter a separate execution preparation and final
+  confirmation phase.
+
+```yaml
+phase: PHASE4_95D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION
+authorization_decision_status: template_only
+network_authorization_decision_ready: false
+network_authorization_decision_recorded: false
+network_dry_run_authorized: false
+network_dry_run_execution_allowed: false
+authorization_decision: not_authorized
+authorization_decision_allowed_values:
+    - not_authorized
+    - denied
+    - needs_revision
+    - conditionally_authorized_for_future_preparation
+filled_intake_reviewed: false
+filled_intake_accepted: false
+authorization_handoff_ready: false
+authorization_handoff_completed: false
+can_proceed_to_network_dry_run_preparation: false
+staging_write_authorized: false
+db_write_authorized: false
+training_authorized: false
+prediction_authorized: false
+final_human_confirmation: false
+
+included_artifacts:
+    authorization_handoff_checklist: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST_TEMPLATE.md
+    filled_intake_review_result: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md
+    filled_intake_review_plan: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md
+    real_parameter_intake: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md
+    validation_closure: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md
+    blocked_summary: docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md
+
+decision_metadata:
+    decision_maker:
+    decision_made_at:
+    decision_notes:
+    source_of_authorization:
+    authorization_decision_id:
+    template_only: true
+
+decision_sections:
+    scope_decision:
+        reviewed: false
+        decision: not_authorized
+        single_target_confirmed: false
+        bulk_scope_allowed: false
+        max_targets: 1
+        blocking_reason: scope_not_authorized
+    source_terms_decision:
+        reviewed: false
+        decision: not_authorized
+        terms_approved: false
+        allowed_use_approved: false
+        blocking_reason: source_terms_not_authorized
+    network_runtime_decision:
+        reviewed: false
+        decision: not_authorized
+        external_network_allowed: false
+        browser_runtime_allowed: false
+        proxy_runtime_allowed: false
+        blocking_reason: network_runtime_not_authorized
+    staging_decision:
+        reviewed: false
+        decision: not_authorized
+        staging_write_allowed: false
+        source_manifest_write_allowed: false
+        blocking_reason: staging_not_authorized
+    db_training_prediction_decision:
+        reviewed: false
+        decision: not_authorized
+        db_write_allowed: false
+        training_allowed: false
+        prediction_allowed: false
+        model_artifact_loading_allowed: false
+        blocking_reason: db_training_prediction_not_authorized
+    final_human_decision:
+        reviewed: false
+        decision: not_authorized
+        final_confirmation: false
+        confirmed_by:
+        blocking_reason: final_human_confirmation_missing
+
+authorization_boundaries:
+    authorization_decision_is_not_execution: true
+    future_execution_preparation_phase_required: true
+    future_final_confirmation_required: true
+    codex_may_not_authorize_network: true
+    codex_may_not_enable_execution: true
+    codex_may_not_self_approve_terms: true
+    codex_may_not_self_accept_handoff: true
+    codex_may_not_convert_decision_to_execution: true
+
+decision_blocking_reasons:
+    - authorization_decision_template_only
+    - authorization_handoff_not_completed
+    - filled_intake_review_result_not_accepted
+    - source_terms_not_authorized
+    - network_runtime_not_authorized
+    - staging_not_authorized
+    - db_training_prediction_not_authorized
+    - final_human_confirmation_missing
+    - future_execution_preparation_phase_required
+
+codex_constraints:
+    codex_may_not_self_fill_real_parameters: true
+    codex_may_not_mark_decision_recorded: true
+    codex_may_not_authorize_network: true
+    codex_may_not_set_execution_allowed: true
+    codex_may_not_mark_reviewed: true
+    codex_may_not_write_runtime_files: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_engine: false
+    would_execute_legacy_titan_discovery: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_approval_packet_file: false
+    would_write_user_input_closure_file: false
+    would_write_blocked_summary_file: false
+    would_write_real_parameter_intake_file: false
+    would_write_real_parameter_validation_closure_file: false
+    would_write_filled_intake_review_file: false
+    would_write_filled_intake_review_result_file: false
+    would_write_authorization_handoff_checklist_file: false
+    would_write_network_authorization_decision_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_bulk_harvest: false
+    would_spawn_child_process: false
+
+next_phase_requirements:
+    - user_supplies_filled_real_parameter_intake
+    - separate_phase_reviews_filled_intake
+    - separate_phase_records_review_result
+    - separate_phase_checks_authorization_handoff
+    - separate_phase_records_authorization_decision
+    - separate_phase_prepares_network_dry_run_execution
+    - separate_phase_still_requires_final_human_confirmation
+    - separate_phase_confirms_no_db_write
+    - separate_phase_confirms_no_training
+    - separate_phase_confirms_no_prediction
+```
+
+## Purpose
+
+This template defines how a future phase should record the final decision about
+whether a single-target network dry-run may proceed to preparation. It answers
+which fields are required, which decision states are valid, why the default is
+`not_authorized`, and which prior artifacts must be referenced before any
+future decision can be considered.
+
+The only allowed decision values are:
+
+- `not_authorized`
+- `denied`
+- `needs_revision`
+- `conditionally_authorized_for_future_preparation`
+
+The default must remain `not_authorized` because Phase 4.95D has no real filled
+intake, no accepted review result, no completed handoff, no human decision, and
+no authorization to access external sources or execute runtime code.
+
+## Required Prior Materials
+
+A future decision record must reference the authorization handoff checklist,
+filled-intake review result, filled-intake review plan, real-parameter intake,
+validation closure, and blocked final preflight summary. The references in this
+template point to templates only, not runtime approvals.
+
+## Scope And Runtime Policy
+
+The `scope_decision` section keeps the future scope single-target by requiring
+`bulk_scope_allowed=false` and `max_targets=1`. The
+`network_runtime_decision` section records whether external network, browser,
+and proxy runtime would be allowed in a future phase. Phase 4.95D keeps all of
+those runtime allowances `false`.
+
+## Prohibited Actions
+
+This template records that DB writes, training, prediction, model artifact
+loading, staging writes, source manifest writes, packet writes, bulk harvest,
+browser automation, proxy runtime, and engine execution are not authorized.
+
+## Authorization Boundaries
+
+An authorization decision template is not authorization. An authorization
+decision is not execution. Even if a future human decision conditionally
+authorizes preparation, a separate execution preparation phase and a separate
+final human confirmation remain required before any network dry-run can occur.
+
+Codex must not self-fill real source, target, terms, authorization, decision
+maker, or confirmation fields. Codex must not convert `not_authorized` to an
+authorized decision, must not set network authorization to `true`, and must not
+enable execution.

--- a/scripts/ops/single_target_acquisition_network_authorization_decision.js
+++ b/scripts/ops/single_target_acquisition_network_authorization_decision.js
@@ -1,0 +1,679 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    extractYamlBlock,
+    buildNonExecutionConfirmations,
+} = require('./single_target_acquisition_pre_network_runbook_validate');
+const { parseIntakeYaml } = require('./single_target_acquisition_network_real_parameter_intake');
+const {
+    runValidation: validateHandoffChecklist,
+} = require('./single_target_acquisition_network_authorization_handoff_checklist');
+
+const OUTPUT_PHASE = 'PHASE4.95D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION';
+const TEMPLATE_PHASE = 'PHASE4_95D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION';
+const MODE = 'single-target-acquisition-network-authorization-decision-preview';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: single-target acquisition network authorization decision execution is not wired in Phase 4.95D.';
+const NEXT_REQUIRED_PHASE = 'Phase 4.96D or explicit user-filled real parameter intake';
+
+const AUTHORIZATION_HANDOFF_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST_TEMPLATE.md';
+const REVIEW_RESULT_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md';
+const REVIEW_PLAN_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md';
+const INTAKE_TEMPLATE = 'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md';
+const VALIDATION_CLOSURE_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md';
+const BLOCKED_SUMMARY_TEMPLATE =
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md';
+
+const AUTHORIZATION_DECISION_ALLOWED_VALUES = [
+    'not_authorized',
+    'denied',
+    'needs_revision',
+    'conditionally_authorized_for_future_preparation',
+];
+
+const DECISION_BLOCKING_REASONS = [
+    'authorization_decision_template_only',
+    'authorization_handoff_not_completed',
+    'filled_intake_review_result_not_accepted',
+    'source_terms_not_authorized',
+    'network_runtime_not_authorized',
+    'staging_not_authorized',
+    'db_training_prediction_not_authorized',
+    'final_human_confirmation_missing',
+    'future_execution_preparation_phase_required',
+];
+
+const DECISION_SECTION_FIELDS = {
+    scope_decision: w('reviewed decision single_target_confirmed bulk_scope_allowed max_targets blocking_reason'),
+    source_terms_decision: w('reviewed decision terms_approved allowed_use_approved blocking_reason'),
+    network_runtime_decision: w(
+        'reviewed decision external_network_allowed browser_runtime_allowed proxy_runtime_allowed blocking_reason'
+    ),
+    staging_decision: w('reviewed decision staging_write_allowed source_manifest_write_allowed blocking_reason'),
+    db_training_prediction_decision: w(
+        'reviewed decision db_write_allowed training_allowed prediction_allowed model_artifact_loading_allowed blocking_reason'
+    ),
+    final_human_decision: w('reviewed decision final_confirmation confirmed_by blocking_reason'),
+};
+
+const REQUIRED_TOP = w(
+    'phase authorization_decision_status network_authorization_decision_ready network_authorization_decision_recorded network_dry_run_authorized network_dry_run_execution_allowed authorization_decision authorization_decision_allowed_values filled_intake_reviewed filled_intake_accepted authorization_handoff_ready authorization_handoff_completed can_proceed_to_network_dry_run_preparation staging_write_authorized db_write_authorized training_authorized prediction_authorized final_human_confirmation included_artifacts decision_metadata decision_sections authorization_boundaries decision_blocking_reasons codex_constraints safety next_phase_requirements'
+);
+
+const TOP_FALSE = {
+    network_authorization_decision_ready: 'network_authorization_decision_ready true is not allowed',
+    network_authorization_decision_recorded: 'network_authorization_decision_recorded true is not allowed',
+    network_dry_run_authorized: 'network_dry_run_authorized true is not allowed',
+    network_dry_run_execution_allowed: 'network_dry_run_execution_allowed true is not allowed',
+    filled_intake_reviewed: 'filled_intake_reviewed true is not allowed',
+    filled_intake_accepted: 'filled_intake_accepted true is not allowed',
+    authorization_handoff_ready: 'authorization_handoff_ready true is not allowed',
+    authorization_handoff_completed: 'authorization_handoff_completed true is not allowed',
+    can_proceed_to_network_dry_run_preparation: 'can_proceed_to_network_dry_run_preparation true is not allowed',
+    staging_write_authorized: 'staging_write_authorized true is not allowed',
+    db_write_authorized: 'db_write_authorized true is not allowed',
+    training_authorized: 'training_authorized true is not allowed',
+    prediction_authorized: 'prediction_authorized true is not allowed',
+    final_human_confirmation: 'final_human_confirmation true is not allowed',
+};
+
+const INCLUDED_ARTIFACT_FIELDS = {
+    authorization_handoff_checklist: AUTHORIZATION_HANDOFF_TEMPLATE,
+    filled_intake_review_result: REVIEW_RESULT_TEMPLATE,
+    filled_intake_review_plan: REVIEW_PLAN_TEMPLATE,
+    real_parameter_intake: INTAKE_TEMPLATE,
+    validation_closure: VALIDATION_CLOSURE_TEMPLATE,
+    blocked_summary: BLOCKED_SUMMARY_TEMPLATE,
+};
+
+const DECISION_METADATA_FIELDS = w(
+    'decision_maker decision_made_at decision_notes source_of_authorization authorization_decision_id template_only'
+);
+const AUTHORIZATION_BOUNDARY_FIELDS = w(
+    'authorization_decision_is_not_execution future_execution_preparation_phase_required future_final_confirmation_required codex_may_not_authorize_network codex_may_not_enable_execution codex_may_not_self_approve_terms codex_may_not_self_accept_handoff codex_may_not_convert_decision_to_execution'
+);
+const CODEX_FIELDS = w(
+    'codex_may_not_self_fill_real_parameters codex_may_not_mark_decision_recorded codex_may_not_authorize_network codex_may_not_set_execution_allowed codex_may_not_mark_reviewed codex_may_not_write_runtime_files'
+);
+const SAFETY_FIELDS = w(
+    'would_access_network would_launch_browser would_use_proxy would_execute_engine would_execute_legacy_titan_discovery would_write_staging would_create_staging_directory would_write_source_manifest would_write_packet_file would_write_approval_packet_file would_write_user_input_closure_file would_write_blocked_summary_file would_write_real_parameter_intake_file would_write_real_parameter_validation_closure_file would_write_filled_intake_review_file would_write_filled_intake_review_result_file would_write_authorization_handoff_checklist_file would_write_network_authorization_decision_file would_write_db would_train would_predict would_bulk_harvest would_spawn_child_process'
+);
+
+function w(text) {
+    return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/single_target_acquisition_network_authorization_decision.js --authorization-decision <path> --handoff-checklist <path> --review-result <path> --review-plan <path> --intake <path> --validation-closure <path> --blocked-summary <path>',
+        '',
+        'Safety: Phase 4.95D previews a local network authorization decision template only. No network, no writes.',
+    ].join('\n');
+}
+
+function parseArgs(argv) {
+    const args = {
+        authorization_decision: '',
+        handoff_checklist: '',
+        review_result: '',
+        review_plan: '',
+        intake: '',
+        validation_closure: '',
+        blocked_summary: '',
+        commit: false,
+        help: false,
+    };
+    for (let i = 0; i < argv.length; i += 1) {
+        const token = argv[i];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) throw new Error('Unknown: ' + token);
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[i + 1] || '');
+            i += 1;
+        } else {
+            throw new Error('Unknown: ' + token);
+        }
+    }
+    return args;
+}
+
+function buildSafetyFlags() {
+    return {
+        network_authorization_decision_template_only: true,
+        authorization_decision_valid: false,
+        handoff_checklist_valid: false,
+        review_result_valid: false,
+        review_plan_valid: false,
+        real_parameter_intake_valid: false,
+        validation_closure_valid: false,
+        blocked_summary_valid: false,
+        network_authorization_decision_ready: false,
+        network_authorization_decision_recorded: false,
+        authorization_decision: 'not_authorized',
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        authorization_decision_is_not_execution: true,
+        future_execution_preparation_phase_required: true,
+        future_final_confirmation_required: true,
+        can_proceed_to_network_dry_run_preparation: false,
+        authorization_handoff_ready: false,
+        authorization_handoff_completed: false,
+        filled_intake_reviewed: false,
+        filled_intake_accepted: false,
+        staging_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        final_human_confirmation: false,
+        decision_sections_complete: false,
+        decision_sections_authorized: false,
+        decision_blocking_reasons: DECISION_BLOCKING_REASONS,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_engine: false,
+        would_execute_legacy_titan_discovery: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_approval_packet_file: false,
+        would_write_user_input_closure_file: false,
+        would_write_blocked_summary_file: false,
+        would_write_real_parameter_intake_file: false,
+        would_write_real_parameter_validation_closure_file: false,
+        would_write_filled_intake_review_file: false,
+        would_write_filled_intake_review_result_file: false,
+        would_write_authorization_handoff_checklist_file: false,
+        would_write_network_authorization_decision_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildFailurePayload(args, fields = {}) {
+    return {
+        phase: OUTPUT_PHASE,
+        mode: fields.mode || MODE,
+        ok: false,
+        authorization_decision_path: args.authorization_decision || null,
+        handoff_checklist: args.handoff_checklist || null,
+        review_result: args.review_result || null,
+        review_plan: args.review_plan || null,
+        intake: args.intake || null,
+        validation_closure: args.validation_closure || null,
+        blocked_summary: args.blocked_summary || null,
+        authorization_decision_found: false,
+        handoff_checklist_found: false,
+        review_result_found: false,
+        review_plan_found: false,
+        intake_found: false,
+        validation_closure_found: false,
+        blocked_summary_found: false,
+        yaml_block_found: false,
+        required_fields_present: false,
+        missing_fields: [],
+        errors: [],
+        warnings: [],
+        ...buildSafetyFlags(),
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+            'no_filled_intake_review_file_writes',
+            'no_filled_intake_review_result_file_writes',
+            'no_authorization_handoff_checklist_file_writes',
+            'no_network_authorization_decision_file_writes',
+            'no_legacy_titan_discovery_execution',
+            'no_child_process_spawn',
+        ],
+        ...fields,
+    };
+}
+
+function buildBlockedCommitPayload(args) {
+    return buildFailurePayload(args, {
+        mode: 'blocked-commit',
+        blocked: true,
+        blocked_reason: BLOCKED_COMMIT_MESSAGE,
+        errors: [BLOCKED_COMMIT_MESSAGE],
+    });
+}
+
+function resolveLocalPath(rawPath, cwd) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function validateRequiredCliFields(args) {
+    const errors = [];
+    if (!args.authorization_decision) errors.push('missing authorization decision');
+    if (!args.handoff_checklist) errors.push('missing handoff checklist');
+    if (!args.review_result) errors.push('missing review result');
+    if (!args.review_plan) errors.push('missing review plan');
+    if (!args.intake) errors.push('missing intake');
+    if (!args.validation_closure) errors.push('missing validation closure');
+    if (!args.blocked_summary) errors.push('missing blocked summary');
+    return errors;
+}
+
+function validateCliArgsOrPayload(args) {
+    const errors = validateRequiredCliFields(args);
+    return errors.length ? buildFailurePayload(args, { mode: 'argument-error', errors }) : null;
+}
+
+function loadYamlFile(args, deps, fieldName, missingLabel, mode) {
+    const targetPath = resolveLocalPath(args[fieldName], deps.cwd);
+    if (!deps.existsSync(targetPath)) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: false,
+                errors: ['missing ' + missingLabel + ': ' + toRelativePath(targetPath, deps.cwd)],
+            }),
+        };
+    }
+
+    const yamlText = extractYamlBlock(deps.readFileSync(targetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return { parsedYaml: parseIntakeYaml(yamlText), yamlText };
+    } catch (error) {
+        return {
+            payload: buildFailurePayload(args, {
+                mode,
+                [`${fieldName}_found`]: true,
+                yaml_block_found: true,
+                errors: ['invalid YAML: ' + error.message],
+            }),
+        };
+    }
+}
+
+function hasOwn(root, key) {
+    return Object.prototype.hasOwnProperty.call(root, key);
+}
+
+function gp(root, dottedPath) {
+    return dottedPath.split('.').reduce((current, key) => {
+        if (!current || typeof current !== 'object') return undefined;
+        return current[key];
+    }, root);
+}
+
+function addMissing(root, parentPath, requiredKeys, missingFields) {
+    const value = gp(root, parentPath);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        missingFields.push(parentPath);
+        return;
+    }
+    requiredKeys.filter(key => !hasOwn(value, key)).forEach(key => missingFields.push(parentPath + '.' + key));
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP.filter(key => !hasOwn(parsedYaml, key));
+    addMissing(parsedYaml, 'included_artifacts', Object.keys(INCLUDED_ARTIFACT_FIELDS), missingFields);
+    addMissing(parsedYaml, 'decision_metadata', DECISION_METADATA_FIELDS, missingFields);
+    Object.entries(DECISION_SECTION_FIELDS).forEach(([sectionName, fields]) => {
+        addMissing(parsedYaml, 'decision_sections.' + sectionName, fields, missingFields);
+    });
+    addMissing(parsedYaml, 'authorization_boundaries', AUTHORIZATION_BOUNDARY_FIELDS, missingFields);
+    addMissing(parsedYaml, 'codex_constraints', CODEX_FIELDS, missingFields);
+    addMissing(parsedYaml, 'safety', SAFETY_FIELDS, missingFields);
+    return missingFields;
+}
+
+function validateAllowedValues(parsedYaml, errors) {
+    const values = parsedYaml.authorization_decision_allowed_values;
+    if (!Array.isArray(values)) {
+        errors.push('authorization_decision_allowed_values missing');
+        return;
+    }
+    const missing = AUTHORIZATION_DECISION_ALLOWED_VALUES.filter(value => !values.includes(value));
+    if (missing.length) errors.push('missing authorization_decision_allowed_values: ' + missing.join(','));
+}
+
+function validateTopLevelFalse(parsedYaml, errors) {
+    Object.entries(TOP_FALSE).forEach(([key, message]) => {
+        if (parsedYaml[key] !== false) errors.push(message);
+    });
+}
+
+function validateIncludedArtifacts(parsedYaml, errors) {
+    const included = parsedYaml.included_artifacts || {};
+    Object.entries(INCLUDED_ARTIFACT_FIELDS).forEach(([field, expected]) => {
+        if (included[field] !== expected) errors.push('included_artifacts.' + field + ' must be ' + expected);
+    });
+}
+
+function validateDecisionMetadata(parsedYaml, errors) {
+    const metadata = parsedYaml.decision_metadata || {};
+    if (metadata.template_only !== true) errors.push('decision_metadata.template_only must be true');
+}
+
+function validateDecisionSectionCommon(sectionName, section, errors) {
+    if (!section || typeof section !== 'object' || Array.isArray(section)) {
+        errors.push('missing decision_sections.' + sectionName);
+        return false;
+    }
+    if (section.reviewed !== false) {
+        errors.push('decision_sections.' + sectionName + '.reviewed true is not allowed');
+    }
+    if (section.decision !== 'not_authorized') {
+        errors.push('decision_sections.' + sectionName + '.decision not not_authorized');
+    }
+    return true;
+}
+
+function requireFalse(sectionName, section, field, errors) {
+    if (section[field] !== false) {
+        errors.push('decision_sections.' + sectionName + '.' + field + ' true is not allowed');
+    }
+}
+
+function validateDecisionSections(parsedYaml, errors) {
+    const sections = parsedYaml.decision_sections || {};
+
+    const scope = sections.scope_decision;
+    if (validateDecisionSectionCommon('scope_decision', scope, errors)) {
+        requireFalse('scope_decision', scope, 'single_target_confirmed', errors);
+        requireFalse('scope_decision', scope, 'bulk_scope_allowed', errors);
+        if (typeof scope.max_targets !== 'number') {
+            errors.push('decision_sections.scope_decision.max_targets must be 1');
+        } else if (scope.max_targets > 1) {
+            errors.push('decision_sections.scope_decision.max_targets > 1 is not allowed');
+        } else if (scope.max_targets !== 1) {
+            errors.push('decision_sections.scope_decision.max_targets must be 1');
+        }
+    }
+
+    const sourceTerms = sections.source_terms_decision;
+    if (validateDecisionSectionCommon('source_terms_decision', sourceTerms, errors)) {
+        requireFalse('source_terms_decision', sourceTerms, 'terms_approved', errors);
+        requireFalse('source_terms_decision', sourceTerms, 'allowed_use_approved', errors);
+    }
+
+    const runtime = sections.network_runtime_decision;
+    if (validateDecisionSectionCommon('network_runtime_decision', runtime, errors)) {
+        requireFalse('network_runtime_decision', runtime, 'external_network_allowed', errors);
+        requireFalse('network_runtime_decision', runtime, 'browser_runtime_allowed', errors);
+        requireFalse('network_runtime_decision', runtime, 'proxy_runtime_allowed', errors);
+    }
+
+    const staging = sections.staging_decision;
+    if (validateDecisionSectionCommon('staging_decision', staging, errors)) {
+        requireFalse('staging_decision', staging, 'staging_write_allowed', errors);
+        requireFalse('staging_decision', staging, 'source_manifest_write_allowed', errors);
+    }
+
+    const dbTrainingPrediction = sections.db_training_prediction_decision;
+    if (validateDecisionSectionCommon('db_training_prediction_decision', dbTrainingPrediction, errors)) {
+        requireFalse('db_training_prediction_decision', dbTrainingPrediction, 'db_write_allowed', errors);
+        requireFalse('db_training_prediction_decision', dbTrainingPrediction, 'training_allowed', errors);
+        requireFalse('db_training_prediction_decision', dbTrainingPrediction, 'prediction_allowed', errors);
+        requireFalse('db_training_prediction_decision', dbTrainingPrediction, 'model_artifact_loading_allowed', errors);
+    }
+
+    const finalHuman = sections.final_human_decision;
+    if (validateDecisionSectionCommon('final_human_decision', finalHuman, errors)) {
+        requireFalse('final_human_decision', finalHuman, 'final_confirmation', errors);
+    }
+}
+
+function validateAuthorizationBoundaries(parsedYaml, errors) {
+    const boundaries = parsedYaml.authorization_boundaries || {};
+    AUTHORIZATION_BOUNDARY_FIELDS.forEach(field => {
+        if (boundaries[field] !== true) errors.push('authorization_boundaries.' + field + ' must be true');
+    });
+}
+
+function validateBlockingReasons(parsedYaml, errors) {
+    const reasons = parsedYaml.decision_blocking_reasons;
+    if (!Array.isArray(reasons)) {
+        errors.push('missing decision_blocking_reasons');
+        return;
+    }
+    const missing = DECISION_BLOCKING_REASONS.filter(reason => !reasons.includes(reason));
+    if (missing.length) errors.push('missing decision_blocking_reasons: ' + missing.join(','));
+}
+
+function validateCodexConstraints(parsedYaml, errors) {
+    const constraints = parsedYaml.codex_constraints || {};
+    CODEX_FIELDS.forEach(field => {
+        if (constraints[field] !== true) errors.push('codex_constraints.' + field + ' false is not allowed');
+    });
+}
+
+function validateSafety(parsedYaml, errors) {
+    const safety = parsedYaml.safety || {};
+    SAFETY_FIELDS.forEach(field => {
+        if (safety[field] !== false) errors.push('safety.' + field + ' must remain false');
+    });
+}
+
+function validateParsedYaml(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) errors.push('missing required fields: ' + missingFields.join(','));
+    if (parsedYaml.phase !== TEMPLATE_PHASE) errors.push('phase must be ' + TEMPLATE_PHASE);
+    if (parsedYaml.authorization_decision_status !== 'template_only') {
+        errors.push('authorization_decision_status not template_only');
+    }
+    if (parsedYaml.authorization_decision !== 'not_authorized') {
+        errors.push('authorization_decision not not_authorized');
+    }
+    validateAllowedValues(parsedYaml, errors);
+    validateTopLevelFalse(parsedYaml, errors);
+    validateIncludedArtifacts(parsedYaml, errors);
+    validateDecisionMetadata(parsedYaml, errors);
+    validateDecisionSections(parsedYaml, errors);
+    validateAuthorizationBoundaries(parsedYaml, errors);
+    validateBlockingReasons(parsedYaml, errors);
+    validateCodexConstraints(parsedYaml, errors);
+    validateSafety(parsedYaml, errors);
+    return { ok: errors.length === 0, missingFields, errors };
+}
+
+function pickHandoffFlags(payload) {
+    return {
+        handoff_checklist_found: payload.handoff_checklist_found || false,
+        review_result_found: payload.review_result_found || false,
+        review_plan_found: payload.review_plan_found || false,
+        intake_found: payload.intake_found || false,
+        validation_closure_found: payload.validation_closure_found || false,
+        blocked_summary_found: payload.blocked_summary_found || false,
+        handoff_checklist_valid: payload.handoff_checklist_valid || false,
+        review_result_valid: payload.review_result_valid || false,
+        review_plan_valid: payload.review_plan_valid || false,
+        real_parameter_intake_valid: payload.real_parameter_intake_valid || false,
+        validation_closure_valid: payload.validation_closure_valid || false,
+        blocked_summary_valid: payload.blocked_summary_valid || false,
+    };
+}
+
+function buildSuccessPayload(args) {
+    return {
+        ...buildSafetyFlags(),
+        phase: OUTPUT_PHASE,
+        mode: MODE,
+        ok: true,
+        authorization_decision_path: args.authorization_decision,
+        handoff_checklist: args.handoff_checklist,
+        review_result: args.review_result,
+        review_plan: args.review_plan,
+        intake: args.intake,
+        validation_closure: args.validation_closure,
+        blocked_summary: args.blocked_summary,
+        authorization_decision_found: true,
+        handoff_checklist_found: true,
+        review_result_found: true,
+        review_plan_found: true,
+        intake_found: true,
+        validation_closure_found: true,
+        blocked_summary_found: true,
+        yaml_block_found: true,
+        required_fields_present: true,
+        authorization_decision_valid: true,
+        handoff_checklist_valid: true,
+        review_result_valid: true,
+        review_plan_valid: true,
+        real_parameter_intake_valid: true,
+        validation_closure_valid: true,
+        blocked_summary_valid: true,
+        decision_sections_complete: true,
+        decision_sections_authorized: false,
+        errors: [],
+        warnings: [
+            'Phase 4.95D remains template-only.',
+            'Authorization decision template does not constitute authorization or execution.',
+        ],
+        non_execution_confirmations: [
+            ...buildNonExecutionConfirmations(),
+            'no_blocked_summary_file_writes',
+            'no_real_parameter_intake_file_writes',
+            'no_real_parameter_validation_closure_file_writes',
+            'no_filled_intake_review_file_writes',
+            'no_filled_intake_review_result_file_writes',
+            'no_authorization_handoff_checklist_file_writes',
+            'no_network_authorization_decision_file_writes',
+            'no_legacy_titan_discovery_execution',
+            'no_child_process_spawn',
+        ],
+    };
+}
+
+function runValidation(args, dependencies = {}) {
+    const deps = {
+        cwd: dependencies.cwd || process.cwd(),
+        existsSync: dependencies.existsSync || fs.existsSync,
+        readFileSync: dependencies.readFileSync || fs.readFileSync,
+    };
+
+    const cliPayload = validateCliArgsOrPayload(args);
+    if (cliPayload) return cliPayload;
+
+    const decisionLoad = loadYamlFile(
+        args,
+        deps,
+        'authorization_decision',
+        'authorization decision',
+        'authorization-decision-error'
+    );
+    if (decisionLoad.payload) return decisionLoad.payload;
+
+    const decisionValidation = validateParsedYaml(decisionLoad.parsedYaml);
+    if (!decisionValidation.ok) {
+        return buildFailurePayload(args, {
+            mode: 'authorization-decision-error',
+            authorization_decision_found: true,
+            yaml_block_found: true,
+            required_fields_present: decisionValidation.missingFields.length === 0,
+            missing_fields: decisionValidation.missingFields,
+            errors: decisionValidation.errors,
+        });
+    }
+
+    const handoffPayload = validateHandoffChecklist(
+        {
+            handoff_checklist: args.handoff_checklist,
+            review_result: args.review_result,
+            review_plan: args.review_plan,
+            intake: args.intake,
+            validation_closure: args.validation_closure,
+            blocked_summary: args.blocked_summary,
+        },
+        deps
+    );
+    if (!handoffPayload.ok) {
+        return buildFailurePayload(args, {
+            mode: 'handoff-chain-error',
+            authorization_decision_found: true,
+            yaml_block_found: true,
+            required_fields_present: true,
+            authorization_decision_valid: true,
+            ...pickHandoffFlags(handoffPayload),
+            errors: handoffPayload.errors || ['handoff checklist chain validation failed'],
+        });
+    }
+
+    return buildSuccessPayload(args);
+}
+
+function writePayload(payload, io) {
+    io.stdout(JSON.stringify(payload, null, 2) + '\n');
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const output = { stdout: io.stdout || (text => process.stdout.write(text)) };
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            output.stdout(usage() + '\n');
+            return 0;
+        }
+        if (args.commit) {
+            writePayload(buildBlockedCommitPayload(args), output);
+            return 1;
+        }
+        const payload = runValidation(args, dependencies);
+        writePayload(payload, output);
+        return payload.ok ? 0 : 1;
+    } catch (error) {
+        writePayload(buildFailurePayload({}, { mode: 'argument-error', errors: [error.message] }), output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    OUTPUT_PHASE,
+    TEMPLATE_PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    AUTHORIZATION_DECISION_ALLOWED_VALUES,
+    DECISION_BLOCKING_REASONS,
+    parseArgs,
+    validateParsedYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/single_target_acquisition_network_authorization_decision.test.js
+++ b/tests/unit/single_target_acquisition_network_authorization_decision.test.js
@@ -1,0 +1,670 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/single_target_acquisition_network_authorization_decision.js');
+const AD_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION_TEMPLATE.md'
+);
+const HC_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_HANDOFF_CHECKLIST_TEMPLATE.md'
+);
+const RR_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_RESULT_TEMPLATE.md'
+);
+const RP_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_FILLED_INTAKE_REVIEW_PLAN_TEMPLATE.md'
+);
+const INTAKE_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_TEMPLATE.md'
+);
+const VC_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_REAL_PARAMETER_INTAKE_VALIDATION_CLOSURE_TEMPLATE.md'
+);
+const BS_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_BLOCKED_FINAL_PREFLIGHT_SUMMARY_TEMPLATE.md'
+);
+const AD_TEXT = fs.readFileSync(AD_PATH, 'utf8');
+
+function loadFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        authorization_decision: AD_PATH,
+        handoff_checklist: HC_PATH,
+        review_result: RR_PATH,
+        review_plan: RP_PATH,
+        intake: INTAKE_PATH,
+        validation_closure: VC_PATH,
+        blocked_summary: BS_PATH,
+        ...overrides,
+    };
+}
+
+function buildDeps(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: p => fs.existsSync(p),
+        readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
+        ...overrides,
+    };
+}
+
+function buildTextDeps(text, targetPath = AD_PATH) {
+    return buildDeps({
+        existsSync: p => p === targetPath || fs.existsSync(p),
+        readFileSync: (p, encoding) => {
+            if (p === targetPath) return text;
+            return fs.readFileSync(p, encoding);
+        },
+    });
+}
+
+function installGuards(t) {
+    const original = {
+        http: http.request,
+        https: https.request,
+        fetch: global.fetch,
+        spawn: childProcess.spawn,
+        exec: childProcess.exec,
+        execFile: childProcess.execFile,
+        writeFile: fs.writeFile,
+        writeFileSync: fs.writeFileSync,
+        createWriteStream: fs.createWriteStream,
+        mkdir: fs.mkdir,
+        mkdirSync: fs.mkdirSync,
+        net: net.connect,
+        load: Module._load,
+    };
+    const fail = name => () => {
+        throw new Error(name + ' should not be called');
+    };
+
+    http.request = fail('http');
+    https.request = fail('https');
+    global.fetch = fail('fetch');
+    childProcess.spawn = fail('spawn');
+    childProcess.exec = fail('exec');
+    childProcess.execFile = fail('execFile');
+    fs.writeFile = fail('writeFile');
+    fs.writeFileSync = fail('writeFileSync');
+    fs.createWriteStream = fail('createWriteStream');
+    fs.mkdir = fail('mkdir');
+    fs.mkdirSync = fail('mkdirSync');
+    net.connect = fail('net');
+    Module._load = function guardedLoad(request, parent, isMain) {
+        if (
+            new Set([
+                'http',
+                'node:http',
+                'https',
+                'node:https',
+                'child_process',
+                'node:child_process',
+                'pg',
+                'redis',
+                'ioredis',
+                'playwright',
+                'playwright-core',
+            ]).has(request)
+        ) {
+            throw new Error('blocked: ' + request);
+        }
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error('blocked: ' + request);
+        }
+        return original.load.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        Object.assign(http, { request: original.http });
+        Object.assign(https, { request: original.https });
+        global.fetch = original.fetch;
+        Object.assign(childProcess, { spawn: original.spawn, exec: original.exec, execFile: original.execFile });
+        Object.assign(fs, {
+            writeFile: original.writeFile,
+            writeFileSync: original.writeFileSync,
+            createWriteStream: original.createWriteStream,
+            mkdir: original.mkdir,
+            mkdirSync: original.mkdirSync,
+        });
+        net.connect = original.net;
+        Module._load = original.load;
+    });
+}
+
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceInDecision(search, replacement) {
+    assert.match(AD_TEXT, new RegExp(escapeRegExp(search)));
+    return AD_TEXT.replace(search, replacement);
+}
+
+function removeLine(line) {
+    return AD_TEXT.replace(line + '\n', '');
+}
+
+function replaceSectionField(sectionName, fieldName, replacementValue) {
+    const regex = new RegExp('(' + escapeRegExp(sectionName) + ':[\\s\\S]*?' + escapeRegExp(fieldName) + ': )[^\\n]+');
+    const modified = AD_TEXT.replace(regex, '$1' + replacementValue);
+    assert.notEqual(modified, AD_TEXT, sectionName + '.' + fieldName + ' should be modified');
+    return modified;
+}
+
+function runMain(gate, argv, deps = buildDeps()) {
+    let stdout = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        deps
+    );
+    return { status, stdout };
+}
+
+function extractJson(stdout) {
+    const text = String(stdout || '').trim();
+    const index = text.lastIndexOf('\n{');
+    return JSON.parse(index >= 0 ? text.slice(index + 1) : text);
+}
+
+[
+    ['authorization_decision', 'authorization decision'],
+    ['handoff_checklist', 'handoff checklist'],
+    ['review_result', 'review result'],
+    ['review_plan', 'review plan'],
+    ['intake', 'intake'],
+    ['validation_closure', 'validation closure'],
+    ['blocked_summary', 'blocked summary'],
+].forEach(([field, label]) => {
+    test('缺 ' + label + ' 失败', () => {
+        const gate = loadFresh();
+        const args = buildArgs();
+        delete args[field];
+        const payload = gate.runValidation(args, buildDeps());
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), new RegExp('missing ' + label, 'i'));
+    });
+});
+
+test('authorization decision 缺 YAML block 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDeps('# no yaml\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing YAML block/i);
+});
+
+test('authorization decision invalid YAML 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDeps('```yaml\nnot yaml\n```\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /invalid YAML/i);
+});
+
+test('missing phase 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(removeLine('phase: PHASE4_95D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing required fields: phase|phase must be/);
+});
+
+[
+    [
+        'authorization_decision_status 非 template_only 失败',
+        'authorization_decision_status: template_only',
+        'authorization_decision_status: ready',
+        /authorization_decision_status not template_only/,
+    ],
+    [
+        'network_authorization_decision_ready=true 失败',
+        'network_authorization_decision_ready: false',
+        'network_authorization_decision_ready: true',
+        /network_authorization_decision_ready true/,
+    ],
+    [
+        'network_authorization_decision_recorded=true 失败',
+        'network_authorization_decision_recorded: false',
+        'network_authorization_decision_recorded: true',
+        /network_authorization_decision_recorded true/,
+    ],
+    [
+        'authorization_decision 不是 not_authorized 失败',
+        'authorization_decision: not_authorized',
+        'authorization_decision: conditionally_authorized_for_future_preparation',
+        /authorization_decision not not_authorized/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'authorization_decision_is_not_execution=false 失败',
+        'authorization_decision_is_not_execution: true',
+        'authorization_decision_is_not_execution: false',
+        /authorization_decision_is_not_execution/,
+    ],
+    [
+        'future_execution_preparation_phase_required=false 失败',
+        'future_execution_preparation_phase_required: true',
+        'future_execution_preparation_phase_required: false',
+        /future_execution_preparation_phase_required/,
+    ],
+    [
+        'future_final_confirmation_required=false 失败',
+        'future_final_confirmation_required: true',
+        'future_final_confirmation_required: false',
+        /future_final_confirmation_required/,
+    ],
+    [
+        'can_proceed_to_network_dry_run_preparation=true 失败',
+        'can_proceed_to_network_dry_run_preparation: false',
+        'can_proceed_to_network_dry_run_preparation: true',
+        /can_proceed_to_network_dry_run_preparation true/,
+    ],
+].forEach(([name, search, replacement, pattern]) => {
+    test(name, () => {
+        const gate = loadFresh();
+        const payload = gate.runValidation(buildArgs(), buildTextDeps(replaceInDecision(search, replacement)));
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+[
+    [
+        'decision_sections.scope_decision.reviewed=true 失败',
+        'scope_decision',
+        'reviewed',
+        'true',
+        /scope_decision.*reviewed/,
+    ],
+    [
+        'decision_sections.scope_decision.decision 不是 not_authorized 失败',
+        'scope_decision',
+        'decision',
+        'denied',
+        /scope_decision.*decision not not_authorized/,
+    ],
+    [
+        'decision_sections.source_terms_decision.reviewed=true 失败',
+        'source_terms_decision',
+        'reviewed',
+        'true',
+        /source_terms_decision.*reviewed/,
+    ],
+    [
+        'decision_sections.source_terms_decision.decision 不是 not_authorized 失败',
+        'source_terms_decision',
+        'decision',
+        'needs_revision',
+        /source_terms_decision.*decision not not_authorized/,
+    ],
+    [
+        'decision_sections.network_runtime_decision.reviewed=true 失败',
+        'network_runtime_decision',
+        'reviewed',
+        'true',
+        /network_runtime_decision.*reviewed/,
+    ],
+    [
+        'decision_sections.network_runtime_decision.decision 不是 not_authorized 失败',
+        'network_runtime_decision',
+        'decision',
+        'denied',
+        /network_runtime_decision.*decision not not_authorized/,
+    ],
+    [
+        'decision_sections.network_runtime_decision.external_network_allowed=true 失败',
+        'network_runtime_decision',
+        'external_network_allowed',
+        'true',
+        /external_network_allowed true/,
+    ],
+    [
+        'decision_sections.network_runtime_decision.browser_runtime_allowed=true 失败',
+        'network_runtime_decision',
+        'browser_runtime_allowed',
+        'true',
+        /browser_runtime_allowed true/,
+    ],
+    [
+        'decision_sections.network_runtime_decision.proxy_runtime_allowed=true 失败',
+        'network_runtime_decision',
+        'proxy_runtime_allowed',
+        'true',
+        /proxy_runtime_allowed true/,
+    ],
+    [
+        'decision_sections.staging_decision.reviewed=true 失败',
+        'staging_decision',
+        'reviewed',
+        'true',
+        /staging_decision.*reviewed/,
+    ],
+    [
+        'decision_sections.staging_decision.staging_write_allowed=true 失败',
+        'staging_decision',
+        'staging_write_allowed',
+        'true',
+        /staging_write_allowed true/,
+    ],
+    [
+        'decision_sections.staging_decision.source_manifest_write_allowed=true 失败',
+        'staging_decision',
+        'source_manifest_write_allowed',
+        'true',
+        /source_manifest_write_allowed true/,
+    ],
+    [
+        'decision_sections.db_training_prediction_decision.db_write_allowed=true 失败',
+        'db_training_prediction_decision',
+        'db_write_allowed',
+        'true',
+        /db_write_allowed true/,
+    ],
+    [
+        'decision_sections.db_training_prediction_decision.training_allowed=true 失败',
+        'db_training_prediction_decision',
+        'training_allowed',
+        'true',
+        /training_allowed true/,
+    ],
+    [
+        'decision_sections.db_training_prediction_decision.prediction_allowed=true 失败',
+        'db_training_prediction_decision',
+        'prediction_allowed',
+        'true',
+        /prediction_allowed true/,
+    ],
+    [
+        'decision_sections.db_training_prediction_decision.model_artifact_loading_allowed=true 失败',
+        'db_training_prediction_decision',
+        'model_artifact_loading_allowed',
+        'true',
+        /model_artifact_loading_allowed true/,
+    ],
+    [
+        'decision_sections.final_human_decision.final_confirmation=true 失败',
+        'final_human_decision',
+        'final_confirmation',
+        'true',
+        /final_confirmation true/,
+    ],
+    ['bulk_scope_allowed=true 失败', 'scope_decision', 'bulk_scope_allowed', 'true', /bulk_scope_allowed true/],
+    ['max_targets > 1 失败', 'scope_decision', 'max_targets', '2', /max_targets > 1/],
+].forEach(([name, sectionName, fieldName, replacementValue, pattern]) => {
+    test(name, () => {
+        const gate = loadFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildTextDeps(replaceSectionField(sectionName, fieldName, replacementValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+[
+    [
+        'codex_may_not_authorize_network=false 失败',
+        'codex_may_not_authorize_network: true',
+        'codex_may_not_authorize_network: false',
+        /codex_may_not_authorize_network/,
+    ],
+    [
+        'codex_may_not_set_execution_allowed=false 失败',
+        'codex_may_not_set_execution_allowed: true',
+        'codex_may_not_set_execution_allowed: false',
+        /codex_may_not_set_execution_allowed/,
+    ],
+    [
+        'safety would_access_network=true 失败',
+        'would_access_network: false',
+        'would_access_network: true',
+        /safety\.would_access_network/,
+    ],
+    ['safety would_write_db=true 失败', 'would_write_db: false', 'would_write_db: true', /safety\.would_write_db/],
+    [
+        'safety would_write_network_authorization_decision_file=true 失败',
+        'would_write_network_authorization_decision_file: false',
+        'would_write_network_authorization_decision_file: true',
+        /safety\.would_write_network_authorization_decision_file/,
+    ],
+].forEach(([name, search, replacement, pattern]) => {
+    test(name, () => {
+        const gate = loadFresh();
+        const payload = gate.runValidation(buildArgs(), buildTextDeps(replaceInDecision(search, replacement)));
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), pattern);
+    });
+});
+
+test('decision_sections missing 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInDecision('decision_sections:', 'decision_sections_missing:'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing required fields.*decision_sections/);
+});
+
+test('decision_blocking_reasons missing 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(
+        buildArgs(),
+        buildTextDeps(replaceInDecision('decision_blocking_reasons:', 'decision_blocking_reasons_missing:'))
+    );
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing decision_blocking_reasons/);
+});
+
+test('valid network authorization decision preview 成功', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildDeps());
+    assert.equal(payload.ok, true);
+    assert.equal(payload.phase, 'PHASE4.95D_SINGLE_TARGET_ACQUISITION_NETWORK_DRY_RUN_AUTHORIZATION_DECISION');
+    assert.equal(payload.network_authorization_decision_template_only, true);
+    assert.equal(payload.authorization_decision_valid, true);
+    assert.equal(payload.handoff_checklist_valid, true);
+    assert.equal(payload.review_result_valid, true);
+    assert.equal(payload.review_plan_valid, true);
+    assert.equal(payload.real_parameter_intake_valid, true);
+    assert.equal(payload.validation_closure_valid, true);
+    assert.equal(payload.blocked_summary_valid, true);
+    assert.equal(payload.network_authorization_decision_ready, false);
+    assert.equal(payload.network_authorization_decision_recorded, false);
+    assert.equal(payload.authorization_decision, 'not_authorized');
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.authorization_decision_is_not_execution, true);
+    assert.equal(payload.future_execution_preparation_phase_required, true);
+    assert.equal(payload.future_final_confirmation_required, true);
+    assert.equal(payload.can_proceed_to_network_dry_run_preparation, false);
+    assert.equal(payload.authorization_handoff_ready, false);
+    assert.equal(payload.authorization_handoff_completed, false);
+    assert.equal(payload.filled_intake_reviewed, false);
+    assert.equal(payload.filled_intake_accepted, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.decision_sections_complete, true);
+    assert.equal(payload.decision_sections_authorized, false);
+    assert.deepEqual(payload.decision_blocking_reasons, [
+        'authorization_decision_template_only',
+        'authorization_handoff_not_completed',
+        'filled_intake_review_result_not_accepted',
+        'source_terms_not_authorized',
+        'network_runtime_not_authorized',
+        'staging_not_authorized',
+        'db_training_prediction_not_authorized',
+        'final_human_confirmation_missing',
+        'future_execution_preparation_phase_required',
+    ]);
+    for (const field of [
+        'would_access_network',
+        'would_launch_browser',
+        'would_use_proxy',
+        'would_execute_engine',
+        'would_execute_legacy_titan_discovery',
+        'would_write_staging',
+        'would_create_staging_directory',
+        'would_write_source_manifest',
+        'would_write_packet_file',
+        'would_write_approval_packet_file',
+        'would_write_user_input_closure_file',
+        'would_write_blocked_summary_file',
+        'would_write_real_parameter_intake_file',
+        'would_write_real_parameter_validation_closure_file',
+        'would_write_filled_intake_review_file',
+        'would_write_filled_intake_review_result_file',
+        'would_write_authorization_handoff_checklist_file',
+        'would_write_network_authorization_decision_file',
+        'would_write_db',
+        'would_train',
+        'would_predict',
+        'would_spawn_child_process',
+    ]) {
+        assert.equal(payload[field], false, field);
+    }
+    assert.equal(payload.commit_gate, 'blocked');
+});
+
+test('--commit blocked', () => {
+    const gate = loadFresh();
+    const result = runMain(
+        gate,
+        [
+            '--authorization-decision',
+            AD_PATH,
+            '--handoff-checklist',
+            HC_PATH,
+            '--review-result',
+            RR_PATH,
+            '--review-plan',
+            RP_PATH,
+            '--intake',
+            INTAKE_PATH,
+            '--validation-closure',
+            VC_PATH,
+            '--blocked-summary',
+            BS_PATH,
+            '--commit',
+        ],
+        buildDeps()
+    );
+    assert.equal(result.status, 1);
+    assert.match(JSON.parse(result.stdout).errors.join('\n'), /not wired in Phase 4.95D/);
+});
+
+test('Makefile preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-authorization-decision-preview',
+            'NETWORK_AUTHORIZATION_DECISION_NODE=node',
+            'AUTHORIZATION_DECISION=' + AD_PATH,
+            'HANDOFF_CHECKLIST=' + HC_PATH,
+            'REVIEW_RESULT=' + RR_PATH,
+            'REVIEW_PLAN=' + RP_PATH,
+            'INTAKE=' + INTAKE_PATH,
+            'VALIDATION_CLOSURE=' + VC_PATH,
+            'BLOCKED_SUMMARY=' + BS_PATH,
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(extractJson(result.stdout).ok, true);
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-single-target-acquisition-network-authorization-decision-commit',
+            'CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not wired in Phase 4.95D/);
+});
+
+[
+    ['不访问网络', 'would_access_network'],
+    ['不启动 browser', 'would_launch_browser'],
+    ['不执行 proxy runtime', 'would_use_proxy'],
+    ['不执行 engine', 'would_execute_engine'],
+    ['不执行 legacy titan_discovery', 'would_execute_legacy_titan_discovery'],
+    ['不写 staging', 'would_write_staging'],
+    ['不创建目录', 'would_create_staging_directory'],
+    ['不写 source manifest', 'would_write_source_manifest'],
+    ['不写 packet file', 'would_write_packet_file'],
+    ['不写 approval packet file', 'would_write_approval_packet_file'],
+    ['不写 blocked summary file', 'would_write_blocked_summary_file'],
+    ['不写 real parameter intake file', 'would_write_real_parameter_intake_file'],
+    ['不写 validation closure file', 'would_write_real_parameter_validation_closure_file'],
+    ['不写 filled-intake review plan file', 'would_write_filled_intake_review_file'],
+    ['不写 filled-intake review result file', 'would_write_filled_intake_review_result_file'],
+    ['不写 authorization handoff checklist file', 'would_write_authorization_handoff_checklist_file'],
+    ['不写 network authorization decision file', 'would_write_network_authorization_decision_file'],
+    ['不写 DB', 'would_write_db'],
+    ['不 spawn child process', 'would_spawn_child_process'],
+].forEach(([name, field]) => {
+    test(name, t => {
+        installGuards(t);
+        const gate = loadFresh();
+        const payload = gate.runValidation(buildArgs(), buildDeps());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], false);
+    });
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"].*titan_discovery/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*DiscoveryService/.test(source));
+    assert.ok(!/require\s*\(\s*['"].*FixtureRepository/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.95D single-target acquisition network authorization decision template.

Scope:
- Adds network authorization decision template
- Adds local-only network authorization decision preview validator
- Defines future authorization decision sections and authorization boundaries
- Validates decision remains template-only, not authorized, and not executable
- Keeps network dry-run blocked
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.95D report

Safety:
- No DB writes
- No external downloads
- No external football or odds data access
- No scraping
- No browser automation
- No proxy runtime execution
- No harvest / ingest
- No network dry-run execution
- No runtime staging writes
- No runtime staging directory creation
- No runtime source manifest writes
- No packet file writes
- No approval packet file writes
- No user input closure file writes
- No blocked summary file writes
- No real parameter intake file writes
- No real parameter validation closure file writes
- No filled-intake review plan file writes
- No filled-intake review result file writes
- No authorization handoff checklist file writes
- No network authorization decision file writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No model artifact loading

Validation:
- preview missing params failed as expected
- valid network authorization decision preview passed
- commit gate remained blocked
- unit tests passed
- npm test passed
- npm run test:coverage passed
- integration tests passed / project-expected status
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed
