### PR TITLE
feat(data): add L1 discovery safe preview wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 - 开始修改前先确认当前 Git 分支；如果是 `main`，先切出工作分支。
 - 如果命令已经封装为 `npm script`，优先使用脚本入口。
 - 如果 `npm script` 指向缺失文件，先修正文档或脚本，再继续依赖该入口。
+- 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` 进入，除非用户后续显式授权受控网络阶段。
 
 ### 2.3 禁止行为
 
@@ -213,6 +214,7 @@ AI / Codex 默认只能执行：
 
 - `make data-help`
 - `make data-check`
+- `make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
@@ -338,6 +340,18 @@ AI / Codex 不能直接执行：
 - 任何 `--commit` 命令
 - 任何外网收割命令
 - 任何写 DB 命令
+
+Phase 5.03L1 补充约定：
+
+- `make data-l1-discovery-preview` 仅允许 config / plan preview。
+- 不得访问外部网络。
+- 不得写 `matches`。
+- 不得写 `raw_match_data`。
+- 不得调用 `FixtureRepository.persist()`。
+- 不得调用 `DiscoveryService.discover()`，除非未来阶段补齐 safe injection 或抽出 `discoverCandidates()`。
+- 不得启用 browser / proxy runtime。
+- `make data-l1-discovery-commit` 在 Phase 5.03L1 固定 blocked。
+- 未来受控 L1 network preview 必须用户显式授权。
 
 执行 `make data-l3-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
         data-prediction-write-dry-run data-prediction-write-commit \
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
+        data-l1-discovery-preview data-l1-discovery-commit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -308,6 +309,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
+	@echo "  make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...  # Phase 5.03L1 preview-only, no network/browser/proxy/DB, no titan_discovery/DiscoveryService.discover/FixtureRepository.persist"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -358,6 +360,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-packet-file-preauth-closure CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-packet-file-preauth-closure-commit CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_PREAUTH_CLOSURE=1  # blocked in Phase 4.76C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
+	@echo "  make data-l1-discovery-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_DISCOVERY_COMMIT=1  # blocked in Phase 5.03L1"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
 	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
@@ -420,6 +423,29 @@ data-check: ## Read-only data environment check
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/local_dom_ingestor.js --help >/tmp/fp_data_local_dom_help.txt
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/csv_bulk_loader.js --help >/tmp/fp_data_csv_loader_help.txt
 	@echo "OK: read-only data environment check completed."
+
+data-l1-discovery-preview: ## L1 safe preview wrapper. Phase 5.03L1. Preview-only, no network, no DB, no browser/proxy.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(SCOPE)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob and SCOPE=<config_only_preview|league_season_date|league_season_window_preview>"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
+		--source="$(SOURCE)" \
+		--scope="$(SCOPE)" \
+		$(if $(LEAGUE_ID),--league-id="$(LEAGUE_ID)") \
+		$(if $(SEASON),--season="$(SEASON)") \
+		$(if $(DATE),--date="$(DATE)") \
+		--concurrency="$(or $(CONCURRENCY),1)" \
+		--max-targets="$(or $(MAX_TARGETS),1)" \
+		$(if $(LOOKBACK),--lookback="$(LOOKBACK)") \
+		$(if $(LOOKAHEAD),--lookahead="$(LOOKAHEAD)") \
+		--dry-run=true
+
+data-l1-discovery-commit: ## Blocked L1 safe preview commit gate. Remains blocked in Phase 5.03L1.
+	@echo "BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.03L1."
+	@echo "  No titan_discovery direct call, no DiscoveryService.discover call, no FixtureRepository.persist call."
+	@echo "  Even with CONFIRM_L1_DISCOVERY_COMMIT=1, network execution and DB writes remain blocked."
+	@exit 1
 
 data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.
 	@if [ -n "$(SAMPLE_HTML)" ]; then \

--- a/docs/_reports/L1_DISCOVERY_SAFE_PREVIEW_WRAPPER_PHASE5_03L1.md
+++ b/docs/_reports/L1_DISCOVERY_SAFE_PREVIEW_WRAPPER_PHASE5_03L1.md
@@ -1,0 +1,97 @@
+# L1 Discovery Safe Preview Wrapper - Phase 5.03L1
+
+## 1. Executive summary
+
+项目已经有工业级 L1 Discovery Engine，本阶段不是重写 L1，也不是继续手搓 FotMob 单场链路。
+
+本阶段新增的是一个 thin safe wrapper：[`scripts/ops/l1_discovery_safe_preview.js`](/home/xupeng/FootballPrediction.clean-dev/scripts/ops/l1_discovery_safe_preview.js)，目标是安全 preview L1 discovery plan。
+
+这个 wrapper 只读本地配置和治理 registry，输出 JSON preview，不触网，不写 DB，不写 `matches`，不写 `raw_match_data`。
+
+## 2. Implemented files
+
+- [`scripts/ops/l1_discovery_safe_preview.js`](/home/xupeng/FootballPrediction.clean-dev/scripts/ops/l1_discovery_safe_preview.js)
+- [`tests/unit/l1_discovery_safe_preview.test.js`](/home/xupeng/FootballPrediction.clean-dev/tests/unit/l1_discovery_safe_preview.test.js)
+- [`Makefile`](/home/xupeng/FootballPrediction.clean-dev/Makefile)
+- [`AGENTS.md`](/home/xupeng/FootballPrediction.clean-dev/AGENTS.md)
+- [`docs/_reports/L1_DISCOVERY_SAFE_PREVIEW_WRAPPER_PHASE5_03L1.md`](/home/xupeng/FootballPrediction.clean-dev/docs/_reports/L1_DISCOVERY_SAFE_PREVIEW_WRAPPER_PHASE5_03L1.md)
+
+## 3. Why wrapper lowers risk
+
+`titan_discovery` 是大入口，默认可能触网、批量扫描、调用 `DiscoveryService.discover()`，最后落到 `FixtureRepository.persist()` 写 `matches`。
+
+这个 wrapper 是窄入口：
+
+- `source` 必须显式给出，首期只允许 `fotmob`
+- `scope` 必须显式给出
+- `concurrency` 固定收紧到 `1`
+- `max_targets` 固定收紧到 `1`
+- 默认 preview-only
+- 默认 no DB
+- 默认不调用 `persist`
+- commit 固定 blocked
+
+这样后续如果要放开 network preview 或小范围写入，可以单独授权，不会误撞 legacy 大入口。
+
+## 4. Current L1 boundary
+
+当前 L1 负责 discovery / match candidates。
+
+raw JSON 入库属于 L2 / raw acquisition。现在 `raw_match_data` 对 `matches` 有 FK，所以最终路线应该还是：
+
+1. L1 controlled seed matches
+2. L2 raw JSON acquisition
+3. `raw_match_data` ingest
+4. local parser
+
+所以本阶段 wrapper 只做 plan preview，不去碰 L2/L3/训练/预测链路。
+
+## 5. Validation
+
+本地验证范围：
+
+- 新增 unit tests
+- `make data-l1-discovery-preview` preview 成功
+- `make data-l1-discovery-commit` blocked
+- `npm test`
+- `npm run test:coverage`
+- `eslint`
+- `prettier`
+- `git diff --check`
+- DB row counts unchanged
+- `tests/fixtures/l1-config-*` absent
+- `docs/_staging_preview` absent
+
+`npm run test:integration` 没有本地执行；如果该 suite 需要真实 Chromium / browser automation，则按本阶段 no-browser / no-network 约束留给 PR CI / main CI。
+
+## 6. Recommended next phase
+
+推荐下一步是 Phase 5.04L1：controlled L1 network preview design / `discoverCandidates()` extraction。
+
+目标：
+
+- 不直接跑 `titan_discovery`
+- 尽量复用 `DiscoveryService` 核心能力
+- 增加 `discoverCandidates()` 或 safe dependency injection
+- 允许未来受控 network discovery preview
+- 仍默认不写 DB
+- 后续再讨论 controlled matches seed commit
+
+## 7. Explicit non-execution
+
+本阶段明确未执行：
+
+- external FotMob access
+- network dry-run
+- browser automation
+- proxy runtime
+- harvest
+- ingest
+- DB writes
+- `raw_match_data` writes
+- `matches` writes
+- feature writes
+- prediction writes
+- staging writes
+- file deletion
+- `titan_discovery` execution

--- a/scripts/ops/l1_discovery_safe_preview.js
+++ b/scripts/ops/l1_discovery_safe_preview.js
@@ -1,0 +1,662 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { L1ConfigManager } = require('../../src/infrastructure/services/L1ConfigManager');
+
+const PHASE = 'PHASE5_03L1_L1_DISCOVERY_SAFE_PREVIEW_WRAPPER';
+const SAFE_SOURCE = 'fotmob';
+const SAFE_SCOPES = new Set(['config_only_preview', 'league_season_date', 'league_season_window_preview']);
+const DEFAULT_CONCURRENCY = 1;
+const DEFAULT_MAX_TARGETS = 1;
+const DEFAULT_LOOKBACK = 30;
+const DEFAULT_LOOKAHEAD = 7;
+const NEXT_REQUIRED_PHASE =
+    'controlled L1 network preview with explicit user authorization, or implement discoverCandidates() extraction';
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.03L1.';
+const REGISTRY_PATH = path.resolve(__dirname, '../../config/acquisition_engines.phase454.json');
+
+function parseBooleanLike(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value !== 'string') {
+        return fallback;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+
+    return fallback;
+}
+
+function parseIntegerLike(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(String(value), 10);
+    return Number.isInteger(parsed) ? parsed : Number.NaN;
+}
+
+function parseOptionValue(currentArg, argv, index) {
+    if (currentArg.includes('=')) {
+        const separatorIndex = currentArg.indexOf('=');
+        return {
+            value: currentArg.slice(separatorIndex + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+
+    return { value: true, consumedNext: false };
+}
+
+function toDateOnlyText(date) {
+    return date.toISOString().slice(0, 10);
+}
+
+function parseDateStrict(value) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(String(value || ''))) {
+        return null;
+    }
+
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function clampDateRange(referenceDate, daysOffset) {
+    const next = new Date(referenceDate.getTime());
+    next.setUTCDate(next.getUTCDate() + daysOffset);
+    return next;
+}
+
+function safeReadJson(targetPath, dependencies = {}) {
+    const readFileSync = dependencies.readFileSync || fs.readFileSync;
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+}
+
+function loadTitanDiscoveryRegistryMetadata(dependencies = {}) {
+    const registry = safeReadJson(REGISTRY_PATH, dependencies);
+    const engine = Array.isArray(registry.engines)
+        ? registry.engines.find(entry => entry && entry.id === 'titan_discovery') || null
+        : null;
+
+    return {
+        path: REGISTRY_PATH,
+        registry,
+        engine,
+    };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        scope: null,
+        leagueId: null,
+        season: null,
+        date: null,
+        lookback: null,
+        lookahead: null,
+        concurrency: null,
+        maxTargets: null,
+        dryRun: undefined,
+        commit: false,
+        dbWrite: false,
+        browser: false,
+        proxy: false,
+        all: false,
+        allLeagues: false,
+        fullSync: false,
+        help: false,
+        json: true,
+    };
+
+    const keyMap = {
+        source: 'source',
+        scope: 'scope',
+        'league-id': 'leagueId',
+        league_id: 'leagueId',
+        season: 'season',
+        date: 'date',
+        lookback: 'lookback',
+        lookahead: 'lookahead',
+        concurrency: 'concurrency',
+        'max-targets': 'maxTargets',
+        max_targets: 'maxTargets',
+        'dry-run': 'dryRun',
+        dry_run: 'dryRun',
+        commit: 'commit',
+        'db-write': 'dbWrite',
+        db_write: 'dbWrite',
+        browser: 'browser',
+        proxy: 'proxy',
+        all: 'all',
+        'all-leagues': 'allLeagues',
+        all_leagues: 'allLeagues',
+        'full-sync': 'fullSync',
+        full_sync: 'fullSync',
+        help: 'help',
+        h: 'help',
+        json: 'json',
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (!arg.startsWith('--')) {
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        if (!optionKey) {
+            continue;
+        }
+
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (
+            ['commit', 'dbWrite', 'browser', 'proxy', 'all', 'allLeagues', 'fullSync', 'help', 'json'].includes(
+                optionKey
+            )
+        ) {
+            options[optionKey] = parseBooleanLike(value, true);
+            continue;
+        }
+
+        if (optionKey === 'dryRun') {
+            options.dryRun = parseBooleanLike(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function normalizeSafePreviewInput(input = {}) {
+    const source = typeof input.source === 'string' ? input.source.trim().toLowerCase() : '';
+    const scope = typeof input.scope === 'string' ? input.scope.trim() : '';
+    const concurrency = parseIntegerLike(input.concurrency, DEFAULT_CONCURRENCY);
+    const maxTargets = parseIntegerLike(input.maxTargets, DEFAULT_MAX_TARGETS);
+    const lookback = parseIntegerLike(input.lookback, DEFAULT_LOOKBACK);
+    const lookahead = parseIntegerLike(input.lookahead, DEFAULT_LOOKAHEAD);
+    const leagueIdText =
+        input.leagueId === null || input.leagueId === undefined || input.leagueId === ''
+            ? null
+            : String(input.leagueId).trim();
+    const leagueIdNumber = leagueIdText === null ? null : parseIntegerLike(leagueIdText, Number.NaN);
+
+    return {
+        source,
+        scope,
+        leagueId: leagueIdText,
+        leagueIdNumber: Number.isInteger(leagueIdNumber) ? leagueIdNumber : null,
+        season: typeof input.season === 'string' ? input.season.trim() : null,
+        date: typeof input.date === 'string' ? input.date.trim() : null,
+        lookback,
+        lookahead,
+        concurrency,
+        maxTargets,
+        dryRun: input.dryRun === undefined ? true : parseBooleanLike(input.dryRun, undefined),
+        commit: parseBooleanLike(input.commit, false),
+        dbWrite: parseBooleanLike(input.dbWrite, false),
+        browser: parseBooleanLike(input.browser, false),
+        proxy: parseBooleanLike(input.proxy, false),
+        all: parseBooleanLike(input.all, false),
+        allLeagues: parseBooleanLike(input.allLeagues, false),
+        fullSync: parseBooleanLike(input.fullSync, false),
+    };
+}
+
+function pushIf(condition, errors, message) {
+    if (condition) {
+        errors.push(message);
+    }
+}
+
+function validateSourceAndScope(input, errors) {
+    if (!input.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (input.source !== SAFE_SOURCE) {
+        errors.push(`unsupported source: only ${SAFE_SOURCE} is allowed in Phase 5.03L1`);
+    }
+
+    if (!input.scope) {
+        errors.push(
+            'missing scope: provide --scope=<config_only_preview|league_season_date|league_season_window_preview>'
+        );
+    } else if (!SAFE_SCOPES.has(input.scope)) {
+        errors.push(`unsupported scope: ${input.scope}`);
+    }
+}
+
+function validateBlockedFlags(input, errors) {
+    pushIf(input.all, errors, 'bulk flag not allowed: --all is blocked in Phase 5.03L1');
+    pushIf(input.allLeagues, errors, 'bulk flag not allowed: --all-leagues is blocked in Phase 5.03L1');
+    pushIf(input.fullSync, errors, 'bulk flag not allowed: --full-sync is blocked in Phase 5.03L1');
+    pushIf(input.commit, errors, BLOCKED_COMMIT_MESSAGE);
+    pushIf(input.dryRun !== true, errors, 'dry_run=false is not allowed: preview wrapper is fixed to dry-run mode');
+    pushIf(input.dbWrite === true, errors, 'db_write=true is not allowed in Phase 5.03L1');
+    pushIf(input.browser === true, errors, 'browser=true is not allowed in Phase 5.03L1');
+    pushIf(input.proxy === true, errors, 'proxy=true is not allowed in Phase 5.03L1');
+}
+
+function validateLimits(input, errors) {
+    if (!Number.isInteger(input.concurrency) || input.concurrency < 1) {
+        errors.push('invalid concurrency: provide a positive integer');
+    } else if (input.concurrency > 1) {
+        errors.push('concurrency > 1 is blocked in Phase 5.03L1');
+    }
+
+    if (!Number.isInteger(input.maxTargets) || input.maxTargets < 1) {
+        errors.push('invalid max_targets: provide a positive integer');
+    } else if (input.maxTargets > 1) {
+        errors.push('max_targets > 1 is blocked in Phase 5.03L1');
+    }
+
+    if (!Number.isInteger(input.lookback) || input.lookback < 0) {
+        errors.push('invalid lookback: provide a non-negative integer');
+    }
+    if (!Number.isInteger(input.lookahead) || input.lookahead < 0) {
+        errors.push('invalid lookahead: provide a non-negative integer');
+    }
+}
+
+function validateLeagueScope(input, errors) {
+    const isLeagueScope = input.scope === 'league_season_date' || input.scope === 'league_season_window_preview';
+
+    if (!isLeagueScope) {
+        return;
+    }
+
+    if (!input.leagueId) {
+        errors.push('missing league-id for league scope');
+    } else if (!Number.isInteger(parseIntegerLike(input.leagueId, Number.NaN)) || Number(input.leagueId) <= 0) {
+        errors.push('invalid league-id: provide a positive integer');
+    }
+
+    if (!input.season) {
+        errors.push('missing season for league scope');
+    }
+
+    if (input.scope === 'league_season_date') {
+        if (!input.date) {
+            errors.push('missing date for league_season_date scope');
+        } else if (!parseDateStrict(input.date)) {
+            errors.push('invalid date: provide YYYY-MM-DD');
+        }
+    }
+}
+
+function validateSafePreviewInput(input) {
+    const errors = [];
+    const normalized = normalizeSafePreviewInput(input);
+
+    validateSourceAndScope(normalized, errors);
+    validateBlockedFlags(normalized, errors);
+    validateLimits(normalized, errors);
+    validateLeagueScope(normalized, errors);
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value: {
+            ...normalized,
+            source: normalized.source || null,
+            scope: normalized.scope || null,
+            season: normalized.season || null,
+            date: normalized.date || null,
+            dryRun: true,
+            commit: false,
+            dbWrite: false,
+            browser: false,
+            proxy: false,
+            all: false,
+            allLeagues: false,
+            fullSync: false,
+        },
+    };
+}
+
+function loadLeagueConfigSafe(input, dependencies = {}) {
+    const configManager = dependencies.configManager || new L1ConfigManager();
+    if (!input.leagueIdNumber) {
+        return { found: false, league: null };
+    }
+
+    const league = configManager.getLeagueById(input.leagueIdNumber);
+    return {
+        found: Boolean(league),
+        league: league || null,
+    };
+}
+
+function loadSeasonWindowSafe(input, dependencies = {}) {
+    const configManager = dependencies.configManager || new L1ConfigManager();
+    if (!input.leagueIdNumber || !input.season) {
+        return {
+            found: false,
+            window: null,
+            expectedMatches: null,
+        };
+    }
+
+    const window = configManager.getSeasonDateWindow(input.leagueIdNumber, input.season);
+    const expectedMatches = configManager.getExpectedMatches(input.leagueIdNumber, input.season);
+
+    return {
+        found: Boolean(window),
+        window: window || null,
+        expectedMatches: expectedMatches || null,
+    };
+}
+
+function buildSafetySummary(input, metadata = {}) {
+    return {
+        phase: PHASE,
+        preview_only: true,
+        safe_for_ai_default: true,
+        source: input.source,
+        scope: input.scope,
+        league_id: input.leagueId,
+        season: input.season,
+        date: input.date,
+        concurrency: input.concurrency,
+        max_targets: input.maxTargets,
+        bulk_allowed: false,
+        full_sync_allowed: false,
+        all_leagues_allowed: false,
+        network_execution_allowed: false,
+        browser_runtime_allowed: false,
+        proxy_runtime_allowed: false,
+        db_write_allowed: false,
+        matches_write_allowed: false,
+        raw_match_data_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        would_access_network: false,
+        would_launch_browser: false,
+        would_use_proxy: false,
+        would_call_titan_discovery: false,
+        would_call_discovery_service_discover: false,
+        would_call_fixture_repository_persist: false,
+        would_write_matches: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        would_create_files: false,
+        would_spawn_child_process: false,
+        safety_classification: 'safe_preview_only',
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+        registry_reference: metadata.registryReference || null,
+    };
+}
+
+function buildSourceUrlPreview(configManager, input) {
+    if (input.leagueIdNumber && input.season) {
+        return configManager.buildLeagueApiUrl(input.leagueIdNumber, input.season);
+    }
+
+    return 'https://www.fotmob.com/api/data/leagues?id={providerLeagueId}&season={season}';
+}
+
+function buildWindowPreview(input, seasonWindow, dependencies = {}) {
+    if (!seasonWindow.found || !seasonWindow.window?.start || !seasonWindow.window?.end) {
+        return null;
+    }
+
+    const referenceDate = dependencies.referenceDate instanceof Date ? dependencies.referenceDate : new Date();
+    const seasonStart = parseDateStrict(seasonWindow.window.start);
+    const seasonEnd = parseDateStrict(seasonWindow.window.end);
+    if (!seasonStart || !seasonEnd) {
+        return null;
+    }
+
+    const tentativeStart = clampDateRange(referenceDate, -1 * input.lookback);
+    const tentativeEnd = clampDateRange(referenceDate, input.lookahead);
+    const boundedStart = tentativeStart < seasonStart ? seasonStart : tentativeStart;
+    const boundedEnd = tentativeEnd > seasonEnd ? seasonEnd : tentativeEnd;
+
+    return {
+        start: toDateOnlyText(boundedStart),
+        end: toDateOnlyText(boundedEnd),
+        season_start: seasonWindow.window.start,
+        season_end: seasonWindow.window.end,
+        reference_date: toDateOnlyText(referenceDate),
+        lookback_days: input.lookback,
+        lookahead_days: input.lookahead,
+        source: seasonWindow.window.source || 'explicit_or_derived',
+    };
+}
+
+function buildCandidatePreview(input, context, dependencies = {}) {
+    const { configManager, leagueConfig, seasonWindow } = context;
+    const sourceUrlTemplate = buildSourceUrlPreview(configManager, input);
+
+    const basePreview = {
+        mode: 'config_only_or_plan_only',
+        source_url_template: sourceUrlTemplate,
+        league_config_found: leagueConfig.found,
+        season_window_found: seasonWindow.found,
+        estimated_target_limit: input.maxTargets,
+        would_do: ['load local L1 config', 'load local season window config', 'emit bounded preview JSON only'],
+    };
+
+    if (leagueConfig.league) {
+        basePreview.league = {
+            id: leagueConfig.league.id,
+            code: leagueConfig.league.code,
+            name: leagueConfig.league.name,
+            country: leagueConfig.league.country,
+            tier: leagueConfig.league.tier,
+            provider_id: leagueConfig.league.providerId,
+        };
+    }
+
+    if (seasonWindow.window) {
+        basePreview.season_window = {
+            start: seasonWindow.window.start,
+            end: seasonWindow.window.end,
+            source: seasonWindow.window.source || 'explicit_or_derived',
+            expected_matches: seasonWindow.expectedMatches,
+        };
+    }
+
+    if (input.scope === 'config_only_preview') {
+        basePreview.plan_summary = {
+            preview_kind: 'config_only',
+            network_execution: 'blocked',
+            persistence: 'blocked',
+            browser_runtime: 'blocked',
+            proxy_runtime: 'blocked',
+        };
+        return basePreview;
+    }
+
+    if (input.scope === 'league_season_date') {
+        const targetDate = parseDateStrict(input.date);
+        basePreview.plan_summary = {
+            preview_kind: 'single_date_plan',
+            target_date: input.date,
+            date_in_season_window: Boolean(
+                targetDate &&
+                seasonWindow.window?.start &&
+                seasonWindow.window?.end &&
+                input.date >= seasonWindow.window.start &&
+                input.date <= seasonWindow.window.end
+            ),
+            bounded_target_count: 1,
+        };
+        return basePreview;
+    }
+
+    basePreview.plan_summary = {
+        preview_kind: 'season_window_plan',
+        bounded_window: buildWindowPreview(input, seasonWindow, dependencies),
+        bounded_target_count: input.maxTargets,
+    };
+    return basePreview;
+}
+
+function buildL1DiscoveryPlanPreview(input, dependencies = {}) {
+    const validation = validateSafePreviewInput(input);
+    if (!validation.ok) {
+        const error = new Error(validation.errors[0]);
+        error.validationErrors = validation.errors;
+        throw error;
+    }
+
+    const normalizedInput = validation.value;
+    const configManager = dependencies.configManager || new L1ConfigManager();
+    const leagueConfig = loadLeagueConfigSafe(normalizedInput, { configManager });
+    const seasonWindow = loadSeasonWindowSafe(normalizedInput, { configManager });
+    const registryMetadata = loadTitanDiscoveryRegistryMetadata(dependencies);
+
+    if (normalizedInput.scope !== 'config_only_preview' && !leagueConfig.found) {
+        throw new Error(`league config not found for league-id ${normalizedInput.leagueId}`);
+    }
+
+    const registryReference = registryMetadata.engine
+        ? {
+              engine_id: registryMetadata.engine.id,
+              accesses_network: registryMetadata.engine.accesses_network,
+              writes_db: registryMetadata.engine.writes_db,
+              dry_run_trust_level: registryMetadata.engine.dry_run_trust_level,
+              safe_for_ai_default: registryMetadata.engine.safe_for_ai_default,
+              phase454_policy: registryMetadata.engine.phase454_policy,
+          }
+        : null;
+
+    return {
+        ...buildSafetySummary(normalizedInput, { registryReference }),
+        candidate_preview: buildCandidatePreview(
+            normalizedInput,
+            {
+                configManager,
+                leagueConfig,
+                seasonWindow,
+            },
+            dependencies
+        ),
+    };
+}
+
+function buildErrorPayload(options, errors, mode = 'validation-error') {
+    const safeInput = validateSafePreviewInput({
+        ...options,
+        source: options.source || null,
+        scope: options.scope || null,
+        dryRun: options.dryRun === undefined ? true : options.dryRun,
+        commit: false,
+        dbWrite: false,
+        browser: false,
+        proxy: false,
+        all: false,
+        allLeagues: false,
+        fullSync: false,
+    }).value;
+
+    return {
+        ...buildSafetySummary(safeInput),
+        ok: false,
+        mode,
+        errors: Array.isArray(errors) ? errors : [String(errors)],
+    };
+}
+
+function showHelp(io = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    stdout(
+        [
+            'L1 discovery safe preview wrapper',
+            '',
+            '用法:',
+            '  node scripts/ops/l1_discovery_safe_preview.js --source=fotmob --scope=league_season_date --league-id=53 --season=2025/2026 --date=2026-05-10 --concurrency=1 --max-targets=1',
+            '',
+            '允许 scope:',
+            '  config_only_preview',
+            '  league_season_date',
+            '  league_season_window_preview',
+            '',
+            'Phase 5.03L1 约束:',
+            '  preview-only',
+            '  no network',
+            '  no browser',
+            '  no proxy',
+            '  no DB write',
+            '  commit blocked',
+            '',
+        ].join('\n')
+    );
+}
+
+function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+    const options = parseArgs(argv);
+
+    if (options.help) {
+        showHelp({ stdout });
+        return 0;
+    }
+
+    if (options.commit === true) {
+        const payload = buildErrorPayload(options, [BLOCKED_COMMIT_MESSAGE], 'blocked-commit');
+        payload.blocked_reason = BLOCKED_COMMIT_MESSAGE;
+        stderr(`${BLOCKED_COMMIT_MESSAGE}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+
+    const validation = validateSafePreviewInput(options);
+    if (!validation.ok) {
+        const payload = buildErrorPayload(options, validation.errors);
+        stderr(`${validation.errors[0]}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+
+    try {
+        const payload = buildL1DiscoveryPlanPreview(validation.value, dependencies);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 0;
+    } catch (error) {
+        const payload = buildErrorPayload(options, error.validationErrors || [error.message]);
+        stderr(`${error.message}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    process.exitCode = runCli();
+}
+
+module.exports = {
+    parseArgs,
+    validateSafePreviewInput,
+    buildL1DiscoveryPlanPreview,
+    loadLeagueConfigSafe,
+    loadSeasonWindowSafe,
+    buildSafetySummary,
+    runCli,
+};

--- a/tests/unit/l1_discovery_safe_preview.test.js
+++ b/tests/unit/l1_discovery_safe_preview.test.js
@@ -1,0 +1,512 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l1_discovery_safe_preview.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function installExecutionGuards(t) {
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalFetch = global.fetch;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalNetConnect = net.connect;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l1_discovery_safe_preview`);
+    };
+
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    global.fetch = fail('global.fetch');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    net.connect = fail('net.connect');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+            'child_process',
+            'node:child_process',
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+        ]);
+
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/titan_discovery|DiscoveryService|FixtureRepository/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        global.fetch = originalFetch;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        net.connect = originalNetConnect;
+        Module._load = originalLoad;
+    });
+}
+
+function runCli(gate, argv, dependencies = {}) {
+    let stdout = '';
+    let stderr = '';
+    const status = gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+
+    return {
+        status,
+        stdout,
+        stderr,
+    };
+}
+
+function parseJsonOutput(stdout) {
+    const payload = String(stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload in stdout');
+    return JSON.parse(payload);
+}
+
+function assertSafePreviewFlags(payload) {
+    assert.equal(payload.preview_only, true);
+    assert.equal(payload.safe_for_ai_default, true);
+    assert.equal(payload.network_execution_allowed, false);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.matches_write_allowed, false);
+    assert.equal(payload.raw_match_data_write_allowed, false);
+    assert.equal(payload.would_call_titan_discovery, false);
+    assert.equal(payload.would_call_discovery_service_discover, false);
+    assert.equal(payload.would_call_fixture_repository_persist, false);
+    assert.equal(payload.would_write_matches, false);
+    assert.equal(payload.would_write_raw_match_data, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_spawn_child_process, false);
+    assert.equal(payload.would_access_network, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_create_files, false);
+    assert.equal(payload.commit_gate, 'blocked');
+    assert.equal(payload.safety_classification, 'safe_preview_only');
+}
+
+function buildDependencies() {
+    return {
+        cwd: PROJECT_ROOT,
+        readFileSync: (targetPath, encoding) => fs.readFileSync(targetPath, encoding),
+    };
+}
+
+test('parseArgs 能解析 league_season_date 参数', () => {
+    const gate = loadModuleFresh();
+    const options = gate.parseArgs([
+        '--source=fotmob',
+        '--scope=league_season_date',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--concurrency=1',
+        '--max-targets=1',
+    ]);
+
+    assert.equal(options.source, 'fotmob');
+    assert.equal(options.scope, 'league_season_date');
+    assert.equal(options.leagueId, '53');
+    assert.equal(options.season, '2025/2026');
+    assert.equal(options.date, '2026-05-10');
+    assert.equal(options.concurrency, '1');
+    assert.equal(options.maxTargets, '1');
+});
+
+test('valid config_only_preview 成功', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.scope, 'config_only_preview');
+    assert.equal(payload.source, 'fotmob');
+    assert.equal(payload.candidate_preview.mode, 'config_only_or_plan_only');
+    assert.equal(payload.candidate_preview.league_config_found, false);
+    assert.equal(payload.candidate_preview.season_window_found, false);
+    assertSafePreviewFlags(payload);
+});
+
+test('valid league_season_date 成功', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        [
+            '--source=fotmob',
+            '--scope=league_season_date',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--date=2026-05-10',
+            '--concurrency=1',
+            '--max-targets=1',
+        ],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.scope, 'league_season_date');
+    assert.equal(payload.league_id, '53');
+    assert.equal(payload.season, '2025/2026');
+    assert.equal(payload.date, '2026-05-10');
+    assert.equal(payload.candidate_preview.league_config_found, true);
+    assert.equal(payload.candidate_preview.season_window_found, true);
+    assert.equal(payload.candidate_preview.plan_summary.preview_kind, 'single_date_plan');
+    assert.equal(payload.candidate_preview.plan_summary.bounded_target_count, 1);
+    assertSafePreviewFlags(payload);
+});
+
+test('valid league_season_window_preview 成功', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        [
+            '--source=fotmob',
+            '--scope=league_season_window_preview',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--lookback=5',
+            '--lookahead=3',
+            '--concurrency=1',
+            '--max-targets=1',
+        ],
+        {
+            ...buildDependencies(),
+            referenceDate: new Date('2026-05-11T00:00:00.000Z'),
+        }
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.scope, 'league_season_window_preview');
+    assert.equal(payload.candidate_preview.plan_summary.preview_kind, 'season_window_plan');
+    assert.deepEqual(payload.candidate_preview.plan_summary.bounded_window, {
+        start: '2026-05-06',
+        end: '2026-05-14',
+        season_start: '2025-08-15',
+        season_end: '2026-05-16',
+        reference_date: '2026-05-11',
+        lookback_days: 5,
+        lookahead_days: 3,
+        source: 'explicit',
+    });
+    assertSafePreviewFlags(payload);
+});
+
+test('缺 source 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--scope=config_only_preview'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /missing source/i);
+});
+
+test('source 不是 fotmob 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--source=other', '--scope=config_only_preview'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /unsupported source/i);
+});
+
+test('缺 scope 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--source=fotmob'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /missing scope/i);
+});
+
+test('unsupported scope 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--source=fotmob', '--scope=bulk'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /unsupported scope/i);
+});
+
+test('league scope 缺 league-id 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=league_season_date', '--season=2025/2026', '--date=2026-05-10'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /missing league-id/i);
+});
+
+test('league scope 缺 season 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--date=2026-05-10'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /missing season/i);
+});
+
+test('league_season_date 缺 date 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--season=2025/2026'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /missing date/i);
+});
+
+test('concurrency > 1 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--concurrency=2'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /concurrency > 1/i);
+});
+
+test('max_targets > 1 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--max-targets=2'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /max_targets > 1/i);
+});
+
+test('--all 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--all'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /--all/i);
+});
+
+test('--all-leagues 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--all-leagues'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /--all-leagues/i);
+});
+
+test('--full-sync 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--full-sync'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /--full-sync/i);
+});
+
+test('dry_run=false 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--dry-run=false'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /dry_run=false/i);
+});
+
+test('db_write=true 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--db-write=true'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /db_write=true/i);
+});
+
+test('browser=true 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--browser=true'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /browser=true/i);
+});
+
+test('proxy=true 失败', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--proxy=true'],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.match(payload.errors.join('\n'), /proxy=true/i);
+});
+
+test('--commit blocked', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--commit'], buildDependencies());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.mode, 'blocked-commit');
+    assert.match(payload.blocked_reason, /does not execute writes/i);
+    assertSafePreviewFlags(payload);
+});
+
+test('buildL1DiscoveryPlanPreview 直接构建时仍保持 no-side-effect 摘要', t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const payload = gate.buildL1DiscoveryPlanPreview(
+        {
+            source: 'fotmob',
+            scope: 'league_season_date',
+            leagueId: '53',
+            season: '2025/2026',
+            date: '2026-05-10',
+            concurrency: 1,
+            maxTargets: 1,
+            dryRun: true,
+        },
+        buildDependencies()
+    );
+
+    assert.equal(payload.phase, 'PHASE5_03L1_L1_DISCOVERY_SAFE_PREVIEW_WRAPPER');
+    assert.equal(payload.candidate_preview.estimated_target_limit, 1);
+    assert.equal(payload.registry_reference.engine_id, 'titan_discovery');
+    assert.equal(payload.registry_reference.accesses_network, true);
+    assert.equal(payload.registry_reference.writes_db, true);
+    assert.equal(payload.registry_reference.phase454_policy, 'blocked');
+    assertSafePreviewFlags(payload);
+});
+
+test('Makefile preview target 已注册', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l1-discovery-preview:/m);
+    assert.match(makefile, /scripts\/ops\/l1_discovery_safe_preview\.js/);
+});
+
+test('Makefile commit target blocked 文案存在', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l1-discovery-commit:/m);
+    assert.match(makefile, /BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5\.03L1\./);
+});
+
+test('测试不在仓库内创建随机目录', () => {
+    const tmpRoot = os.tmpdir();
+    assert.ok(typeof tmpRoot === 'string' && tmpRoot.length > 0);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.03L1 L1 discovery safe preview wrapper.

Scope:
- Adds a thin safe wrapper around existing L1 discovery configuration/planning
- Keeps titan_discovery blocked for agents
- Keeps network execution blocked
- Keeps DB writes blocked
- Keeps matches/raw_match_data writes blocked
- Requires explicit source/scope/concurrency/max_targets
- Defaults to preview-only, concurrency=1, max_targets=1
- Adds Makefile preview and blocked commit targets
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 5.03L1 report

Safety:
- No external FotMob access
- No network dry-run
- No browser automation
- No proxy runtime
- No titan_discovery execution
- No DiscoveryService.discover execution
- No FixtureRepository.persist execution
- No harvest / ingest
- No matches writes
- No raw_match_data writes
- No DB writes
- No training / prediction

Validation:
- L1 safe preview unit tests passed
- Makefile preview passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally if browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed