### PR TITLE
feat(data): add FotMob single-target adapter scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1028,6 +1028,16 @@ Phase 4.96F FotMob single-target dry-run readiness rules：
 - A future FotMob dry-run must first use a trusted single-target adapter scaffold.
 - The first FotMob network dry-run should be stdout-only, no DB, no staging, and no browser/proxy by default.
 
+Phase 4.97F FotMob trusted single-target adapter scaffold rules：
+
+- FotMob trusted single-target adapter scaffold is allowed only for no-network preflight.
+- `make data-fotmob-single-target-adapter-preflight` must not access external FotMob or any external football / odds data source.
+- `make data-fotmob-single-target-adapter-preflight` must not launch browser or proxy runtime.
+- `make data-fotmob-single-target-adapter-preflight` must not write staging, source manifest, packet, or DB.
+- `make data-fotmob-single-target-adapter-commit` is blocked.
+- CLI `yes` flags must not override Phase 4.97F blocked behavior.
+- Future FotMob network dry-run requires explicit user target, terms, allowed-use, and network authorization in a separate phase.
+
 Phase 4.57C football-data adapter rules：
 
 - `fetch_and_adapt_euro_leagues` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
         data-prediction-write-dry-run data-prediction-write-commit \
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
+        data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-single-target-network-dry-run data-single-target-network-commit \
         data-single-target-acquisition-runtime-scaffold data-single-target-acquisition-runtime-commit \
         data-single-target-acquisition-staging-schema-validate data-single-target-acquisition-staging-schema-commit \
@@ -99,6 +100,7 @@ NETWORK_FILLED_INTAKE_REVIEW_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_FILLED_INTAKE_REVIEW_RESULT_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTHORIZATION_DECISION_NODE?=$(COMPOSE_DEV) exec -T dev node
+FOTMOB_SINGLE_TARGET_ADAPTER_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -302,6 +304,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
+	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # scaffold-only, Phase 4.97F"
 	@echo "  make data-real-source-audit SOURCE_MANIFEST=<path>"
 	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
@@ -392,6 +395,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-authorization-handoff-checklist-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST=1  # blocked in Phase 4.94D"
 	@echo "  make data-single-target-acquisition-network-authorization-decision-preview AUTHORIZATION_DECISION=<path> HANDOFF_CHECKLIST=<path> REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # authorization decision preview, Phase 4.95D"
 	@echo "  make data-single-target-acquisition-network-authorization-decision-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION=1  # blocked in Phase 4.95D"
+	@echo "  make data-fotmob-single-target-adapter-commit TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1  # blocked in Phase 4.97F"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -886,6 +890,34 @@ data-acquisition-engines: ## List acquisition engine registry entries. No networ
 
 data-acquisition-engine-audit: ## Audit acquisition engine registry. No network, no DB writes.
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/acquisition_engine_gate.js --audit
+
+data-fotmob-single-target-adapter-preflight: ## No-network FotMob trusted single-target adapter scaffold preflight. Phase 4.97F.
+	@$(FOTMOB_SINGLE_TARGET_ADAPTER_NODE) scripts/ops/fotmob_single_target_adapter_scaffold.js \
+		--target-source "$(TARGET_SOURCE)" \
+		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
+		$(if $(TARGET_MATCH_ID),--target-match-id "$(TARGET_MATCH_ID)") \
+		$(if $(TARGET_LEAGUE),--target-league "$(TARGET_LEAGUE)") \
+		$(if $(TARGET_SEASON),--target-season "$(TARGET_SEASON)") \
+		$(if $(TARGET_DATE),--target-date "$(TARGET_DATE)") \
+		$(if $(TARGET_COUNT),--target-count "$(TARGET_COUNT)") \
+		$(if $(BULK_SCOPE_ALLOWED),--bulk-scope-allowed "$(BULK_SCOPE_ALLOWED)") \
+		$(if $(MAX_TARGETS),--max-targets "$(MAX_TARGETS)") \
+		--terms-approval "$(or $(TERMS_APPROVAL),no)" \
+		--network-authorization "$(or $(NETWORK_AUTHORIZATION),no)" \
+		--allow-browser-runtime "$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime "$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-external-network "$(or $(ALLOW_EXTERNAL_NETWORK),no)" \
+		--allow-staging-write "$(or $(ALLOW_STAGING_WRITE),no)" \
+		--allow-db-write "$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-training "$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction "$(or $(ALLOW_PREDICTION),no)" \
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-fotmob-single-target-adapter-commit: ## Blocked FotMob trusted single-target adapter execution gate. Remains blocked in Phase 4.97F.
+	@echo "BLOCKED: FotMob trusted single-target adapter scaffold is not executable in Phase 4.97F."
+	@echo "  Even with CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1, this path remains blocked."
+	@echo "  Future FotMob network dry-run requires separate user target, terms, allowed-use, and network authorization."
+	@exit 1
 
 data-single-target-network-dry-run: ## Scaffold-only single-target network dry-run gate. Requires ENGINE, TARGET_MATCH_ID, SOURCE_MANIFEST.
 	@if [ -z "$(ENGINE)" ] || [ -z "$(TARGET_MATCH_ID)" ] || [ -z "$(SOURCE_MANIFEST)" ]; then \

--- a/docs/_reports/FOTMOB_SINGLE_TARGET_ADAPTER_SCAFFOLD_PHASE4_97F.md
+++ b/docs/_reports/FOTMOB_SINGLE_TARGET_ADAPTER_SCAFFOLD_PHASE4_97F.md
@@ -1,0 +1,141 @@
+# FotMob Single-Target Adapter Scaffold
+
+Phase: 4.97F
+Status: scaffold-only, no-network preflight
+Starting HEAD: `ea9fa12cb7c8b6f2ec05dd89d6d89e3f7b8cdf01`
+
+## 1. Executive Summary
+
+Phase 4.97F adds a FotMob trusted single-target adapter scaffold.
+
+This is not a network dry-run. It does not access FotMob, collect data, write DB rows, or
+write staging artifacts. It only provides parameter validation, dependency injection
+shape, no-network preflight, and stdout-only JSON summary behavior.
+
+The scaffold keeps FotMob legacy runtime blocked and proves the first future adapter path
+can remain no-side-effect by default.
+
+## 2. Implemented Files
+
+- `scripts/ops/fotmob_single_target_adapter_scaffold.js`: FotMob single-target adapter
+  scaffold CLI and exported testable functions.
+- `tests/unit/fotmob_single_target_adapter_scaffold.test.js`: no-side-effect unit tests
+  covering validation, blocked commit behavior, disabled dependencies, and safety flags.
+- `Makefile`: adds `data-fotmob-single-target-adapter-preflight` and blocked
+  `data-fotmob-single-target-adapter-commit`.
+- `AGENTS.md`: records Phase 4.97F FotMob scaffold rules.
+- `docs/_reports/FOTMOB_SINGLE_TARGET_ADAPTER_SCAFFOLD_PHASE4_97F.md`: this report.
+
+## 3. Adapter Behavior
+
+- single-target only
+- supports `match_id` and `league_season_date` target scope types
+- `max_targets=1`
+- no bulk scope
+- no network access
+- no browser runtime
+- no proxy runtime
+- no staging write
+- no source manifest write
+- no packet write
+- no DB read or write dependency
+- stdout-only JSON preflight
+- `--commit` is blocked and exits non-zero
+- all `yes` CLI authorization flags remain no-op and do not authorize execution
+
+## 4. Dependency Injection
+
+The scaffold exposes `createFotMobSingleTargetAdapter({ networkClient, parser, clock, logger })`.
+
+- The network client is injected.
+- The default network client is disabled and throws if `fetch()` is called.
+- The parser is a stubbed no-op preview parser.
+- The logger is a no-op console-safe dependency by default.
+- The adapter does not import FotMob legacy runtime.
+- The adapter does not import browser, proxy, Redis, or DB clients.
+
+`dryRunFetchSingleTarget()` remains disabled in Phase 4.97F. A future phase must implement
+and authorize any real network behavior separately.
+
+## 5. Guardrails
+
+The preflight summary keeps these flags false:
+
+- `would_access_network=false`
+- `would_launch_browser=false`
+- `would_use_proxy=false`
+- `would_execute_legacy_runtime=false`
+- `would_execute_engine=false`
+- `would_write_staging=false`
+- `would_create_staging_directory=false`
+- `would_write_source_manifest=false`
+- `would_write_packet_file=false`
+- `would_write_db=false`
+- `would_train=false`
+- `would_predict=false`
+- `would_spawn_child_process=false`
+
+The commit gate remains `blocked`.
+
+## 6. Validation
+
+Required validation for this phase:
+
+- new unit tests
+- `npm test`
+- `npm run test:coverage`
+- `npm run test:integration`
+- ESLint
+- Prettier
+- `git diff --check`
+- DB row counts unchanged
+- `l1-config-*` residue absent
+- `docs/_staging_preview` absent
+
+The expected DB counts remain:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 7. Recommended Next Phase
+
+Recommended next phase: Phase 4.98F, FotMob adapter preflight hardening.
+
+Phase 4.98F should:
+
+- not access the network
+- not write DB
+- not write staging
+- add source manifest candidate preview
+- add parser confidence stub
+- add stricter policy validation
+- continue to avoid any network dry-run execution
+
+## 8. Explicit Non-Execution
+
+Phase 4.97F did not execute:
+
+- external FotMob access
+- external football data access
+- external odds data access
+- curl / wget
+- browser automation
+- proxy runtime
+- scraping
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- staging write
+- source manifest write
+- packet write
+- DB writes
+- pg_dump / pg_restore
+- training
+- prediction
+- file deletion
+- legacy FotMob runtime execution

--- a/scripts/ops/fotmob_single_target_adapter_scaffold.js
+++ b/scripts/ops/fotmob_single_target_adapter_scaffold.js
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.97F: FotMob trusted single-target adapter scaffold.
+ *
+ * This command is preflight-only. It does not access the network, launch browser
+ * or proxy runtime, execute legacy FotMob runtime, write staging, write DB,
+ * spawn child processes, train, or predict.
+ */
+
+'use strict';
+
+const PHASE = 'PHASE4_97F_FOTMOB_TRUSTED_SINGLE_TARGET_ADAPTER_SCAFFOLD';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: FotMob trusted single-target adapter scaffold is not executable in Phase 4.97F.';
+
+const ALLOWED_SCOPE_TYPES = ['match_id', 'league_season_date'];
+const BOOLEAN_FIELDS = [
+    'terms_approval',
+    'network_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'allow_db_write',
+    'allow_training',
+    'allow_prediction',
+    'final_human_confirmation',
+];
+
+const TRUE_VALUES = new Set(['yes', 'true']);
+const FALSE_VALUES = new Set(['no', 'false']);
+
+function assignArgValue(args, key, value) {
+    if (args[key] === undefined) {
+        args[key] = value;
+    } else if (Array.isArray(args[key])) {
+        args[key].push(value);
+    } else {
+        args[key] = [args[key], value];
+    }
+}
+
+function parseArgs(argv) {
+    const args = {};
+    const positional = [];
+
+    for (let i = 0; i < argv.length; i++) {
+        const current = argv[i];
+        if (current === '--commit') {
+            args.commit = true;
+        } else if (current.startsWith('--')) {
+            const eq = current.indexOf('=');
+            if (eq !== -1) {
+                assignArgValue(args, current.slice(2, eq).replace(/-/g, '_'), current.slice(eq + 1));
+            } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+                assignArgValue(args, current.slice(2).replace(/-/g, '_'), argv[i + 1]);
+                i++;
+            } else {
+                assignArgValue(args, current.slice(2).replace(/-/g, '_'), 'true');
+            }
+        } else {
+            positional.push(current);
+        }
+    }
+
+    if (positional.length > 0) {
+        args.positional = positional;
+    }
+
+    return args;
+}
+
+function singleValue(params, field) {
+    const value = params[field];
+    if (Array.isArray(value)) {
+        return value.length === 1 ? value[0] : value;
+    }
+    return value;
+}
+
+function normalizeBooleanFlag(value) {
+    if (Array.isArray(value)) {
+        return undefined;
+    }
+    if (value === undefined || value === null || value === '') {
+        return undefined;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    if (TRUE_VALUES.has(normalized)) {
+        return true;
+    }
+    if (FALSE_VALUES.has(normalized)) {
+        return false;
+    }
+    return undefined;
+}
+
+function hasMultipleTargets(params) {
+    const matchId = params.target_match_id;
+    if (Array.isArray(matchId) && matchId.length !== 1) {
+        return true;
+    }
+    if (typeof matchId === 'string' && matchId.includes(',')) {
+        return true;
+    }
+    if (params.target_match_ids !== undefined || params.target_ids !== undefined || params.targets !== undefined) {
+        return true;
+    }
+    return false;
+}
+
+function normalizeInput(params) {
+    return {
+        target_source: singleValue(params, 'target_source'),
+        target_scope_type: singleValue(params, 'target_scope_type'),
+        target_match_id: singleValue(params, 'target_match_id'),
+        target_league: singleValue(params, 'target_league'),
+        target_season: singleValue(params, 'target_season'),
+        target_date: singleValue(params, 'target_date'),
+        target_count: 1,
+        bulk_scope_allowed: false,
+        max_targets: 1,
+        ignored_yes_flags: [],
+    };
+}
+
+function validateCommitFlag(params, errors) {
+    if (params.commit) {
+        errors.push(BLOCKED_COMMIT_MESSAGE);
+    }
+}
+
+function validateSource(normalized, errors) {
+    if (normalized.target_source !== 'fotmob') {
+        errors.push('ERROR: --target-source must be "fotmob".');
+    }
+}
+
+function validateScopeType(normalized, errors) {
+    if (!normalized.target_scope_type) {
+        errors.push('ERROR: --target-scope-type is required. Allowed: match_id, league_season_date.');
+    } else if (!ALLOWED_SCOPE_TYPES.includes(normalized.target_scope_type)) {
+        errors.push(
+            `ERROR: unsupported --target-scope-type "${normalized.target_scope_type}". Allowed: match_id, league_season_date.`
+        );
+    }
+}
+
+function validateScopeFields(params, normalized, errors) {
+    if (hasMultipleTargets(params)) {
+        errors.push('ERROR: FotMob adapter scaffold is single-target only; provide exactly one target-match-id.');
+    }
+
+    if (normalized.target_scope_type === 'match_id' && !normalized.target_match_id) {
+        errors.push('ERROR: --target-match-id is required when --target-scope-type=match_id.');
+    }
+
+    if (normalized.target_scope_type === 'league_season_date') {
+        if (!normalized.target_league) {
+            errors.push('ERROR: --target-league is required when --target-scope-type=league_season_date.');
+        }
+        if (!normalized.target_season) {
+            errors.push('ERROR: --target-season is required when --target-scope-type=league_season_date.');
+        }
+        if (!normalized.target_date) {
+            errors.push('ERROR: --target-date is required when --target-scope-type=league_season_date.');
+        }
+    }
+}
+
+function validateTargetLimits(params, errors) {
+    const targetCount = singleValue(params, 'target_count');
+    if (targetCount !== undefined) {
+        const parsedCount = Number(targetCount);
+        if (!Number.isFinite(parsedCount) || parsedCount !== 1) {
+            errors.push('ERROR: --target-count must be 1.');
+        }
+    }
+
+    const maxTargets = singleValue(params, 'max_targets');
+    if (maxTargets !== undefined) {
+        const parsedMax = Number(maxTargets);
+        if (!Number.isFinite(parsedMax) || parsedMax !== 1) {
+            errors.push('ERROR: --max-targets must be 1.');
+        }
+    }
+
+    const bulkScopeAllowed = normalizeBooleanFlag(singleValue(params, 'bulk_scope_allowed'));
+    if (params.bulk_scope_allowed !== undefined && bulkScopeAllowed === undefined) {
+        errors.push('ERROR: --bulk-scope-allowed must be yes/no or true/false.');
+    } else if (bulkScopeAllowed === true) {
+        errors.push('ERROR: --bulk-scope-allowed must remain false.');
+    }
+}
+
+function validateBooleanFields(params, normalized, errors) {
+    for (const field of BOOLEAN_FIELDS) {
+        const value = singleValue(params, field);
+        const parsed = normalizeBooleanFlag(value);
+        if (value === undefined || value === '') {
+            errors.push(`ERROR: --${field.replace(/_/g, '-')} is required (no/false in Phase 4.97F).`);
+        } else if (parsed === undefined) {
+            errors.push(`ERROR: --${field.replace(/_/g, '-')} must be yes/no or true/false.`);
+        } else if (parsed === true) {
+            normalized.ignored_yes_flags.push(field);
+        }
+        normalized[field] = false;
+    }
+}
+
+function validateSingleTargetInput(params) {
+    const errors = [];
+    const normalized = normalizeInput(params);
+
+    validateCommitFlag(params, errors);
+    validateSource(normalized, errors);
+    validateScopeType(normalized, errors);
+    validateScopeFields(params, normalized, errors);
+    validateTargetLimits(params, errors);
+    validateBooleanFields(params, normalized, errors);
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        normalized,
+    };
+}
+
+function buildPreflightSummary(params) {
+    const validation = validateSingleTargetInput(params);
+    if (!validation.valid) {
+        const error = new Error(validation.errors.join('\n'));
+        error.errors = validation.errors;
+        throw error;
+    }
+
+    const input = validation.normalized;
+    return {
+        phase: PHASE,
+        adapter_scaffold_only: true,
+        target_source: 'fotmob',
+        target_scope_type: input.target_scope_type,
+        target_match_id: input.target_scope_type === 'match_id' ? input.target_match_id : null,
+        target_league: input.target_scope_type === 'league_season_date' ? input.target_league : null,
+        target_season: input.target_scope_type === 'league_season_date' ? input.target_season : null,
+        target_date: input.target_scope_type === 'league_season_date' ? input.target_date : null,
+        target_count: 1,
+        single_target: true,
+        bulk_scope_allowed: false,
+        max_targets: 1,
+        terms_approval: false,
+        network_authorization: false,
+        browser_runtime_allowed: false,
+        proxy_runtime_allowed: false,
+        external_network_allowed: false,
+        staging_write_allowed: false,
+        db_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        final_human_confirmation: false,
+        trusted_adapter_ready: false,
+        network_dry_run_ready: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_legacy_runtime: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        ignored_yes_flags: input.ignored_yes_flags,
+        next_required_phase:
+            'Phase 4.98F FotMob adapter preflight hardening or explicit user-supplied real target authorization',
+    };
+}
+
+function createDisabledNetworkClient() {
+    return {
+        fetch() {
+            throw new Error('Network access is disabled in Phase 4.97F.');
+        },
+    };
+}
+
+function createNoopParser() {
+    return {
+        parsePreview() {
+            return {
+                parser_stub_only: true,
+                parsed_remote_response: false,
+            };
+        },
+    };
+}
+
+function createNoopLogger() {
+    return {
+        debug() {},
+        info() {},
+        warn() {},
+        error() {},
+    };
+}
+
+function createFotMobSingleTargetAdapter(dependencies = {}) {
+    const networkClient = dependencies.networkClient || createDisabledNetworkClient();
+    const parser = dependencies.parser || createNoopParser();
+    const clock = dependencies.clock || (() => new Date().toISOString());
+    const logger = dependencies.logger || createNoopLogger();
+
+    return {
+        dependencies: {
+            networkClient,
+            parser,
+            clock,
+            logger,
+        },
+        validateInputs: validateSingleTargetInput,
+        preflight(input) {
+            logger.debug('FotMob adapter scaffold preflight only; no network, DB, staging, browser, or proxy.');
+            return buildPreflightSummary(input);
+        },
+        dryRunFetchSingleTarget() {
+            throw new Error('Network dry-run execution is disabled in Phase 4.97F.');
+        },
+        parsePreview(payload) {
+            return parser.parsePreview(payload);
+        },
+        summarizeToStdout(input) {
+            return `${JSON.stringify(this.preflight(input), null, 2)}\n`;
+        },
+    };
+}
+
+function runCli(argv = process.argv.slice(2), io = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+    const args = parseArgs(argv);
+
+    if (args.commit) {
+        stderr(`${BLOCKED_COMMIT_MESSAGE}\n`);
+        return 1;
+    }
+
+    try {
+        const adapter = createFotMobSingleTargetAdapter();
+        stdout(adapter.summarizeToStdout(args));
+        return 0;
+    } catch (error) {
+        stderr(`${error.message}\n`);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = runCli();
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validateSingleTargetInput,
+    createFotMobSingleTargetAdapter,
+    buildPreflightSummary,
+    runCli,
+    PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+};

--- a/tests/unit/fotmob_single_target_adapter_scaffold.test.js
+++ b/tests/unit/fotmob_single_target_adapter_scaffold.test.js
@@ -1,0 +1,417 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fotmob_single_target_adapter_scaffold.js');
+const LEGACY_PATHS = [
+    path.join(PROJECT_ROOT, 'scripts/ops/titan_discovery.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/run_production.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/batch_historical_backfill.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/backfill_historical_raw_match_data.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/titan_seeder.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/ProductionHarvester.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/strategies/FotMobStrategy.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/services/FixtureRepository.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/components/Persistence.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/services/BrowserProvider.js'),
+];
+
+const BOOLEAN_FIELDS = [
+    'terms_approval',
+    'network_authorization',
+    'allow_browser_runtime',
+    'allow_proxy_runtime',
+    'allow_external_network',
+    'allow_staging_write',
+    'allow_db_write',
+    'allow_training',
+    'allow_prediction',
+    'final_human_confirmation',
+];
+
+const WOULD_FALSE_FIELDS = [
+    'would_access_network',
+    'would_launch_browser',
+    'would_use_proxy',
+    'would_execute_legacy_runtime',
+    'would_execute_engine',
+    'would_write_staging',
+    'would_create_staging_directory',
+    'would_write_source_manifest',
+    'would_write_packet_file',
+    'would_write_db',
+    'would_train',
+    'would_predict',
+    'would_spawn_child_process',
+];
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalConnect = net.connect;
+    const originalCreateConnection = net.createConnection;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by fotmob_single_target_adapter_scaffold`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    net.connect = fail('net.connect');
+    net.createConnection = fail('net.createConnection');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+            'chromium',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'net',
+            'node:net',
+            'child_process',
+            'node:child_process',
+        ]);
+        const blockedFragments = [
+            'titan_discovery',
+            'run_production',
+            'batch_historical_backfill',
+            'backfill_historical_raw_match_data',
+            'titan_seeder',
+            'ProductionHarvester',
+            'FotMobStrategy',
+            'FixtureRepository',
+            'Persistence',
+            'BrowserProvider',
+            'ProxyProvider',
+        ];
+
+        if (blockedImports.has(request) || blockedFragments.some(fragment => String(request).includes(fragment))) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        net.connect = originalConnect;
+        net.createConnection = originalCreateConnection;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+function loadFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function baseInput(overrides = {}) {
+    return {
+        target_source: 'fotmob',
+        target_scope_type: 'match_id',
+        target_match_id: 'sample-match-001',
+        terms_approval: 'no',
+        network_authorization: 'no',
+        allow_browser_runtime: 'no',
+        allow_proxy_runtime: 'no',
+        allow_external_network: 'no',
+        allow_staging_write: 'no',
+        allow_db_write: 'no',
+        allow_training: 'no',
+        allow_prediction: 'no',
+        final_human_confirmation: 'no',
+        ...overrides,
+    };
+}
+
+function cliArgs(input) {
+    const args = [];
+    for (const [key, value] of Object.entries(input)) {
+        if (key === 'commit' && value) {
+            args.push('--commit');
+        } else if (Array.isArray(value)) {
+            for (const item of value) {
+                args.push(`--${key.replace(/_/g, '-')}=${item}`);
+            }
+        } else {
+            args.push(`--${key.replace(/_/g, '-')}=${value}`);
+        }
+    }
+    return args;
+}
+
+function runCli(gate, input) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.runCli(cliArgs(input), {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+    return {
+        status,
+        stdout,
+        stderr,
+        payload: stdout ? JSON.parse(stdout) : null,
+    };
+}
+
+function assertSafePayload(payload) {
+    assert.equal(payload.adapter_scaffold_only, true);
+    assert.equal(payload.target_source, 'fotmob');
+    assert.equal(payload.target_count, 1);
+    assert.equal(payload.single_target, true);
+    assert.equal(payload.bulk_scope_allowed, false);
+    assert.equal(payload.max_targets, 1);
+    assert.equal(payload.trusted_adapter_ready, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.commit_gate, 'blocked');
+
+    for (const field of WOULD_FALSE_FIELDS) {
+        assert.equal(payload[field], false, `${field} must remain false`);
+    }
+}
+
+test('valid match_id preflight succeeds and returns stdout-only safety JSON', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runCli(gate, baseInput());
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stderr, '');
+    assert.equal(result.payload.phase, gate.PHASE);
+    assert.equal(result.payload.target_scope_type, 'match_id');
+    assert.equal(result.payload.target_match_id, 'sample-match-001');
+    assertSafePayload(result.payload);
+});
+
+test('valid league_season_date preflight succeeds', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runCli(
+        gate,
+        baseInput({
+            target_scope_type: 'league_season_date',
+            target_match_id: undefined,
+            target_league: 'premier-league',
+            target_season: '2025-2026',
+            target_date: '2026-05-11',
+        })
+    );
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.target_scope_type, 'league_season_date');
+    assert.equal(result.payload.target_league, 'premier-league');
+    assert.equal(result.payload.target_season, '2025-2026');
+    assert.equal(result.payload.target_date, '2026-05-11');
+    assertSafePayload(result.payload);
+});
+
+test('target-source must be fotmob', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const validation = gate.validateSingleTargetInput(baseInput({ target_source: 'other' }));
+
+    assert.equal(validation.valid, false);
+    assert.match(validation.errors.join('\n'), /target-source must be "fotmob"/);
+});
+
+test('target-scope-type is required and must be supported', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const missing = gate.validateSingleTargetInput(baseInput({ target_scope_type: undefined }));
+    const unsupported = gate.validateSingleTargetInput(baseInput({ target_scope_type: 'bulk' }));
+
+    assert.equal(missing.valid, false);
+    assert.match(missing.errors.join('\n'), /target-scope-type is required/);
+    assert.equal(unsupported.valid, false);
+    assert.match(unsupported.errors.join('\n'), /unsupported --target-scope-type "bulk"/);
+});
+
+test('match_id scope requires exactly one target-match-id', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const missing = gate.validateSingleTargetInput(baseInput({ target_match_id: undefined }));
+    const duplicate = gate.validateSingleTargetInput(baseInput({ target_match_id: ['a', 'b'] }));
+    const commaSeparated = gate.validateSingleTargetInput(baseInput({ target_match_id: 'a,b' }));
+
+    assert.equal(missing.valid, false);
+    assert.match(missing.errors.join('\n'), /target-match-id is required/);
+    assert.equal(duplicate.valid, false);
+    assert.match(duplicate.errors.join('\n'), /single-target only/);
+    assert.equal(commaSeparated.valid, false);
+    assert.match(commaSeparated.errors.join('\n'), /single-target only/);
+});
+
+test('league_season_date requires league, season, and date', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const base = {
+        target_scope_type: 'league_season_date',
+        target_match_id: undefined,
+        target_league: 'premier-league',
+        target_season: '2025-2026',
+        target_date: '2026-05-11',
+    };
+    const missingLeague = gate.validateSingleTargetInput(baseInput({ ...base, target_league: undefined }));
+    const missingSeason = gate.validateSingleTargetInput(baseInput({ ...base, target_season: undefined }));
+    const missingDate = gate.validateSingleTargetInput(baseInput({ ...base, target_date: undefined }));
+
+    assert.equal(missingLeague.valid, false);
+    assert.match(missingLeague.errors.join('\n'), /target-league is required/);
+    assert.equal(missingSeason.valid, false);
+    assert.match(missingSeason.errors.join('\n'), /target-season is required/);
+    assert.equal(missingDate.valid, false);
+    assert.match(missingDate.errors.join('\n'), /target-date is required/);
+});
+
+test('bulk scope and max_targets greater than one fail closed', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const targetCount = gate.validateSingleTargetInput(baseInput({ target_count: '2' }));
+    const bulkScope = gate.validateSingleTargetInput(baseInput({ bulk_scope_allowed: 'yes' }));
+    const maxTargets = gate.validateSingleTargetInput(baseInput({ max_targets: '2' }));
+
+    assert.equal(targetCount.valid, false);
+    assert.match(targetCount.errors.join('\n'), /target-count must be 1/);
+    assert.equal(bulkScope.valid, false);
+    assert.match(bulkScope.errors.join('\n'), /bulk-scope-allowed must remain false/);
+    assert.equal(maxTargets.valid, false);
+    assert.match(maxTargets.errors.join('\n'), /max-targets must be 1/);
+});
+
+test('yes authorization flags are accepted as input but ignored by Phase 4.97F policy', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+
+    for (const field of BOOLEAN_FIELDS) {
+        const payload = gate.buildPreflightSummary(baseInput({ [field]: 'yes' }));
+        assertSafePayload(payload);
+        assert.equal(payload.ignored_yes_flags.includes(field), true);
+        assert.equal(payload.network_dry_run_ready, false);
+    }
+});
+
+test('all-yes CLI remains blocked no-op and does not authorize execution', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const allYes = {};
+    for (const field of BOOLEAN_FIELDS) {
+        allYes[field] = 'yes';
+    }
+    const result = runCli(gate, baseInput(allYes));
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.adapter_scaffold_only, true);
+    assert.equal(result.payload.ignored_yes_flags.length, BOOLEAN_FIELDS.length);
+    assertSafePayload(result.payload);
+});
+
+test('--commit is blocked and exits non-zero', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    let stdout = '';
+    let stderr = '';
+    const status = gate.runCli(['--commit'], {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+
+    assert.equal(status, 1);
+    assert.equal(stdout, '');
+    assert.match(stderr, /BLOCKED: FotMob trusted single-target adapter scaffold is not executable/);
+});
+
+test('default networkClient.fetch and dryRunFetchSingleTarget are disabled', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const adapter = gate.createFotMobSingleTargetAdapter();
+
+    assert.throws(
+        () => adapter.dependencies.networkClient.fetch('https://example.invalid'),
+        /Network access is disabled/
+    );
+    assert.throws(() => adapter.dryRunFetchSingleTarget(), /Network dry-run execution is disabled/);
+    assert.deepEqual(adapter.parsePreview({}), {
+        parser_stub_only: true,
+        parsed_remote_response: false,
+    });
+});
+
+test('adapter import and preflight do not import or execute legacy runtime, browser, proxy, DB, files, or child process paths', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runCli(gate, baseInput());
+
+    assert.equal(result.status, 0);
+    assertSafePayload(result.payload);
+    for (const legacyPath of LEGACY_PATHS) {
+        assert.equal(require.cache[legacyPath], undefined, `${legacyPath} must not be loaded`);
+    }
+});
+
+test('parseArgs supports equals and space forms while preserving duplicate target detection', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const parsed = gate.parseArgs([
+        '--target-source=fotmob',
+        '--target-scope-type',
+        'match_id',
+        '--target-match-id=a',
+        '--target-match-id=b',
+    ]);
+
+    assert.equal(parsed.target_source, 'fotmob');
+    assert.equal(parsed.target_scope_type, 'match_id');
+    assert.deepEqual(parsed.target_match_id, ['a', 'b']);
+    assert.equal(gate.validateSingleTargetInput(baseInput(parsed)).valid, false);
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.97F FotMob trusted single-target adapter scaffold.

Scope:
- Adds no-network FotMob single-target adapter scaffold
- Adds strict single-target input validation
- Adds dependency injection shape with disabled default network client
- Adds stdout-only preflight summary
- Adds blocked commit target
- Adds no-side-effect unit tests
- Updates AGENTS.md and Makefile
- Adds Phase 4.97F report

Safety:
- No external FotMob access
- No external football or odds data access
- No curl / wget
- No browser automation in the FotMob adapter path
- No proxy runtime execution
- No legacy FotMob runtime execution
- No scraping
- No harvest / ingest
- No network dry-run execution
- No staging writes
- No source manifest writes
- No packet writes
- No DB writes
- No pg_dump / pg_restore
- No training
- No prediction execution

Validation:
- FotMob adapter scaffold unit tests passed
- preflight passed
- all-yes preflight remained blocked / no-op
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- npm run test:integration passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed