### PR TITLE
docs(data): add FotMob single-target dry-run readiness plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1018,6 +1018,16 @@ Phase 4.78D single-target acquisition runtime design rules：
 - staging artifact schema 只是设计产物，不等于 staging write authorization；source manifest candidate 也不等于 DB write authorization。
 - 未来 network dry-run 必须 single-target、用户明确授权、source / terms 明确、最多只落 staging、不写 DB、不训练、不预测，且后续 DB write 必须另行授权并先完成 `pg_dump`。
 
+Phase 4.96F FotMob single-target dry-run readiness rules：
+
+- FotMob legacy runtime must not be executed directly by agents.
+- `scripts/ops/titan_discovery.js` is not a trusted single-target dry-run adapter.
+- `run_production` / `ProductionHarvester` / `FotMobStrategy` must not be used for the first safe FotMob dry-run.
+- `FixtureRepository.persist` and `Persistence.dualSave` are DB/file write paths and must remain blocked unless separately authorized.
+- FotMob browser / proxy / session helpers must not be launched without explicit user authorization.
+- A future FotMob dry-run must first use a trusted single-target adapter scaffold.
+- The first FotMob network dry-run should be stdout-only, no DB, no staging, and no browser/proxy by default.
+
 Phase 4.57C football-data adapter rules：
 
 - `fetch_and_adapt_euro_leagues` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。

--- a/docs/_reports/FOTMOB_SINGLE_TARGET_DRY_RUN_READINESS_GAP_PHASE4_96F.md
+++ b/docs/_reports/FOTMOB_SINGLE_TARGET_DRY_RUN_READINESS_GAP_PHASE4_96F.md
@@ -1,0 +1,176 @@
+# FotMob Single-Target Dry-Run Readiness Gap Report
+
+Phase: 4.96F
+Status: docs-only readiness gap report
+Starting HEAD: `eaa8e9f3f5d6121c9f5b5a60f724c0bb8d139a92`
+
+## 1. Executive Summary
+
+FotMob legacy capability exists in this repository. The project has discovery, harvest,
+API client, extractor, parser, browser/proxy/session, DB persistence, tests, config, and
+historical documentation around FotMob.
+
+Safe single-target dry-run capability does not yet exist.
+
+Direct execution of legacy FotMob runtime is not recommended. The next engineering work
+should be a trusted FotMob single-target adapter scaffold, not direct harvest.
+
+## 2. Current FotMob Inventory Summary
+
+Discovery:
+
+- `scripts/ops/titan_discovery.js` is the legacy L1 CLI.
+- `src/infrastructure/services/DiscoveryService.js` wires FotMob HTTP, browser,
+  proxy, parser, and persistence.
+- `titan_discovery --dry-run` is not trusted because dry-run behavior is not proven
+  through the service and repository layers.
+
+Harvest:
+
+- `scripts/ops/run_production.js`, `ProductionHarvester`, `AbstractHarvester`, and
+  `FotMobStrategy` form the legacy L2 raw harvest path.
+- `run_production --dry-run` is still a live acquisition path and is not a safe
+  no-side-effect dry-run.
+
+Parser:
+
+- `src/parsers/fotmob/*` contains FotMob parser utilities including `NextDataParser`,
+  match / league / team / player parsers, and `XGExtractor`.
+- These can inform future pure parsing, but must only parse caller-provided payloads.
+
+API client:
+
+- `src/infrastructure/network/FotMobApiClient.js` builds FotMob match details requests.
+- It can use proxy agents and browser bootstrap behavior, so it is not safe as a direct
+  first dry-run entrypoint.
+
+Extractor:
+
+- `src/infrastructure/services/FotMobExtractor.js` can inspect FotMob page data and
+  fallback DOM payloads.
+- It depends on browser navigation and must remain blocked unless browser runtime is
+  explicitly authorized in a later phase.
+
+Browser / proxy / session:
+
+- `src/infrastructure/services/BrowserProvider.js` launches Playwright Chromium.
+- `config/proxy_pools.json` defines `fotmob_pool`.
+- Session and cookie helpers exist in `scripts/capture_auth*.js`,
+  `scripts/import_manual_cookies.js`, `scripts/inject_cookie.js`, and
+  `scripts/inject_total_war_cookies.js`.
+- The requested path `src/infrastructure/network/BrowserProvider.js` was not present;
+  the active browser provider path is `src/infrastructure/services/BrowserProvider.js`.
+
+DB persistence:
+
+- `FixtureRepository.persist` writes `matches`.
+- `Persistence.dualSave` writes `raw_match_data` and local raw JSON files.
+- These paths must remain blocked unless a separate DB write phase is authorized.
+
+Tests:
+
+- FotMob tests cover parser helpers, compliance mode, schema guard, API client,
+  discovery behavior, and no-network governance.
+- Future adapter tests still need explicit no-network, no-DB, and no-file-write guards.
+
+Config:
+
+- `config/acquisition_engines.phase454.json` marks `titan_discovery` as
+  `adapter_candidate`, with network and DB write risk and low dry-run trust.
+- `config/registry.js` contains FotMob URL helper conventions.
+- `config/proxy_pools.json` contains `fotmob_pool`.
+
+Docs:
+
+- Existing reports document that `run_production`, `titan_discovery`, and other
+  acquisition engines remain blocked legacy paths.
+- Single-target acquisition schemas and templates exist, but they are generic and do not
+  create a trusted FotMob adapter.
+
+## 3. Main Risks
+
+- network access risk: legacy FotMob paths can call external FotMob endpoints.
+- browser runtime risk: discovery and extraction can launch Playwright / Chromium.
+- proxy runtime risk: `fotmob_pool`, `ProxyProvider`, and `NetworkManager` can be used.
+- DB write risk: `FixtureRepository.persist` and `Persistence.dualSave` write DB tables.
+- bulk / batch risk: default discovery can scan P0 leagues, and harvest / backfill paths
+  can operate in batches.
+- dry-run trust risk: `titan_discovery --dry-run` and `run_production --dry-run` are not
+  trusted safe dry-runs.
+- terms / allowed-use gap: there is no approved FotMob terms or allowed-use evidence for a
+  future network dry-run.
+- staging / manifest gap: there is no approved FotMob source manifest or staging writer.
+- source schema drift risk: FotMob payload fields can change and break parser assumptions.
+- anti-bot / login / paywall boundary risk: browser, cookie, and session helpers exist and
+  must not be used to bypass source controls.
+
+## 4. Adapter Readiness Gaps
+
+The following gaps must be closed before a real FotMob single-target network dry-run:
+
+- trusted single-target adapter entrypoint
+- strict input contract
+- no-network preflight
+- no-DB guarantee
+- no-staging default
+- no-browser/proxy default
+- bounded stdout preview
+- source manifest candidate design
+- schema validation
+- parser confidence and error reporting
+- rate limit / retry policy
+- terms / allowed-use evidence
+- tests guarding no network, no DB, and no file writes
+
+## 5. Recommended Next Phase
+
+Recommended next phase: Phase 4.97F, FotMob trusted single-target adapter scaffold.
+
+Phase 4.97F should:
+
+- not access the network
+- not write DB
+- not write staging
+- only implement parameter validation, dependency injection, and no-side-effect scaffold
+- not call legacy runtime
+- not call browser or proxy runtime
+- not call DB
+- add no-network, no-DB, and no-write tests
+
+The scaffold should prove safety before any future external request is considered.
+
+## 6. Why Not Collect Data Now
+
+Do not collect data now because there is no real target, no terms / allowed-use evidence,
+and no explicit network authorization.
+
+The existing FotMob runtime is not safe for first use. Its dry-run behavior is not trusted,
+and legacy paths may touch the network, write DB rows, write local files, or expand into
+batch scope.
+
+The correct order is to build a trusted adapter first, prove that it has no side effects,
+and only then run one minimal stdout-only dry-run after explicit authorization.
+
+## 7. Explicit Non-Execution
+
+Phase 4.96F did not execute:
+
+- external FotMob access
+- external football data access
+- external odds data access
+- curl / wget
+- browser automation
+- proxy runtime
+- scraping
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- staging write
+- source manifest write
+- packet write
+- DB writes
+- pg_dump / pg_restore
+- training
+- prediction
+- file deletion

--- a/docs/runbooks/FOTMOB_SINGLE_TARGET_NETWORK_DRY_RUN_RUNBOOK_DRAFT.md
+++ b/docs/runbooks/FOTMOB_SINGLE_TARGET_NETWORK_DRY_RUN_RUNBOOK_DRAFT.md
@@ -1,0 +1,211 @@
+# FotMob Single-Target Network Dry-Run Runbook Draft
+
+Phase: 4.96F
+Status: draft-only, non-executing
+
+## 1. Purpose
+
+This runbook is a draft for a future FotMob single-target network dry-run.
+
+It is not execution authorization. It is not a network execution plan. It is not a DB
+write runbook. It is not a staging write runbook. Its only purpose is to prepare the
+requirements and guardrails for one future minimal FotMob dry-run.
+
+The future run must remain explicitly authorized, tightly scoped, and non-persistent by
+default.
+
+## 2. Current Codebase Reality
+
+The repository already contains legacy FotMob capability:
+
+- L1 discovery through `scripts/ops/titan_discovery.js` and `DiscoveryService`
+- L2 harvest through `scripts/ops/run_production.js`, `ProductionHarvester`, and
+  `FotMobStrategy`
+- FotMob API client code in `src/infrastructure/network/FotMobApiClient.js`
+- FotMob extractor and parser code in `FotMobExtractor` and `src/parsers/fotmob`
+- Browser, proxy, cookie, and session helper paths
+- DB persistence paths for `matches` and `raw_match_data`
+- FotMob-related tests, fixtures, config, and historical reports
+
+These paths cannot be used directly for a safe single-target dry-run. The legacy runtime
+couples network access, browser launch, proxy runtime, DB writes, file writes, and batch
+scope risk.
+
+`titan_discovery --dry-run` is not trusted as a safe dry-run. The CLI parses the flag and
+prints a warning, but the dry-run contract is not proven end to end at the service layer.
+
+`run_production --dry-run` is not a safe no-side-effect dry-run. It can still initialize
+live acquisition runtime and should be treated as a network dry-run requiring separate
+authorization.
+
+## 3. Forbidden Legacy Paths
+
+The following paths must not be directly executed for the first FotMob safe dry-run:
+
+- `scripts/ops/titan_discovery.js`
+- `scripts/ops/run_production.js`
+- `scripts/ops/batch_historical_backfill.js`
+- `scripts/ops/backfill_historical_raw_match_data.js`
+- `scripts/ops/titan_seeder.js`
+- `ProductionHarvester`
+- `FotMobStrategy` live harvest
+- `FixtureRepository.persist`
+- `Persistence.dualSave`
+- `BrowserProvider` launch path
+- `ProxyProvider` / proxy pool runtime
+- any batch or bulk path
+
+These paths may be useful for source reading, but not for execution.
+
+## 4. Candidate Reusable Components
+
+These components may be referenced when designing a future trusted adapter, but they must
+not be executed directly from this runbook:
+
+| Component                                               | Can reference                                                     | Cannot execute directly                                                       | Future isolation requirement                                        |
+| ------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `FotMobApiClient`                                       | URL shape, headers, response handling, error semantics            | It may perform HTTP requests, proxy agent setup, and browser cookie bootstrap | Must sit behind an injected network client in a trusted adapter     |
+| `FotMobExtractor`                                       | `__NEXT_DATA__`, DOM payload, and league fixture extraction ideas | It drives browser navigation and DOM evaluation                               | Must be isolated behind explicit browser authorization, default off |
+| `src/parsers/fotmob/*`                                  | Pure parsing patterns and fixture shape                           | Parser use must not imply network, browser, DB, or file writes                | Must be called only on caller-provided payloads                     |
+| `FotMobSchemaGuard`                                     | Raw payload schema drift inspection                               | It must not be combined with DB reads or writes by default                    | Must inspect bounded in-memory samples only                         |
+| `config/registry.js` FotMob URL helpers                 | Existing FotMob URL conventions                                   | URL construction must not trigger requests                                    | Must remain pure config/reference data                              |
+| FotMob tests and fixtures                               | Parser behavior and no-network test examples                      | Tests must not launch live runtime or hit external URLs                       | Must guard no-network, no-DB, no-write behavior                     |
+| Single-target acquisition schemas and manifest examples | Staging and manifest field vocabulary                             | Examples are not source approval or write authorization                       | Must remain candidate-only until human approval                     |
+
+All reusable pieces must be placed behind a future trusted adapter with dependency
+injection, explicit authorization inputs, and no-side-effect defaults.
+
+## 5. Required First Real Target Inputs
+
+A future operator must provide all real parameters and approvals before any FotMob network
+step:
+
+- `target_source=fotmob`
+- `target_scope_type=match_id` or `target_scope_type=league_season_date`
+- `target_match_id`, or `target_league` plus `target_season` plus `target_date`
+- target URL, if available
+- source homepage URL
+- terms URL
+- license URL, if available
+- allowed-use summary
+- terms reviewed by human
+- explicit network authorization
+- browser allowed yes/no
+- proxy allowed yes/no
+- external network allowed yes/no
+- staging write allowed yes/no
+- no DB write confirmation
+- no training confirmation
+- no prediction confirmation
+- final human confirmation
+
+Missing or ambiguous inputs must stop the run.
+
+## 6. Recommended First Dry-Run Policy
+
+The first future FotMob dry-run should use this default policy:
+
+- single target only
+- `max_targets=1`
+- stdout-only
+- no DB write
+- no staging write in first run
+- no source manifest write in first run
+- no packet write
+- no browser by default
+- no proxy by default
+- no bulk
+- no login
+- no paywall bypass
+- no anti-bot bypass
+- no retries beyond a small bounded limit
+- no model training
+- no prediction
+- no artifact loading
+
+Any deviation from this policy requires a later, explicit authorization phase.
+
+## 7. Proposed Future Adapter Shape
+
+Future adapter should expose a narrow interface like:
+
+- `validateInputs()`
+- `preflight()`
+- `dryRunFetchSingleTarget()`
+- `parsePreview()`
+- `summarizeToStdout()`
+
+`dryRunFetchSingleTarget()` must only be implemented and executed in a later authorized
+phase. Phase 4.96F does not implement or run it.
+
+The adapter must follow these rules:
+
+- inject the network client; do not directly import legacy runtime
+- default to no DB access and no DB writes
+- default to no staging write
+- default to no browser unless explicitly authorized
+- default to no proxy unless explicitly authorized
+- forbid bulk expansion
+- output a bounded JSON preview to stdout
+- include no-network unit tests
+- include no-DB unit tests
+- include no-file-write unit tests before any live network step
+
+The trusted adapter must fail closed when authorization or target scope is incomplete.
+
+## 8. Stop Gates
+
+Stop immediately if any of these conditions appear:
+
+- no terms approval
+- no explicit network authorization
+- target scope is not single-target
+- target count is greater than 1
+- source requires login
+- source requires paywall bypass
+- source requires anti-bot bypass
+- source requires proxy without authorization
+- source requires browser without authorization
+- any path attempts DB write
+- any path attempts staging write without authorization
+- any path attempts bulk expansion
+- unexpected redirect or block page is encountered
+- response schema is unknown or unsafe
+- parser confidence is low
+
+Stop gates must be evaluated before any external request in future phases.
+
+## 9. Future Execution Sequence
+
+The safe future sequence is:
+
+1. User provides real FotMob target and terms / authorization.
+2. Review the filled intake in a separate phase.
+3. Record the review result in a separate phase.
+4. Record the authorization decision in a separate phase.
+5. Create a FotMob trusted adapter scaffold in a separate phase.
+6. Add no-network and no-DB adapter tests in a separate phase.
+7. Run a stdout-only network dry-run in a separate authorized phase.
+8. If successful, consider staging preview in a later phase.
+9. Only after staging preview passes, consider DB write preflight.
+10. DB write requires separate small-write approval, backup, and rollback plan.
+
+No step may skip the previous approval boundary.
+
+## 10. Non-Execution Statement
+
+Phase 4.96F did not execute:
+
+- no FotMob access
+- no network
+- no browser
+- no proxy
+- no scrape
+- no harvest
+- no ingest
+- no DB write
+- no staging write
+- no source manifest write
+- no packet write
+- no training
+- no prediction


### PR DESCRIPTION
## Summary

Adds Phase 4.96F FotMob single-target dry-run readiness plan.

Scope:
- Adds FotMob single-target network dry-run runbook draft
- Adds FotMob adapter readiness gap report
- Updates AGENTS.md with FotMob-specific safety rules
- Documents why legacy FotMob runtime must not be executed directly
- Recommends future trusted FotMob single-target adapter scaffold

Safety:
- No external FotMob access
- No external football or odds data access
- No curl / wget
- No browser automation
- No proxy runtime execution
- No scraping
- No harvest / ingest
- No network dry-run execution
- No staging writes
- No source manifest writes
- No packet writes
- No DB writes
- No pg_dump / pg_restore
- No training
- No prediction execution
- No code execution of legacy FotMob runtime

Validation:
- git diff --check passed
- prettier check passed
- worktree clean before commit
- l1-config residue absent
- no staging preview directory created
- DB row counts unchanged if checked