### PR TITLE
docs(data): add FotMob network dry-run authorization packet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1047,6 +1047,15 @@ Phase 4.98F FotMob adapter preflight hardening rules：
 - All `yes` flags remain blocked until an explicit future authorization phase.
 - Network dry-run remains prohibited in Phase 4.98F.
 
+Phase 4.99F FotMob stdout-only network dry-run authorization packet rules：
+
+- FotMob stdout-only network dry-run authorization packet is template-only in Phase 4.99F.
+- It must not access external FotMob or execute a network dry-run.
+- It must not write runtime packet files, staging, source manifest, packet, or DB.
+- Codex must not self-fill a real FotMob target, source terms, license, or allowed-use approval.
+- Codex must not self-authorize network access or convert the authorization packet into execution.
+- Future FotMob stdout-only network dry-run requires an explicit user-filled authorization packet and a separate execution phase.
+
 Phase 4.57C football-data adapter rules：
 
 - `fetch_and_adapt_euro_leagues` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
+        data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-single-target-network-dry-run data-single-target-network-commit \
         data-single-target-acquisition-runtime-scaffold data-single-target-acquisition-runtime-commit \
         data-single-target-acquisition-staging-schema-validate data-single-target-acquisition-staging-schema-commit \
@@ -101,6 +102,7 @@ NETWORK_FILLED_INTAKE_REVIEW_RESULT_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTHORIZATION_DECISION_NODE?=$(COMPOSE_DEV) exec -T dev node
 FOTMOB_SINGLE_TARGET_ADAPTER_NODE?=$(COMPOSE_DEV) exec -T dev node
+FOTMOB_STDOUT_NETWORK_AUTH_PACKET_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -305,6 +307,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
+	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-real-source-audit SOURCE_MANIFEST=<path>"
 	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
@@ -396,6 +399,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-authorization-decision-preview AUTHORIZATION_DECISION=<path> HANDOFF_CHECKLIST=<path> REVIEW_RESULT=<path> REVIEW_PLAN=<path> INTAKE=<path> VALIDATION_CLOSURE=<path> BLOCKED_SUMMARY=<path>  # authorization decision preview, Phase 4.95D"
 	@echo "  make data-single-target-acquisition-network-authorization-decision-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION=1  # blocked in Phase 4.95D"
 	@echo "  make data-fotmob-single-target-adapter-commit TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1  # blocked in Phase 4.98F"
+	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-commit PACKET=<path> CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET=1  # blocked in Phase 4.99F"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -927,6 +931,19 @@ data-fotmob-single-target-adapter-commit: ## Blocked FotMob trusted single-targe
 	@echo "BLOCKED: FotMob adapter preflight hardening is not executable in Phase 4.98F."
 	@echo "  Even with CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1, this path remains blocked."
 	@echo "  Future FotMob network dry-run requires separate user target, terms, allowed-use, and network authorization."
+	@exit 1
+
+data-fotmob-stdout-network-dry-run-authorization-packet-preview: ## Validate FotMob stdout-only network dry-run authorization packet template. Phase 4.99F.
+	@if [ -z "$(PACKET)" ]; then \
+		echo "ERROR: provide PACKET=<path>"; \
+		exit 1; \
+	fi
+	@$(FOTMOB_STDOUT_NETWORK_AUTH_PACKET_NODE) scripts/ops/fotmob_stdout_network_dry_run_authorization_packet.js --packet "$(PACKET)"
+
+data-fotmob-stdout-network-dry-run-authorization-packet-commit: ## Blocked FotMob stdout-only network dry-run authorization packet execution gate. Remains blocked in Phase 4.99F.
+	@echo "BLOCKED: FotMob stdout-only network dry-run authorization packet is not executable in Phase 4.99F."
+	@echo "  Even with CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET=1, this path remains blocked."
+	@echo "  The packet is template-only and does not authorize or execute a network dry-run."
 	@exit 1
 
 data-single-target-network-dry-run: ## Scaffold-only single-target network dry-run gate. Requires ENGINE, TARGET_MATCH_ID, SOURCE_MANIFEST.

--- a/docs/_reports/FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_PHASE4_99F.md
+++ b/docs/_reports/FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_PHASE4_99F.md
@@ -1,0 +1,114 @@
+# FotMob Stdout Network Dry-Run Authorization Packet
+
+Phase: 4.99F
+Status: template-only, local validation only
+Starting HEAD: `e1db303d3b18ee9220cd6bcad2d2c75b8b51fb80`
+
+## 1. Executive Summary
+
+Phase 4.99F creates a FotMob stdout-only network dry-run authorization packet
+template.
+
+This phase does not access FotMob, collect data, write DB rows, or write staging
+artifacts. The authorization packet itself is not execution and does not authorize a
+network dry-run.
+
+## 2. Implemented Files
+
+- `docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_TEMPLATE.md`
+- `scripts/ops/fotmob_stdout_network_dry_run_authorization_packet.js`
+- `tests/unit/fotmob_stdout_network_dry_run_authorization_packet.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_PHASE4_99F.md`
+
+## 3. Packet Sections
+
+The packet template includes these machine-readable sections:
+
+- `target`
+- `source_terms`
+- `network_policy`
+- `output_policy`
+- `data_safety_policy`
+- `authorization_decision`
+- `included_artifacts`
+- `authorization_blocking_reasons`
+- `codex_constraints`
+- `safety`
+- `next_phase_requirements`
+
+## 4. Authorization Boundary
+
+- The packet is not an authorization result.
+- The packet is not execution.
+- `target_count=0` by default.
+- `network_dry_run_authorized=false` by default.
+- `network_dry_run_execution_allowed=false` by default.
+- A future execution phase is required.
+- The user must supply the real target, source terms, allowed-use approval, and
+  network authorization.
+
+## 5. Validation
+
+Required validation for this phase:
+
+- `node --test tests/unit/fotmob_stdout_network_dry_run_authorization_packet.test.js`
+- valid packet preview
+- blocked commit gate
+- `npm test`
+- `npm run test:coverage`
+- `npm run test:integration` skipped locally if it would require browser automation
+- ESLint
+- Prettier
+- `git diff --check`
+- DB row counts unchanged
+- `l1-config-*` residue absent
+- `docs/_staging_preview` absent
+
+Expected DB counts remain:
+
+- `matches=2`
+- `bookmaker_odds_history=2`
+- `raw_match_data=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+## 6. Recommended Next Phase
+
+Recommended next phase: Phase 5.00F, FotMob stdout-only network dry-run execution
+plan.
+
+Phase 5.00F should:
+
+- still not directly access the network
+- first convert a user-filled authorization packet into an execution plan
+- still not write DB
+- default to no staging write
+- require explicit user authorization again before any network access
+
+## 7. Explicit Non-Execution
+
+Phase 4.99F did not execute:
+
+- external FotMob access
+- external football data access
+- external odds data access
+- curl / wget
+- browser automation
+- proxy runtime
+- scraping
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- staging write
+- source manifest write
+- packet runtime write
+- DB writes
+- pg_dump / pg_restore
+- training
+- prediction
+- file deletion
+- legacy FotMob runtime execution

--- a/docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_TEMPLATE.md
+++ b/docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_TEMPLATE.md
@@ -1,0 +1,162 @@
+# FotMob Stdout-Only Network Dry-Run Authorization Packet Template
+
+Phase: 4.99F
+Status: template-only, non-executing
+
+## Purpose
+
+This is an authorization packet template for one future FotMob stdout-only
+single-target network dry-run. It is not an authorization result, not an execution
+plan, and not a network dry-run.
+
+Phase 4.99F does not access FotMob, collect real data, launch a browser, use a proxy,
+write staging, write a source manifest, write a runtime packet, write DB rows, train,
+predict, or execute legacy FotMob runtime.
+
+## Machine-Readable Packet
+
+```yaml
+phase: PHASE4_99F_FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET
+authorization_packet_status: template_only
+authorization_packet_ready: false
+authorization_packet_reviewed: false
+authorization_packet_accepted: false
+
+target:
+    target_source: fotmob
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+    target_url:
+    target_count: 0
+    max_targets: 1
+    single_target_only: true
+    bulk_scope_allowed: false
+
+source_terms:
+    source_homepage_url:
+    terms_url:
+    license_url:
+    allowed_use_summary:
+    terms_reviewed_by:
+    terms_reviewed_at:
+    terms_approval: false
+    allowed_use_approved: false
+
+network_policy:
+    external_network_authorized: false
+    stdout_only_network_dry_run_authorized: false
+    browser_runtime_authorized: false
+    proxy_runtime_authorized: false
+    login_required: false
+    paywall_bypass_allowed: false
+    anti_bot_bypass_allowed: false
+    rate_limit_policy:
+    retry_policy:
+    user_agent_policy:
+
+output_policy:
+    stdout_only: true
+    staging_write_authorized: false
+    source_manifest_write_authorized: false
+    packet_write_authorized: false
+    output_root:
+    bounded_preview_required: true
+
+data_safety_policy:
+    db_write_authorized: false
+    training_authorized: false
+    prediction_authorized: false
+    model_artifact_loading_authorized: false
+    no_db_write_confirmation: false
+    no_training_confirmation: false
+    no_prediction_confirmation: false
+
+authorization_decision:
+    network_dry_run_authorized: false
+    network_dry_run_execution_allowed: false
+    authorization_decision: not_authorized
+    final_human_confirmation: false
+    confirmed_by:
+    confirmed_at:
+    reviewer_notes:
+
+included_artifacts:
+    adapter_scaffold: scripts/ops/fotmob_single_target_adapter_scaffold.js
+    preflight_hardening_report: docs/_reports/FOTMOB_ADAPTER_PREFLIGHT_HARDENING_PHASE4_98F.md
+    adapter_scaffold_report: docs/_reports/FOTMOB_SINGLE_TARGET_ADAPTER_SCAFFOLD_PHASE4_97F.md
+    readiness_gap_report: docs/_reports/FOTMOB_SINGLE_TARGET_DRY_RUN_READINESS_GAP_PHASE4_96F.md
+    runbook_draft: docs/runbooks/FOTMOB_SINGLE_TARGET_NETWORK_DRY_RUN_RUNBOOK_DRAFT.md
+
+authorization_blocking_reasons:
+    - authorization_packet_template_only
+    - real_target_not_provided
+    - source_terms_not_approved
+    - allowed_use_not_approved
+    - external_network_not_authorized
+    - stdout_only_network_dry_run_not_authorized
+    - final_human_confirmation_missing
+    - future_execution_phase_required
+
+codex_constraints:
+    codex_may_not_self_fill_target: true
+    codex_may_not_self_approve_terms: true
+    codex_may_not_self_authorize_network: true
+    codex_may_not_enable_execution: true
+    codex_may_not_write_runtime_packet: true
+    codex_may_not_execute_network_dry_run: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_legacy_runtime: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_spawn_child_process: false
+
+next_phase_requirements:
+    - user_supplies_real_fotmob_target
+    - user_reviews_source_terms
+    - user_approves_allowed_use
+    - user_authorizes_stdout_only_external_network_access
+    - user_confirms_no_browser_by_default
+    - user_confirms_no_proxy_by_default
+    - user_confirms_no_staging_write_by_default
+    - user_confirms_no_db_write
+    - user_confirms_no_training
+    - user_confirms_no_prediction
+    - separate_execution_phase_required
+```
+
+## Authorization Boundary
+
+- This template is not an authorization result.
+- `authorization_packet_status` defaults to `template_only`.
+- `authorization_packet_ready` defaults to `false`.
+- `authorization_packet_accepted` defaults to `false`.
+- `network_dry_run_authorized` defaults to `false`.
+- `network_dry_run_execution_allowed` defaults to `false`.
+- `stdout_only_network_dry_run_authorized` defaults to `false`.
+- `target_count` defaults to `0`.
+- `max_targets` defaults to `1`.
+- `bulk_scope_allowed` defaults to `false`.
+
+## Codex Boundary
+
+Codex must not self-fill a real FotMob target, approve terms, approve allowed use,
+authorize network access, turn this packet into execution, or execute a FotMob
+network dry-run.
+
+Phase 4.99F writes no runtime authorization packet. It only adds this template and a
+stdout preview validator. A real stdout-only FotMob network dry-run requires a later,
+separate execution phase after a user-filled packet is explicitly reviewed and
+authorized again.

--- a/scripts/ops/fotmob_stdout_network_dry_run_authorization_packet.js
+++ b/scripts/ops/fotmob_stdout_network_dry_run_authorization_packet.js
@@ -1,0 +1,677 @@
+#!/usr/bin/env node
+/**
+ * Phase 4.99F: FotMob stdout-only network dry-run authorization packet preview.
+ *
+ * This command reads a local packet template and prints a JSON summary to stdout.
+ * It does not access the network, launch browser or proxy runtime, execute legacy
+ * FotMob runtime, write files, connect to DB, spawn child processes, train, or predict.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PHASE = 'PHASE4_99F_FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: FotMob stdout-only network dry-run authorization packet is not executable in Phase 4.99F.';
+const NEXT_REQUIRED_PHASE =
+    'Phase 5.00F FotMob stdout-only network dry-run execution plan or explicit user-filled authorization packet review';
+
+const EXPECTED_BLOCKING_REASONS = [
+    'authorization_packet_template_only',
+    'real_target_not_provided',
+    'source_terms_not_approved',
+    'allowed_use_not_approved',
+    'external_network_not_authorized',
+    'stdout_only_network_dry_run_not_authorized',
+    'final_human_confirmation_missing',
+    'future_execution_phase_required',
+];
+
+const REQUIRED_TOP_LEVEL_FIELDS = [
+    'phase',
+    'authorization_packet_status',
+    'authorization_packet_ready',
+    'authorization_packet_reviewed',
+    'authorization_packet_accepted',
+    'target',
+    'source_terms',
+    'network_policy',
+    'output_policy',
+    'data_safety_policy',
+    'authorization_decision',
+    'included_artifacts',
+    'authorization_blocking_reasons',
+    'codex_constraints',
+    'safety',
+    'next_phase_requirements',
+];
+
+const REQUIRED_NESTED_FIELDS = {
+    target: [
+        'target_source',
+        'target_scope_type',
+        'target_match_id',
+        'target_league',
+        'target_season',
+        'target_date',
+        'target_url',
+        'target_count',
+        'max_targets',
+        'single_target_only',
+        'bulk_scope_allowed',
+    ],
+    source_terms: [
+        'source_homepage_url',
+        'terms_url',
+        'license_url',
+        'allowed_use_summary',
+        'terms_reviewed_by',
+        'terms_reviewed_at',
+        'terms_approval',
+        'allowed_use_approved',
+    ],
+    network_policy: [
+        'external_network_authorized',
+        'stdout_only_network_dry_run_authorized',
+        'browser_runtime_authorized',
+        'proxy_runtime_authorized',
+        'login_required',
+        'paywall_bypass_allowed',
+        'anti_bot_bypass_allowed',
+        'rate_limit_policy',
+        'retry_policy',
+        'user_agent_policy',
+    ],
+    output_policy: [
+        'stdout_only',
+        'staging_write_authorized',
+        'source_manifest_write_authorized',
+        'packet_write_authorized',
+        'output_root',
+        'bounded_preview_required',
+    ],
+    data_safety_policy: [
+        'db_write_authorized',
+        'training_authorized',
+        'prediction_authorized',
+        'model_artifact_loading_authorized',
+        'no_db_write_confirmation',
+        'no_training_confirmation',
+        'no_prediction_confirmation',
+    ],
+    authorization_decision: [
+        'network_dry_run_authorized',
+        'network_dry_run_execution_allowed',
+        'authorization_decision',
+        'final_human_confirmation',
+        'confirmed_by',
+        'confirmed_at',
+        'reviewer_notes',
+    ],
+    included_artifacts: [
+        'adapter_scaffold',
+        'preflight_hardening_report',
+        'adapter_scaffold_report',
+        'readiness_gap_report',
+        'runbook_draft',
+    ],
+    codex_constraints: [
+        'codex_may_not_self_fill_target',
+        'codex_may_not_self_approve_terms',
+        'codex_may_not_self_authorize_network',
+        'codex_may_not_enable_execution',
+        'codex_may_not_write_runtime_packet',
+        'codex_may_not_execute_network_dry_run',
+    ],
+    safety: [
+        'would_access_network',
+        'would_launch_browser',
+        'would_use_proxy',
+        'would_execute_legacy_runtime',
+        'would_execute_engine',
+        'would_write_staging',
+        'would_create_staging_directory',
+        'would_write_source_manifest',
+        'would_write_packet_file',
+        'would_write_db',
+        'would_train',
+        'would_predict',
+        'would_spawn_child_process',
+    ],
+};
+
+const SAFETY_FALSE_FIELDS = REQUIRED_NESTED_FIELDS.safety;
+const CODEX_TRUE_FIELDS = REQUIRED_NESTED_FIELDS.codex_constraints;
+
+function parseArgs(argv = []) {
+    const args = {
+        packet: '',
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/fotmob_stdout_network_dry_run_authorization_packet.js --packet <path>',
+        '  node scripts/ops/fotmob_stdout_network_dry_run_authorization_packet.js --packet <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 4.99F validates a local authorization packet template only.',
+        '  No network, browser, proxy, legacy runtime, DB, file writes, child processes, training, or prediction.',
+    ].join('\n');
+}
+
+function defaultDependencies() {
+    return {
+        cwd: process.cwd(),
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+    };
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function extractYamlBlock(markdownText) {
+    const match = String(markdownText || '').match(/```yaml\s*\r?\n([\s\S]*?)```/i);
+    return match ? match[1] : '';
+}
+
+function parseScalar(rawValue) {
+    const value = String(rawValue || '').trim();
+    if (value === '') return null;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    if (/^-?\d+$/.test(value)) return Number(value);
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+
+function getNextContainerType(lines, currentIndex, currentIndent) {
+    for (let index = currentIndex + 1; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (!line.trim() || line.trim().startsWith('#')) continue;
+        const indent = line.match(/^ */)[0].length;
+        if (indent <= currentIndent) return false;
+        return line.trim().startsWith('- ') ? 'list' : 'object';
+    }
+    return false;
+}
+
+function parsePacketYaml(yamlText) {
+    const root = {};
+    const stack = [{ indent: -1, value: root }];
+    const lines = String(yamlText || '').split(/\r?\n/);
+
+    lines.forEach((rawLine, lineIndex) => {
+        if (!rawLine.trim() || rawLine.trim().startsWith('#')) return;
+        if (/^\t+/.test(rawLine)) throw new Error(`unsupported YAML indentation: ${rawLine.trim()}`);
+
+        const indent = rawLine.match(/^ */)[0].length;
+        const trimmed = rawLine.trim();
+
+        while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop();
+        const parent = stack[stack.length - 1].value;
+
+        if (trimmed.startsWith('- ')) {
+            if (!Array.isArray(parent)) throw new Error(`unsupported YAML list line: ${trimmed}`);
+            parent.push(parseScalar(trimmed.slice(2)));
+            return;
+        }
+
+        const match = trimmed.match(/^([A-Za-z0-9_]+):(.*)$/);
+        if (!match) throw new Error(`unsupported YAML line: ${trimmed}`);
+
+        const key = match[1];
+        const valueText = match[2].trim();
+        if (valueText !== '') {
+            parent[key] = parseScalar(valueText);
+            return;
+        }
+
+        const nextContainerType = getNextContainerType(lines, lineIndex, indent);
+        if (!nextContainerType) {
+            parent[key] = null;
+            return;
+        }
+
+        const container = nextContainerType === 'list' ? [] : {};
+        parent[key] = container;
+        stack.push({ indent, value: container });
+    });
+
+    return root;
+}
+
+function getPath(root, dottedPath) {
+    return dottedPath.split('.').reduce((current, key) => {
+        if (!current || typeof current !== 'object') return undefined;
+        return current[key];
+    }, root);
+}
+
+function hasOwn(root, key) {
+    return Object.prototype.hasOwnProperty.call(root, key);
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_LEVEL_FIELDS.filter(key => !hasOwn(parsedYaml, key));
+    Object.entries(REQUIRED_NESTED_FIELDS).forEach(([sectionName, fields]) => {
+        const section = parsedYaml[sectionName];
+        if (!section || typeof section !== 'object' || Array.isArray(section)) {
+            fields.forEach(field => missingFields.push(`${sectionName}.${field}`));
+            return;
+        }
+        fields.filter(field => !hasOwn(section, field)).forEach(field => missingFields.push(`${sectionName}.${field}`));
+    });
+    return missingFields;
+}
+
+function expectValue(parsedYaml, dottedPath, expectedValue, errors, message) {
+    if (getPath(parsedYaml, dottedPath) !== expectedValue) {
+        errors.push(message || `${dottedPath} must be ${expectedValue}`);
+    }
+}
+
+function validatePacketValues(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) {
+        errors.push(`missing required fields: ${missingFields.join(', ')}`);
+    }
+
+    expectValue(parsedYaml, 'phase', PHASE, errors, `phase must be ${PHASE}`);
+    expectValue(
+        parsedYaml,
+        'authorization_packet_status',
+        'template_only',
+        errors,
+        'authorization_packet_status not template_only'
+    );
+    expectValue(parsedYaml, 'authorization_packet_ready', false, errors, 'authorization_packet_ready true');
+    expectValue(parsedYaml, 'authorization_packet_reviewed', false, errors, 'authorization_packet_reviewed true');
+    expectValue(parsedYaml, 'authorization_packet_accepted', false, errors, 'authorization_packet_accepted true');
+
+    expectValue(parsedYaml, 'target.target_source', 'fotmob', errors, 'target_source not fotmob');
+    const targetCount = getPath(parsedYaml, 'target.target_count');
+    if (targetCount > 1) errors.push('target_count > 1');
+    if (targetCount !== 0) errors.push('target_count must remain 0 in Phase 4.99F template');
+    const maxTargets = getPath(parsedYaml, 'target.max_targets');
+    if (maxTargets > 1) errors.push('max_targets > 1');
+    if (maxTargets !== 1) errors.push('max_targets must be 1');
+    expectValue(parsedYaml, 'target.single_target_only', true, errors, 'single_target_only not true');
+    expectValue(parsedYaml, 'target.bulk_scope_allowed', false, errors, 'bulk_scope_allowed true');
+
+    expectValue(parsedYaml, 'source_terms.terms_approval', false, errors, 'terms_approval true');
+    expectValue(parsedYaml, 'source_terms.allowed_use_approved', false, errors, 'allowed_use_approved true');
+
+    expectValue(
+        parsedYaml,
+        'network_policy.external_network_authorized',
+        false,
+        errors,
+        'external_network_authorized true'
+    );
+    expectValue(
+        parsedYaml,
+        'network_policy.stdout_only_network_dry_run_authorized',
+        false,
+        errors,
+        'stdout_only_network_dry_run_authorized true'
+    );
+    expectValue(
+        parsedYaml,
+        'network_policy.browser_runtime_authorized',
+        false,
+        errors,
+        'browser_runtime_authorized true'
+    );
+    expectValue(parsedYaml, 'network_policy.proxy_runtime_authorized', false, errors, 'proxy_runtime_authorized true');
+    expectValue(parsedYaml, 'network_policy.login_required', false, errors, 'login_required true');
+    expectValue(parsedYaml, 'network_policy.paywall_bypass_allowed', false, errors, 'paywall_bypass_allowed true');
+    expectValue(parsedYaml, 'network_policy.anti_bot_bypass_allowed', false, errors, 'anti_bot_bypass_allowed true');
+
+    expectValue(parsedYaml, 'output_policy.stdout_only', true, errors, 'stdout_only not true');
+    expectValue(parsedYaml, 'output_policy.staging_write_authorized', false, errors, 'staging_write_authorized true');
+    expectValue(
+        parsedYaml,
+        'output_policy.source_manifest_write_authorized',
+        false,
+        errors,
+        'source_manifest_write_authorized true'
+    );
+    expectValue(parsedYaml, 'output_policy.packet_write_authorized', false, errors, 'packet_write_authorized true');
+    expectValue(
+        parsedYaml,
+        'output_policy.bounded_preview_required',
+        true,
+        errors,
+        'bounded_preview_required not true'
+    );
+
+    expectValue(parsedYaml, 'data_safety_policy.db_write_authorized', false, errors, 'db_write_authorized true');
+    expectValue(parsedYaml, 'data_safety_policy.training_authorized', false, errors, 'training_authorized true');
+    expectValue(parsedYaml, 'data_safety_policy.prediction_authorized', false, errors, 'prediction_authorized true');
+    expectValue(
+        parsedYaml,
+        'data_safety_policy.model_artifact_loading_authorized',
+        false,
+        errors,
+        'model_artifact_loading_authorized true'
+    );
+
+    expectValue(
+        parsedYaml,
+        'authorization_decision.network_dry_run_authorized',
+        false,
+        errors,
+        'network_dry_run_authorized true'
+    );
+    expectValue(
+        parsedYaml,
+        'authorization_decision.network_dry_run_execution_allowed',
+        false,
+        errors,
+        'network_dry_run_execution_allowed true'
+    );
+    expectValue(
+        parsedYaml,
+        'authorization_decision.authorization_decision',
+        'not_authorized',
+        errors,
+        'authorization_decision not not_authorized'
+    );
+    expectValue(
+        parsedYaml,
+        'authorization_decision.final_human_confirmation',
+        false,
+        errors,
+        'final_human_confirmation true'
+    );
+
+    const blockingReasons = parsedYaml.authorization_blocking_reasons;
+    if (!Array.isArray(blockingReasons)) {
+        errors.push('authorization_blocking_reasons missing or not list');
+    } else {
+        const missingReasons = EXPECTED_BLOCKING_REASONS.filter(reason => !blockingReasons.includes(reason));
+        if (missingReasons.length) {
+            errors.push(`missing authorization_blocking_reasons: ${missingReasons.join(', ')}`);
+        }
+    }
+
+    CODEX_TRUE_FIELDS.forEach(field => {
+        expectValue(parsedYaml, `codex_constraints.${field}`, true, errors, `${field} false`);
+    });
+
+    SAFETY_FALSE_FIELDS.forEach(field => {
+        expectValue(parsedYaml, `safety.${field}`, false, errors, `safety ${field} not false`);
+    });
+
+    return errors;
+}
+
+function buildBasePayload(args, fields = {}) {
+    return {
+        phase: PHASE,
+        ok: false,
+        packet: args.packet || null,
+        packet_found: false,
+        yaml_block_found: false,
+        authorization_packet_template_only: true,
+        authorization_packet_valid: false,
+        authorization_packet_ready: false,
+        authorization_packet_reviewed: false,
+        authorization_packet_accepted: false,
+        target_source: null,
+        target_count: null,
+        max_targets: null,
+        single_target_only: false,
+        bulk_scope_allowed: false,
+        terms_approval: false,
+        allowed_use_approved: false,
+        external_network_authorized: false,
+        stdout_only_network_dry_run_authorized: false,
+        browser_runtime_authorized: false,
+        proxy_runtime_authorized: false,
+        staging_write_authorized: false,
+        source_manifest_write_authorized: false,
+        db_write_authorized: false,
+        training_authorized: false,
+        prediction_authorized: false,
+        network_dry_run_authorized: false,
+        network_dry_run_execution_allowed: false,
+        authorization_decision: 'not_authorized',
+        final_human_confirmation: false,
+        authorization_blocking_reasons: [],
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_legacy_runtime: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+        errors: [],
+        ...fields,
+    };
+}
+
+function buildSuccessPayload(args, parsedYaml) {
+    return buildBasePayload(args, {
+        ok: true,
+        packet_found: true,
+        yaml_block_found: true,
+        authorization_packet_valid: true,
+        authorization_packet_ready: parsedYaml.authorization_packet_ready,
+        authorization_packet_reviewed: parsedYaml.authorization_packet_reviewed,
+        authorization_packet_accepted: parsedYaml.authorization_packet_accepted,
+        target_source: parsedYaml.target.target_source,
+        target_count: parsedYaml.target.target_count,
+        max_targets: parsedYaml.target.max_targets,
+        single_target_only: parsedYaml.target.single_target_only,
+        bulk_scope_allowed: parsedYaml.target.bulk_scope_allowed,
+        terms_approval: parsedYaml.source_terms.terms_approval,
+        allowed_use_approved: parsedYaml.source_terms.allowed_use_approved,
+        external_network_authorized: parsedYaml.network_policy.external_network_authorized,
+        stdout_only_network_dry_run_authorized: parsedYaml.network_policy.stdout_only_network_dry_run_authorized,
+        browser_runtime_authorized: parsedYaml.network_policy.browser_runtime_authorized,
+        proxy_runtime_authorized: parsedYaml.network_policy.proxy_runtime_authorized,
+        staging_write_authorized: parsedYaml.output_policy.staging_write_authorized,
+        source_manifest_write_authorized: parsedYaml.output_policy.source_manifest_write_authorized,
+        db_write_authorized: parsedYaml.data_safety_policy.db_write_authorized,
+        training_authorized: parsedYaml.data_safety_policy.training_authorized,
+        prediction_authorized: parsedYaml.data_safety_policy.prediction_authorized,
+        network_dry_run_authorized: parsedYaml.authorization_decision.network_dry_run_authorized,
+        network_dry_run_execution_allowed: parsedYaml.authorization_decision.network_dry_run_execution_allowed,
+        authorization_decision: parsedYaml.authorization_decision.authorization_decision,
+        final_human_confirmation: parsedYaml.authorization_decision.final_human_confirmation,
+        authorization_blocking_reasons: parsedYaml.authorization_blocking_reasons,
+        would_access_network: parsedYaml.safety.would_access_network,
+        would_launch_browser: parsedYaml.safety.would_launch_browser,
+        would_use_proxy: parsedYaml.safety.would_use_proxy,
+        would_execute_legacy_runtime: parsedYaml.safety.would_execute_legacy_runtime,
+        would_execute_engine: parsedYaml.safety.would_execute_engine,
+        would_write_staging: parsedYaml.safety.would_write_staging,
+        would_create_staging_directory: parsedYaml.safety.would_create_staging_directory,
+        would_write_source_manifest: parsedYaml.safety.would_write_source_manifest,
+        would_write_packet_file: parsedYaml.safety.would_write_packet_file,
+        would_write_db: parsedYaml.safety.would_write_db,
+        would_train: parsedYaml.safety.would_train,
+        would_predict: parsedYaml.safety.would_predict,
+        would_spawn_child_process: parsedYaml.safety.would_spawn_child_process,
+    });
+}
+
+function loadPacketYaml(args, dependencies) {
+    if (!args.packet) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'argument-error',
+                errors: ['missing packet'],
+            }),
+        };
+    }
+
+    const packetPath = resolveLocalPath(args.packet, dependencies.cwd);
+    if (!dependencies.existsSync(packetPath)) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'packet-error',
+                packet: args.packet,
+                packet_found: false,
+                errors: [`missing packet: ${toRelativePath(packetPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+
+    const yamlText = extractYamlBlock(dependencies.readFileSync(packetPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'packet-error',
+                packet_found: true,
+                yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return {
+            parsedYaml: parsePacketYaml(yamlText),
+            yamlText,
+        };
+    } catch (error) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'packet-error',
+                packet_found: true,
+                yaml_block_found: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function runValidation(args, dependencies = defaultDependencies()) {
+    const loaded = loadPacketYaml(args, dependencies);
+    if (loaded.payload) return loaded.payload;
+
+    const errors = validatePacketValues(loaded.parsedYaml);
+    if (errors.length) {
+        return buildBasePayload(args, {
+            mode: 'validation-error',
+            packet_found: true,
+            yaml_block_found: true,
+            errors,
+        });
+    }
+
+    return buildSuccessPayload(args, loaded.parsedYaml);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = defaultDependencies()) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+
+    let args;
+    try {
+        args = parseArgs(argv);
+    } catch (error) {
+        stderr(`${error.message}\n`);
+        return 1;
+    }
+
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    if (args.commit) {
+        stderr(`${BLOCKED_COMMIT_MESSAGE}\n`);
+        return 1;
+    }
+
+    const payload = runValidation(args, dependencies);
+    if (!payload.ok) {
+        stderr(`${payload.errors.join('\n')}\n`);
+        return 1;
+    }
+
+    stdout(`${JSON.stringify(payload, null, 2)}\n`);
+    return 0;
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    NEXT_REQUIRED_PHASE,
+    EXPECTED_BLOCKING_REASONS,
+    REQUIRED_TOP_LEVEL_FIELDS,
+    REQUIRED_NESTED_FIELDS,
+    SAFETY_FALSE_FIELDS,
+    CODEX_TRUE_FIELDS,
+    parseArgs,
+    usage,
+    extractYamlBlock,
+    parseScalar,
+    parsePacketYaml,
+    findMissingFields,
+    validatePacketValues,
+    buildBasePayload,
+    buildSuccessPayload,
+    loadPacketYaml,
+    runValidation,
+    main,
+};

--- a/tests/unit/fotmob_stdout_network_dry_run_authorization_packet.test.js
+++ b/tests/unit/fotmob_stdout_network_dry_run_authorization_packet.test.js
@@ -1,0 +1,502 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fotmob_stdout_network_dry_run_authorization_packet.js');
+const PACKET_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_TEMPLATE.md'
+);
+const PACKET_TEXT = fs.readFileSync(PACKET_PATH, 'utf8');
+
+const LEGACY_PATHS = [
+    path.join(PROJECT_ROOT, 'scripts/ops/titan_discovery.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/run_production.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/batch_historical_backfill.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/backfill_historical_raw_match_data.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/titan_seeder.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/ProductionHarvester.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/strategies/FotMobStrategy.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/services/FixtureRepository.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/components/Persistence.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/services/BrowserProvider.js'),
+];
+
+const SAFE_FALSE_FIELDS = [
+    'would_access_network',
+    'would_launch_browser',
+    'would_use_proxy',
+    'would_execute_legacy_runtime',
+    'would_execute_engine',
+    'would_write_staging',
+    'would_create_staging_directory',
+    'would_write_source_manifest',
+    'would_write_packet_file',
+    'would_write_db',
+    'would_train',
+    'would_predict',
+    'would_spawn_child_process',
+];
+
+function loadFresh() {
+    delete require.cache[require.resolve(SCRIPT_PATH)];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        packet: PACKET_PATH,
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function buildTextDependencies(markdownText, targetPath = PACKET_PATH) {
+    const resolvedTarget = path.resolve(targetPath);
+    return buildDependencies({
+        existsSync: candidate => path.resolve(candidate) === resolvedTarget || fs.existsSync(candidate),
+        readFileSync: (candidate, encoding) => {
+            if (path.resolve(candidate) === resolvedTarget) return markdownText;
+            return fs.readFileSync(candidate, encoding);
+        },
+    });
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalNetConnect = net.connect;
+    const originalNetCreateConnection = net.createConnection;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by fotmob_stdout_network_dry_run_authorization_packet`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    net.connect = fail('net.connect');
+    net.createConnection = fail('net.createConnection');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'net',
+            'node:net',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+            'chromium',
+        ]);
+        const blockedFragments = [
+            'titan_discovery',
+            'run_production',
+            'batch_historical_backfill',
+            'backfill_historical_raw_match_data',
+            'titan_seeder',
+            'DiscoveryService',
+            'ProductionHarvester',
+            'FotMobStrategy',
+            'FixtureRepository',
+            'Persistence',
+            'BrowserProvider',
+            'ProxyProvider',
+        ];
+
+        if (blockedImports.has(request) || blockedFragments.some(fragment => String(request).includes(fragment))) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        net.connect = originalNetConnect;
+        net.createConnection = originalNetCreateConnection;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(PACKET_TEXT, new RegExp(escapeRegExp(searchValue)));
+    return PACKET_TEXT.replace(searchValue, replaceValue);
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function extractJson(stdout) {
+    return JSON.parse(String(stdout || '').trim());
+}
+
+function assertSafePayload(payload) {
+    assert.equal(payload.phase, 'PHASE4_99F_FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET');
+    assert.equal(payload.authorization_packet_template_only, true);
+    assert.equal(payload.authorization_packet_valid, true);
+    assert.equal(payload.authorization_packet_ready, false);
+    assert.equal(payload.authorization_packet_reviewed, false);
+    assert.equal(payload.authorization_packet_accepted, false);
+    assert.equal(payload.target_source, 'fotmob');
+    assert.equal(payload.target_count, 0);
+    assert.equal(payload.max_targets, 1);
+    assert.equal(payload.single_target_only, true);
+    assert.equal(payload.bulk_scope_allowed, false);
+    assert.equal(payload.terms_approval, false);
+    assert.equal(payload.allowed_use_approved, false);
+    assert.equal(payload.external_network_authorized, false);
+    assert.equal(payload.stdout_only_network_dry_run_authorized, false);
+    assert.equal(payload.browser_runtime_authorized, false);
+    assert.equal(payload.proxy_runtime_authorized, false);
+    assert.equal(payload.staging_write_authorized, false);
+    assert.equal(payload.source_manifest_write_authorized, false);
+    assert.equal(payload.db_write_authorized, false);
+    assert.equal(payload.training_authorized, false);
+    assert.equal(payload.prediction_authorized, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.network_dry_run_execution_allowed, false);
+    assert.equal(payload.authorization_decision, 'not_authorized');
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.commit_gate, 'blocked');
+    for (const field of SAFE_FALSE_FIELDS) {
+        assert.equal(payload[field], false, `${field} must remain false`);
+    }
+}
+
+test('缺 packet 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation({}, buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing packet/i);
+});
+
+test('缺 YAML block 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('# no yaml\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing YAML block/i);
+});
+
+test('invalid YAML 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('```yaml\nnot yaml\n```\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /invalid YAML/i);
+});
+
+[
+    [
+        'authorization_packet_status 非 template_only 失败',
+        'authorization_packet_status: template_only',
+        'authorization_packet_status: approved',
+        /authorization_packet_status not template_only/,
+    ],
+    [
+        'authorization_packet_ready=true 失败',
+        'authorization_packet_ready: false',
+        'authorization_packet_ready: true',
+        /authorization_packet_ready true/,
+    ],
+    [
+        'authorization_packet_accepted=true 失败',
+        'authorization_packet_accepted: false',
+        'authorization_packet_accepted: true',
+        /authorization_packet_accepted true/,
+    ],
+    ['target_source 不是 fotmob 失败', 'target_source: fotmob', 'target_source: other', /target_source not fotmob/],
+    ['target_count > 1 失败', 'target_count: 0', 'target_count: 2', /target_count > 1/],
+    ['max_targets > 1 失败', 'max_targets: 1', 'max_targets: 2', /max_targets > 1/],
+    [
+        'bulk_scope_allowed=true 失败',
+        'bulk_scope_allowed: false',
+        'bulk_scope_allowed: true',
+        /bulk_scope_allowed true/,
+    ],
+    ['terms_approval=true 失败', 'terms_approval: false', 'terms_approval: true', /terms_approval true/],
+    [
+        'allowed_use_approved=true 失败',
+        'allowed_use_approved: false',
+        'allowed_use_approved: true',
+        /allowed_use_approved true/,
+    ],
+    [
+        'external_network_authorized=true 失败',
+        'external_network_authorized: false',
+        'external_network_authorized: true',
+        /external_network_authorized true/,
+    ],
+    [
+        'stdout_only_network_dry_run_authorized=true 失败',
+        'stdout_only_network_dry_run_authorized: false',
+        'stdout_only_network_dry_run_authorized: true',
+        /stdout_only_network_dry_run_authorized true/,
+    ],
+    [
+        'browser_runtime_authorized=true 失败',
+        'browser_runtime_authorized: false',
+        'browser_runtime_authorized: true',
+        /browser_runtime_authorized true/,
+    ],
+    [
+        'proxy_runtime_authorized=true 失败',
+        'proxy_runtime_authorized: false',
+        'proxy_runtime_authorized: true',
+        /proxy_runtime_authorized true/,
+    ],
+    [
+        'staging_write_authorized=true 失败',
+        'staging_write_authorized: false',
+        'staging_write_authorized: true',
+        /staging_write_authorized true/,
+    ],
+    [
+        'source_manifest_write_authorized=true 失败',
+        'source_manifest_write_authorized: false',
+        'source_manifest_write_authorized: true',
+        /source_manifest_write_authorized true/,
+    ],
+    [
+        'db_write_authorized=true 失败',
+        'db_write_authorized: false',
+        'db_write_authorized: true',
+        /db_write_authorized true/,
+    ],
+    [
+        'training_authorized=true 失败',
+        'training_authorized: false',
+        'training_authorized: true',
+        /training_authorized true/,
+    ],
+    [
+        'prediction_authorized=true 失败',
+        'prediction_authorized: false',
+        'prediction_authorized: true',
+        /prediction_authorized true/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'network_dry_run_execution_allowed=true 失败',
+        'network_dry_run_execution_allowed: false',
+        'network_dry_run_execution_allowed: true',
+        /network_dry_run_execution_allowed true/,
+    ],
+    [
+        'authorization_decision 不是 not_authorized 失败',
+        'authorization_decision: not_authorized',
+        'authorization_decision: authorized',
+        /authorization_decision not not_authorized/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+    [
+        'codex_may_not_self_fill_target=false 失败',
+        'codex_may_not_self_fill_target: true',
+        'codex_may_not_self_fill_target: false',
+        /codex_may_not_self_fill_target false/,
+    ],
+    [
+        'codex_may_not_self_authorize_network=false 失败',
+        'codex_may_not_self_authorize_network: true',
+        'codex_may_not_self_authorize_network: false',
+        /codex_may_not_self_authorize_network false/,
+    ],
+    [
+        'safety would_access_network=true 失败',
+        'would_access_network: false',
+        'would_access_network: true',
+        /safety would_access_network not false/,
+    ],
+    [
+        'safety would_write_db=true 失败',
+        'would_write_db: false',
+        'would_write_db: true',
+        /safety would_write_db not false/,
+    ],
+    [
+        'safety would_write_packet_file=true 失败',
+        'would_write_packet_file: false',
+        'would_write_packet_file: true',
+        /safety would_write_packet_file not false/,
+    ],
+].forEach(([name, searchValue, replaceValue, expectedError]) => {
+    test(name, () => {
+        const gate = loadFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildTextDependencies(replaceInTemplate(searchValue, replaceValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), expectedError);
+    });
+});
+
+test('valid template preview 成功', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runMain(gate, [`--packet=${PACKET_PATH}`], buildDependencies());
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, '');
+    const payload = extractJson(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.deepEqual(payload.authorization_blocking_reasons, gate.EXPECTED_BLOCKING_REASONS);
+    assertSafePayload(payload);
+});
+
+test('--commit blocked', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runMain(gate, [`--packet=${PACKET_PATH}`, '--commit'], buildDependencies());
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /BLOCKED: FotMob stdout-only network dry-run authorization packet is not executable/);
+});
+
+test('Makefile preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-fotmob-stdout-network-dry-run-authorization-packet-preview',
+            'FOTMOB_STDOUT_NETWORK_AUTH_PACKET_NODE=node',
+            `PACKET=${PACKET_PATH}`,
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assertSafePayload(extractJson(result.stdout));
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-fotmob-stdout-network-dry-run-authorization-packet-commit',
+            `PACKET=${PACKET_PATH}`,
+            'CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not executable in Phase 4\.99F/);
+});
+
+[
+    ['不访问网络', 'would_access_network'],
+    ['不启动 browser', 'would_launch_browser'],
+    ['不执行 proxy runtime', 'would_use_proxy'],
+    ['不执行 legacy runtime', 'would_execute_legacy_runtime'],
+    ['不写 staging', 'would_write_staging'],
+    ['不创建目录', 'would_create_staging_directory'],
+    ['不写 source manifest', 'would_write_source_manifest'],
+    ['不写 packet file', 'would_write_packet_file'],
+    ['不写 DB', 'would_write_db'],
+    ['不 spawn child process', 'would_spawn_child_process'],
+].forEach(([name, field]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], false);
+    });
+});
+
+test('adapter import and validation do not import legacy runtime, browser, proxy, DB, or child process paths', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    for (const legacyPath of LEGACY_PATHS) {
+        assert.equal(require.cache[legacyPath], undefined, `${legacyPath} must not be loaded`);
+    }
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"](?:node:)?http['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?https['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?net['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+    assert.ok(!/titan_discovery|DiscoveryService|ProductionHarvester|FotMobStrategy/.test(source));
+    assert.ok(!/FixtureRepository|Persistence|BrowserProvider|ProxyProvider/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 4.99F FotMob stdout-only network dry-run authorization packet.

Scope:
- Adds FotMob stdout-only network dry-run authorization packet template
- Adds local-only packet preview validator
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 4.99F report

Safety:
- No external FotMob access
- No external football or odds data access
- No curl / wget
- No browser automation
- No proxy runtime execution
- No legacy FotMob runtime execution
- No scraping
- No harvest / ingest
- No network dry-run execution
- No staging writes
- No source manifest writes
- No runtime packet writes
- No DB writes
- No pg_dump / pg_restore
- No training
- No prediction execution

Validation:
- Authorization packet unit tests passed
- packet preview passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally if browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed