### PR TITLE
docs(data): add FotMob network dry-run execution plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1056,6 +1056,16 @@ Phase 4.99F FotMob stdout-only network dry-run authorization packet rules：
 - Codex must not self-authorize network access or convert the authorization packet into execution.
 - Future FotMob stdout-only network dry-run requires an explicit user-filled authorization packet and a separate execution phase.
 
+Phase 5.00F FotMob stdout-only network dry-run execution plan rules：
+
+- FotMob stdout-only network dry-run execution plan is template-only in Phase 5.00F.
+- It must not access external FotMob or execute a network dry-run.
+- It must not write runtime execution plan files, staging, source manifest, packet, or DB.
+- Codex must not self-fill a real FotMob target, source terms, license, or allowed-use approval.
+- Codex must not self-authorize network access or convert the execution plan into execution.
+- Phase 5.00F is intended to stop template expansion and wait for user real input.
+- Next action after Phase 5.00F should be user-provided real FotMob target, terms, allowed-use, and authorization, not automatic Phase 5.01F.
+
 Phase 4.57C football-data adapter rules：
 
 - `fetch_and_adapt_euro_leagues` 属于 `adapter_candidate`，不是 Codex 可直接执行入口。

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
+        data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
         data-single-target-network-dry-run data-single-target-network-commit \
         data-single-target-acquisition-runtime-scaffold data-single-target-acquisition-runtime-commit \
         data-single-target-acquisition-staging-schema-validate data-single-target-acquisition-staging-schema-commit \
@@ -103,6 +104,7 @@ NETWORK_AUTHORIZATION_HANDOFF_CHECKLIST_NODE?=$(COMPOSE_DEV) exec -T dev node
 NETWORK_AUTHORIZATION_DECISION_NODE?=$(COMPOSE_DEV) exec -T dev node
 FOTMOB_SINGLE_TARGET_ADAPTER_NODE?=$(COMPOSE_DEV) exec -T dev node
 FOTMOB_STDOUT_NETWORK_AUTH_PACKET_NODE?=$(COMPOSE_DEV) exec -T dev node
+FOTMOB_STDOUT_NETWORK_EXECUTION_PLAN_NODE?=$(COMPOSE_DEV) exec -T dev node
 
 up: ## 启动核心服务 (db + redis)
 	docker-compose up -d
@@ -308,6 +310,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-acquisition-engine-audit"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
+	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
 	@echo "  make data-real-source-audit SOURCE_MANIFEST=<path>"
 	@echo "  make data-real-finished-csv-dry-run SOURCE_MANIFEST=<path> SAMPLE_CSV=<path>"
 	@echo "  make data-football-data-csv-dry-run SOURCE_MANIFEST=<path> LOCAL_CSV=<path>"
@@ -400,6 +403,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-single-target-acquisition-network-authorization-decision-commit ... CONFIRM_SINGLE_TARGET_ACQUISITION_NETWORK_AUTHORIZATION_DECISION=1  # blocked in Phase 4.95D"
 	@echo "  make data-fotmob-single-target-adapter-commit TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> CONFIRM_FOTMOB_SINGLE_TARGET_ADAPTER=1  # blocked in Phase 4.98F"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-commit PACKET=<path> CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET=1  # blocked in Phase 4.99F"
+	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-commit PLAN=<path> PACKET=<path> CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_EXECUTION_PLAN=1  # blocked in Phase 5.00F"
 	@echo "  make data-network-dry-run CONFIRM_NETWORK=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-db-write-small CONFIRM_DB_WRITE=1 LIMIT=<n> SCOPE=<scope>"
 	@echo "  make data-harvest CONFIRM_BULK_HARVEST=1 RUNBOOK=<path>"
@@ -944,6 +948,19 @@ data-fotmob-stdout-network-dry-run-authorization-packet-commit: ## Blocked FotMo
 	@echo "BLOCKED: FotMob stdout-only network dry-run authorization packet is not executable in Phase 4.99F."
 	@echo "  Even with CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_AUTHORIZATION_PACKET=1, this path remains blocked."
 	@echo "  The packet is template-only and does not authorize or execute a network dry-run."
+	@exit 1
+
+data-fotmob-stdout-network-dry-run-execution-plan-preview: ## Validate FotMob stdout-only network dry-run execution plan template. Phase 5.00F.
+	@if [ -z "$(PLAN)" ] || [ -z "$(PACKET)" ]; then \
+		echo "ERROR: provide PLAN=<path> and PACKET=<path>"; \
+		exit 1; \
+	fi
+	@$(FOTMOB_STDOUT_NETWORK_EXECUTION_PLAN_NODE) scripts/ops/fotmob_stdout_network_dry_run_execution_plan.js --plan "$(PLAN)" --packet "$(PACKET)"
+
+data-fotmob-stdout-network-dry-run-execution-plan-commit: ## Blocked FotMob stdout-only network dry-run execution plan execution gate. Remains blocked in Phase 5.00F.
+	@echo "BLOCKED: FotMob stdout-only network dry-run execution plan is not executable in Phase 5.00F."
+	@echo "  Even with CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_EXECUTION_PLAN=1, this path remains blocked."
+	@echo "  The execution plan is template-only and does not authorize or execute a network dry-run."
 	@exit 1
 
 data-single-target-network-dry-run: ## Scaffold-only single-target network dry-run gate. Requires ENGINE, TARGET_MATCH_ID, SOURCE_MANIFEST.

--- a/docs/_reports/FOTMOB_STDOUT_NETWORK_DRY_RUN_EXECUTION_PLAN_PHASE5_00F.md
+++ b/docs/_reports/FOTMOB_STDOUT_NETWORK_DRY_RUN_EXECUTION_PLAN_PHASE5_00F.md
@@ -1,0 +1,123 @@
+# FotMob Stdout-Only Network Dry-Run Execution Plan - Phase 5.00F
+
+## 1. Executive summary
+
+Phase 5.00F creates a FotMob stdout-only network dry-run execution plan template.
+It does not access FotMob, collect real data, write DB rows, or write staging.
+
+The execution plan is not execution and is not final authorization. Phase 5.00F
+should stop further template expansion and wait for user-provided real input.
+
+## 2. Implemented files
+
+- `docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md`
+- `scripts/ops/fotmob_stdout_network_dry_run_execution_plan.js`
+- `tests/unit/fotmob_stdout_network_dry_run_execution_plan.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/FOTMOB_STDOUT_NETWORK_DRY_RUN_EXECUTION_PLAN_PHASE5_00F.md`
+
+## 3. Execution plan sections
+
+- `authorization_packet`: requires a future user-filled authorization packet.
+- `target`: keeps FotMob scope empty, single-target, and max one target.
+- `runtime_policy`: keeps stdout-only intent and blocks network, browser, proxy,
+  legacy runtime, and acquisition engine execution in this phase.
+- `output_policy`: blocks stdout preview execution, staging writes, source
+  manifest writes, and packet writes in this phase.
+- `data_safety_policy`: blocks DB writes, training, prediction, and model artifact
+  loading.
+- `pre_execution_checks`: lists required checks, all unchecked and unpassed.
+- `abort_conditions`: lists conditions that must stop future execution.
+- `stdout_preview_expected_shape`: defines bounded future stdout summary shape.
+- `post_run_review`: documents required review after a future execution.
+- `codex_constraints`: blocks self-filled target, terms, authorization, execution,
+  and runtime file writes.
+- `safety`: confirms all `would_*` actions remain false.
+- `execution_blocking_reasons`: records why Phase 5.00F remains blocked.
+- `next_step_after_phase_5_00f`: stops template phases and requires user input.
+
+## 4. Execution boundary
+
+- The execution plan is not execution.
+- `target_count=0` by default.
+- `external_network_allowed=false` by default.
+- `execution_allowed=false` by default.
+- `stdout_preview_allowed=false` by default.
+- `staging_write_allowed=false` by default.
+- DB write remains false by default.
+- Future user input is required before any execution.
+- Future explicit execution confirmation is required after user input.
+
+## 5. Validation
+
+Local validation completed for this phase:
+
+- Unit tests passed for missing parameters, invalid YAML, unsafe field changes,
+  valid execution plan preview, blocked commit gate, Makefile targets, and
+  no-side-effect guards.
+- Valid execution plan preview through Makefile passed.
+- Blocked commit target through Makefile returned blocked as expected.
+- `npm test` passed.
+- `npm run test:coverage` passed.
+- `npm run test:integration` was skipped locally because the integration suite
+  includes Playwright / Chromium browser automation paths, which are outside
+  Phase 5.00F no-browser/no-network constraints.
+- `git diff --check` passed.
+- ESLint and Prettier checks passed.
+- DB row-count review remained unchanged.
+- `l1-config-*` residue remained absent.
+- `docs/_staging_preview` remained absent.
+
+## 6. Recommended next action
+
+Do not continue to Phase 5.01F automatically.
+Do not continue adding empty templates.
+
+The next action should be user-provided real FotMob dry-run parameters:
+
+- real FotMob target
+- target type: `match_id` or `league_season_date`
+- target URL, if any
+- source homepage URL
+- terms URL
+- license URL, if any
+- allowed-use summary
+- explicit stdout-only network authorization
+- browser policy
+- proxy policy
+- staging policy
+- no DB write confirmation
+- no training confirmation
+- no prediction confirmation
+- final human confirmation
+
+Only after those real parameters and authorization are provided should the project
+enter a final pre-execution confirmation for the first stdout-only single-target
+network dry-run.
+
+## 7. Explicit non-execution
+
+Phase 5.00F did not execute:
+
+- external FotMob access
+- external football data access
+- external odds data access
+- `curl` / `wget`
+- browser automation
+- proxy runtime
+- scraping
+- harvest
+- ingest
+- batch backfill
+- network dry-run
+- staging write
+- source manifest write
+- packet runtime write
+- execution plan runtime write
+- DB writes
+- `pg_dump` / `pg_restore`
+- training
+- prediction
+- file deletion
+- legacy FotMob runtime execution

--- a/docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md
+++ b/docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md
@@ -1,0 +1,256 @@
+# FotMob Stdout-Only Network Dry-Run Execution Plan Template
+
+Phase: 5.00F
+Status: template-only, non-executing
+
+## Purpose
+
+This is an execution plan template for one future FotMob stdout-only
+single-target network dry-run after a user-filled authorization packet has been
+reviewed and accepted. It is not execution, not final authorization, and not a
+network dry-run.
+
+Phase 5.00F does not access FotMob, collect real data, launch a browser, use a
+proxy, write staging, write a source manifest, write a runtime packet, write a
+runtime execution plan, write DB rows, train, predict, or execute legacy FotMob
+runtime.
+
+## Machine-Readable Execution Plan
+
+```yaml
+phase: PHASE5_00F_FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_EXECUTION_PLAN
+execution_plan_status: template_only
+execution_plan_ready: false
+execution_plan_reviewed: false
+execution_plan_accepted: false
+execution_allowed: false
+
+authorization_packet:
+    required: true
+    user_filled_packet_provided: false
+    authorization_packet_reviewed: false
+    authorization_packet_accepted: false
+    network_dry_run_authorized: false
+    final_human_confirmation: false
+
+target:
+    target_source: fotmob
+    target_scope_type:
+    target_match_id:
+    target_league:
+    target_season:
+    target_date:
+    target_url:
+    target_count: 0
+    max_targets: 1
+    single_target_only: true
+    bulk_scope_allowed: false
+
+runtime_policy:
+    stdout_only: true
+    external_network_allowed: false
+    browser_runtime_allowed: false
+    proxy_runtime_allowed: false
+    legacy_runtime_allowed: false
+    acquisition_engine_allowed: false
+    rate_limit_policy:
+    retry_policy:
+    user_agent_policy:
+
+output_policy:
+    stdout_preview_allowed: false
+    staging_write_allowed: false
+    source_manifest_write_allowed: false
+    packet_write_allowed: false
+    output_root:
+
+data_safety_policy:
+    db_write_allowed: false
+    training_allowed: false
+    prediction_allowed: false
+    model_artifact_loading_allowed: false
+
+pre_execution_checks:
+    user_filled_authorization_packet_check:
+        required: true
+        checked: false
+        passed: false
+    real_target_check:
+        required: true
+        checked: false
+        passed: false
+    source_terms_check:
+        required: true
+        checked: false
+        passed: false
+    allowed_use_check:
+        required: true
+        checked: false
+        passed: false
+    explicit_network_authorization_check:
+        required: true
+        checked: false
+        passed: false
+    single_target_scope_check:
+        required: true
+        checked: false
+        passed: false
+    no_browser_proxy_by_default_check:
+        required: true
+        checked: false
+        passed: false
+    no_staging_write_by_default_check:
+        required: true
+        checked: false
+        passed: false
+    no_db_training_prediction_check:
+        required: true
+        checked: false
+        passed: false
+    final_human_confirmation_check:
+        required: true
+        checked: false
+        passed: false
+
+abort_conditions:
+    - missing_user_filled_authorization_packet
+    - real_target_not_provided
+    - source_terms_not_approved
+    - allowed_use_not_approved
+    - external_network_not_authorized
+    - target_scope_not_single_target
+    - target_count_not_one
+    - browser_required_without_authorization
+    - proxy_required_without_authorization
+    - login_required
+    - paywall_bypass_required
+    - anti_bot_bypass_required
+    - staging_write_requested
+    - source_manifest_write_requested
+    - db_write_requested
+    - training_requested
+    - prediction_requested
+    - legacy_runtime_requested
+    - final_human_confirmation_missing
+
+stdout_preview_expected_shape:
+    expected_top_level_fields:
+        - phase
+        - target
+        - request_summary
+        - response_status_summary
+        - parser_preview
+        - parser_confidence
+        - safety_summary
+        - stop_gates
+    bounded_preview_required: true
+    include_raw_html: false
+    include_large_payload: false
+    include_personal_data: false
+    max_preview_bytes:
+
+post_run_review:
+    required_after_future_execution: true
+    review_stdout_preview: true
+    review_response_status: true
+    review_parser_confidence: true
+    review_schema_drift: true
+    review_stop_gates: true
+    decide_whether_to_allow_staging_preview_later: true
+    db_write_still_forbidden: true
+
+codex_constraints:
+    codex_may_not_self_fill_target: true
+    codex_may_not_self_approve_terms: true
+    codex_may_not_self_authorize_network: true
+    codex_may_not_enable_execution: true
+    codex_may_not_execute_network_dry_run: true
+    codex_may_not_write_runtime_files: true
+
+safety:
+    would_access_network: false
+    would_launch_browser: false
+    would_use_proxy: false
+    would_execute_legacy_runtime: false
+    would_execute_engine: false
+    would_write_staging: false
+    would_create_staging_directory: false
+    would_write_source_manifest: false
+    would_write_packet_file: false
+    would_write_execution_plan_file: false
+    would_write_db: false
+    would_train: false
+    would_predict: false
+    would_spawn_child_process: false
+
+execution_blocking_reasons:
+    - execution_plan_template_only
+    - user_filled_authorization_packet_missing
+    - real_target_not_provided
+    - source_terms_not_approved
+    - allowed_use_not_approved
+    - external_network_not_authorized
+    - final_human_confirmation_missing
+    - future_explicit_execution_confirmation_required
+
+next_step_after_phase_5_00f:
+    continue_template_phases: false
+    requires_user_real_input: true
+    required_user_inputs:
+        - real_fotmob_target
+        - source_homepage_url
+        - terms_url
+        - license_url_if_any
+        - allowed_use_summary
+        - explicit_stdout_only_network_authorization
+        - browser_policy
+        - proxy_policy
+        - staging_policy
+        - no_db_write_confirmation
+        - no_training_confirmation
+        - no_prediction_confirmation
+        - final_human_confirmation
+```
+
+## Execution Boundary
+
+- This template is not execution.
+- This template is not final authorization.
+- `execution_plan_status` defaults to `template_only`.
+- `execution_plan_ready` defaults to `false`.
+- `execution_allowed` defaults to `false`.
+- `network_dry_run_authorized` defaults to `false`.
+- `target_count` defaults to `0`.
+- `max_targets` defaults to `1`.
+- `bulk_scope_allowed` defaults to `false`.
+- `external_network_allowed` defaults to `false`.
+- `stdout_preview_allowed` defaults to `false`.
+- `staging_write_allowed` defaults to `false`.
+- DB writes, training, and prediction all default to `false`.
+
+## Future Runtime Boundary
+
+A future dry-run must be stdout-only, single-target, bounded, and explicitly
+authorized by a user-filled authorization packet plus a separate execution
+confirmation. It must not be bulk, must not use browser or proxy runtime by
+default, must not write staging by default, and must not write DB rows, train, or
+predict.
+
+Pre-execution checks and abort conditions must be reviewed before any future
+execution. A future stdout preview should expose only bounded summary fields and
+must not include raw HTML, large payloads, personal data, or unbounded remote
+content.
+
+Post-run review is required after any future execution, but Phase 5.00F does not
+perform that review because no execution occurs in this phase.
+
+## Codex Boundary
+
+Codex must not self-fill a real FotMob target, approve terms, approve allowed use,
+authorize network access, turn this execution plan into execution, or execute a
+FotMob network dry-run.
+
+Phase 5.00F writes no runtime execution plan. It only adds this template and a
+stdout preview validator. After Phase 5.00F, the next step should wait for user
+real input instead of continuing automatic template expansion or creating a new
+empty template phase.

--- a/scripts/ops/fotmob_stdout_network_dry_run_execution_plan.js
+++ b/scripts/ops/fotmob_stdout_network_dry_run_execution_plan.js
@@ -1,0 +1,828 @@
+#!/usr/bin/env node
+/**
+ * Phase 5.00F: FotMob stdout-only network dry-run execution plan preview.
+ *
+ * This command reads a local execution plan template and authorization packet
+ * template, then prints a JSON summary to stdout. It does not access the
+ * network, launch browser or proxy runtime, execute legacy FotMob runtime,
+ * write files, connect to DB, spawn child processes, train, or predict.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const authorizationPacketGate = require('./fotmob_stdout_network_dry_run_authorization_packet.js');
+
+const PHASE = 'PHASE5_00F_FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_EXECUTION_PLAN';
+const BLOCKED_COMMIT_MESSAGE =
+    'BLOCKED: FotMob stdout-only network dry-run execution plan is not executable in Phase 5.00F.';
+const NEXT_REQUIRED_ACTION = 'user_must_fill_real_fotmob_target_terms_allowed_use_and_network_authorization';
+
+const EXPECTED_ABORT_CONDITIONS = [
+    'missing_user_filled_authorization_packet',
+    'real_target_not_provided',
+    'source_terms_not_approved',
+    'allowed_use_not_approved',
+    'external_network_not_authorized',
+    'target_scope_not_single_target',
+    'target_count_not_one',
+    'browser_required_without_authorization',
+    'proxy_required_without_authorization',
+    'login_required',
+    'paywall_bypass_required',
+    'anti_bot_bypass_required',
+    'staging_write_requested',
+    'source_manifest_write_requested',
+    'db_write_requested',
+    'training_requested',
+    'prediction_requested',
+    'legacy_runtime_requested',
+    'final_human_confirmation_missing',
+];
+
+const EXPECTED_BLOCKING_REASONS = [
+    'execution_plan_template_only',
+    'user_filled_authorization_packet_missing',
+    'real_target_not_provided',
+    'source_terms_not_approved',
+    'allowed_use_not_approved',
+    'external_network_not_authorized',
+    'final_human_confirmation_missing',
+    'future_explicit_execution_confirmation_required',
+];
+
+const EXPECTED_STDOUT_FIELDS = [
+    'phase',
+    'target',
+    'request_summary',
+    'response_status_summary',
+    'parser_preview',
+    'parser_confidence',
+    'safety_summary',
+    'stop_gates',
+];
+
+const EXPECTED_REQUIRED_USER_INPUTS = [
+    'real_fotmob_target',
+    'source_homepage_url',
+    'terms_url',
+    'license_url_if_any',
+    'allowed_use_summary',
+    'explicit_stdout_only_network_authorization',
+    'browser_policy',
+    'proxy_policy',
+    'staging_policy',
+    'no_db_write_confirmation',
+    'no_training_confirmation',
+    'no_prediction_confirmation',
+    'final_human_confirmation',
+];
+
+const PRE_EXECUTION_CHECKS = [
+    'user_filled_authorization_packet_check',
+    'real_target_check',
+    'source_terms_check',
+    'allowed_use_check',
+    'explicit_network_authorization_check',
+    'single_target_scope_check',
+    'no_browser_proxy_by_default_check',
+    'no_staging_write_by_default_check',
+    'no_db_training_prediction_check',
+    'final_human_confirmation_check',
+];
+
+const REQUIRED_TOP_LEVEL_FIELDS = [
+    'phase',
+    'execution_plan_status',
+    'execution_plan_ready',
+    'execution_plan_reviewed',
+    'execution_plan_accepted',
+    'execution_allowed',
+    'authorization_packet',
+    'target',
+    'runtime_policy',
+    'output_policy',
+    'data_safety_policy',
+    'pre_execution_checks',
+    'abort_conditions',
+    'stdout_preview_expected_shape',
+    'post_run_review',
+    'codex_constraints',
+    'safety',
+    'execution_blocking_reasons',
+    'next_step_after_phase_5_00f',
+];
+
+const REQUIRED_NESTED_FIELDS = {
+    authorization_packet: [
+        'required',
+        'user_filled_packet_provided',
+        'authorization_packet_reviewed',
+        'authorization_packet_accepted',
+        'network_dry_run_authorized',
+        'final_human_confirmation',
+    ],
+    target: [
+        'target_source',
+        'target_scope_type',
+        'target_match_id',
+        'target_league',
+        'target_season',
+        'target_date',
+        'target_url',
+        'target_count',
+        'max_targets',
+        'single_target_only',
+        'bulk_scope_allowed',
+    ],
+    runtime_policy: [
+        'stdout_only',
+        'external_network_allowed',
+        'browser_runtime_allowed',
+        'proxy_runtime_allowed',
+        'legacy_runtime_allowed',
+        'acquisition_engine_allowed',
+        'rate_limit_policy',
+        'retry_policy',
+        'user_agent_policy',
+    ],
+    output_policy: [
+        'stdout_preview_allowed',
+        'staging_write_allowed',
+        'source_manifest_write_allowed',
+        'packet_write_allowed',
+        'output_root',
+    ],
+    data_safety_policy: [
+        'db_write_allowed',
+        'training_allowed',
+        'prediction_allowed',
+        'model_artifact_loading_allowed',
+    ],
+    stdout_preview_expected_shape: [
+        'expected_top_level_fields',
+        'bounded_preview_required',
+        'include_raw_html',
+        'include_large_payload',
+        'include_personal_data',
+        'max_preview_bytes',
+    ],
+    post_run_review: [
+        'required_after_future_execution',
+        'review_stdout_preview',
+        'review_response_status',
+        'review_parser_confidence',
+        'review_schema_drift',
+        'review_stop_gates',
+        'decide_whether_to_allow_staging_preview_later',
+        'db_write_still_forbidden',
+    ],
+    codex_constraints: [
+        'codex_may_not_self_fill_target',
+        'codex_may_not_self_approve_terms',
+        'codex_may_not_self_authorize_network',
+        'codex_may_not_enable_execution',
+        'codex_may_not_execute_network_dry_run',
+        'codex_may_not_write_runtime_files',
+    ],
+    safety: [
+        'would_access_network',
+        'would_launch_browser',
+        'would_use_proxy',
+        'would_execute_legacy_runtime',
+        'would_execute_engine',
+        'would_write_staging',
+        'would_create_staging_directory',
+        'would_write_source_manifest',
+        'would_write_packet_file',
+        'would_write_execution_plan_file',
+        'would_write_db',
+        'would_train',
+        'would_predict',
+        'would_spawn_child_process',
+    ],
+    next_step_after_phase_5_00f: ['continue_template_phases', 'requires_user_real_input', 'required_user_inputs'],
+};
+
+const SAFETY_FALSE_FIELDS = REQUIRED_NESTED_FIELDS.safety;
+const CODEX_TRUE_FIELDS = REQUIRED_NESTED_FIELDS.codex_constraints;
+
+function parseArgs(argv = []) {
+    const args = {
+        plan: '',
+        packet: '',
+        commit: false,
+        help: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (token === '--commit') {
+            args.commit = true;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            args.help = true;
+            continue;
+        }
+        if (!token.startsWith('--')) {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+
+        const eqIndex = token.indexOf('=');
+        if (eqIndex !== -1) {
+            args[token.slice(2, eqIndex).replace(/-/g, '_')] = token.slice(eqIndex + 1);
+        } else if (index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+            args[token.slice(2).replace(/-/g, '_')] = String(argv[index + 1] || '');
+            index += 1;
+        } else {
+            throw new Error(`Unknown argument: ${token}`);
+        }
+    }
+
+    return args;
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/fotmob_stdout_network_dry_run_execution_plan.js --plan <path> --packet <path>',
+        '  node scripts/ops/fotmob_stdout_network_dry_run_execution_plan.js --plan <path> --packet <path> --commit',
+        '',
+        'Safety:',
+        '  Phase 5.00F validates a local execution plan template only.',
+        '  No network, browser, proxy, legacy runtime, DB, file writes, child processes, training, or prediction.',
+    ].join('\n');
+}
+
+function defaultDependencies() {
+    return {
+        cwd: process.cwd(),
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+    };
+}
+
+function resolveLocalPath(rawPath, cwd = process.cwd()) {
+    if (!rawPath) return '';
+    return path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(cwd, rawPath);
+}
+
+function toRelativePath(absolutePath, cwd = process.cwd()) {
+    if (!absolutePath) return '';
+    return path.relative(cwd, absolutePath) || '.';
+}
+
+function extractYamlBlock(markdownText) {
+    return authorizationPacketGate.extractYamlBlock(markdownText);
+}
+
+function parsePlanYaml(yamlText) {
+    return authorizationPacketGate.parsePacketYaml(yamlText);
+}
+
+function getPath(root, dottedPath) {
+    return dottedPath.split('.').reduce((current, key) => {
+        if (!current || typeof current !== 'object') return undefined;
+        return current[key];
+    }, root);
+}
+
+function hasOwn(root, key) {
+    return Object.prototype.hasOwnProperty.call(root, key);
+}
+
+function findMissingFields(parsedYaml) {
+    const missingFields = REQUIRED_TOP_LEVEL_FIELDS.filter(key => !hasOwn(parsedYaml, key));
+    Object.entries(REQUIRED_NESTED_FIELDS).forEach(([sectionName, fields]) => {
+        const section = parsedYaml[sectionName];
+        if (!section || typeof section !== 'object' || Array.isArray(section)) {
+            fields.forEach(field => missingFields.push(`${sectionName}.${field}`));
+            return;
+        }
+        fields.filter(field => !hasOwn(section, field)).forEach(field => missingFields.push(`${sectionName}.${field}`));
+    });
+
+    PRE_EXECUTION_CHECKS.forEach(checkName => {
+        const check = getPath(parsedYaml, `pre_execution_checks.${checkName}`);
+        if (!check || typeof check !== 'object' || Array.isArray(check)) {
+            missingFields.push(`pre_execution_checks.${checkName}`);
+            ['required', 'checked', 'passed'].forEach(field =>
+                missingFields.push(`pre_execution_checks.${checkName}.${field}`)
+            );
+            return;
+        }
+        ['required', 'checked', 'passed']
+            .filter(field => !hasOwn(check, field))
+            .forEach(field => missingFields.push(`pre_execution_checks.${checkName}.${field}`));
+    });
+
+    return missingFields;
+}
+
+function expectValue(parsedYaml, dottedPath, expectedValue, errors, message) {
+    if (getPath(parsedYaml, dottedPath) !== expectedValue) {
+        errors.push(message || `${dottedPath} must be ${expectedValue}`);
+    }
+}
+
+function expectListIncludes(parsedYaml, dottedPath, expectedItems, errors, messagePrefix) {
+    const value = getPath(parsedYaml, dottedPath);
+    if (!Array.isArray(value)) {
+        errors.push(`${dottedPath} missing or not list`);
+        return;
+    }
+
+    const missingItems = expectedItems.filter(item => !value.includes(item));
+    if (missingItems.length) {
+        errors.push(`${messagePrefix}: ${missingItems.join(', ')}`);
+    }
+}
+
+function validatePreExecutionChecks(parsedYaml, errors) {
+    PRE_EXECUTION_CHECKS.forEach(checkName => {
+        expectValue(
+            parsedYaml,
+            `pre_execution_checks.${checkName}.required`,
+            true,
+            errors,
+            `pre_execution_checks.${checkName}.required not true`
+        );
+        expectValue(
+            parsedYaml,
+            `pre_execution_checks.${checkName}.checked`,
+            false,
+            errors,
+            `pre_execution_checks.${checkName}.checked true`
+        );
+        expectValue(
+            parsedYaml,
+            `pre_execution_checks.${checkName}.passed`,
+            false,
+            errors,
+            `pre_execution_checks.${checkName}.passed true`
+        );
+    });
+}
+
+function validatePlanValues(parsedYaml) {
+    const errors = [];
+    const missingFields = findMissingFields(parsedYaml);
+    if (missingFields.length) {
+        errors.push(`missing required fields: ${missingFields.join(', ')}`);
+    }
+
+    expectValue(parsedYaml, 'phase', PHASE, errors, `phase must be ${PHASE}`);
+    expectValue(
+        parsedYaml,
+        'execution_plan_status',
+        'template_only',
+        errors,
+        'execution_plan_status not template_only'
+    );
+    expectValue(parsedYaml, 'execution_plan_ready', false, errors, 'execution_plan_ready true');
+    expectValue(parsedYaml, 'execution_plan_reviewed', false, errors, 'execution_plan_reviewed true');
+    expectValue(parsedYaml, 'execution_plan_accepted', false, errors, 'execution_plan_accepted true');
+    expectValue(parsedYaml, 'execution_allowed', false, errors, 'execution_allowed true');
+
+    expectValue(parsedYaml, 'authorization_packet.required', true, errors, 'authorization_packet.required not true');
+    expectValue(
+        parsedYaml,
+        'authorization_packet.user_filled_packet_provided',
+        false,
+        errors,
+        'user_filled_packet_provided true'
+    );
+    expectValue(
+        parsedYaml,
+        'authorization_packet.authorization_packet_reviewed',
+        false,
+        errors,
+        'authorization_packet_reviewed true'
+    );
+    expectValue(
+        parsedYaml,
+        'authorization_packet.authorization_packet_accepted',
+        false,
+        errors,
+        'authorization_packet_accepted true'
+    );
+    expectValue(
+        parsedYaml,
+        'authorization_packet.network_dry_run_authorized',
+        false,
+        errors,
+        'network_dry_run_authorized true'
+    );
+    expectValue(
+        parsedYaml,
+        'authorization_packet.final_human_confirmation',
+        false,
+        errors,
+        'final_human_confirmation true'
+    );
+
+    expectValue(parsedYaml, 'target.target_source', 'fotmob', errors, 'target_source not fotmob');
+    const targetCount = getPath(parsedYaml, 'target.target_count');
+    if (targetCount > 1) errors.push('target_count > 1');
+    if (targetCount !== 0) errors.push('target_count must remain 0 in Phase 5.00F template');
+    const maxTargets = getPath(parsedYaml, 'target.max_targets');
+    if (maxTargets > 1) errors.push('max_targets > 1');
+    if (maxTargets !== 1) errors.push('max_targets must be 1');
+    expectValue(parsedYaml, 'target.single_target_only', true, errors, 'single_target_only not true');
+    expectValue(parsedYaml, 'target.bulk_scope_allowed', false, errors, 'bulk_scope_allowed true');
+
+    expectValue(parsedYaml, 'runtime_policy.stdout_only', true, errors, 'stdout_only false');
+    expectValue(parsedYaml, 'runtime_policy.external_network_allowed', false, errors, 'external_network_allowed true');
+    expectValue(parsedYaml, 'runtime_policy.browser_runtime_allowed', false, errors, 'browser_runtime_allowed true');
+    expectValue(parsedYaml, 'runtime_policy.proxy_runtime_allowed', false, errors, 'proxy_runtime_allowed true');
+    expectValue(parsedYaml, 'runtime_policy.legacy_runtime_allowed', false, errors, 'legacy_runtime_allowed true');
+    expectValue(
+        parsedYaml,
+        'runtime_policy.acquisition_engine_allowed',
+        false,
+        errors,
+        'acquisition_engine_allowed true'
+    );
+
+    expectValue(parsedYaml, 'output_policy.stdout_preview_allowed', false, errors, 'stdout_preview_allowed true');
+    expectValue(parsedYaml, 'output_policy.staging_write_allowed', false, errors, 'staging_write_allowed true');
+    expectValue(
+        parsedYaml,
+        'output_policy.source_manifest_write_allowed',
+        false,
+        errors,
+        'source_manifest_write_allowed true'
+    );
+    expectValue(parsedYaml, 'output_policy.packet_write_allowed', false, errors, 'packet_write_allowed true');
+
+    expectValue(parsedYaml, 'data_safety_policy.db_write_allowed', false, errors, 'db_write_allowed true');
+    expectValue(parsedYaml, 'data_safety_policy.training_allowed', false, errors, 'training_allowed true');
+    expectValue(parsedYaml, 'data_safety_policy.prediction_allowed', false, errors, 'prediction_allowed true');
+    expectValue(
+        parsedYaml,
+        'data_safety_policy.model_artifact_loading_allowed',
+        false,
+        errors,
+        'model_artifact_loading_allowed true'
+    );
+
+    validatePreExecutionChecks(parsedYaml, errors);
+
+    expectListIncludes(parsedYaml, 'abort_conditions', EXPECTED_ABORT_CONDITIONS, errors, 'missing abort_conditions');
+    expectListIncludes(
+        parsedYaml,
+        'stdout_preview_expected_shape.expected_top_level_fields',
+        EXPECTED_STDOUT_FIELDS,
+        errors,
+        'missing stdout_preview_expected_shape.expected_top_level_fields'
+    );
+    expectValue(
+        parsedYaml,
+        'stdout_preview_expected_shape.bounded_preview_required',
+        true,
+        errors,
+        'bounded_preview_required not true'
+    );
+    expectValue(parsedYaml, 'stdout_preview_expected_shape.include_raw_html', false, errors, 'include_raw_html true');
+    expectValue(
+        parsedYaml,
+        'stdout_preview_expected_shape.include_large_payload',
+        false,
+        errors,
+        'include_large_payload true'
+    );
+    expectValue(
+        parsedYaml,
+        'stdout_preview_expected_shape.include_personal_data',
+        false,
+        errors,
+        'include_personal_data true'
+    );
+
+    Object.entries(parsedYaml.post_run_review || {}).forEach(([key, value]) => {
+        if (value !== true) errors.push(`post_run_review.${key} not true`);
+    });
+
+    CODEX_TRUE_FIELDS.forEach(field => {
+        expectValue(parsedYaml, `codex_constraints.${field}`, true, errors, `${field} false`);
+    });
+
+    SAFETY_FALSE_FIELDS.forEach(field => {
+        expectValue(parsedYaml, `safety.${field}`, false, errors, `safety ${field} not false`);
+    });
+
+    expectListIncludes(
+        parsedYaml,
+        'execution_blocking_reasons',
+        EXPECTED_BLOCKING_REASONS,
+        errors,
+        'missing execution_blocking_reasons'
+    );
+    expectValue(
+        parsedYaml,
+        'next_step_after_phase_5_00f.continue_template_phases',
+        false,
+        errors,
+        'continue_template_phases true'
+    );
+    expectValue(
+        parsedYaml,
+        'next_step_after_phase_5_00f.requires_user_real_input',
+        true,
+        errors,
+        'requires_user_real_input false'
+    );
+    expectListIncludes(
+        parsedYaml,
+        'next_step_after_phase_5_00f.required_user_inputs',
+        EXPECTED_REQUIRED_USER_INPUTS,
+        errors,
+        'missing next_step_after_phase_5_00f.required_user_inputs'
+    );
+
+    return errors;
+}
+
+function buildBasePayload(args, fields = {}) {
+    return {
+        phase: PHASE,
+        ok: false,
+        plan: args.plan || null,
+        packet: args.packet || null,
+        plan_found: false,
+        packet_found: false,
+        plan_yaml_block_found: false,
+        packet_yaml_block_found: false,
+        execution_plan_template_only: true,
+        execution_plan_valid: false,
+        authorization_packet_valid: false,
+        execution_plan_ready: false,
+        execution_plan_reviewed: false,
+        execution_plan_accepted: false,
+        execution_allowed: false,
+        user_filled_packet_provided: false,
+        network_dry_run_authorized: false,
+        final_human_confirmation: false,
+        target_source: null,
+        target_count: null,
+        max_targets: null,
+        single_target_only: false,
+        bulk_scope_allowed: false,
+        stdout_only: false,
+        external_network_allowed: false,
+        browser_runtime_allowed: false,
+        proxy_runtime_allowed: false,
+        legacy_runtime_allowed: false,
+        acquisition_engine_allowed: false,
+        stdout_preview_allowed: false,
+        staging_write_allowed: false,
+        source_manifest_write_allowed: false,
+        db_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        pre_execution_checks_complete: false,
+        pre_execution_checks_passed: false,
+        abort_conditions_active: true,
+        continue_template_phases: false,
+        requires_user_real_input: true,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_execute_legacy_runtime: false,
+        would_execute_engine: false,
+        would_write_staging: false,
+        would_create_staging_directory: false,
+        would_write_source_manifest: false,
+        would_write_packet_file: false,
+        would_write_execution_plan_file: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_spawn_child_process: false,
+        commit_gate: 'blocked',
+        next_required_action: NEXT_REQUIRED_ACTION,
+        errors: [],
+        ...fields,
+    };
+}
+
+function preExecutionChecksComplete(parsedYaml) {
+    return PRE_EXECUTION_CHECKS.every(checkName => {
+        const check = getPath(parsedYaml, `pre_execution_checks.${checkName}`);
+        return check && check.required === true && check.checked === false && check.passed === false;
+    });
+}
+
+function buildSuccessPayload(args, parsedYaml) {
+    return buildBasePayload(args, {
+        ok: true,
+        plan_found: true,
+        packet_found: true,
+        plan_yaml_block_found: true,
+        packet_yaml_block_found: true,
+        execution_plan_valid: true,
+        authorization_packet_valid: true,
+        execution_plan_ready: parsedYaml.execution_plan_ready,
+        execution_plan_reviewed: parsedYaml.execution_plan_reviewed,
+        execution_plan_accepted: parsedYaml.execution_plan_accepted,
+        execution_allowed: parsedYaml.execution_allowed,
+        user_filled_packet_provided: parsedYaml.authorization_packet.user_filled_packet_provided,
+        network_dry_run_authorized: parsedYaml.authorization_packet.network_dry_run_authorized,
+        final_human_confirmation: parsedYaml.authorization_packet.final_human_confirmation,
+        target_source: parsedYaml.target.target_source,
+        target_count: parsedYaml.target.target_count,
+        max_targets: parsedYaml.target.max_targets,
+        single_target_only: parsedYaml.target.single_target_only,
+        bulk_scope_allowed: parsedYaml.target.bulk_scope_allowed,
+        stdout_only: parsedYaml.runtime_policy.stdout_only,
+        external_network_allowed: parsedYaml.runtime_policy.external_network_allowed,
+        browser_runtime_allowed: parsedYaml.runtime_policy.browser_runtime_allowed,
+        proxy_runtime_allowed: parsedYaml.runtime_policy.proxy_runtime_allowed,
+        legacy_runtime_allowed: parsedYaml.runtime_policy.legacy_runtime_allowed,
+        acquisition_engine_allowed: parsedYaml.runtime_policy.acquisition_engine_allowed,
+        stdout_preview_allowed: parsedYaml.output_policy.stdout_preview_allowed,
+        staging_write_allowed: parsedYaml.output_policy.staging_write_allowed,
+        source_manifest_write_allowed: parsedYaml.output_policy.source_manifest_write_allowed,
+        db_write_allowed: parsedYaml.data_safety_policy.db_write_allowed,
+        training_allowed: parsedYaml.data_safety_policy.training_allowed,
+        prediction_allowed: parsedYaml.data_safety_policy.prediction_allowed,
+        pre_execution_checks_complete: preExecutionChecksComplete(parsedYaml),
+        pre_execution_checks_passed: false,
+        abort_conditions_active: true,
+        continue_template_phases: parsedYaml.next_step_after_phase_5_00f.continue_template_phases,
+        requires_user_real_input: parsedYaml.next_step_after_phase_5_00f.requires_user_real_input,
+        would_access_network: parsedYaml.safety.would_access_network,
+        would_launch_browser: parsedYaml.safety.would_launch_browser,
+        would_use_proxy: parsedYaml.safety.would_use_proxy,
+        would_execute_legacy_runtime: parsedYaml.safety.would_execute_legacy_runtime,
+        would_execute_engine: parsedYaml.safety.would_execute_engine,
+        would_write_staging: parsedYaml.safety.would_write_staging,
+        would_create_staging_directory: parsedYaml.safety.would_create_staging_directory,
+        would_write_source_manifest: parsedYaml.safety.would_write_source_manifest,
+        would_write_packet_file: parsedYaml.safety.would_write_packet_file,
+        would_write_execution_plan_file: parsedYaml.safety.would_write_execution_plan_file,
+        would_write_db: parsedYaml.safety.would_write_db,
+        would_train: parsedYaml.safety.would_train,
+        would_predict: parsedYaml.safety.would_predict,
+        would_spawn_child_process: parsedYaml.safety.would_spawn_child_process,
+    });
+}
+
+function loadPlanYaml(args, dependencies) {
+    if (!args.plan) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'argument-error',
+                errors: ['missing plan'],
+            }),
+        };
+    }
+
+    const planPath = resolveLocalPath(args.plan, dependencies.cwd);
+    if (!dependencies.existsSync(planPath)) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'plan-error',
+                plan: args.plan,
+                plan_found: false,
+                errors: [`missing plan: ${toRelativePath(planPath, dependencies.cwd)}`],
+            }),
+        };
+    }
+
+    const yamlText = extractYamlBlock(dependencies.readFileSync(planPath, 'utf8'));
+    if (!yamlText) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'plan-error',
+                plan_found: true,
+                plan_yaml_block_found: false,
+                errors: ['missing YAML block'],
+            }),
+        };
+    }
+
+    try {
+        return {
+            parsedYaml: parsePlanYaml(yamlText),
+            yamlText,
+        };
+    } catch (error) {
+        return {
+            payload: buildBasePayload(args, {
+                mode: 'plan-error',
+                plan_found: true,
+                plan_yaml_block_found: true,
+                errors: [`invalid YAML: ${error.message}`],
+            }),
+        };
+    }
+}
+
+function validateAuthorizationPacket(args, dependencies) {
+    if (!args.packet) {
+        return buildBasePayload(args, {
+            mode: 'argument-error',
+            errors: ['missing packet'],
+        });
+    }
+
+    const packetPayload = authorizationPacketGate.runValidation({ packet: args.packet }, dependencies);
+    if (!packetPayload.ok) {
+        return buildBasePayload(args, {
+            mode: 'packet-error',
+            packet_found: packetPayload.packet_found,
+            packet_yaml_block_found: packetPayload.yaml_block_found,
+            errors: packetPayload.errors,
+        });
+    }
+
+    return null;
+}
+
+function runValidation(args, dependencies = defaultDependencies()) {
+    const loadedPlan = loadPlanYaml(args, dependencies);
+    if (loadedPlan.payload) return loadedPlan.payload;
+
+    const packetErrorPayload = validateAuthorizationPacket(args, dependencies);
+    if (packetErrorPayload) return packetErrorPayload;
+
+    const errors = validatePlanValues(loadedPlan.parsedYaml);
+    if (errors.length) {
+        return buildBasePayload(args, {
+            mode: 'validation-error',
+            plan_found: true,
+            packet_found: true,
+            plan_yaml_block_found: true,
+            packet_yaml_block_found: true,
+            errors,
+        });
+    }
+
+    return buildSuccessPayload(args, loadedPlan.parsedYaml);
+}
+
+function main(argv = process.argv.slice(2), io = {}, dependencies = defaultDependencies()) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+
+    let args;
+    try {
+        args = parseArgs(argv);
+    } catch (error) {
+        stderr(`${error.message}\n`);
+        return 1;
+    }
+
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    if (args.commit) {
+        stderr(`${BLOCKED_COMMIT_MESSAGE}\n`);
+        return 1;
+    }
+
+    const payload = runValidation(args, dependencies);
+    if (!payload.ok) {
+        stderr(`${payload.errors.join('\n')}\n`);
+        return 1;
+    }
+
+    stdout(`${JSON.stringify(payload, null, 2)}\n`);
+    return 0;
+}
+
+if (require.main === module) {
+    process.exitCode = main();
+}
+
+module.exports = {
+    PHASE,
+    BLOCKED_COMMIT_MESSAGE,
+    NEXT_REQUIRED_ACTION,
+    EXPECTED_ABORT_CONDITIONS,
+    EXPECTED_BLOCKING_REASONS,
+    EXPECTED_STDOUT_FIELDS,
+    EXPECTED_REQUIRED_USER_INPUTS,
+    PRE_EXECUTION_CHECKS,
+    REQUIRED_TOP_LEVEL_FIELDS,
+    REQUIRED_NESTED_FIELDS,
+    SAFETY_FALSE_FIELDS,
+    CODEX_TRUE_FIELDS,
+    parseArgs,
+    usage,
+    extractYamlBlock,
+    parsePlanYaml,
+    findMissingFields,
+    validatePlanValues,
+    buildBasePayload,
+    buildSuccessPayload,
+    loadPlanYaml,
+    validateAuthorizationPacket,
+    runValidation,
+    main,
+};

--- a/tests/unit/fotmob_stdout_network_dry_run_execution_plan.test.js
+++ b/tests/unit/fotmob_stdout_network_dry_run_execution_plan.test.js
@@ -1,0 +1,529 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/fotmob_stdout_network_dry_run_execution_plan.js');
+const PLAN_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_EXECUTION_PLAN_TEMPLATE.md'
+);
+const PACKET_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/runbooks/FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_AUTHORIZATION_PACKET_TEMPLATE.md'
+);
+const PLAN_TEXT = fs.readFileSync(PLAN_PATH, 'utf8');
+
+const LEGACY_PATHS = [
+    path.join(PROJECT_ROOT, 'scripts/ops/titan_discovery.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/run_production.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/batch_historical_backfill.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/backfill_historical_raw_match_data.js'),
+    path.join(PROJECT_ROOT, 'scripts/ops/titan_seeder.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/ProductionHarvester.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/strategies/FotMobStrategy.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/services/FixtureRepository.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/harvesters/components/Persistence.js'),
+    path.join(PROJECT_ROOT, 'src/infrastructure/services/BrowserProvider.js'),
+];
+
+const SAFE_FALSE_FIELDS = [
+    'would_access_network',
+    'would_launch_browser',
+    'would_use_proxy',
+    'would_execute_legacy_runtime',
+    'would_execute_engine',
+    'would_write_staging',
+    'would_create_staging_directory',
+    'would_write_source_manifest',
+    'would_write_packet_file',
+    'would_write_execution_plan_file',
+    'would_write_db',
+    'would_train',
+    'would_predict',
+    'would_spawn_child_process',
+];
+
+function loadFresh() {
+    delete require.cache[require.resolve(SCRIPT_PATH)];
+    return require(SCRIPT_PATH);
+}
+
+function buildArgs(overrides = {}) {
+    return {
+        plan: PLAN_PATH,
+        packet: PACKET_PATH,
+        ...overrides,
+    };
+}
+
+function buildDependencies(overrides = {}) {
+    return {
+        cwd: PROJECT_ROOT,
+        existsSync: targetPath => fs.existsSync(targetPath),
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+        ...overrides,
+    };
+}
+
+function buildTextDependencies(planMarkdownText, targetPath = PLAN_PATH) {
+    const resolvedPlan = path.resolve(targetPath);
+    return buildDependencies({
+        existsSync: candidate => path.resolve(candidate) === resolvedPlan || fs.existsSync(candidate),
+        readFileSync: (candidate, encoding) => {
+            if (path.resolve(candidate) === resolvedPlan) return planMarkdownText;
+            return fs.readFileSync(candidate, encoding);
+        },
+    });
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalNetConnect = net.connect;
+    const originalNetCreateConnection = net.createConnection;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by fotmob_stdout_network_dry_run_execution_plan`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    net.connect = fail('net.connect');
+    net.createConnection = fail('net.createConnection');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'net',
+            'node:net',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+            'chromium',
+        ]);
+        const blockedFragments = [
+            'titan_discovery',
+            'run_production',
+            'batch_historical_backfill',
+            'backfill_historical_raw_match_data',
+            'titan_seeder',
+            'DiscoveryService',
+            'ProductionHarvester',
+            'FotMobStrategy',
+            'FixtureRepository',
+            'Persistence',
+            'BrowserProvider',
+            'ProxyProvider',
+        ];
+
+        if (blockedImports.has(request) || blockedFragments.some(fragment => String(request).includes(fragment))) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        net.connect = originalNetConnect;
+        net.createConnection = originalNetCreateConnection;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceInTemplate(searchValue, replaceValue) {
+    assert.match(PLAN_TEXT, new RegExp(escapeRegExp(searchValue)));
+    return PLAN_TEXT.replace(searchValue, replaceValue);
+}
+
+function runMain(gate, argv, dependencies = buildDependencies()) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.main(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function extractJson(stdout) {
+    return JSON.parse(String(stdout || '').trim());
+}
+
+function assertSafePayload(payload) {
+    assert.equal(payload.phase, 'PHASE5_00F_FOTMOB_STDOUT_ONLY_NETWORK_DRY_RUN_EXECUTION_PLAN');
+    assert.equal(payload.execution_plan_template_only, true);
+    assert.equal(payload.execution_plan_valid, true);
+    assert.equal(payload.authorization_packet_valid, true);
+    assert.equal(payload.execution_plan_ready, false);
+    assert.equal(payload.execution_plan_reviewed, false);
+    assert.equal(payload.execution_plan_accepted, false);
+    assert.equal(payload.execution_allowed, false);
+    assert.equal(payload.user_filled_packet_provided, false);
+    assert.equal(payload.network_dry_run_authorized, false);
+    assert.equal(payload.final_human_confirmation, false);
+    assert.equal(payload.target_source, 'fotmob');
+    assert.equal(payload.target_count, 0);
+    assert.equal(payload.max_targets, 1);
+    assert.equal(payload.single_target_only, true);
+    assert.equal(payload.bulk_scope_allowed, false);
+    assert.equal(payload.stdout_only, true);
+    assert.equal(payload.external_network_allowed, false);
+    assert.equal(payload.browser_runtime_allowed, false);
+    assert.equal(payload.proxy_runtime_allowed, false);
+    assert.equal(payload.legacy_runtime_allowed, false);
+    assert.equal(payload.acquisition_engine_allowed, false);
+    assert.equal(payload.stdout_preview_allowed, false);
+    assert.equal(payload.staging_write_allowed, false);
+    assert.equal(payload.source_manifest_write_allowed, false);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.training_allowed, false);
+    assert.equal(payload.prediction_allowed, false);
+    assert.equal(payload.pre_execution_checks_complete, true);
+    assert.equal(payload.pre_execution_checks_passed, false);
+    assert.equal(payload.abort_conditions_active, true);
+    assert.equal(payload.continue_template_phases, false);
+    assert.equal(payload.requires_user_real_input, true);
+    assert.equal(payload.commit_gate, 'blocked');
+    assert.equal(
+        payload.next_required_action,
+        'user_must_fill_real_fotmob_target_terms_allowed_use_and_network_authorization'
+    );
+    for (const field of SAFE_FALSE_FIELDS) {
+        assert.equal(payload[field], false, `${field} must remain false`);
+    }
+}
+
+test('缺 plan 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs({ plan: '' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing plan/i);
+});
+
+test('缺 packet 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs({ packet: '' }), buildDependencies());
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing packet/i);
+});
+
+test('plan 缺 YAML block 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('# no yaml\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /missing YAML block/i);
+});
+
+test('invalid YAML 失败', () => {
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildTextDependencies('```yaml\nnot yaml\n```\n'));
+    assert.equal(payload.ok, false);
+    assert.match(payload.errors.join('\n'), /invalid YAML/i);
+});
+
+[
+    [
+        'execution_plan_status 非 template_only 失败',
+        'execution_plan_status: template_only',
+        'execution_plan_status: approved',
+        /execution_plan_status not template_only/,
+    ],
+    [
+        'execution_plan_ready=true 失败',
+        'execution_plan_ready: false',
+        'execution_plan_ready: true',
+        /execution_plan_ready true/,
+    ],
+    [
+        'execution_plan_accepted=true 失败',
+        'execution_plan_accepted: false',
+        'execution_plan_accepted: true',
+        /execution_plan_accepted true/,
+    ],
+    ['execution_allowed=true 失败', 'execution_allowed: false', 'execution_allowed: true', /execution_allowed true/],
+    [
+        'user_filled_packet_provided=true 失败',
+        'user_filled_packet_provided: false',
+        'user_filled_packet_provided: true',
+        /user_filled_packet_provided true/,
+    ],
+    [
+        'network_dry_run_authorized=true 失败',
+        'network_dry_run_authorized: false',
+        'network_dry_run_authorized: true',
+        /network_dry_run_authorized true/,
+    ],
+    [
+        'final_human_confirmation=true 失败',
+        'final_human_confirmation: false',
+        'final_human_confirmation: true',
+        /final_human_confirmation true/,
+    ],
+    ['target_source 不是 fotmob 失败', 'target_source: fotmob', 'target_source: other', /target_source not fotmob/],
+    ['target_count > 1 失败', 'target_count: 0', 'target_count: 2', /target_count > 1/],
+    ['max_targets > 1 失败', 'max_targets: 1', 'max_targets: 2', /max_targets > 1/],
+    [
+        'bulk_scope_allowed=true 失败',
+        'bulk_scope_allowed: false',
+        'bulk_scope_allowed: true',
+        /bulk_scope_allowed true/,
+    ],
+    ['stdout_only=false 失败', 'stdout_only: true', 'stdout_only: false', /stdout_only false/],
+    [
+        'external_network_allowed=true 失败',
+        'external_network_allowed: false',
+        'external_network_allowed: true',
+        /external_network_allowed true/,
+    ],
+    [
+        'browser_runtime_allowed=true 失败',
+        'browser_runtime_allowed: false',
+        'browser_runtime_allowed: true',
+        /browser_runtime_allowed true/,
+    ],
+    [
+        'proxy_runtime_allowed=true 失败',
+        'proxy_runtime_allowed: false',
+        'proxy_runtime_allowed: true',
+        /proxy_runtime_allowed true/,
+    ],
+    [
+        'legacy_runtime_allowed=true 失败',
+        'legacy_runtime_allowed: false',
+        'legacy_runtime_allowed: true',
+        /legacy_runtime_allowed true/,
+    ],
+    [
+        'acquisition_engine_allowed=true 失败',
+        'acquisition_engine_allowed: false',
+        'acquisition_engine_allowed: true',
+        /acquisition_engine_allowed true/,
+    ],
+    [
+        'staging_write_allowed=true 失败',
+        'staging_write_allowed: false',
+        'staging_write_allowed: true',
+        /staging_write_allowed true/,
+    ],
+    [
+        'source_manifest_write_allowed=true 失败',
+        'source_manifest_write_allowed: false',
+        'source_manifest_write_allowed: true',
+        /source_manifest_write_allowed true/,
+    ],
+    ['db_write_allowed=true 失败', 'db_write_allowed: false', 'db_write_allowed: true', /db_write_allowed true/],
+    ['training_allowed=true 失败', 'training_allowed: false', 'training_allowed: true', /training_allowed true/],
+    [
+        'prediction_allowed=true 失败',
+        'prediction_allowed: false',
+        'prediction_allowed: true',
+        /prediction_allowed true/,
+    ],
+    [
+        'pre_execution_checks 任一 checked=true 失败',
+        'checked: false',
+        'checked: true',
+        /pre_execution_checks\.user_filled_authorization_packet_check\.checked true/,
+    ],
+    [
+        'pre_execution_checks 任一 passed=true 失败',
+        'passed: false',
+        'passed: true',
+        /pre_execution_checks\.user_filled_authorization_packet_check\.passed true/,
+    ],
+    [
+        'continue_template_phases=true 失败',
+        'continue_template_phases: false',
+        'continue_template_phases: true',
+        /continue_template_phases true/,
+    ],
+    [
+        'requires_user_real_input=false 失败',
+        'requires_user_real_input: true',
+        'requires_user_real_input: false',
+        /requires_user_real_input false/,
+    ],
+    [
+        'codex_may_not_execute_network_dry_run=false 失败',
+        'codex_may_not_execute_network_dry_run: true',
+        'codex_may_not_execute_network_dry_run: false',
+        /codex_may_not_execute_network_dry_run false/,
+    ],
+    [
+        'safety would_access_network=true 失败',
+        'would_access_network: false',
+        'would_access_network: true',
+        /safety would_access_network not false/,
+    ],
+    [
+        'safety would_write_db=true 失败',
+        'would_write_db: false',
+        'would_write_db: true',
+        /safety would_write_db not false/,
+    ],
+    [
+        'safety would_write_execution_plan_file=true 失败',
+        'would_write_execution_plan_file: false',
+        'would_write_execution_plan_file: true',
+        /safety would_write_execution_plan_file not false/,
+    ],
+].forEach(([name, searchValue, replaceValue, expectedError]) => {
+    test(name, () => {
+        const gate = loadFresh();
+        const payload = gate.runValidation(
+            buildArgs(),
+            buildTextDependencies(replaceInTemplate(searchValue, replaceValue))
+        );
+        assert.equal(payload.ok, false);
+        assert.match(payload.errors.join('\n'), expectedError);
+    });
+});
+
+test('valid execution plan preview 成功', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runMain(gate, [`--plan=${PLAN_PATH}`, `--packet=${PACKET_PATH}`], buildDependencies());
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, '');
+    assertSafePayload(extractJson(result.stdout));
+});
+
+test('--commit blocked', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const result = runMain(gate, [`--plan=${PLAN_PATH}`, `--packet=${PACKET_PATH}`, '--commit'], buildDependencies());
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /BLOCKED: FotMob stdout-only network dry-run execution plan is not executable/);
+});
+
+test('Makefile preview 成功', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-fotmob-stdout-network-dry-run-execution-plan-preview',
+            'FOTMOB_STDOUT_NETWORK_EXECUTION_PLAN_NODE=node',
+            `PLAN=${PLAN_PATH}`,
+            `PACKET=${PACKET_PATH}`,
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assertSafePayload(extractJson(result.stdout));
+});
+
+test('Makefile commit blocked', () => {
+    const result = childProcess.spawnSync(
+        'make',
+        [
+            'data-fotmob-stdout-network-dry-run-execution-plan-commit',
+            `PLAN=${PLAN_PATH}`,
+            `PACKET=${PACKET_PATH}`,
+            'CONFIRM_FOTMOB_STDOUT_NETWORK_DRY_RUN_EXECUTION_PLAN=1',
+        ],
+        { cwd: PROJECT_ROOT, encoding: 'utf8', shell: false }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /not executable in Phase 5\.00F/);
+});
+
+[
+    ['不访问网络', 'would_access_network'],
+    ['不启动 browser', 'would_launch_browser'],
+    ['不执行 proxy runtime', 'would_use_proxy'],
+    ['不执行 legacy runtime', 'would_execute_legacy_runtime'],
+    ['不写 staging', 'would_write_staging'],
+    ['不创建目录', 'would_create_staging_directory'],
+    ['不写 source manifest', 'would_write_source_manifest'],
+    ['不写 packet file', 'would_write_packet_file'],
+    ['不写 execution plan file', 'would_write_execution_plan_file'],
+    ['不写 DB', 'would_write_db'],
+    ['不 spawn child process', 'would_spawn_child_process'],
+].forEach(([name, field]) => {
+    test(name, t => {
+        installExecutionGuards(t);
+        const gate = loadFresh();
+        const payload = gate.runValidation(buildArgs(), buildDependencies());
+        assert.equal(payload.ok, true);
+        assert.equal(payload[field], false);
+    });
+});
+
+test('execution plan validation does not import legacy runtime, browser, proxy, DB, or child process paths', t => {
+    installExecutionGuards(t);
+    const gate = loadFresh();
+    const payload = gate.runValidation(buildArgs(), buildDependencies());
+    assert.equal(payload.ok, true);
+    for (const legacyPath of LEGACY_PATHS) {
+        assert.equal(require.cache[legacyPath], undefined, `${legacyPath} must not be loaded`);
+    }
+});
+
+test('source audit: 不 import forbidden modules', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"](?:node:)?http['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?https['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?net['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]redis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]ioredis['"]/.test(source));
+    assert.ok(!/require\s*\(\s*['"]playwright/.test(source));
+    assert.ok(!/titan_discovery|DiscoveryService|ProductionHarvester|FotMobStrategy/.test(source));
+    assert.ok(!/FixtureRepository|Persistence|BrowserProvider|ProxyProvider/.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.00F FotMob stdout-only network dry-run execution plan.

Scope:
- Adds FotMob stdout-only network dry-run execution plan template
- Adds local-only execution plan preview validator
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 5.00F report

Safety:
- No external FotMob access
- No external football or odds data access
- No curl / wget
- No browser automation
- No proxy runtime execution
- No legacy FotMob runtime execution
- No scraping
- No harvest / ingest
- No network dry-run execution
- No staging writes
- No source manifest writes
- No packet runtime writes
- No execution plan runtime writes
- No DB writes
- No pg_dump / pg_restore
- No training
- No prediction execution

Validation:
- Execution plan unit tests passed
- execution plan preview passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally if browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed

Post-merge direction:
- Do not continue automatic template phases.
- Next action should be user-provided real FotMob target, terms / allowed-use review, and explicit stdout-only network authorization.