### PR TITLE
feat(data): harden FotMob adapter preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1038,6 +1038,15 @@ Phase 4.97F FotMob trusted single-target adapter scaffold rules：
 - CLI `yes` flags must not override Phase 4.97F blocked behavior.
 - Future FotMob network dry-run requires explicit user target, terms, allowed-use, and network authorization in a separate phase.
 
+Phase 4.98F FotMob adapter preflight hardening rules：
+
+- FotMob adapter preflight may generate source manifest candidate preview only to stdout.
+- It must not write source manifest files.
+- Parser confidence in Phase 4.98F is stub-only and must not parse real network responses.
+- Response schema preview in Phase 4.98F is stub-only and must not validate real remote payloads.
+- All `yes` flags remain blocked until an explicit future authorization phase.
+- Network dry-run remains prohibited in Phase 4.98F.
+
 Phase 4.57C football-data adapter rules：
 
 - `fetch_and_adapt_euro_leagues` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
-	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # scaffold-only, Phase 4.97F"
+	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-real-source-audit SOURCE_MANIFEST=<path>"
 	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
@@ -395,7 +395,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-authorization-handoff-checklist-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST=1  # blocked in Phase 4.94D"
 	@echo "  make data-single-target-acquisition-network-authorization-decision-preview AUTHORIZATION_DECISION=<path> HANDOFF_CHECKLIST=<path> REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # authorization decision preview, Phase 4.95D"
 	@echo "  make data-single-target-acquisition-network-authorization-decision-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION=1  # blocked in Phase 4.95D"
-	@echo "  make data-fotmob-single-target-adapter-commit TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1  # blocked in Phase 4.97F"
+	@echo "  make data-fotmob-single-target-adapter-commit TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1  # blocked in Phase 4.98F"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -891,7 +891,7 @@ data-acquisition-engines: ## List acquisition engine registry entries. No networ
 data-acquisition-engine-audit: ## Audit acquisition engine registry. No network, no DB writes.
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/acquisition_engine_gate.js --audit
 
-data-fotmob-single-target-adapter-preflight: ## No-network FotMob trusted single-target adapter scaffold preflight. Phase 4.97F.
+data-fotmob-single-target-adapter-preflight: ## Hardened no-network FotMob adapter preflight. Phase 4.98F.
 	@$(FOTMOB_SINGLE_TARGET_ADAPTER_NODE) scripts/ops/fotmob_single_target_adapter_scaffold.js \
 		--target-source "$(TARGET_SOURCE)" \
 		--target-scope-type "$(TARGET_SCOPE_TYPE)" \
@@ -911,10 +911,20 @@ data-fotmob-single-target-adapter-preflight: ## No-network FotMob trusted single
 		--allow-db-write "$(or $(ALLOW_DB_WRITE),no)" \
 		--allow-training "$(or $(ALLOW_TRAINING),no)" \
 		--allow-prediction "$(or $(ALLOW_PREDICTION),no)" \
-		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+		--final-human-confirmation "$(or $(FINAL_HUMAN_CONFIRMATION),no)" \
+		$(if $(SOURCE_HOMEPAGE_URL),--source-homepage-url "$(SOURCE_HOMEPAGE_URL)") \
+		$(if $(TERMS_URL),--terms-url "$(TERMS_URL)") \
+		$(if $(LICENSE_URL),--license-url "$(LICENSE_URL)") \
+		$(if $(ALLOWED_USE_SUMMARY),--allowed-use-summary "$(ALLOWED_USE_SUMMARY)") \
+		$(if $(RATE_LIMIT_POLICY),--rate-limit-policy "$(RATE_LIMIT_POLICY)") \
+		$(if $(RETRY_POLICY),--retry-policy "$(RETRY_POLICY)") \
+		$(if $(USER_AGENT_POLICY),--user-agent-policy "$(USER_AGENT_POLICY)") \
+		$(if $(OUTPUT_ROOT),--output-root "$(OUTPUT_ROOT)") \
+		$(if $(EXPECTED_RESPONSE_KIND),--expected-response-kind "$(EXPECTED_RESPONSE_KIND)") \
+		$(if $(PARSER_CONFIDENCE_THRESHOLD),--parser-confidence-threshold "$(PARSER_CONFIDENCE_THRESHOLD)")
 
-data-fotmob-single-target-adapter-commit: ## Blocked FotMob trusted single-target adapter execution gate. Remains blocked in Phase 4.97F.
-	@echo "BLOCKED: FotMob trusted single-target adapter scaffold is not executable in Phase 4.97F."
+data-fotmob-single-target-adapter-commit: ## Blocked FotMob trusted single-target adapter execution gate. Remains blocked in Phase 4.98F.
+	@echo "BLOCKED: FotMob adapter preflight hardening is not executable in Phase 4.98F."
 	@echo "  Even with CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1, this path remains blocked."
 	@echo "  Future FotMob network dry-run requires separate user target, terms, allowed-use, and network authorization."
 	@exit 1

--- a/docs/_reports/FOTMOB_ADAPTER_PREFLIGHT_HARDENING_PHASE4_98F.md
+++ b/docs/_reports/FOTMOB_ADAPTER_PREFLIGHT_HARDENING_PHASE4_98F.md
@@ -1,0 +1,116 @@
+# FotMob Adapter Preflight Hardening
+
+Phase: 4.98F
+Status: hardened preflight, no-network, no-write
+Starting HEAD: `bf2e0ccc04d78d6121799f55e58433521f8c058e`
+
+## 1. Executive Summary
+
+Phase 4.98F hardens the FotMob trusted single-target adapter preflight.
+
+This phase does not access FotMob, collect data, write DB rows, or write staging
+artifacts. It adds stdout-only source manifest candidate preview, parser confidence stub,
+response schema stub, stop gates, and readiness summary while keeping all execution paths
+blocked.
+
+## 2. Implemented Files
+
+- `scripts/ops/fotmob_single_target_adapter_scaffold.js`
+- `tests/unit/fotmob_single_target_adapter_scaffold.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/FOTMOB_ADAPTER_PREFLIGHT_HARDENING_PHASE4_98F.md`
+
+## 3. Hardened Preflight Outputs
+
+The preflight JSON now includes:
+
+- `source_manifest_candidate_preview`: source, target identifier, provenance input
+  presence flags, preview-only status, and `would_write_source_manifest=false`.
+- `parser_confidence_stub`: parser readiness and confidence placeholders with no real
+  response parsing.
+- `response_preview_schema_stub`: expected response kind and schema readiness placeholders
+  with no real payload validation.
+- `stop_gates`: active blockers for terms, authorization, browser/proxy/network,
+  staging, DB, parser readiness, manifest approval, and future phase requirements.
+- `readiness_summary`: separates scaffold readiness from network dry-run readiness,
+  authorization, and execution allowance.
+
+## 4. Safety Boundaries
+
+- Source manifest candidate preview is stdout-only.
+- Parser confidence is stub-only.
+- Response schema validation is stub-only.
+- No real response is available or parsed.
+- No network access is performed.
+- No browser runtime is launched.
+- No proxy runtime is used.
+- No staging directory or artifact is written.
+- No source manifest file is written.
+- No packet file is written.
+- No DB dependency is used.
+- No legacy FotMob runtime is imported or executed.
+
+## 5. Validation
+
+Validation completed for this phase:
+
+- `node --test tests/unit/fotmob_single_target_adapter_scaffold.test.js` passed.
+- Valid Makefile preflight passed and emitted stdout-only JSON.
+- All-yes preflight passed and remained blocked / no-op.
+- Commit target returned the expected blocked non-zero result.
+- `npm test` passed.
+- `npm run test:coverage` passed.
+- `npm run test:integration` was not run locally because the integration suite includes
+  real `chromium.launch` paths, and Phase 4.98F prohibits browser automation.
+- ESLint / Prettier / `git diff --check` passed.
+- DB row counts remained unchanged.
+- `l1-config-*` residue was absent.
+- `docs/_staging_preview` was absent.
+
+Expected DB counts remain:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 6. Recommended Next Phase
+
+Recommended next phase: Phase 4.99F, FotMob stdout-only network dry-run authorization
+packet.
+
+Phase 4.99F should:
+
+- still not directly access the network
+- only generate the authorization packet required before a real network dry-run
+- require user-provided real target, terms, allowed-use, and network authorization
+- not write DB
+- not write staging by default
+
+## 7. Explicit Non-Execution
+
+Phase 4.98F did not execute:
+
+- external FotMob access
+- external football data access
+- external odds data access
+- curl / wget
+- browser automation
+- proxy runtime
+- scraping
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- staging write
+- source manifest write
+- packet write
+- DB writes
+- pg_dump / pg_restore
+- training
+- prediction
+- file deletion
+- legacy FotMob runtime execution

--- a/scripts/ops/fotmob_single_target_adapter_scaffold.js
+++ b/scripts/ops/fotmob_single_target_adapter_scaffold.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Phase 4.97F: FotMob trusted single-target adapter scaffold.
+ * Phase 4.98F: FotMob trusted single-target adapter preflight hardening.
  *
  * This command is preflight-only. It does not access the network, launch browser
  * or proxy runtime, execute legacy FotMob runtime, write staging, write DB,
@@ -9,9 +9,9 @@
 
 'use strict';
 
-const PHASE = 'PHASE4_97F_FOTMOB_TRUSTED_SINGLE_TARGET_ADAPTER_SCAFFOLD';
-const BLOCKED_COMMIT_MESSAGE =
-    'BLOCKED: FotMob trusted single-target adapter scaffold is not executable in Phase 4.97F.';
+const PHASE = 'PHASE4_98F_FOTMOB_ADAPTER_PREFLIGHT_HARDENING';
+const DEFAULT_PARSER_CONFIDENCE_THRESHOLD = 0.8;
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: FotMob adapter preflight hardening is not executable in Phase 4.98F.';
 
 const ALLOWED_SCOPE_TYPES = ['match_id', 'league_season_date'];
 const BOOLEAN_FIELDS = [
@@ -29,6 +29,19 @@ const BOOLEAN_FIELDS = [
 
 const TRUE_VALUES = new Set(['yes', 'true']);
 const FALSE_VALUES = new Set(['no', 'false']);
+
+const OPTIONAL_POLICY_FIELDS = [
+    'source_homepage_url',
+    'terms_url',
+    'license_url',
+    'allowed_use_summary',
+    'rate_limit_policy',
+    'retry_policy',
+    'user_agent_policy',
+    'output_root',
+    'expected_response_kind',
+    'parser_confidence_threshold',
+];
 
 function assignArgValue(args, key, value) {
     if (args[key] === undefined) {
@@ -110,7 +123,7 @@ function hasMultipleTargets(params) {
 }
 
 function normalizeInput(params) {
-    return {
+    const normalized = {
         target_source: singleValue(params, 'target_source'),
         target_scope_type: singleValue(params, 'target_scope_type'),
         target_match_id: singleValue(params, 'target_match_id'),
@@ -122,6 +135,18 @@ function normalizeInput(params) {
         max_targets: 1,
         ignored_yes_flags: [],
     };
+
+    for (const field of OPTIONAL_POLICY_FIELDS) {
+        normalized[field] = singleValue(params, field);
+    }
+
+    normalized.expected_response_kind = normalized.expected_response_kind || 'unknown';
+    normalized.parser_confidence_threshold =
+        normalized.parser_confidence_threshold === undefined
+            ? DEFAULT_PARSER_CONFIDENCE_THRESHOLD
+            : Number(normalized.parser_confidence_threshold);
+
+    return normalized;
 }
 
 function validateCommitFlag(params, errors) {
@@ -198,13 +223,23 @@ function validateBooleanFields(params, normalized, errors) {
         const value = singleValue(params, field);
         const parsed = normalizeBooleanFlag(value);
         if (value === undefined || value === '') {
-            errors.push(`ERROR: --${field.replace(/_/g, '-')} is required (no/false in Phase 4.97F).`);
+            errors.push(`ERROR: --${field.replace(/_/g, '-')} is required (no/false in Phase 4.98F).`);
         } else if (parsed === undefined) {
             errors.push(`ERROR: --${field.replace(/_/g, '-')} must be yes/no or true/false.`);
         } else if (parsed === true) {
             normalized.ignored_yes_flags.push(field);
         }
         normalized[field] = false;
+    }
+}
+
+function validatePolicyFlags(normalized, errors) {
+    if (
+        !Number.isFinite(normalized.parser_confidence_threshold) ||
+        normalized.parser_confidence_threshold < 0 ||
+        normalized.parser_confidence_threshold > 1
+    ) {
+        errors.push('ERROR: --parser-confidence-threshold must be a number between 0 and 1.');
     }
 }
 
@@ -218,11 +253,107 @@ function validateSingleTargetInput(params) {
     validateScopeFields(params, normalized, errors);
     validateTargetLimits(params, errors);
     validateBooleanFields(params, normalized, errors);
+    validatePolicyFlags(normalized, errors);
 
     return {
         valid: errors.length === 0,
         errors,
         normalized,
+    };
+}
+
+function hasProvided(value) {
+    return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
+function buildTargetIdentifier(input) {
+    if (input.target_scope_type === 'match_id') {
+        return input.target_match_id;
+    }
+    if (input.target_scope_type === 'league_season_date') {
+        return [input.target_league, input.target_season, input.target_date].join('|');
+    }
+    return null;
+}
+
+function buildSourceManifestCandidatePreview(input) {
+    return {
+        source: 'fotmob',
+        target_scope_type: input.target_scope_type,
+        target_identifier: buildTargetIdentifier(input),
+        source_homepage_url_provided: hasProvided(input.source_homepage_url),
+        terms_url_provided: hasProvided(input.terms_url),
+        license_url_provided: hasProvided(input.license_url),
+        allowed_use_summary_provided: hasProvided(input.allowed_use_summary),
+        network_authorization: false,
+        created_for_preview_only: true,
+        would_write_source_manifest: false,
+    };
+}
+
+function buildParserConfidenceStub(input) {
+    return {
+        parser_ready: false,
+        real_response_available: false,
+        parser_confidence: 0,
+        parser_confidence_threshold: input.parser_confidence_threshold,
+        parser_confidence_passed: false,
+        would_parse_real_response: false,
+    };
+}
+
+function buildResponsePreviewSchemaStub(input) {
+    return {
+        expected_response_kind: input.expected_response_kind || 'unknown',
+        schema_ready: false,
+        schema_validation_passed: false,
+        would_validate_real_response: false,
+    };
+}
+
+function stopGate(gate, reason) {
+    return {
+        gate,
+        blocked: true,
+        reason,
+    };
+}
+
+function buildStopGates(input) {
+    return [
+        stopGate('missing_terms_approval', 'terms approval is not granted in Phase 4.98F'),
+        stopGate('missing_network_authorization', 'network authorization is not granted in Phase 4.98F'),
+        stopGate('no_real_target_authorization', 'real target authorization must be reviewed in a later phase'),
+        stopGate('source_terms_not_verified', 'source terms and allowed-use evidence are not verified'),
+        stopGate('browser_runtime_not_authorized', 'browser runtime remains blocked by default'),
+        stopGate('proxy_runtime_not_authorized', 'proxy runtime remains blocked by default'),
+        stopGate('external_network_not_authorized', 'external network access remains blocked in Phase 4.98F'),
+        stopGate('staging_write_not_authorized', 'staging writes remain blocked in Phase 4.98F'),
+        stopGate('db_write_not_authorized', 'DB writes remain blocked in Phase 4.98F'),
+        stopGate('parser_not_ready', 'parser confidence is stub-only and no real response is available'),
+        stopGate('source_manifest_not_approved', 'source manifest candidate preview is not an approved manifest'),
+        stopGate('network_execution_blocked', 'network dry-run execution is blocked in Phase 4.98F'),
+        stopGate('future_phase_required', 'a later authorization phase is required before any execution'),
+        stopGate(
+            'allowed_use_summary_missing',
+            hasProvided(input.allowed_use_summary)
+                ? 'allowed-use summary is provided but not approved in Phase 4.98F'
+                : 'allowed-use summary is missing'
+        ),
+    ];
+}
+
+function buildReadinessSummary() {
+    return {
+        adapter_scaffold_ready: true,
+        preflight_hardened: true,
+        source_manifest_candidate_preview_ready: true,
+        parser_confidence_stub_ready: true,
+        network_dry_run_ready: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        next_required_phase:
+            'Phase 4.99F FotMob stdout-only network dry-run authorization packet or explicit user-supplied real target authorization',
     };
 }
 
@@ -238,6 +369,8 @@ function buildPreflightSummary(params) {
     return {
         phase: PHASE,
         adapter_scaffold_only: true,
+        adapter_scaffold_ready: true,
+        preflight_hardened: true,
         target_source: 'fotmob',
         target_scope_type: input.target_scope_type,
         target_match_id: input.target_scope_type === 'match_id' ? input.target_match_id : null,
@@ -248,6 +381,18 @@ function buildPreflightSummary(params) {
         single_target: true,
         bulk_scope_allowed: false,
         max_targets: 1,
+        policy_inputs: {
+            source_homepage_url_provided: hasProvided(input.source_homepage_url),
+            terms_url_provided: hasProvided(input.terms_url),
+            license_url_provided: hasProvided(input.license_url),
+            allowed_use_summary_provided: hasProvided(input.allowed_use_summary),
+            rate_limit_policy: input.rate_limit_policy || null,
+            retry_policy: input.retry_policy || null,
+            user_agent_policy: input.user_agent_policy || null,
+            output_root_provided: hasProvided(input.output_root),
+            expected_response_kind: input.expected_response_kind,
+            parser_confidence_threshold: input.parser_confidence_threshold,
+        },
         terms_approval: false,
         network_authorization: false,
         browser_runtime_allowed: false,
@@ -275,17 +420,22 @@ function buildPreflightSummary(params) {
         would_train: false,
         would_predict: false,
         would_spawn_child_process: false,
+        source_manifest_candidate_preview: buildSourceManifestCandidatePreview(input),
+        parser_confidence_stub: buildParserConfidenceStub(input),
+        response_preview_schema_stub: buildResponsePreviewSchemaStub(input),
+        stop_gates: buildStopGates(input),
+        readiness_summary: buildReadinessSummary(),
         commit_gate: 'blocked',
         ignored_yes_flags: input.ignored_yes_flags,
         next_required_phase:
-            'Phase 4.98F FotMob adapter preflight hardening or explicit user-supplied real target authorization',
+            'Phase 4.99F FotMob stdout-only network dry-run authorization packet or explicit user-supplied real target authorization',
     };
 }
 
 function createDisabledNetworkClient() {
     return {
         fetch() {
-            throw new Error('Network access is disabled in Phase 4.97F.');
+            throw new Error('Network access is disabled in Phase 4.98F.');
         },
     };
 }
@@ -329,7 +479,7 @@ function createFotMobSingleTargetAdapter(dependencies = {}) {
             return buildPreflightSummary(input);
         },
         dryRunFetchSingleTarget() {
-            throw new Error('Network dry-run execution is disabled in Phase 4.97F.');
+            throw new Error('Network dry-run execution is disabled in Phase 4.98F.');
         },
         parsePreview(payload) {
             return parser.parsePreview(payload);
@@ -368,9 +518,16 @@ module.exports = {
     parseArgs,
     normalizeBooleanFlag,
     validateSingleTargetInput,
+    validatePolicyFlags,
     createFotMobSingleTargetAdapter,
     buildPreflightSummary,
+    buildStopGates,
+    buildSourceManifestCandidatePreview,
+    buildParserConfidenceStub,
+    buildResponsePreviewSchemaStub,
+    buildReadinessSummary,
     runCli,
     PHASE,
     BLOCKED_COMMIT_MESSAGE,
+    DEFAULT_PARSER_CONFIDENCE_THRESHOLD,
 };

--- a/tests/unit/fotmob_single_target_adapter_scaffold.test.js
+++ b/tests/unit/fotmob_single_target_adapter_scaffold.test.js
@@ -202,6 +202,8 @@ function runCli(gate, input) {
 
 function assertSafePayload(payload) {
     assert.equal(payload.adapter_scaffold_only, true);
+    assert.equal(payload.adapter_scaffold_ready, true);
+    assert.equal(payload.preflight_hardened, true);
     assert.equal(payload.target_source, 'fotmob');
     assert.equal(payload.target_count, 1);
     assert.equal(payload.single_target, true);
@@ -211,10 +213,19 @@ function assertSafePayload(payload) {
     assert.equal(payload.network_dry_run_authorized, false);
     assert.equal(payload.network_dry_run_execution_allowed, false);
     assert.equal(payload.commit_gate, 'blocked');
+    assert.equal(payload.readiness_summary.adapter_scaffold_ready, true);
+    assert.equal(payload.readiness_summary.preflight_hardened, true);
+    assert.equal(payload.readiness_summary.network_dry_run_ready, false);
+    assert.equal(payload.readiness_summary.network_dry_run_authorized, false);
+    assert.equal(payload.readiness_summary.network_dry_run_execution_allowed, false);
 
     for (const field of WOULD_FALSE_FIELDS) {
         assert.equal(payload[field], false, `${field} must remain false`);
     }
+}
+
+function findStopGate(payload, gateName) {
+    return payload.stop_gates.find(gate => gate.gate === gateName);
 }
 
 test('valid match_id preflight succeeds and returns stdout-only safety JSON', t => {
@@ -325,7 +336,7 @@ test('bulk scope and max_targets greater than one fail closed', t => {
     assert.match(maxTargets.errors.join('\n'), /max-targets must be 1/);
 });
 
-test('yes authorization flags are accepted as input but ignored by Phase 4.97F policy', t => {
+test('yes authorization flags are accepted as input but ignored by Phase 4.98F policy', t => {
     installExecutionGuards(t);
     const gate = loadFresh();
 
@@ -349,6 +360,12 @@ test('all-yes CLI remains blocked no-op and does not authorize execution', t => 
     assert.equal(result.status, 0);
     assert.equal(result.payload.adapter_scaffold_only, true);
     assert.equal(result.payload.ignored_yes_flags.length, BOOLEAN_FIELDS.length);
+    assert.equal(result.payload.network_dry_run_authorized, false);
+    assert.equal(result.payload.network_dry_run_execution_allowed, false);
+    assert.equal(result.payload.would_access_network, false);
+    assert.equal(result.payload.would_write_source_manifest, false);
+    assert.equal(result.payload.would_write_staging, false);
+    assert.equal(result.payload.would_write_db, false);
     assertSafePayload(result.payload);
 });
 
@@ -368,7 +385,7 @@ test('--commit is blocked and exits non-zero', t => {
 
     assert.equal(status, 1);
     assert.equal(stdout, '');
-    assert.match(stderr, /BLOCKED: FotMob trusted single-target adapter scaffold is not executable/);
+    assert.match(stderr, /BLOCKED: FotMob adapter preflight hardening is not executable in Phase 4\.98F/);
 });
 
 test('default networkClient.fetch and dryRunFetchSingleTarget are disabled', t => {
@@ -385,6 +402,148 @@ test('default networkClient.fetch and dryRunFetchSingleTarget are disabled', t =
         parser_stub_only: true,
         parsed_remote_response: false,
     });
+});
+
+test('source manifest candidate preview is stdout-only and never writes source manifest files', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runCli(
+        gate,
+        baseInput({
+            source_homepage_url: 'https://example.invalid/fotmob-placeholder',
+            terms_url: 'https://example.invalid/terms-placeholder',
+            license_url: 'https://example.invalid/license-placeholder',
+            allowed_use_summary: 'placeholder-not-approved',
+            output_root: 'docs/_staging_preview/fotmob-placeholder',
+        })
+    );
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.source_manifest_candidate_preview.source, 'fotmob');
+    assert.equal(result.payload.source_manifest_candidate_preview.target_identifier, 'sample-match-001');
+    assert.equal(result.payload.source_manifest_candidate_preview.source_homepage_url_provided, true);
+    assert.equal(result.payload.source_manifest_candidate_preview.terms_url_provided, true);
+    assert.equal(result.payload.source_manifest_candidate_preview.license_url_provided, true);
+    assert.equal(result.payload.source_manifest_candidate_preview.allowed_use_summary_provided, true);
+    assert.equal(result.payload.source_manifest_candidate_preview.created_for_preview_only, true);
+    assert.equal(result.payload.source_manifest_candidate_preview.would_write_source_manifest, false);
+    assert.equal(result.payload.would_create_staging_directory, false);
+});
+
+test('parser confidence stub is present and does not parse a real response', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const payload = gate.buildPreflightSummary(baseInput());
+
+    assert.equal(payload.parser_confidence_stub.parser_ready, false);
+    assert.equal(payload.parser_confidence_stub.real_response_available, false);
+    assert.equal(payload.parser_confidence_stub.parser_confidence, 0);
+    assert.equal(payload.parser_confidence_stub.parser_confidence_threshold, 0.8);
+    assert.equal(payload.parser_confidence_stub.parser_confidence_passed, false);
+    assert.equal(payload.parser_confidence_stub.would_parse_real_response, false);
+});
+
+test('response preview schema stub is present and does not validate real remote payloads', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const payload = gate.buildPreflightSummary(baseInput({ expected_response_kind: 'match_detail' }));
+
+    assert.equal(payload.response_preview_schema_stub.expected_response_kind, 'match_detail');
+    assert.equal(payload.response_preview_schema_stub.schema_ready, false);
+    assert.equal(payload.response_preview_schema_stub.schema_validation_passed, false);
+    assert.equal(payload.response_preview_schema_stub.would_validate_real_response, false);
+});
+
+test('stop gates include required Phase 4.98F blockers', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const payload = gate.buildPreflightSummary(baseInput());
+    const expectedGates = [
+        'missing_terms_approval',
+        'missing_network_authorization',
+        'external_network_not_authorized',
+        'staging_write_not_authorized',
+        'db_write_not_authorized',
+        'allowed_use_summary_missing',
+        'network_execution_blocked',
+        'future_phase_required',
+    ];
+
+    for (const gateName of expectedGates) {
+        const gateEntry = findStopGate(payload, gateName);
+        assert.ok(gateEntry, `${gateName} must be present`);
+        assert.equal(gateEntry.blocked, true);
+    }
+});
+
+test('readiness summary distinguishes scaffold readiness from network readiness', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const payload = gate.buildPreflightSummary(baseInput());
+
+    assert.equal(payload.readiness_summary.adapter_scaffold_ready, true);
+    assert.equal(payload.readiness_summary.preflight_hardened, true);
+    assert.equal(payload.readiness_summary.source_manifest_candidate_preview_ready, true);
+    assert.equal(payload.readiness_summary.parser_confidence_stub_ready, true);
+    assert.equal(payload.readiness_summary.network_dry_run_ready, false);
+    assert.equal(payload.readiness_summary.network_dry_run_authorized, false);
+    assert.equal(payload.readiness_summary.network_dry_run_execution_allowed, false);
+});
+
+test('new policy inputs remain no-network and no-write preview data only', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runCli(
+        gate,
+        baseInput({
+            source_homepage_url: 'https://example.invalid/fotmob-placeholder',
+            terms_url: 'https://example.invalid/terms-placeholder',
+            license_url: 'https://example.invalid/license-placeholder',
+            allowed_use_summary: 'placeholder-not-approved',
+            rate_limit_policy: 'placeholder',
+            retry_policy: 'none',
+            user_agent_policy: 'default',
+            output_root: 'docs/_staging_preview/fotmob-placeholder',
+            expected_response_kind: 'match_detail',
+            parser_confidence_threshold: '0.9',
+        })
+    );
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.policy_inputs.source_homepage_url_provided, true);
+    assert.equal(result.payload.policy_inputs.terms_url_provided, true);
+    assert.equal(result.payload.policy_inputs.license_url_provided, true);
+    assert.equal(result.payload.policy_inputs.output_root_provided, true);
+    assert.equal(result.payload.response_preview_schema_stub.expected_response_kind, 'match_detail');
+    assert.equal(result.payload.response_preview_schema_stub.would_validate_real_response, false);
+    assert.equal(result.payload.parser_confidence_stub.parser_confidence_threshold, 0.9);
+    assertSafePayload(result.payload);
+});
+
+test('parser-confidence-threshold must be numeric between zero and one', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const invalidText = gate.validateSingleTargetInput(baseInput({ parser_confidence_threshold: 'bad' }));
+    const invalidRange = gate.validateSingleTargetInput(baseInput({ parser_confidence_threshold: '1.5' }));
+    const valid = gate.validateSingleTargetInput(baseInput({ parser_confidence_threshold: '0.75' }));
+
+    assert.equal(invalidText.valid, false);
+    assert.match(invalidText.errors.join('\n'), /parser-confidence-threshold/);
+    assert.equal(invalidRange.valid, false);
+    assert.match(invalidRange.errors.join('\n'), /parser-confidence-threshold/);
+    assert.equal(valid.valid, true);
+    assert.equal(valid.normalized.parser_confidence_threshold, 0.75);
+});
+
+test('missing allowed-use-summary keeps stop gate active', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const payload = gate.buildPreflightSummary(baseInput({ allowed_use_summary: undefined }));
+    const gateEntry = findStopGate(payload, 'allowed_use_summary_missing');
+
+    assert.ok(gateEntry);
+    assert.equal(gateEntry.blocked, true);
+    assert.match(gateEntry.reason, /missing/);
 });
 
 test('adapter import and preflight do not import or execute legacy runtime, browser, proxy, DB, files, or child process paths', t => {


### PR DESCRIPTION
## Summary

Adds Phase 4.98F FotMob adapter preflight hardening.

Scope:
- Adds stricter FotMob adapter policy validation
- Adds stdout-only source manifest candidate preview
- Adds parser confidence stub
- Adds response preview schema stub
- Adds stop gates and readiness summary
- Keeps network dry-run blocked
- Keeps source manifest / staging / DB writes blocked
- Updates Makefile, AGENTS.md, tests, and report

Safety:
- No external FotMob access
- No external football or odds data access
- No curl / wget
- No browser automation for the FotMob adapter preflight path
- No proxy runtime execution
- No legacy FotMob runtime execution
- No scraping
- No harvest / ingest
- No network dry-run execution
- No staging writes
- No source manifest writes
- No packet writes
- No DB writes
- No pg_dump / pg_restore
- No training
- No prediction execution

Validation:
- FotMob adapter scaffold tests passed
- valid preflight passed
- all-yes preflight remained blocked / no-op
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- npm run test:integration not run locally because Phase 4.98F prohibits browser automation and the integration suite contains real chromium.launch paths
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed