### PR TITLE
feat(data): extract L1 discovery candidates preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
 - 开始修改前先确认当前 Git 分支；如果是 `main`，先切出工作分支。
 - 如果命令已经封装为 `npm script`，优先使用脚本入口。
 - 如果 `npm script` 指向缺失文件，先修正文档或脚本，再继续依赖该入口。
-- 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` 进入，除非用户后续显式授权受控网络阶段。
+- 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` / `make data-l1-discovery-candidates-preview` 的 safe preview 路径进入，除非用户后续显式授权受控网络阶段。
 
 ### 2.3 禁止行为
 
@@ -215,6 +215,7 @@ AI / Codex 默认只能执行：
 - `make data-help`
 - `make data-check`
 - `make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...`
+- `make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no ...`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
@@ -352,6 +353,19 @@ Phase 5.03L1 补充约定：
 - 不得启用 browser / proxy runtime。
 - `make data-l1-discovery-commit` 在 Phase 5.03L1 固定 blocked。
 - 未来受控 L1 network preview 必须用户显式授权。
+
+Phase 5.04L1 补充约定：
+
+- L1 candidate preview 必须走 `discoverCandidates()` / safe preview path。
+- `make data-l1-discovery-candidates-preview` 仅允许 `controlled_candidates_preview`。
+- 默认不得访问外部网络；即使 `NETWORK_AUTHORIZATION=yes`，本阶段 CLI 仍必须 blocked / plan-only。
+- 不得写 `matches`。
+- 不得写 `raw_match_data`。
+- 不得调用 `FixtureRepository.persist()`。
+- 不得调用 `DiscoveryService.discover()`。
+- 不得启动 browser / proxy runtime。
+- 真实 L1 network preview 必须后续阶段另行授权。
+- matches seed commit 必须后续阶段另行授权。
 
 执行 `make data-l3-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
         data-prediction-write-dry-run data-prediction-write-commit \
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
-        data-l1-discovery-preview data-l1-discovery-commit \
+        data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-commit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -309,7 +309,8 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
-	@echo "  make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...  # Phase 5.03L1 preview-only, no network/browser/proxy/DB, no titan_discovery/DiscoveryService.discover/FixtureRepository.persist"
+	@echo "  make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...  # Phase 5.04L1 preview-only, no network/browser/proxy/DB, no titan_discovery/DiscoveryService.discover/FixtureRepository.persist"
+	@echo "  make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no  # Phase 5.04L1 candidates preview, no external network/browser/proxy/DB, no matches/raw writes"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -360,7 +361,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-packet-file-preauth-closure CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-packet-file-preauth-closure-commit CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_PREAUTH_CLOSURE=1  # blocked in Phase 4.76C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
-	@echo "  make data-l1-discovery-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_DISCOVERY_COMMIT=1  # blocked in Phase 5.03L1"
+	@echo "  make data-l1-discovery-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_DISCOVERY_COMMIT=1  # blocked in Phase 5.04L1"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
 	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
@@ -424,9 +425,9 @@ data-check: ## Read-only data environment check
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/csv_bulk_loader.js --help >/tmp/fp_data_csv_loader_help.txt
 	@echo "OK: read-only data environment check completed."
 
-data-l1-discovery-preview: ## L1 safe preview wrapper. Phase 5.03L1. Preview-only, no network, no DB, no browser/proxy.
+data-l1-discovery-preview: ## L1 safe preview wrapper. Phase 5.04L1. Preview-only, no network, no DB, no browser/proxy.
 	@if [ -z "$(SOURCE)" ] || [ -z "$(SCOPE)" ]; then \
-		echo "ERROR: provide SOURCE=fotmob and SCOPE=<config_only_preview|league_season_date|league_season_window_preview>"; \
+		echo "ERROR: provide SOURCE=fotmob and SCOPE=<config_only_preview|league_season_date|league_season_window_preview|controlled_candidates_preview>"; \
 		exit 1; \
 	fi
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
@@ -441,8 +442,26 @@ data-l1-discovery-preview: ## L1 safe preview wrapper. Phase 5.03L1. Preview-onl
 		$(if $(LOOKAHEAD),--lookahead="$(LOOKAHEAD)") \
 		--dry-run=true
 
-data-l1-discovery-commit: ## Blocked L1 safe preview commit gate. Remains blocked in Phase 5.03L1.
-	@echo "BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.03L1."
+data-l1-discovery-candidates-preview: ## L1 controlled candidates preview. Phase 5.04L1. Default no external network, no DB, no browser/proxy.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(SEASON)" ] || [ -z "$(DATE)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd>"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
+		--source="$(SOURCE)" \
+		--scope="$(or $(SCOPE),controlled_candidates_preview)" \
+		--league-id="$(LEAGUE_ID)" \
+		--season="$(SEASON)" \
+		--date="$(DATE)" \
+		--concurrency="$(or $(CONCURRENCY),1)" \
+		--max-targets="$(or $(MAX_TARGETS),1)" \
+		$(if $(LOOKBACK),--lookback="$(LOOKBACK)") \
+		$(if $(LOOKAHEAD),--lookahead="$(LOOKAHEAD)") \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--dry-run=true
+
+data-l1-discovery-commit: ## Blocked L1 safe preview commit gate. Remains blocked in Phase 5.04L1.
+	@echo "BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.04L1."
 	@echo "  No titan_discovery direct call, no DiscoveryService.discover call, no FixtureRepository.persist call."
 	@echo "  Even with CONFIRM_L1_DISCOVERY_COMMIT=1, network execution and DB writes remain blocked."
 	@exit 1

--- a/docs/_reports/L1_DISCOVERY_CANDIDATES_EXTRACTION_PHASE5_04L1.md
+++ b/docs/_reports/L1_DISCOVERY_CANDIDATES_EXTRACTION_PHASE5_04L1.md
@@ -1,0 +1,113 @@
+# L1 Discovery Candidates Extraction - Phase 5.04L1
+
+## 1. Executive summary
+
+本阶段不是重写 L1 discovery 引擎，也没有直接运行 `titan_discovery.js`。
+
+本阶段从现有 `DiscoveryService` 中新增 candidates-only 的 `discoverCandidates()` 路径，目的是把 discovery candidates 和 DB persist 拆开。新的路径只做受控输入校验、可注入 fetch provider、解析、标准化 candidates 输出，不调用 `FixtureRepository.persist()`。
+
+默认行为仍然是：
+
+- 不触网
+- 不写 DB
+- 不写 `matches`
+- 不写 `raw_match_data`
+- 不启动 browser
+- 不使用 proxy
+- commit gate 继续 blocked
+
+## 2. Implemented files
+
+- `src/infrastructure/services/DiscoveryService.js`
+- `scripts/ops/l1_discovery_safe_preview.js`
+- `tests/unit/l1_discovery_safe_preview.test.js`
+- `tests/unit/DiscoveryService.discoverCandidates.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/L1_DISCOVERY_CANDIDATES_EXTRACTION_PHASE5_04L1.md`
+
+## 3. What changed
+
+- 新增 `DiscoveryService.discoverCandidates()` candidates-only path。
+- `DiscoveryService` 的生产依赖支持 lazy load，并支持在 preview 构造中禁用 DB、browser、proxy、HTTP client、repository。
+- `discoverCandidates()` 支持 fake `fetchLeagueFixtures` / `httpClient` dependency injection。
+- `discoverCandidates()` 默认 `previewOnly=true`、`dryRun=true`、`allowNetwork=false`、`writeDb=false`。
+- `discoverCandidates()` 不调用 `DiscoveryService.discover()`，不调用 `FixtureRepository.persist()`。
+- L1 safe wrapper 新增 `controlled_candidates_preview` scope。
+- 新增 `make data-l1-discovery-candidates-preview`。
+- 即使传入 `NETWORK_AUTHORIZATION=yes`，Phase 5.04L1 CLI 仍 blocked，不执行 external network preview。
+
+## 4. Why this lowers risk
+
+原来 L1 discovery 的 fetch / parse / persist 是绑在一起的，AI 如果想看候选赛程，容易被迫接近 `titan_discovery.js` 大入口或 `DiscoveryService.discover()` 写库路径。
+
+现在可以先拿 candidates，不写库。AI 不需要跑 `titan_discovery.js`，也不需要触碰 `FixtureRepository.persist()`。未来可以先审计 candidates，再由单独阶段决定是否授权写 `matches` seed。DB write、matches seed commit、真实 external network preview 都继续需要单独授权。
+
+## 5. Validation
+
+已运行：
+
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/l1_discovery_safe_preview.test.js`
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/DiscoveryService.discoverCandidates.test.js`
+- `make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CONCURRENCY=1 MAX_TARGETS=1 NETWORK_AUTHORIZATION=no`
+- `make data-l1-discovery-commit SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CONCURRENCY=1 MAX_TARGETS=1 CONFIRM_L1_DISCOVERY_COMMIT=1 || true`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`
+- `git diff --check`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx eslint src/infrastructure/services/DiscoveryService.js scripts/ops/l1_discovery_safe_preview.js tests/unit/l1_discovery_safe_preview.test.js tests/unit/DiscoveryService.discoverCandidates.test.js --no-cache`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md Makefile src/infrastructure/services/DiscoveryService.js scripts/ops/l1_discovery_safe_preview.js tests/unit/l1_discovery_safe_preview.test.js tests/unit/DiscoveryService.discoverCandidates.test.js docs/_reports/L1_DISCOVERY_CANDIDATES_EXTRACTION_PHASE5_04L1.md`
+
+验证结果：
+
+- discoverCandidates unit tests passed.
+- L1 safe wrapper tests passed.
+- Makefile candidates preview passed with `external_network_used=false`, `candidate_count=0`, and `fetch_mode=not_executed`.
+- commit gate remained blocked.
+- `npm test` passed.
+- `npm run test:coverage` passed.
+- `git diff --check`, targeted ESLint, and targeted Prettier passed.
+- DB row counts check after validation: `matches=2`, `bookmaker_odds_history=2`, `raw_match_data=2`, `l3_features=2`, `match_features_training=2`, `predictions=2`.
+- `find tests/fixtures -maxdepth 1 -type d -name 'l1-config-*'` returned no residue.
+- `git ls-files 'tests/fixtures/l1-config-*'` returned no tracked residue.
+- `docs/_staging_preview` was absent.
+
+`npm run test:integration` was skipped locally because that suite can cover browser / Chromium automation; this phase keeps local validation inside no-browser/no-network constraints and relies on PR CI / main CI for broader gates.
+
+## 6. Recommended next phase
+
+推荐 Phase 5.05L1：controlled L1 external network preview authorization。
+
+建议约束：
+
+- 仍不直接运行 `titan_discovery.js`
+- 只走 `discoverCandidates()` safe path
+- 用户显式授权 `source=fotmob`
+- 默认只允许 `league_id=53 / season=2025/2026 / date=2026-05-10` 或用户明确范围
+- `concurrency=1`
+- `max_targets` 小范围
+- 只输出 candidates stdout
+- 不写 `matches`
+- 不写 `raw_match_data`
+- 不启动 browser / proxy
+- 不训练 / 不预测
+
+## 7. Explicit non-execution
+
+本阶段未执行：
+
+- external FotMob access
+- network dry-run
+- browser automation
+- proxy runtime
+- `titan_discovery.js` execution
+- `DiscoveryService.discover()` execution
+- `FixtureRepository.persist()` execution
+- harvest
+- ingest
+- DB writes
+- `raw_match_data` writes
+- `matches` writes
+- feature writes
+- prediction writes
+- staging writes
+- file deletion

--- a/scripts/ops/l1_discovery_safe_preview.js
+++ b/scripts/ops/l1_discovery_safe_preview.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable complexity, max-lines */
 'use strict';
 
 const fs = require('node:fs');
@@ -6,16 +7,21 @@ const path = require('node:path');
 
 const { L1ConfigManager } = require('../../src/infrastructure/services/L1ConfigManager');
 
-const PHASE = 'PHASE5_03L1_L1_DISCOVERY_SAFE_PREVIEW_WRAPPER';
+const PHASE = 'PHASE5_04L1_L1_DISCOVERY_CANDIDATES_EXTRACTION';
 const SAFE_SOURCE = 'fotmob';
-const SAFE_SCOPES = new Set(['config_only_preview', 'league_season_date', 'league_season_window_preview']);
+const CONTROLLED_CANDIDATES_SCOPE = 'controlled_candidates_preview';
+const SAFE_SCOPES = new Set([
+    'config_only_preview',
+    'league_season_date',
+    'league_season_window_preview',
+    CONTROLLED_CANDIDATES_SCOPE,
+]);
 const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_MAX_TARGETS = 1;
 const DEFAULT_LOOKBACK = 30;
 const DEFAULT_LOOKAHEAD = 7;
-const NEXT_REQUIRED_PHASE =
-    'controlled L1 network preview with explicit user authorization, or implement discoverCandidates() extraction';
-const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.03L1.';
+const NEXT_REQUIRED_PHASE = 'controlled L1 external network preview with explicit user authorization';
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.04L1.';
 const REGISTRY_PATH = path.resolve(__dirname, '../../config/acquisition_engines.phase454.json');
 
 function parseBooleanLike(value, fallback = undefined) {
@@ -120,6 +126,7 @@ function parseArgs(argv = process.argv.slice(2)) {
         all: false,
         allLeagues: false,
         fullSync: false,
+        networkAuthorization: false,
         help: false,
         json: true,
     };
@@ -148,6 +155,8 @@ function parseArgs(argv = process.argv.slice(2)) {
         all_leagues: 'allLeagues',
         'full-sync': 'fullSync',
         full_sync: 'fullSync',
+        'network-authorization': 'networkAuthorization',
+        network_authorization: 'networkAuthorization',
         help: 'help',
         h: 'help',
         json: 'json',
@@ -171,9 +180,18 @@ function parseArgs(argv = process.argv.slice(2)) {
         }
 
         if (
-            ['commit', 'dbWrite', 'browser', 'proxy', 'all', 'allLeagues', 'fullSync', 'help', 'json'].includes(
-                optionKey
-            )
+            [
+                'commit',
+                'dbWrite',
+                'browser',
+                'proxy',
+                'all',
+                'allLeagues',
+                'fullSync',
+                'networkAuthorization',
+                'help',
+                'json',
+            ].includes(optionKey)
         ) {
             options[optionKey] = parseBooleanLike(value, true);
             continue;
@@ -222,6 +240,7 @@ function normalizeSafePreviewInput(input = {}) {
         all: parseBooleanLike(input.all, false),
         allLeagues: parseBooleanLike(input.allLeagues, false),
         fullSync: parseBooleanLike(input.fullSync, false),
+        networkAuthorization: parseBooleanLike(input.networkAuthorization, false),
     };
 }
 
@@ -235,12 +254,12 @@ function validateSourceAndScope(input, errors) {
     if (!input.source) {
         errors.push('missing source: provide --source=fotmob');
     } else if (input.source !== SAFE_SOURCE) {
-        errors.push(`unsupported source: only ${SAFE_SOURCE} is allowed in Phase 5.03L1`);
+        errors.push(`unsupported source: only ${SAFE_SOURCE} is allowed in Phase 5.04L1`);
     }
 
     if (!input.scope) {
         errors.push(
-            'missing scope: provide --scope=<config_only_preview|league_season_date|league_season_window_preview>'
+            'missing scope: provide --scope=<config_only_preview|league_season_date|league_season_window_preview|controlled_candidates_preview>'
         );
     } else if (!SAFE_SCOPES.has(input.scope)) {
         errors.push(`unsupported scope: ${input.scope}`);
@@ -248,27 +267,27 @@ function validateSourceAndScope(input, errors) {
 }
 
 function validateBlockedFlags(input, errors) {
-    pushIf(input.all, errors, 'bulk flag not allowed: --all is blocked in Phase 5.03L1');
-    pushIf(input.allLeagues, errors, 'bulk flag not allowed: --all-leagues is blocked in Phase 5.03L1');
-    pushIf(input.fullSync, errors, 'bulk flag not allowed: --full-sync is blocked in Phase 5.03L1');
+    pushIf(input.all, errors, 'bulk flag not allowed: --all is blocked in Phase 5.04L1');
+    pushIf(input.allLeagues, errors, 'bulk flag not allowed: --all-leagues is blocked in Phase 5.04L1');
+    pushIf(input.fullSync, errors, 'bulk flag not allowed: --full-sync is blocked in Phase 5.04L1');
     pushIf(input.commit, errors, BLOCKED_COMMIT_MESSAGE);
     pushIf(input.dryRun !== true, errors, 'dry_run=false is not allowed: preview wrapper is fixed to dry-run mode');
-    pushIf(input.dbWrite === true, errors, 'db_write=true is not allowed in Phase 5.03L1');
-    pushIf(input.browser === true, errors, 'browser=true is not allowed in Phase 5.03L1');
-    pushIf(input.proxy === true, errors, 'proxy=true is not allowed in Phase 5.03L1');
+    pushIf(input.dbWrite === true, errors, 'db_write=true is not allowed in Phase 5.04L1');
+    pushIf(input.browser === true, errors, 'browser=true is not allowed in Phase 5.04L1');
+    pushIf(input.proxy === true, errors, 'proxy=true is not allowed in Phase 5.04L1');
 }
 
 function validateLimits(input, errors) {
     if (!Number.isInteger(input.concurrency) || input.concurrency < 1) {
         errors.push('invalid concurrency: provide a positive integer');
     } else if (input.concurrency > 1) {
-        errors.push('concurrency > 1 is blocked in Phase 5.03L1');
+        errors.push('concurrency > 1 is blocked in Phase 5.04L1');
     }
 
     if (!Number.isInteger(input.maxTargets) || input.maxTargets < 1) {
         errors.push('invalid max_targets: provide a positive integer');
     } else if (input.maxTargets > 1) {
-        errors.push('max_targets > 1 is blocked in Phase 5.03L1');
+        errors.push('max_targets > 1 is blocked in Phase 5.04L1');
     }
 
     if (!Number.isInteger(input.lookback) || input.lookback < 0) {
@@ -280,7 +299,10 @@ function validateLimits(input, errors) {
 }
 
 function validateLeagueScope(input, errors) {
-    const isLeagueScope = input.scope === 'league_season_date' || input.scope === 'league_season_window_preview';
+    const isLeagueScope =
+        input.scope === 'league_season_date' ||
+        input.scope === 'league_season_window_preview' ||
+        input.scope === CONTROLLED_CANDIDATES_SCOPE;
 
     if (!isLeagueScope) {
         return;
@@ -296,9 +318,9 @@ function validateLeagueScope(input, errors) {
         errors.push('missing season for league scope');
     }
 
-    if (input.scope === 'league_season_date') {
+    if (input.scope === 'league_season_date' || input.scope === CONTROLLED_CANDIDATES_SCOPE) {
         if (!input.date) {
-            errors.push('missing date for league_season_date scope');
+            errors.push(`missing date for ${input.scope} scope`);
         } else if (!parseDateStrict(input.date)) {
             errors.push('invalid date: provide YYYY-MM-DD');
         }
@@ -331,6 +353,7 @@ function validateSafePreviewInput(input) {
             all: false,
             allLeagues: false,
             fullSync: false,
+            networkAuthorization: normalized.networkAuthorization,
         },
     };
 }
@@ -389,9 +412,12 @@ function buildSafetySummary(input, metadata = {}) {
         db_write_allowed: false,
         matches_write_allowed: false,
         raw_match_data_write_allowed: false,
+        candidates_preview_available: input.scope === CONTROLLED_CANDIDATES_SCOPE,
+        discover_candidates_available: true,
         training_allowed: false,
         prediction_allowed: false,
         would_access_network: false,
+        external_network_used: false,
         would_launch_browser: false,
         would_use_proxy: false,
         would_call_titan_discovery: false,
@@ -404,6 +430,12 @@ function buildSafetySummary(input, metadata = {}) {
         would_predict: false,
         would_create_files: false,
         would_spawn_child_process: false,
+        network_authorization_requested: input.networkAuthorization === true,
+        network_authorization_effective: false,
+        network_authorization_status:
+            input.networkAuthorization === true ? 'blocked_phase_5_04l1_plan_only' : 'not_requested',
+        candidate_count: 0,
+        candidates: [],
         safety_classification: 'safe_preview_only',
         commit_gate: 'blocked',
         next_required_phase: NEXT_REQUIRED_PHASE,
@@ -446,6 +478,115 @@ function buildWindowPreview(input, seasonWindow, dependencies = {}) {
         lookahead_days: input.lookahead,
         source: seasonWindow.window.source || 'explicit_or_derived',
     };
+}
+
+function resolveDiscoveryServiceFactory(dependencies = {}) {
+    if (dependencies.discoveryService) {
+        return () => dependencies.discoveryService;
+    }
+
+    if (typeof dependencies.createDiscoveryService === 'function') {
+        return dependencies.createDiscoveryService;
+    }
+
+    if (dependencies.allowDiscoveryServiceImport === false) {
+        return null;
+    }
+
+    return () => {
+        const { DiscoveryService } = require('../../src/infrastructure/services/DiscoveryService');
+        return new DiscoveryService({
+            silent: true,
+            disableDbPool: true,
+            disableBrowserProvider: true,
+            disableProxyProvider: true,
+            disableHttpClient: true,
+            disableFixtureRepository: true,
+        });
+    };
+}
+
+async function buildControlledCandidatesPreview(input, context, dependencies = {}) {
+    const createDiscoveryService = resolveDiscoveryServiceFactory(dependencies);
+    const basePreview = buildCandidatePreview(input, context, dependencies);
+
+    basePreview.mode = 'controlled_candidates_preview';
+    basePreview.plan_summary = {
+        preview_kind: CONTROLLED_CANDIDATES_SCOPE,
+        network_execution: 'blocked_by_default',
+        network_authorization_requested: input.networkAuthorization === true,
+        network_authorization_effective: false,
+        persistence: 'blocked',
+        browser_runtime: 'blocked',
+        proxy_runtime: 'blocked',
+    };
+    basePreview.discover_candidates_available = true;
+    basePreview.candidates_preview_available = true;
+    basePreview.external_network_used = false;
+    basePreview.candidate_count = 0;
+    basePreview.candidates = [];
+
+    if (!createDiscoveryService) {
+        basePreview.fetch_mode = 'plan_only_no_service_import';
+        return {
+            preview: basePreview,
+            candidateResult: null,
+        };
+    }
+
+    const service = createDiscoveryService({ input, context, dependencies });
+    if (!service || typeof service.discoverCandidates !== 'function') {
+        throw new Error('discoverCandidates provider is not available');
+    }
+
+    try {
+        const candidateResult = await service.discoverCandidates(
+            {
+                source: input.source,
+                scope: input.scope,
+                leagueId: input.leagueId,
+                season: input.season,
+                date: input.date,
+                lookback: input.lookback,
+                lookahead: input.lookahead,
+                concurrency: input.concurrency,
+                maxTargets: input.maxTargets,
+                dryRun: true,
+                allowNetwork: dependencies.allowFakeNetwork === true,
+                allowBrowserFallback: false,
+                allowProxy: false,
+                writeDb: false,
+                previewOnly: true,
+            },
+            {
+                fetchLeagueFixtures: dependencies.fetchLeagueFixtures,
+                httpClient: dependencies.httpClient,
+                parser: dependencies.parser,
+                logger: dependencies.logger,
+                repository: dependencies.repository,
+                browserProvider: dependencies.browserProvider,
+                networkKind: dependencies.allowFakeNetwork === true ? 'fake' : 'none',
+            }
+        );
+
+        const candidates = Array.isArray(candidateResult.candidates)
+            ? candidateResult.candidates.slice(0, input.maxTargets)
+            : [];
+        basePreview.fetch_mode = candidateResult.fetch_mode || 'discover_candidates';
+        basePreview.source_url_candidate = candidateResult.source_url_candidate || basePreview.source_url_template;
+        basePreview.candidate_count = Number(candidateResult.candidate_count) || candidates.length;
+        basePreview.candidates = candidates;
+        basePreview.safety_summary = candidateResult.safety_summary || null;
+
+        return {
+            preview: basePreview,
+            candidateResult,
+        };
+    } finally {
+        if (service && typeof service.close === 'function') {
+            await service.close();
+        }
+    }
 }
 
 function buildCandidatePreview(input, context, dependencies = {}) {
@@ -517,7 +658,7 @@ function buildCandidatePreview(input, context, dependencies = {}) {
     return basePreview;
 }
 
-function buildL1DiscoveryPlanPreview(input, dependencies = {}) {
+async function buildL1DiscoveryPlanPreview(input, dependencies = {}) {
     const validation = validateSafePreviewInput(input);
     if (!validation.ok) {
         const error = new Error(validation.errors[0]);
@@ -546,7 +687,7 @@ function buildL1DiscoveryPlanPreview(input, dependencies = {}) {
           }
         : null;
 
-    return {
+    const payload = {
         ...buildSafetySummary(normalizedInput, { registryReference }),
         candidate_preview: buildCandidatePreview(
             normalizedInput,
@@ -557,6 +698,48 @@ function buildL1DiscoveryPlanPreview(input, dependencies = {}) {
             },
             dependencies
         ),
+    };
+
+    if (normalizedInput.scope !== CONTROLLED_CANDIDATES_SCOPE) {
+        return payload;
+    }
+
+    const controlledPreview = await buildControlledCandidatesPreview(
+        normalizedInput,
+        {
+            configManager,
+            leagueConfig,
+            seasonWindow,
+        },
+        dependencies
+    );
+    const candidateResult = controlledPreview.candidateResult || {};
+    const candidates = Array.isArray(controlledPreview.preview.candidates) ? controlledPreview.preview.candidates : [];
+
+    return {
+        ...payload,
+        candidates_preview_available: true,
+        discover_candidates_available: true,
+        external_network_used: false,
+        candidate_count: Number(controlledPreview.preview.candidate_count) || candidates.length,
+        candidates,
+        source_url_template:
+            controlledPreview.preview.source_url_template || buildSourceUrlPreview(configManager, normalizedInput),
+        source_url_candidate:
+            controlledPreview.preview.source_url_candidate || buildSourceUrlPreview(configManager, normalizedInput),
+        network_used: false,
+        browser_used: false,
+        proxy_used: false,
+        db_written: false,
+        matches_written: false,
+        raw_match_data_written: false,
+        safety_summary: candidateResult.safety_summary || {
+            would_write_db: false,
+            would_call_persist: false,
+            would_launch_browser: false,
+            would_use_proxy: false,
+        },
+        candidate_preview: controlledPreview.preview,
     };
 }
 
@@ -573,6 +756,7 @@ function buildErrorPayload(options, errors, mode = 'validation-error') {
         all: false,
         allLeagues: false,
         fullSync: false,
+        networkAuthorization: options.networkAuthorization,
     }).value;
 
     return {
@@ -596,8 +780,9 @@ function showHelp(io = {}) {
             '  config_only_preview',
             '  league_season_date',
             '  league_season_window_preview',
+            '  controlled_candidates_preview',
             '',
-            'Phase 5.03L1 约束:',
+            'Phase 5.04L1 约束:',
             '  preview-only',
             '  no network',
             '  no browser',
@@ -609,7 +794,7 @@ function showHelp(io = {}) {
     );
 }
 
-function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
     const stdout = io.stdout || (text => process.stdout.write(text));
     const stderr = io.stderr || (text => process.stderr.write(text));
     const options = parseArgs(argv);
@@ -635,8 +820,24 @@ function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
         return 1;
     }
 
+    if (validation.value.networkAuthorization === true) {
+        const payload = buildErrorPayload(
+            options,
+            ['BLOCKED: external L1 network execution requires a later authorized phase.'],
+            'blocked-network-authorization'
+        );
+        payload.blocked_reason = 'BLOCKED: external L1 network execution requires a later authorized phase.';
+        payload.candidates_preview_available = validation.value.scope === CONTROLLED_CANDIDATES_SCOPE;
+        payload.discover_candidates_available = true;
+        payload.external_network_used = false;
+        payload.network_execution_allowed = false;
+        stderr(`${payload.blocked_reason}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+
     try {
-        const payload = buildL1DiscoveryPlanPreview(validation.value, dependencies);
+        const payload = await buildL1DiscoveryPlanPreview(validation.value, dependencies);
         stdout(`${JSON.stringify(payload, null, 2)}\n`);
         return 0;
     } catch (error) {
@@ -648,7 +849,14 @@ function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
 }
 
 if (require.main === module) {
-    process.exitCode = runCli();
+    runCli()
+        .then(exitCode => {
+            process.exitCode = exitCode;
+        })
+        .catch(error => {
+            process.stderr.write(`${error.message}\n`);
+            process.exitCode = 1;
+        });
 }
 
 module.exports = {
@@ -658,5 +866,6 @@ module.exports = {
     loadLeagueConfigSafe,
     loadSeasonWindowSafe,
     buildSafetySummary,
+    buildControlledCandidatesPreview,
     runCli,
 };

--- a/src/infrastructure/services/DiscoveryService.js
+++ b/src/infrastructure/services/DiscoveryService.js
@@ -6,7 +6,7 @@
  * @description
  * 工业级赛程发现服务 - 影子浏览器版本 (完全重构)
  * 职责: 轻量级协调器，负责流程编排
- * 
+ *
  * 职责分离:
  * - 解析逻辑 -> DiscoveryParser
  * - 浏览器管理 -> BrowserProvider
@@ -18,178 +18,255 @@
 
 'use strict';
 
-const { Pool } = require('pg');
 const path = require('path');
 const pLimit = require('p-limit');
 
 // V6.7.6-FINAL: 引入全模块化组件
 const { DiscoveryParser } = require('./DiscoveryParser');
-const { BrowserProvider } = require('./BrowserProvider');
 const { NetworkInterceptor } = require('./NetworkInterceptor');
 const { SeasonStrategyFactory, SeasonDiscovery } = require('./SeasonStrategy');
 const { FotMobExtractor } = require('./FotMobExtractor');
-const { FixtureRepository } = require('./FixtureRepository');
-const { HttpClient } = require('./HttpClient');
 const { UIHelper } = require('./UIHelper');
 const { L1ConfigManager } = require('./L1ConfigManager');
-const { getProxyProvider } = require('../network/ProxyProvider');
 
 require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
+
+function loadPool() {
+    return require('pg').Pool;
+}
+
+function loadBrowserProvider() {
+    return require('./BrowserProvider').BrowserProvider;
+}
+
+function loadFixtureRepository() {
+    return require('./FixtureRepository').FixtureRepository;
+}
+
+function loadHttpClient() {
+    return require('./HttpClient').HttpClient;
+}
+
+function loadProxyProviderFactory() {
+    return require('../network/ProxyProvider').getProxyProvider;
+}
+
+function createDisabledBrowserProvider() {
+    const blocked = async () => {
+        throw new Error('BrowserProvider disabled for L1 discovery candidates preview');
+    };
+    return {
+        proxyProvider: null,
+        isInitialized: () => false,
+        initialize: blocked,
+        warmup: blocked,
+        close: async () => {},
+        getPage: () => null,
+    };
+}
+
+function createDisabledHttpClient() {
+    return {
+        proxyProvider: null,
+        request: async () => {
+            throw new Error('HttpClient disabled for L1 discovery candidates preview');
+        },
+        close: async () => {},
+    };
+}
+
+function createDisabledFixtureRepository() {
+    return {
+        persist: async () => {
+            throw new Error('FixtureRepository.persist disabled for L1 discovery candidates preview');
+        },
+    };
+}
 
 /**
  * L1 发现服务 (Project Hound)
  * @class DiscoveryService
  */
 class DiscoveryService {
-  constructor(config = {}) {
-    const {
-      dbPool,
-      configManager,
-      parser,
-      browserProvider,
-      networkInterceptor,
-      seasonStrategyFactory,
-      seasonDiscovery,
-      extractor,
-      fixtureRepository,
-      httpClient,
-      uiHelper,
-      proxyProvider,
-      ...runtimeConfig
-    } = config;
+    constructor(config = {}) {
+        const {
+            dbPool,
+            configManager,
+            parser,
+            browserProvider,
+            networkInterceptor,
+            seasonStrategyFactory,
+            seasonDiscovery,
+            extractor,
+            fixtureRepository,
+            httpClient,
+            uiHelper,
+            proxyProvider,
+            disableDbPool = false,
+            disableBrowserProvider = false,
+            disableProxyProvider = false,
+            disableHttpClient = false,
+            disableFixtureRepository = false,
+            ...runtimeConfig
+        } = config;
 
-    this.config = {
-      concurrency: 5,
-      delayMs: 2000,
-      batchSize: 50,
-      lookbackDays: 30,
-      lookaheadDays: 7,
-      fullSync: false,
-      browserCooldownEveryLeagues: 5,
-      browserCooldownMs: 5000,
-      silent: process.env.SILENT_MODE !== 'false',
-      verbose: false,
-      ...runtimeConfig
-    };
-    this.useStealthMode = !process.env.DEBUG_RAW_HTTP;
+        this.config = {
+            concurrency: 5,
+            delayMs: 2000,
+            batchSize: 50,
+            lookbackDays: 30,
+            lookaheadDays: 7,
+            fullSync: false,
+            browserCooldownEveryLeagues: 5,
+            browserCooldownMs: 5000,
+            silent: process.env.SILENT_MODE !== 'false',
+            verbose: false,
+            ...runtimeConfig,
+        };
+        this.useStealthMode = !process.env.DEBUG_RAW_HTTP;
 
-    this.logger = {
-      info: (...args) => !this.config.silent && console.log(...args),
-      warn: (...args) => console.warn(...args),
-      error: (...args) => console.error(...args),
-      banner: (...args) => console.log(...args),
-      progress: (...args) => console.log(...args)
-    };
+        this.logger = {
+            info: (...args) => !this.config.silent && console.log(...args),
+            warn: (...args) => console.warn(...args),
+            error: (...args) => console.error(...args),
+            banner: (...args) => console.log(...args),
+            progress: (...args) => console.log(...args),
+        };
 
-    this.dbPool = dbPool || new Pool({
-      host: process.env.DB_HOST || 'localhost',
-      port: parseInt(process.env.DB_PORT || '5432'),
-      database: process.env.DB_NAME || 'football_db',
-      user: process.env.DB_USER || 'football_user',
-      password: process.env.DB_PASSWORD || 'football_pass',
-      max: 20,
-      idleTimeoutMillis: 30000,
-      connectionTimeoutMillis: 5000,
-      application_name: 'discovery_service_v672'
-    });
+        this.dbPool =
+            dbPool ||
+            (disableDbPool
+                ? null
+                : new (loadPool())({
+                      host: process.env.DB_HOST || 'localhost',
+                      port: parseInt(process.env.DB_PORT || '5432'),
+                      database: process.env.DB_NAME || 'football_db',
+                      user: process.env.DB_USER || 'football_user',
+                      password: process.env.DB_PASSWORD || 'football_pass',
+                      max: 20,
+                      idleTimeoutMillis: 30000,
+                      connectionTimeoutMillis: 5000,
+                      application_name: 'discovery_service_v672',
+                  }));
 
-    this.limiter = pLimit(this.config.concurrency);
-    this.browserHealthPromise = null;
-    this.stats = { total: 0, inserted: 0, updated: 0, failed: 0, startTime: null, criticalWarnings: [] };
-    this.configManager = configManager || new L1ConfigManager({ logger: this.logger });
-    this.leagueConfig = this.configManager.getRuntimeConfig();
-    this.proxyPoolName = runtimeConfig.proxyPoolName || 'fotmob_pool';
-    this.proxyProvider = proxyProvider
-      || browserProvider?.proxyProvider
-      || httpClient?.proxyProvider
-      || getProxyProvider({ poolName: this.proxyPoolName });
-    
-    // V6.7.2: 初始化解析器
-    this.parser = parser || new DiscoveryParser(this.logger, this.leagueConfig);
-    
-    // V6.7.4-REFACTORED: 初始化职责分离的模块
-    this.browserProvider = browserProvider || new BrowserProvider({
-      logger: this.logger,
-      headless: true,
-      proxyProvider: this.proxyProvider,
-      proxyConsumer: 'l1-discovery-browser',
-      proxySessionKey: 'discovery-browser'
-    });
-    
-    this.networkInterceptor = networkInterceptor || new NetworkInterceptor({
-      logger: this.logger
-      // V6.7.5-EXTRACTED: 回调逻辑已移至 FotMobExtractor
-    });
-    
-    this.seasonStrategyFactory = seasonStrategyFactory || new SeasonStrategyFactory({
-      singleYearLeagues: this.configManager.getSingleYearLeagueIds()
-    });
-    
-    this.seasonDiscovery = seasonDiscovery || new SeasonDiscovery({
-      logger: this.logger,
-      apiRequest: (url, requestOptions) => this.httpClient.request(url, requestOptions)
-    });
-    
-    // V6.7.5-EXTRACTED: 初始化数据提取器
-    this.extractor = extractor || new FotMobExtractor({
-      logger: this.logger,
-      browserProvider: this.browserProvider,
-      networkInterceptor: this.networkInterceptor,
-      makeStealthRequest: (url, requestOptions) => this.httpClient.request(url, requestOptions)
-    });
-    
-    // V6.7.5-EXTRACTED: 初始化数据仓储
-    this.fixtureRepository = fixtureRepository || new FixtureRepository({
-      dbPool: this.dbPool,
-      logger: this.logger,
-      batchSize: this.config.batchSize
-    });
-    
-    // V6.7.6-FINAL: 初始化 HTTP 客户端
-    this.httpClient = httpClient || new HttpClient({
-      logger: this.logger,
-      browserProvider: this.browserProvider,
-      useStealthMode: this.useStealthMode,
-      ensureBrowserHealthy: (options) => this.ensureBrowserHealthy(options),
-      proxyProvider: this.proxyProvider,
-      proxyConsumer: 'l1-discovery-http',
-      proxySessionKey: 'discovery-http'
-    });
-    
-    // V6.7.6-FINAL: 初始化 UI 辅助
-    this.uiHelper = uiHelper || new UIHelper({ logger: this.logger });
-  }
+        this.limiter = pLimit(this.config.concurrency);
+        this.browserHealthPromise = null;
+        this.stats = { total: 0, inserted: 0, updated: 0, failed: 0, startTime: null, criticalWarnings: [] };
+        this.configManager = configManager || new L1ConfigManager({ logger: this.logger });
+        this.leagueConfig = this.configManager.getRuntimeConfig();
+        this.proxyPoolName = runtimeConfig.proxyPoolName || 'fotmob_pool';
+        this.proxyProvider =
+            proxyProvider ||
+            browserProvider?.proxyProvider ||
+            httpClient?.proxyProvider ||
+            (disableProxyProvider ? null : loadProxyProviderFactory()({ poolName: this.proxyPoolName }));
 
-  /**
-   * 初始化影子浏览器 (Stealth Mode) - V6.7.4-REFACTORED
-   * 委托给 BrowserProvider 管理
-   * @private
-   */
-  async _initBrowser() {
-    if (!this.useStealthMode || this.browserProvider.isInitialized()) return;
-    
-    this.logger.info('[STEALTH] 🕵️  启动影子浏览器 (闪击模式)...');
-    
-    try {
-      // 初始化浏览器
-      const page = await this.browserProvider.initialize();
-      
-      // 设置网络拦截
-      this.networkInterceptor.setup(page);
-      
-      // 预热页面获取 Cookies
-      await this.browserProvider.warmup('https://www.fotmob.com/', {
-        waitUntil: 'domcontentloaded',
-        timeout: 15000
-      });
-      
-      this.logger.info('[STEALTH] ✅ 影子浏览器就绪');
-    } catch (e) {
-      // 宽容模式: 即使主页加载失败，也继续尝试 API 请求
-      this.logger.warn(`[STEALTH] ⚠️  主页加载警告: ${e.message}`);
-      this.logger.warn('[STEALTH] 💡 继续尝试 API 请求 (Cookie 可能已获取)');
+        // V6.7.2: 初始化解析器
+        this.parser = parser || new DiscoveryParser(this.logger, this.leagueConfig);
+
+        // V6.7.4-REFACTORED: 初始化职责分离的模块
+        this.browserProvider =
+            browserProvider ||
+            (disableBrowserProvider
+                ? createDisabledBrowserProvider()
+                : new (loadBrowserProvider())({
+                      logger: this.logger,
+                      headless: true,
+                      proxyProvider: this.proxyProvider,
+                      proxyConsumer: 'l1-discovery-browser',
+                      proxySessionKey: 'discovery-browser',
+                  }));
+
+        this.networkInterceptor =
+            networkInterceptor ||
+            new NetworkInterceptor({
+                logger: this.logger,
+                // V6.7.5-EXTRACTED: 回调逻辑已移至 FotMobExtractor
+            });
+
+        this.seasonStrategyFactory =
+            seasonStrategyFactory ||
+            new SeasonStrategyFactory({
+                singleYearLeagues: this.configManager.getSingleYearLeagueIds(),
+            });
+
+        this.seasonDiscovery =
+            seasonDiscovery ||
+            new SeasonDiscovery({
+                logger: this.logger,
+                apiRequest: (url, requestOptions) => this.httpClient.request(url, requestOptions),
+            });
+
+        // V6.7.5-EXTRACTED: 初始化数据提取器
+        this.extractor =
+            extractor ||
+            new FotMobExtractor({
+                logger: this.logger,
+                browserProvider: this.browserProvider,
+                networkInterceptor: this.networkInterceptor,
+                makeStealthRequest: (url, requestOptions) => this.httpClient.request(url, requestOptions),
+            });
+
+        // V6.7.5-EXTRACTED: 初始化数据仓储
+        this.fixtureRepository =
+            fixtureRepository ||
+            (disableFixtureRepository
+                ? createDisabledFixtureRepository()
+                : new (loadFixtureRepository())({
+                      dbPool: this.dbPool,
+                      logger: this.logger,
+                      batchSize: this.config.batchSize,
+                  }));
+
+        // V6.7.6-FINAL: 初始化 HTTP 客户端
+        this.httpClient =
+            httpClient ||
+            (disableHttpClient
+                ? createDisabledHttpClient()
+                : new (loadHttpClient())({
+                      logger: this.logger,
+                      browserProvider: this.browserProvider,
+                      useStealthMode: this.useStealthMode,
+                      ensureBrowserHealthy: options => this.ensureBrowserHealthy(options),
+                      proxyProvider: this.proxyProvider,
+                      proxyConsumer: 'l1-discovery-http',
+                      proxySessionKey: 'discovery-http',
+                  }));
+
+        // V6.7.6-FINAL: 初始化 UI 辅助
+        this.uiHelper = uiHelper || new UIHelper({ logger: this.logger });
     }
-  }
+
+    /**
+     * 初始化影子浏览器 (Stealth Mode) - V6.7.4-REFACTORED
+     * 委托给 BrowserProvider 管理
+     * @private
+     */
+    async _initBrowser() {
+        if (!this.useStealthMode || this.browserProvider.isInitialized()) return;
+
+        this.logger.info('[STEALTH] 🕵️  启动影子浏览器 (闪击模式)...');
+
+        try {
+            // 初始化浏览器
+            const page = await this.browserProvider.initialize();
+
+            // 设置网络拦截
+            this.networkInterceptor.setup(page);
+
+            // 预热页面获取 Cookies
+            await this.browserProvider.warmup('https://www.fotmob.com/', {
+                waitUntil: 'domcontentloaded',
+                timeout: 15000,
+            });
+
+            this.logger.info('[STEALTH] ✅ 影子浏览器就绪');
+        } catch (e) {
+            // 宽容模式: 即使主页加载失败，也继续尝试 API 请求
+            this.logger.warn(`[STEALTH] ⚠️  主页加载警告: ${e.message}`);
+            this.logger.warn('[STEALTH] 💡 继续尝试 API 请求 (Cookie 可能已获取)');
+        }
+    }
 
     /**
 
@@ -202,540 +279,789 @@ class DiscoveryService {
      */
 
     get capturedApis() {
-
-      return this.networkInterceptor ? this.networkInterceptor.getCapturedApis() : new Map();
-
+        return this.networkInterceptor ? this.networkInterceptor.getCapturedApis() : new Map();
     }
 
-  /**
-   * 主入口: 执行发现扫描
-   */
-  async discover(options = {}) {
-    this.stats = { total: 0, inserted: 0, updated: 0, failed: 0, startTime: Date.now(), criticalWarnings: [] };
-    this.uiHelper.printBanner('V6.7.6-FINAL');
+    /**
+     * 主入口: 执行发现扫描
+     */
+    async discover(options = {}) {
+        this.stats = { total: 0, inserted: 0, updated: 0, failed: 0, startTime: Date.now(), criticalWarnings: [] };
+        this.uiHelper.printBanner('V6.7.6-FINAL');
 
-    const { leagueId, season, allLeagues = false } = options;
-    const targets = this._buildTargets(leagueId, season, allLeagues);
-    const cooldownEvery = Math.max(1, Number(this.config.browserCooldownEveryLeagues) || 5);
+        const { leagueId, season, allLeagues = false } = options;
+        const targets = this._buildTargets(leagueId, season, allLeagues);
+        const cooldownEvery = Math.max(1, Number(this.config.browserCooldownEveryLeagues) || 5);
 
-    this.uiHelper.printTargets(targets.length);
+        this.uiHelper.printTargets(targets.length);
 
-    const results = [];
-    for (let offset = 0; offset < targets.length; offset += cooldownEvery) {
-      const batch = targets.slice(offset, offset + cooldownEvery);
-      const batchResults = await Promise.all(
-        batch.map((target, batchIndex) =>
-          this.limiter(() => this._scanLeague(target, offset + batchIndex, options))
-        )
-      );
-      results.push(...batchResults);
+        const results = [];
+        for (let offset = 0; offset < targets.length; offset += cooldownEvery) {
+            const batch = targets.slice(offset, offset + cooldownEvery);
+            const batchResults = await Promise.all(
+                batch.map((target, batchIndex) =>
+                    this.limiter(() => this._scanLeague(target, offset + batchIndex, options))
+                )
+            );
+            results.push(...batchResults);
 
-      const hasRemaining = offset + batch.length < targets.length;
-      if (hasRemaining) {
-        await this._coolDownBrowser(offset + batch.length);
-      }
-    }
-
-    results.forEach(r => {
-      this.stats.total += r.total;
-      this.stats.inserted += r.inserted;
-      this.stats.updated += r.updated;
-      this.stats.failed += r.failed;
-      if (Array.isArray(r.criticalWarnings) && r.criticalWarnings.length > 0) {
-        this.stats.criticalWarnings.push(...r.criticalWarnings);
-      }
-    });
-
-    return this.uiHelper.generateReport(this.stats, this.stats.startTime);
-  }
-
-  /**
-   * 构建扫描目标列表
-   * @private
-   */
-  _buildTargets(leagueId, season, allLeagues) {
-    if (leagueId) {
-      const league = this.configManager.getLeagueById(leagueId);
-      if (!league) throw new Error(`联赛 ID ${leagueId} 未找到`);
-      const seasons = season ? [season] : [this.configManager.getDefaultSeason(leagueId)];
-      return seasons.map(s => ({ ...league, season: s }));
-    }
-
-    const targetLeagues = allLeagues
-      ? this.configManager.getActiveLeagues()
-      : this.configManager.getActiveLeagues({ tier: 'P0' });
-    const targetSeasons = season ? [season] : [this.configManager.getDefaultSeason()];
-    
-    if (allLeagues) {
-      return targetLeagues.flatMap(l => targetSeasons.map(s => ({ ...l, season: s })));
-    }
-    return targetLeagues.map(l => ({ ...l, season: targetSeasons[0] }));
-  }
-
-  /**
-   * 扫描单个联赛
-   * @private
-   */
-  async _scanLeague(target, index, options = {}) {
-    const { id: leagueId, name, season } = target;
-    const workerId = (index % this.config.concurrency) + 1;
-    const startTime = Date.now();
-    const fullSync = options.fullSync ?? this.config.fullSync;
-
-    try {
-      this.uiHelper.printScanStart(`W${workerId}`, name, season);
-
-      // 检测历史赛季
-      const isHistorical = this._isHistoricalSeason(season);
-      if (isHistorical) {
-        this.uiHelper.printHistoricalMode(`W${workerId}`, season);
-      }
-
-      // 获取原始数据
-      const response = await this._fetchFixtures(target, season);
-
-      // V6.7.2: 使用解析器
-      const fixtures = this.parser.parse(response, leagueId, season, isHistorical, {
-        lookbackDays: this.config.lookbackDays,
-        lookaheadDays: this.config.lookaheadDays,
-        fullSync
-      });
-      const guardedFixtures = this._applySeasonWindowGuard(fixtures, target, season);
-      const expectedMatches = this.configManager.getExpectedMatches(leagueId, season);
-      const criticalWarnings = [];
-
-      if (!guardedFixtures || guardedFixtures.length === 0) {
-        this.uiHelper.printNoFixtures(`W${workerId}`, name);
-        if (expectedMatches && expectedMatches > 0) {
-          const warning = {
-            leagueId,
-            name,
-            season,
-            actual: 0,
-            expected: expectedMatches,
-            missing: expectedMatches
-          };
-          criticalWarnings.push(warning);
-          this.uiHelper.printCriticalWarn(`W${workerId}`, name, season, 0, expectedMatches);
+            const hasRemaining = offset + batch.length < targets.length;
+            if (hasRemaining) {
+                await this._coolDownBrowser(offset + batch.length);
+            }
         }
-        return { total: 0, inserted: 0, updated: 0, failed: 0, criticalWarnings };
-      }
 
-      this.uiHelper.printParsedFixtures(`W${workerId}`, name, guardedFixtures.length);
-      if (expectedMatches && guardedFixtures.length < expectedMatches) {
-        const warning = {
-          leagueId,
-          name,
-          season,
-          actual: guardedFixtures.length,
-          expected: expectedMatches,
-          missing: expectedMatches - guardedFixtures.length
+        results.forEach(r => {
+            this.stats.total += r.total;
+            this.stats.inserted += r.inserted;
+            this.stats.updated += r.updated;
+            this.stats.failed += r.failed;
+            if (Array.isArray(r.criticalWarnings) && r.criticalWarnings.length > 0) {
+                this.stats.criticalWarnings.push(...r.criticalWarnings);
+            }
+        });
+
+        return this.uiHelper.generateReport(this.stats, this.stats.startTime);
+    }
+
+    /**
+     * 构建扫描目标列表
+     * @private
+     */
+    _buildTargets(leagueId, season, allLeagues) {
+        if (leagueId) {
+            const league = this.configManager.getLeagueById(leagueId);
+            if (!league) throw new Error(`联赛 ID ${leagueId} 未找到`);
+            const seasons = season ? [season] : [this.configManager.getDefaultSeason(leagueId)];
+            return seasons.map(s => ({ ...league, season: s }));
+        }
+
+        const targetLeagues = allLeagues
+            ? this.configManager.getActiveLeagues()
+            : this.configManager.getActiveLeagues({ tier: 'P0' });
+        const targetSeasons = season ? [season] : [this.configManager.getDefaultSeason()];
+
+        if (allLeagues) {
+            return targetLeagues.flatMap(l => targetSeasons.map(s => ({ ...l, season: s })));
+        }
+        return targetLeagues.map(l => ({ ...l, season: targetSeasons[0] }));
+    }
+
+    /**
+     * Phase 5.04L1: candidates-only preview path.
+     * 只做 fetch provider 注入、parse、normalize，不调用 persist，不写 DB。
+     */
+    async discoverCandidates(options = {}, deps = {}) {
+        const input = this._normalizeDiscoverCandidatesOptions(options);
+        const target = this._resolveCandidateTarget(input);
+        const sourceUrl = target ? this._buildCandidateSourceUrl(target) : this._buildCandidateSourceUrlTemplate();
+        const fetchLeagueFixtures = this._resolveCandidateFetch(input, deps);
+        const basePayload = this._buildDiscoverCandidatesPayload(input, target, sourceUrl);
+
+        if (!fetchLeagueFixtures) {
+            return {
+                ...basePayload,
+                fetch_mode: 'not_executed',
+                safety_summary: {
+                    ...basePayload.safety_summary,
+                    network_client_injected: false,
+                },
+            };
+        }
+
+        try {
+            const fetchRequest = {
+                source: input.source,
+                leagueId: target?.id || null,
+                providerLeagueId: target ? target.providerId || target.id : null,
+                season: target?.season || input.season,
+                formattedSeason: this._formatCandidateSeason(target),
+                date: input.date,
+                sourceUrl,
+                target,
+            };
+            const response = await fetchLeagueFixtures(fetchRequest);
+            if (!target) {
+                return {
+                    ...basePayload,
+                    ok: true,
+                    fetch_mode: deps.networkKind === 'fake' ? 'fake_injected_client' : 'injected_client',
+                    raw_candidate_count: 0,
+                    candidate_count: 0,
+                    candidates: [],
+                    response_preview_available: Boolean(response),
+                    safety_summary: {
+                        ...basePayload.safety_summary,
+                        network_client_injected: true,
+                    },
+                };
+            }
+            const parser = deps.parser || this.parser;
+            const isHistorical = this._isHistoricalSeason(target.season);
+            const parsedFixtures = parser.parse(response, target.id, target.season, isHistorical, {
+                lookbackDays: input.lookback,
+                lookaheadDays: input.lookahead,
+                fullSync: input.fullSync === true || Boolean(input.date),
+            });
+            const guardedFixtures = this._applySeasonWindowGuard(parsedFixtures, target, target.season);
+            const datedFixtures = this._filterCandidatesByDate(guardedFixtures, input.date);
+            const candidates = datedFixtures
+                .slice(0, input.maxTargets)
+                .map(fixture => this._toDiscoveryCandidate(fixture));
+
+            return {
+                ...basePayload,
+                ok: true,
+                fetch_mode: deps.networkKind === 'fake' ? 'fake_injected_client' : 'injected_client',
+                raw_candidate_count: datedFixtures.length,
+                candidate_count: candidates.length,
+                candidates,
+                safety_summary: {
+                    ...basePayload.safety_summary,
+                    network_client_injected: true,
+                },
+            };
+        } catch (error) {
+            const controlledError = new Error(`L1 discovery candidates fetch failed: ${error.message}`);
+            controlledError.code = 'L1_DISCOVERY_CANDIDATES_FETCH_FAILED';
+            controlledError.retryCount = 0;
+            controlledError.cause = error;
+            throw controlledError;
+        }
+    }
+
+    _normalizeDiscoverCandidatesOptions(options = {}) {
+        const source = String(options.source || '')
+            .trim()
+            .toLowerCase();
+        const concurrency = Number.parseInt(String(options.concurrency ?? 1), 10);
+        const maxTargets = Number.parseInt(String(options.maxTargets ?? options.max_targets ?? 1), 10);
+        const lookback = Number.parseInt(String(options.lookback ?? 30), 10);
+        const lookahead = Number.parseInt(String(options.lookahead ?? 7), 10);
+        const leagueId = options.leagueId ?? options.league_id ?? null;
+
+        if (!source) {
+            throw new Error('missing source: discoverCandidates requires source=fotmob');
+        }
+        if (source !== 'fotmob') {
+            throw new Error('unsupported source: discoverCandidates currently only allows fotmob');
+        }
+        if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 1) {
+            throw new Error('concurrency > 1 is blocked for discoverCandidates in Phase 5.04L1');
+        }
+        if (!Number.isInteger(maxTargets) || maxTargets < 1 || maxTargets > 1) {
+            throw new Error('maxTargets > 1 is blocked for discoverCandidates in Phase 5.04L1');
+        }
+        if (options.writeDb === true || options.write_db === true) {
+            throw new Error('writeDb=true is not allowed in discoverCandidates');
+        }
+        if (options.allowBrowserFallback === true || options.allow_browser_fallback === true) {
+            throw new Error('allowBrowserFallback=true is not allowed in Phase 5.04L1');
+        }
+        if (options.allowProxy === true || options.allow_proxy === true) {
+            throw new Error('allowProxy=true is not allowed in Phase 5.04L1');
+        }
+
+        return {
+            source,
+            scope: options.scope || 'controlled_candidates_preview',
+            league: options.league || null,
+            leagueId: leagueId === null || leagueId === undefined || leagueId === '' ? null : String(leagueId),
+            season: options.season || null,
+            date: options.date || null,
+            lookback,
+            lookahead,
+            concurrency,
+            maxTargets,
+            dryRun: options.dryRun !== false && options.dry_run !== false,
+            previewOnly: options.previewOnly !== false && options.preview_only !== false,
+            allowNetwork: options.allowNetwork === true || options.allow_network === true,
+            allowBrowserFallback: false,
+            allowProxy: false,
+            writeDb: false,
+            fullSync: options.fullSync === true || options.full_sync === true,
         };
-        criticalWarnings.push(warning);
-        this.uiHelper.printCriticalWarn(`W${workerId}`, name, season, guardedFixtures.length, expectedMatches);
-      }
-
-      // V6.7.5-EXTRACTED: 使用 Repository 入库
-      const result = await this.fixtureRepository.persist(guardedFixtures);
-      result.criticalWarnings = criticalWarnings;
-
-      this.uiHelper.printProgress(`W${workerId}`, name, result);
-
-      if (this.config.delayMs > 0) {
-        await this._sleep(this.config.delayMs);
-      }
-
-      return result;
-    } catch (error) {
-      const failTime = Date.now() - startTime;
-      this.uiHelper.printScanError(`W${workerId}`, name, error.message, failTime);
-      return { total: 0, inserted: 0, updated: 0, failed: 1, error: error.message, criticalWarnings: [] };
     }
-  }
 
-  /**
-   * 检测历史赛季
-   * 支持格式: "2024" (单年), "2023/2024", "2023-2024", "20232024" (双年)
-   * @private
-   */
-  _isHistoricalSeason(season) {
-    const now = new Date();
-    const currentYear = now.getFullYear();
+    _resolveCandidateTarget(input) {
+        if (!input.leagueId && !input.league) {
+            return null;
+        }
 
-    // 提取所有4位年份数字
-    const yearMatches = season.match(/\d{4}/g);
-    if (!yearMatches || yearMatches.length === 0) return false;
+        const league = input.leagueId
+            ? this.configManager.getLeagueById(Number(input.leagueId))
+            : this.configManager.getLeagueByCode(input.league);
+        if (!league) {
+            throw new Error(`league config not found for discoverCandidates target ${input.leagueId || input.league}`);
+        }
 
-    // 获取赛季中的最大年份
-    const seasonYears = yearMatches.map(y => parseInt(y));
-    const maxSeasonYear = Math.max(...seasonYears);
+        const season = input.season || this.configManager.getDefaultSeason(league.id);
+        if (!season) {
+            throw new Error(`season is required for discoverCandidates target ${league.id}`);
+        }
 
-    // 🔧 如果赛季中的任何年份小于当前年份，判定为历史赛季
-    // 示例: "2024" < 2026 -> 历史赛季 ✅
-    // 示例: "2023/2024" < 2026 -> 历史赛季 ✅
-    return maxSeasonYear < currentYear;
-  }
-
-  /**
-   * 探测真实赛季 ID 映射 (V6.7.7-SEASON-DISCOVERY)
-   * V6.7.6-FINAL: 使用 HttpClient 进行请求
-   * @private
-   */
-  async _discoverSeasonId(providerLeagueId, targetYear) {
-    this.logger.info(`[HOUND-DEBUG] 🔍 启动赛季指纹探测: ${providerLeagueId} / ${targetYear}`);
-    return this.seasonDiscovery.discover(providerLeagueId, targetYear);
-  }
-
-  /**
-   * 从 FotMob 获取赛程 (V6.7.7-SEASON-DISCOVERY: 赛季指纹探测 + 全量收割)
-   * V6.7.4-REFACTORED: 使用 SeasonStrategyFactory 处理赛季格式
-   * 优先使用浏览器内 API Fetch 获取全量数据，失败时回退到网页灵魂抽取
-   * @private
-   */
-  async _fetchFixtures(target, season) {
-    const internalLeagueId = Number(target?.id);
-    const providerLeagueId = Number(target?.providerId || internalLeagueId);
-
-    // V6.7.4-REFACTORED: 使用策略工厂处理赛季格式
-    let normalizedSeason = this.seasonStrategyFactory.format(internalLeagueId, season);
-    
-    if (this.seasonStrategyFactory.isSingleYearLeague(internalLeagueId)) {
-      this.logger.info(`[HOUND] 单年份联赛适配: ${season} -> ${normalizedSeason}`);
+        return { ...league, season };
     }
-    
-    // 🔥 V6.7.7: 先探测真实赛季 ID 映射
-    const discoveredSeason = await this._discoverSeasonId(providerLeagueId, normalizedSeason);
-    if (discoveredSeason !== normalizedSeason) {
-      this.logger.info(`[HOUND] 🎯 使用探测到的赛季 ID: ${normalizedSeason} -> ${discoveredSeason}`);
-      normalizedSeason = discoveredSeason;
+
+    _formatCandidateSeason(target) {
+        if (!target) {
+            return null;
+        }
+        return this.seasonStrategyFactory.format(Number(target.id), target.season);
     }
-    
-    // 🔥 V6.7.10: 使用新的 /api/data/leagues 路径 (拦截器确认的真实频率)
-    const apiUrl = this.configManager.buildLeagueApiUrl(internalLeagueId, normalizedSeason);
-    
-    try {
-      this.logger.info(`[HOUND-API] 🎯 优先请求全量 API: ${apiUrl}`);
-      const response = await this.httpClient.request(apiUrl, {
-        expectedLeagueId: providerLeagueId
-      });
-      this._assertProviderIdentity(response, providerLeagueId, target?.name);
-      
-      // 检查是否获取到有效数据
-      if (response && Object.keys(response).length > 0) {
-        // 检查是否包含赛程数据
-        const hasFixtures = response.fixtures || response.allMatches || 
-                           (response.overview && response.overview.leagueMatches);
-        
-        if (hasFixtures) {
-          this.logger.info(`[HOUND-API] ✅ 全量 API 请求成功，获取完整数据`);
-          return response;
+
+    _buildCandidateSourceUrl(target) {
+        return this.configManager.buildLeagueApiUrl(Number(target.id), this._formatCandidateSeason(target));
+    }
+
+    _buildCandidateSourceUrlTemplate() {
+        return 'https://www.fotmob.com/api/data/leagues?id={providerLeagueId}&season={season}';
+    }
+
+    _resolveCandidateFetch(input, deps = {}) {
+        const fakeClientAllowed = deps.networkKind === 'fake';
+        if (!input.allowNetwork && !fakeClientAllowed) {
+            return null;
+        }
+        if (typeof deps.fetchLeagueFixtures === 'function') {
+            return deps.fetchLeagueFixtures;
+        }
+        if (deps.httpClient && typeof deps.httpClient.request === 'function') {
+            return ({ sourceUrl, providerLeagueId }) =>
+                deps.httpClient.request(sourceUrl, {
+                    expectedLeagueId: Number(providerLeagueId),
+                });
+        }
+        return null;
+    }
+
+    _buildDiscoverCandidatesPayload(input, target, sourceUrl) {
+        const safetySummary = {
+            would_write_db: false,
+            would_call_persist: false,
+            would_launch_browser: false,
+            would_use_proxy: false,
+            would_spawn_child_process: false,
+            repository_mode: 'disabled_for_candidates_preview',
+        };
+
+        return {
+            ok: true,
+            source: input.source,
+            scope: input.scope,
+            league_id: target ? String(target.id) : input.leagueId,
+            provider_league_id: target ? String(target.providerId || target.id) : null,
+            season: target?.season || input.season,
+            date: input.date,
+            preview_only: true,
+            dry_run: true,
+            allow_network: input.allowNetwork,
+            network_used: false,
+            external_network_used: false,
+            browser_used: false,
+            proxy_used: false,
+            db_written: false,
+            matches_written: false,
+            raw_match_data_written: false,
+            source_url_template: this._buildCandidateSourceUrlTemplate(),
+            source_url_candidate: sourceUrl,
+            raw_candidate_count: 0,
+            candidate_count: 0,
+            candidates: [],
+            safety_summary: safetySummary,
+        };
+    }
+
+    _filterCandidatesByDate(fixtures, date) {
+        if (!date) {
+            return Array.isArray(fixtures) ? fixtures : [];
+        }
+        return (Array.isArray(fixtures) ? fixtures : []).filter(fixture => {
+            const matchDate = String(fixture?.match_date || '').slice(0, 10);
+            return matchDate === date;
+        });
+    }
+
+    _toDiscoveryCandidate(fixture) {
+        return {
+            match_id: fixture.match_id,
+            external_id: fixture.external_id,
+            league: fixture.league_name,
+            league_name: fixture.league_name,
+            season: fixture.season,
+            home: fixture.home_team,
+            home_team: fixture.home_team,
+            away: fixture.away_team,
+            away_team: fixture.away_team,
+            match_date: fixture.match_date,
+            status: fixture.status,
+            data_source: fixture.data_source,
+        };
+    }
+
+    /**
+     * 扫描单个联赛
+     * @private
+     */
+    async _scanLeague(target, index, options = {}) {
+        const { id: leagueId, name, season } = target;
+        const workerId = (index % this.config.concurrency) + 1;
+        const startTime = Date.now();
+        const fullSync = options.fullSync ?? this.config.fullSync;
+
+        try {
+            this.uiHelper.printScanStart(`W${workerId}`, name, season);
+
+            // 检测历史赛季
+            const isHistorical = this._isHistoricalSeason(season);
+            if (isHistorical) {
+                this.uiHelper.printHistoricalMode(`W${workerId}`, season);
+            }
+
+            // 获取原始数据
+            const response = await this._fetchFixtures(target, season);
+
+            // V6.7.2: 使用解析器
+            const fixtures = this.parser.parse(response, leagueId, season, isHistorical, {
+                lookbackDays: this.config.lookbackDays,
+                lookaheadDays: this.config.lookaheadDays,
+                fullSync,
+            });
+            const guardedFixtures = this._applySeasonWindowGuard(fixtures, target, season);
+            const expectedMatches = this.configManager.getExpectedMatches(leagueId, season);
+            const criticalWarnings = [];
+
+            if (!guardedFixtures || guardedFixtures.length === 0) {
+                this.uiHelper.printNoFixtures(`W${workerId}`, name);
+                if (expectedMatches && expectedMatches > 0) {
+                    const warning = {
+                        leagueId,
+                        name,
+                        season,
+                        actual: 0,
+                        expected: expectedMatches,
+                        missing: expectedMatches,
+                    };
+                    criticalWarnings.push(warning);
+                    this.uiHelper.printCriticalWarn(`W${workerId}`, name, season, 0, expectedMatches);
+                }
+                return { total: 0, inserted: 0, updated: 0, failed: 0, criticalWarnings };
+            }
+
+            this.uiHelper.printParsedFixtures(`W${workerId}`, name, guardedFixtures.length);
+            if (expectedMatches && guardedFixtures.length < expectedMatches) {
+                const warning = {
+                    leagueId,
+                    name,
+                    season,
+                    actual: guardedFixtures.length,
+                    expected: expectedMatches,
+                    missing: expectedMatches - guardedFixtures.length,
+                };
+                criticalWarnings.push(warning);
+                this.uiHelper.printCriticalWarn(`W${workerId}`, name, season, guardedFixtures.length, expectedMatches);
+            }
+
+            // V6.7.5-EXTRACTED: 使用 Repository 入库
+            const result = await this.fixtureRepository.persist(guardedFixtures);
+            result.criticalWarnings = criticalWarnings;
+
+            this.uiHelper.printProgress(`W${workerId}`, name, result);
+
+            if (this.config.delayMs > 0) {
+                await this._sleep(this.config.delayMs);
+            }
+
+            return result;
+        } catch (error) {
+            const failTime = Date.now() - startTime;
+            this.uiHelper.printScanError(`W${workerId}`, name, error.message, failTime);
+            return { total: 0, inserted: 0, updated: 0, failed: 1, error: error.message, criticalWarnings: [] };
+        }
+    }
+
+    /**
+     * 检测历史赛季
+     * 支持格式: "2024" (单年), "2023/2024", "2023-2024", "20232024" (双年)
+     * @private
+     */
+    _isHistoricalSeason(season) {
+        const now = new Date();
+        const currentYear = now.getFullYear();
+
+        // 提取所有4位年份数字
+        const yearMatches = season.match(/\d{4}/g);
+        if (!yearMatches || yearMatches.length === 0) return false;
+
+        // 获取赛季中的最大年份
+        const seasonYears = yearMatches.map(y => parseInt(y));
+        const maxSeasonYear = Math.max(...seasonYears);
+
+        // 🔧 如果赛季中的任何年份小于当前年份，判定为历史赛季
+        // 示例: "2024" < 2026 -> 历史赛季 ✅
+        // 示例: "2023/2024" < 2026 -> 历史赛季 ✅
+        return maxSeasonYear < currentYear;
+    }
+
+    /**
+     * 探测真实赛季 ID 映射 (V6.7.7-SEASON-DISCOVERY)
+     * V6.7.6-FINAL: 使用 HttpClient 进行请求
+     * @private
+     */
+    async _discoverSeasonId(providerLeagueId, targetYear) {
+        this.logger.info(`[HOUND-DEBUG] 🔍 启动赛季指纹探测: ${providerLeagueId} / ${targetYear}`);
+        return this.seasonDiscovery.discover(providerLeagueId, targetYear);
+    }
+
+    /**
+     * 从 FotMob 获取赛程 (V6.7.7-SEASON-DISCOVERY: 赛季指纹探测 + 全量收割)
+     * V6.7.4-REFACTORED: 使用 SeasonStrategyFactory 处理赛季格式
+     * 优先使用浏览器内 API Fetch 获取全量数据，失败时回退到网页灵魂抽取
+     * @private
+     */
+    async _fetchFixtures(target, season) {
+        const internalLeagueId = Number(target?.id);
+        const providerLeagueId = Number(target?.providerId || internalLeagueId);
+
+        // V6.7.4-REFACTORED: 使用策略工厂处理赛季格式
+        let normalizedSeason = this.seasonStrategyFactory.format(internalLeagueId, season);
+
+        if (this.seasonStrategyFactory.isSingleYearLeague(internalLeagueId)) {
+            this.logger.info(`[HOUND] 单年份联赛适配: ${season} -> ${normalizedSeason}`);
+        }
+
+        // 🔥 V6.7.7: 先探测真实赛季 ID 映射
+        const discoveredSeason = await this._discoverSeasonId(providerLeagueId, normalizedSeason);
+        if (discoveredSeason !== normalizedSeason) {
+            this.logger.info(`[HOUND] 🎯 使用探测到的赛季 ID: ${normalizedSeason} -> ${discoveredSeason}`);
+            normalizedSeason = discoveredSeason;
+        }
+
+        // 🔥 V6.7.10: 使用新的 /api/data/leagues 路径 (拦截器确认的真实频率)
+        const apiUrl = this.configManager.buildLeagueApiUrl(internalLeagueId, normalizedSeason);
+
+        try {
+            this.logger.info(`[HOUND-API] 🎯 优先请求全量 API: ${apiUrl}`);
+            const response = await this.httpClient.request(apiUrl, {
+                expectedLeagueId: providerLeagueId,
+            });
+            this._assertProviderIdentity(response, providerLeagueId, target?.name);
+
+            // 检查是否获取到有效数据
+            if (response && Object.keys(response).length > 0) {
+                // 检查是否包含赛程数据
+                const hasFixtures =
+                    response.fixtures || response.allMatches || (response.overview && response.overview.leagueMatches);
+
+                if (hasFixtures) {
+                    this.logger.info(`[HOUND-API] ✅ 全量 API 请求成功，获取完整数据`);
+                    return response;
+                } else {
+                    this.logger.warn(`[HOUND-API] ⚠️  API 返回数据但不含赛程，尝试备选...`);
+                }
+            }
+        } catch (apiError) {
+            if (apiError.code === 'IDENTITY_MISMATCH') {
+                throw apiError;
+            }
+            this.logger.warn(`[HOUND-API] ⚠️  API 请求失败: ${apiError.message}`);
+        }
+
+        // 🔥 回退: 网页灵魂抽取 (数据可能截断)
+        this.logger.info(`[HOUND-SOUL] 🔮 回退到网页灵魂抽取模式...`);
+        try {
+            const soulData = await this.extractor.extractFromWebpage(providerLeagueId, normalizedSeason, {
+                expectedLeagueId: providerLeagueId,
+            });
+            this._assertProviderIdentity(soulData, providerLeagueId, target?.name);
+            if (soulData && Object.keys(soulData).length > 0) {
+                this.logger.info(`[HOUND-SOUL] ✅ 灵魂抽取成功 (注意：数据可能截断)`);
+                return soulData;
+            }
+        } catch (soulError) {
+            if (soulError.code === 'IDENTITY_MISMATCH') {
+                throw soulError;
+            }
+            this.logger.error(`[HOUND-SOUL] ❌ 灵魂抽取失败: ${soulError.message}`);
+        }
+
+        throw new Error(`无法获取联赛 ${internalLeagueId} 赛季 ${normalizedSeason} 的数据`);
+    }
+
+    _applySeasonWindowGuard(fixtures, target, season) {
+        if (!Array.isArray(fixtures) || fixtures.length === 0) {
+            return [];
+        }
+
+        const leagueId = Number(target?.id);
+        const seasonWindow =
+            typeof this.configManager?.getSeasonDateWindow === 'function'
+                ? this.configManager.getSeasonDateWindow(leagueId, season)
+                : null;
+
+        if (!seasonWindow?.start || !seasonWindow?.end) {
+            return fixtures;
+        }
+
+        const start = new Date(`${seasonWindow.start}T00:00:00.000Z`);
+        const end = new Date(`${seasonWindow.end}T23:59:59.999Z`);
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+            this.logger.warn(
+                `[HOUND-GUARD] ⚠️  赛季窗口配置非法，跳过过滤: league=${leagueId} season=${season} ` +
+                    `start=${seasonWindow.start} end=${seasonWindow.end}`
+            );
+            return fixtures;
+        }
+
+        const filteredFixtures = fixtures.filter(fixture => {
+            const matchDate = new Date(fixture?.match_date);
+            if (Number.isNaN(matchDate.getTime())) {
+                return true;
+            }
+            return matchDate >= start && matchDate <= end;
+        });
+
+        const droppedCount = fixtures.length - filteredFixtures.length;
+        if (droppedCount > 0) {
+            this.logger.warn(
+                `[HOUND-GUARD] 🛡️  拦截越界赛程: league=${leagueId} season=${season} ` +
+                    `window=${seasonWindow.start}..${seasonWindow.end} source=${seasonWindow.source || 'unknown'} ` +
+                    `dropped=${droppedCount}/${fixtures.length}`
+            );
+        }
+
+        return filteredFixtures;
+    }
+
+    /**
+     * 搜索联赛/球队 (V6.7.6-FINAL: 从 titan_discovery.js 迁移)
+     * @param {string} term - 搜索关键词
+     * @returns {Promise<Object>} 搜索结果
+     */
+    async search(term) {
+        this.logger.info(`\n🔍 正在搜索: "${term}"...`);
+
+        // 🔥 硬编码提示：日本 J 联赛直接提示已知 ID
+        const searchTermUpper = term.toUpperCase();
+        if (searchTermUpper.includes('J1') || searchTermUpper.includes('J2') || searchTermUpper.includes('日职')) {
+            this.logger.info('╔══════════════════════════════════════════════════════════════════╗');
+            this.logger.info('║  💡 侦察建议：已通过实时搜索确认 J1 为 223，J2 为 8974              ║');
+            this.logger.info('║     请尝试直接扫描: node scripts/ops/titan_discovery.js --league=223 ║');
+            this.logger.info('╚══════════════════════════════════════════════════════════════════╝\n');
+        }
+
+        // 🔥 V6.7.6-FINAL: 先尝试模拟搜索框输入 (DOM 交互)
+        let response;
+        try {
+            response = await this.extractor.searchViaDOM(term);
+        } catch (domError) {
+            this.logger.info(`[STEALTH-SOUL] ⚠️  DOM 搜索失败: ${domError.message}`);
+            this.logger.info(`[STEALTH-SOUL] 🔄 回退到 API 搜索...\n`);
+
+            // 回退到 API 搜索
+            const encodedTerm = encodeURIComponent(term);
+            const url = `https://www.fotmob.com/api/search/suggest?term=${encodedTerm}`;
+            this.logger.info(`🌐 前端拟态搜索: ${url}`);
+            response = await this.httpClient.request(url);
+        }
+
+        return response;
+    }
+
+    /**
+     * 关闭服务
+     * V6.7.6-PRINCIPAL: 防御性编程，确保资源在任何情况下都能释放
+     */
+    async close() {
+        const errors = [];
+
+        if (this.httpClient?.close) {
+            try {
+                await this.httpClient.close();
+                this.logger.info('[DiscoveryService] HTTP 客户端已关闭');
+            } catch (e) {
+                errors.push({ component: 'httpClient', error: e.message });
+                this.logger.error(`[DiscoveryService] HTTP 客户端关闭失败: ${e.message}`);
+            }
+        }
+
+        // 关闭浏览器提供者
+        if (this.browserProvider) {
+            try {
+                if (this.networkInterceptor) {
+                    this.networkInterceptor.reset();
+                }
+                await this.browserProvider.close();
+                this.logger.info('[DiscoveryService] 浏览器提供者已关闭');
+            } catch (e) {
+                errors.push({ component: 'browserProvider', error: e.message });
+                this.logger.error(`[DiscoveryService] 浏览器关闭失败: ${e.message}`);
+            }
+        }
+
+        // 关闭数据库连接池
+        if (this.dbPool) {
+            try {
+                await this.dbPool.end();
+                this.logger.info('[DiscoveryService] 数据库连接池已关闭');
+            } catch (e) {
+                errors.push({ component: 'dbPool', error: e.message });
+                this.logger.error(`[DiscoveryService] 数据库连接池关闭失败: ${e.message}`);
+            }
+        }
+
+        // 如果有错误，汇总抛出
+        if (errors.length > 0) {
+            const errorMessage = errors.map(e => `${e.component}: ${e.error}`).join('; ');
+            throw new Error(`[DiscoveryService] 资源关闭过程中发生错误: ${errorMessage}`);
+        }
+    }
+
+    /**
+     * 延迟工具 (V6.7.6-FIX: 恢复此方法)
+     * @private
+     */
+    _sleep(ms) {
+        return new Promise(resolve => {
+            setTimeout(resolve, ms);
+        });
+    }
+
+    async ensureBrowserHealthy(options = {}) {
+        if (!this.useStealthMode || !this.browserProvider) {
+            return;
+        }
+
+        const forceRebuild = options.forceRebuild === true;
+        const recoverPage = options.recoverPage === true;
+        const isInitialized =
+            typeof this.browserProvider.isInitialized === 'function'
+                ? this.browserProvider.isInitialized()
+                : Boolean(this.browserProvider.getPage?.());
+
+        if (!forceRebuild && !recoverPage && isInitialized) {
+            return;
+        }
+
+        if (this.browserHealthPromise) {
+            await this.browserHealthPromise;
+            return;
+        }
+
+        this.browserHealthPromise = recoverPage
+            ? this._recoverBrowserPage(options.reason || 'page-recovery')
+            : this._rebuildBrowserContext(options.reason || 'health-check', options.cooldownMs || 0);
+
+        try {
+            await this.browserHealthPromise;
+        } finally {
+            this.browserHealthPromise = null;
+        }
+    }
+
+    async _coolDownBrowser(completedCount) {
+        if (!this.useStealthMode) {
+            return;
+        }
+
+        const cooldownMs = Math.max(0, Number(this.config.browserCooldownMs) || 0);
+        this.logger.warn(`[HOUND-COOLDOWN] 已完成 ${completedCount} 个联赛，执行浏览器冷却 ${cooldownMs}ms`);
+        await this.ensureBrowserHealthy({
+            forceRebuild: true,
+            reason: `cooldown-${completedCount}`,
+            cooldownMs,
+        });
+    }
+
+    async _recoverBrowserPage(reason) {
+        if (!this.browserProvider) {
+            return;
+        }
+
+        this.logger.warn(`[HOUND-SELFHEAL] 恢复浏览器页面: ${reason}`);
+
+        if (this.networkInterceptor?.reset) {
+            this.networkInterceptor.reset();
+        }
+
+        let page = null;
+        if (typeof this.browserProvider.recoverPage === 'function') {
+            page = await this.browserProvider.recoverPage(reason);
         } else {
-          this.logger.warn(`[HOUND-API] ⚠️  API 返回数据但不含赛程，尝试备选...`);
+            if (typeof this.browserProvider.close === 'function') {
+                await this.browserProvider.close();
+            }
+            if (typeof this.browserProvider.initialize === 'function') {
+                page = await this.browserProvider.initialize();
+            }
         }
-      }
-    } catch (apiError) {
-      if (apiError.code === 'IDENTITY_MISMATCH') {
-        throw apiError;
-      }
-      this.logger.warn(`[HOUND-API] ⚠️  API 请求失败: ${apiError.message}`);
-    }
-    
-    // 🔥 回退: 网页灵魂抽取 (数据可能截断)
-    this.logger.info(`[HOUND-SOUL] 🔮 回退到网页灵魂抽取模式...`);
-    try {
-      const soulData = await this.extractor.extractFromWebpage(providerLeagueId, normalizedSeason, {
-        expectedLeagueId: providerLeagueId
-      });
-      this._assertProviderIdentity(soulData, providerLeagueId, target?.name);
-      if (soulData && Object.keys(soulData).length > 0) {
-        this.logger.info(`[HOUND-SOUL] ✅ 灵魂抽取成功 (注意：数据可能截断)`);
-        return soulData;
-      }
-    } catch (soulError) {
-      if (soulError.code === 'IDENTITY_MISMATCH') {
-        throw soulError;
-      }
-      this.logger.error(`[HOUND-SOUL] ❌ 灵魂抽取失败: ${soulError.message}`);
-    }
 
-    throw new Error(`无法获取联赛 ${internalLeagueId} 赛季 ${normalizedSeason} 的数据`);
-  }
-
-  _applySeasonWindowGuard(fixtures, target, season) {
-    if (!Array.isArray(fixtures) || fixtures.length === 0) {
-      return [];
-    }
-
-    const leagueId = Number(target?.id);
-    const seasonWindow = typeof this.configManager?.getSeasonDateWindow === 'function'
-      ? this.configManager.getSeasonDateWindow(leagueId, season)
-      : null;
-
-    if (!seasonWindow?.start || !seasonWindow?.end) {
-      return fixtures;
-    }
-
-    const start = new Date(`${seasonWindow.start}T00:00:00.000Z`);
-    const end = new Date(`${seasonWindow.end}T23:59:59.999Z`);
-    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-      this.logger.warn(
-        `[HOUND-GUARD] ⚠️  赛季窗口配置非法，跳过过滤: league=${leagueId} season=${season} `
-        + `start=${seasonWindow.start} end=${seasonWindow.end}`
-      );
-      return fixtures;
-    }
-
-    const filteredFixtures = fixtures.filter((fixture) => {
-      const matchDate = new Date(fixture?.match_date);
-      if (Number.isNaN(matchDate.getTime())) {
-        return true;
-      }
-      return matchDate >= start && matchDate <= end;
-    });
-
-    const droppedCount = fixtures.length - filteredFixtures.length;
-    if (droppedCount > 0) {
-      this.logger.warn(
-        `[HOUND-GUARD] 🛡️  拦截越界赛程: league=${leagueId} season=${season} `
-        + `window=${seasonWindow.start}..${seasonWindow.end} source=${seasonWindow.source || 'unknown'} `
-        + `dropped=${droppedCount}/${fixtures.length}`
-      );
-    }
-
-    return filteredFixtures;
-  }
-
-  /**
-   * 搜索联赛/球队 (V6.7.6-FINAL: 从 titan_discovery.js 迁移)
-   * @param {string} term - 搜索关键词
-   * @returns {Promise<Object>} 搜索结果
-   */
-  async search(term) {
-    this.logger.info(`\n🔍 正在搜索: "${term}"...`);
-
-    // 🔥 硬编码提示：日本 J 联赛直接提示已知 ID
-    const searchTermUpper = term.toUpperCase();
-    if (searchTermUpper.includes('J1') || searchTermUpper.includes('J2') || searchTermUpper.includes('日职')) {
-      this.logger.info('╔══════════════════════════════════════════════════════════════════╗');
-      this.logger.info('║  💡 侦察建议：已通过实时搜索确认 J1 为 223，J2 为 8974              ║');
-      this.logger.info('║     请尝试直接扫描: node scripts/ops/titan_discovery.js --league=223 ║');
-      this.logger.info('╚══════════════════════════════════════════════════════════════════╝\n');
-    }
-
-    // 🔥 V6.7.6-FINAL: 先尝试模拟搜索框输入 (DOM 交互)
-    let response;
-    try {
-      response = await this.extractor.searchViaDOM(term);
-    } catch (domError) {
-      this.logger.info(`[STEALTH-SOUL] ⚠️  DOM 搜索失败: ${domError.message}`);
-      this.logger.info(`[STEALTH-SOUL] 🔄 回退到 API 搜索...\n`);
-
-      // 回退到 API 搜索
-      const encodedTerm = encodeURIComponent(term);
-      const url = `https://www.fotmob.com/api/search/suggest?term=${encodedTerm}`;
-      this.logger.info(`🌐 前端拟态搜索: ${url}`);
-      response = await this.httpClient.request(url);
-    }
-
-    return response;
-  }
-
-  /**
-   * 关闭服务
-   * V6.7.6-PRINCIPAL: 防御性编程，确保资源在任何情况下都能释放
-   */
-  async close() {
-    const errors = [];
-
-    if (this.httpClient?.close) {
-      try {
-        await this.httpClient.close();
-        this.logger.info('[DiscoveryService] HTTP 客户端已关闭');
-      } catch (e) {
-        errors.push({ component: 'httpClient', error: e.message });
-        this.logger.error(`[DiscoveryService] HTTP 客户端关闭失败: ${e.message}`);
-      }
-    }
-
-    // 关闭浏览器提供者
-    if (this.browserProvider) {
-      try {
-        if (this.networkInterceptor) {
-          this.networkInterceptor.reset();
+        if (page && this.networkInterceptor?.setup) {
+            this.networkInterceptor.setup(page);
         }
-        await this.browserProvider.close();
-        this.logger.info('[DiscoveryService] 浏览器提供者已关闭');
-      } catch (e) {
-        errors.push({ component: 'browserProvider', error: e.message });
-        this.logger.error(`[DiscoveryService] 浏览器关闭失败: ${e.message}`);
-      }
+
+        if (typeof this.browserProvider.warmup === 'function') {
+            await this.browserProvider.warmup('https://www.fotmob.com/', {
+                waitUntil: 'domcontentloaded',
+                timeout: 15000,
+            });
+        }
     }
 
-    // 关闭数据库连接池
-    if (this.dbPool) {
-      try {
-        await this.dbPool.end();
-        this.logger.info('[DiscoveryService] 数据库连接池已关闭');
-      } catch (e) {
-        errors.push({ component: 'dbPool', error: e.message });
-        this.logger.error(`[DiscoveryService] 数据库连接池关闭失败: ${e.message}`);
-      }
+    async _rebuildBrowserContext(reason, cooldownMs = 0) {
+        if (!this.browserProvider) {
+            return;
+        }
+
+        this.logger.warn(`[HOUND-SELFHEAL] 重建浏览器上下文: ${reason}`);
+
+        if (this.networkInterceptor?.reset) {
+            this.networkInterceptor.reset();
+        }
+
+        if (typeof this.browserProvider.close === 'function') {
+            await this.browserProvider.close();
+        }
+
+        if (cooldownMs > 0) {
+            await this._sleep(cooldownMs);
+        }
+
+        if (typeof this.browserProvider.initialize === 'function') {
+            const page = await this.browserProvider.initialize();
+            if (page && this.networkInterceptor?.setup) {
+                this.networkInterceptor.setup(page);
+            }
+        }
+
+        if (typeof this.browserProvider.warmup === 'function') {
+            await this.browserProvider.warmup('https://www.fotmob.com/', {
+                waitUntil: 'domcontentloaded',
+                timeout: 15000,
+            });
+        }
     }
 
-    // 如果有错误，汇总抛出
-    if (errors.length > 0) {
-      const errorMessage = errors.map(e => `${e.component}: ${e.error}`).join('; ');
-      throw new Error(`[DiscoveryService] 资源关闭过程中发生错误: ${errorMessage}`);
+    _assertProviderIdentity(response, expectedProviderId, leagueName = 'unknown') {
+        if (!expectedProviderId) {
+            return;
+        }
+
+        const actualProviderId = Number(response?.details?.id);
+        if (!Number.isFinite(actualProviderId)) {
+            return;
+        }
+
+        if (actualProviderId !== Number(expectedProviderId)) {
+            const error = new Error(
+                `IDENTITY_MISMATCH: ${leagueName} 请求联赛 ${expectedProviderId}，响应联赛 ${actualProviderId}`
+            );
+            error.code = 'IDENTITY_MISMATCH';
+            error.expectedLeagueId = Number(expectedProviderId);
+            error.actualLeagueId = actualProviderId;
+            throw error;
+        }
     }
-  }
-
-  /**
-   * 延迟工具 (V6.7.6-FIX: 恢复此方法)
-   * @private
-   */
-  _sleep(ms) {
-    return new Promise(resolve => {
-      setTimeout(resolve, ms);
-    });
-  }
-
-  async ensureBrowserHealthy(options = {}) {
-    if (!this.useStealthMode || !this.browserProvider) {
-      return;
-    }
-
-    const forceRebuild = options.forceRebuild === true;
-    const recoverPage = options.recoverPage === true;
-    const isInitialized = typeof this.browserProvider.isInitialized === 'function'
-      ? this.browserProvider.isInitialized()
-      : Boolean(this.browserProvider.getPage?.());
-
-    if (!forceRebuild && !recoverPage && isInitialized) {
-      return;
-    }
-
-    if (this.browserHealthPromise) {
-      await this.browserHealthPromise;
-      return;
-    }
-
-    this.browserHealthPromise = recoverPage
-      ? this._recoverBrowserPage(options.reason || 'page-recovery')
-      : this._rebuildBrowserContext(
-        options.reason || 'health-check',
-        options.cooldownMs || 0
-      );
-
-    try {
-      await this.browserHealthPromise;
-    } finally {
-      this.browserHealthPromise = null;
-    }
-  }
-
-  async _coolDownBrowser(completedCount) {
-    if (!this.useStealthMode) {
-      return;
-    }
-
-    const cooldownMs = Math.max(0, Number(this.config.browserCooldownMs) || 0);
-    this.logger.warn(`[HOUND-COOLDOWN] 已完成 ${completedCount} 个联赛，执行浏览器冷却 ${cooldownMs}ms`);
-    await this.ensureBrowserHealthy({
-      forceRebuild: true,
-      reason: `cooldown-${completedCount}`,
-      cooldownMs
-    });
-  }
-
-  async _recoverBrowserPage(reason) {
-    if (!this.browserProvider) {
-      return;
-    }
-
-    this.logger.warn(`[HOUND-SELFHEAL] 恢复浏览器页面: ${reason}`);
-
-    if (this.networkInterceptor?.reset) {
-      this.networkInterceptor.reset();
-    }
-
-    let page = null;
-    if (typeof this.browserProvider.recoverPage === 'function') {
-      page = await this.browserProvider.recoverPage(reason);
-    } else {
-      if (typeof this.browserProvider.close === 'function') {
-        await this.browserProvider.close();
-      }
-      if (typeof this.browserProvider.initialize === 'function') {
-        page = await this.browserProvider.initialize();
-      }
-    }
-
-    if (page && this.networkInterceptor?.setup) {
-      this.networkInterceptor.setup(page);
-    }
-
-    if (typeof this.browserProvider.warmup === 'function') {
-      await this.browserProvider.warmup('https://www.fotmob.com/', {
-        waitUntil: 'domcontentloaded',
-        timeout: 15000
-      });
-    }
-  }
-
-  async _rebuildBrowserContext(reason, cooldownMs = 0) {
-    if (!this.browserProvider) {
-      return;
-    }
-
-    this.logger.warn(`[HOUND-SELFHEAL] 重建浏览器上下文: ${reason}`);
-
-    if (this.networkInterceptor?.reset) {
-      this.networkInterceptor.reset();
-    }
-
-    if (typeof this.browserProvider.close === 'function') {
-      await this.browserProvider.close();
-    }
-
-    if (cooldownMs > 0) {
-      await this._sleep(cooldownMs);
-    }
-
-    if (typeof this.browserProvider.initialize === 'function') {
-      const page = await this.browserProvider.initialize();
-      if (page && this.networkInterceptor?.setup) {
-        this.networkInterceptor.setup(page);
-      }
-    }
-
-    if (typeof this.browserProvider.warmup === 'function') {
-      await this.browserProvider.warmup('https://www.fotmob.com/', {
-        waitUntil: 'domcontentloaded',
-        timeout: 15000
-      });
-    }
-  }
-
-  _assertProviderIdentity(response, expectedProviderId, leagueName = 'unknown') {
-    if (!expectedProviderId) {
-      return;
-    }
-
-    const actualProviderId = Number(response?.details?.id);
-    if (!Number.isFinite(actualProviderId)) {
-      return;
-    }
-
-    if (actualProviderId !== Number(expectedProviderId)) {
-      const error = new Error(
-        `IDENTITY_MISMATCH: ${leagueName} 请求联赛 ${expectedProviderId}，响应联赛 ${actualProviderId}`
-      );
-      error.code = 'IDENTITY_MISMATCH';
-      error.expectedLeagueId = Number(expectedProviderId);
-      error.actualLeagueId = actualProviderId;
-      throw error;
-    }
-  }
 }
 
 module.exports = { DiscoveryService };

--- a/tests/unit/DiscoveryService.discoverCandidates.test.js
+++ b/tests/unit/DiscoveryService.discoverCandidates.test.js
@@ -1,0 +1,330 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const SERVICE_PATH = '../../src/infrastructure/services/DiscoveryService';
+
+function installNoSideEffectGuards(t) {
+    const originalLoad = Module._load;
+    const originalFetch = global.fetch;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalNetConnect = net.connect;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by discoverCandidates`);
+    };
+
+    global.fetch = fail('global.fetch');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    net.connect = fail('net.connect');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (['pg', 'playwright', 'playwright-core', 'redis', 'ioredis'].includes(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/titan_discovery/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        Module._load = originalLoad;
+        global.fetch = originalFetch;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        net.connect = originalNetConnect;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+    });
+}
+
+function loadDiscoveryServiceFresh() {
+    delete require.cache[require.resolve(SERVICE_PATH)];
+    return require(SERVICE_PATH).DiscoveryService;
+}
+
+function createConfigManager() {
+    const league = {
+        id: 53,
+        providerId: 53,
+        code: 'LIGUE1',
+        name: 'Ligue 1',
+        country: 'France',
+        tier: 'P0',
+        enabled: true,
+        defaultSeason: '2025/2026',
+    };
+    return {
+        getRuntimeConfig: () => ({
+            active_leagues: [league],
+            active_seasons: ['2025/2026'],
+            default_season: '2025/2026',
+            single_year_league_ids: [],
+        }),
+        getLeagueById: leagueId => (Number(leagueId) === 53 ? league : null),
+        getLeagueByCode: code => (code === 'LIGUE1' ? league : null),
+        getActiveLeagues: () => [league],
+        getDefaultSeason: () => '2025/2026',
+        getSingleYearLeagueIds: () => [],
+        getExpectedMatches: () => null,
+        getSeasonDateWindow: () => ({
+            start: '2025-08-15',
+            end: '2026-05-16',
+            source: 'test',
+        }),
+        buildLeagueApiUrl: (leagueId, season) =>
+            `https://www.fotmob.com/api/data/leagues?id=${leagueId}&season=${encodeURIComponent(season)}`,
+    };
+}
+
+function createService() {
+    const DiscoveryService = loadDiscoveryServiceFresh();
+    const calls = {
+        persist: 0,
+        browserInitialize: 0,
+        proxyAcquire: 0,
+        httpRequest: 0,
+    };
+    const service = new DiscoveryService({
+        silent: true,
+        delayMs: 0,
+        concurrency: 1,
+        disableDbPool: true,
+        disableBrowserProvider: true,
+        disableProxyProvider: true,
+        disableHttpClient: true,
+        disableFixtureRepository: true,
+        configManager: createConfigManager(),
+        dbPool: null,
+        browserProvider: {
+            proxyProvider: null,
+            isInitialized: () => false,
+            initialize: async () => {
+                calls.browserInitialize += 1;
+                throw new Error('browser should not initialize');
+            },
+            close: async () => {},
+        },
+        networkInterceptor: {
+            getCapturedApis: () => new Map(),
+            reset: () => {},
+        },
+        fixtureRepository: {
+            persist: async () => {
+                calls.persist += 1;
+                throw new Error('persist should not be called');
+            },
+        },
+        httpClient: {
+            proxyProvider: null,
+            request: async () => {
+                calls.httpRequest += 1;
+                throw new Error('http should not be called');
+            },
+            close: async () => {},
+        },
+        proxyProvider: {
+            acquire: async () => {
+                calls.proxyAcquire += 1;
+                throw new Error('proxy should not be used');
+            },
+        },
+    });
+    return { service, calls };
+}
+
+function fakePayload() {
+    return {
+        fixtures: {
+            allMatches: [
+                {
+                    id: 123,
+                    home: { name: 'Paris SG' },
+                    away: { name: 'Lyon' },
+                    status: {
+                        scheduled: true,
+                        utcTime: '2026-05-10T19:00:00.000Z',
+                    },
+                },
+                {
+                    id: 124,
+                    home: { name: 'Marseille' },
+                    away: { name: 'Nice' },
+                    status: {
+                        scheduled: true,
+                        utcTime: '2026-05-10T21:00:00.000Z',
+                    },
+                },
+            ],
+        },
+    };
+}
+
+function baseOptions(overrides = {}) {
+    return {
+        source: 'fotmob',
+        scope: 'controlled_candidates_preview',
+        leagueId: 53,
+        season: '2025/2026',
+        date: '2026-05-10',
+        concurrency: 1,
+        maxTargets: 1,
+        ...overrides,
+    };
+}
+
+test('discoverCandidates 存在并默认 safe preview/no network/no DB', async t => {
+    installNoSideEffectGuards(t);
+    const { service, calls } = createService();
+
+    const result = await service.discoverCandidates({ source: 'fotmob' });
+
+    assert.equal(typeof service.discoverCandidates, 'function');
+    assert.equal(result.preview_only, true);
+    assert.equal(result.dry_run, true);
+    assert.equal(result.allow_network, false);
+    assert.equal(result.db_written, false);
+    assert.equal(result.matches_written, false);
+    assert.equal(result.raw_match_data_written, false);
+    assert.equal(result.candidate_count, 0);
+    assert.equal(calls.persist, 0);
+    assert.equal(calls.browserInitialize, 0);
+    assert.equal(calls.proxyAcquire, 0);
+    assert.equal(calls.httpRequest, 0);
+});
+
+test('discoverCandidates source 缺失或非 fotmob 会失败', async t => {
+    installNoSideEffectGuards(t);
+    const { service } = createService();
+
+    await assert.rejects(() => service.discoverCandidates({}), /missing source/i);
+    await assert.rejects(() => service.discoverCandidates({ source: 'other' }), /unsupported source/i);
+});
+
+test('discoverCandidates 拒绝并发、批量、写库、browser fallback 和 proxy', async t => {
+    installNoSideEffectGuards(t);
+    const { service } = createService();
+
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ concurrency: 2 })), /concurrency > 1/i);
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ maxTargets: 2 })), /maxTargets > 1/i);
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ writeDb: true })), /writeDb=true/i);
+    await assert.rejects(
+        () => service.discoverCandidates(baseOptions({ allowBrowserFallback: true })),
+        /allowBrowserFallback=true/i
+    );
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ allowProxy: true })), /allowProxy=true/i);
+});
+
+test('allowNetwork=false 时不调用注入的真实 fetch', async t => {
+    installNoSideEffectGuards(t);
+    const { service } = createService();
+    let fetchCalls = 0;
+
+    const result = await service.discoverCandidates(baseOptions(), {
+        fetchLeagueFixtures: async () => {
+            fetchCalls += 1;
+            return fakePayload();
+        },
+    });
+
+    assert.equal(fetchCalls, 0);
+    assert.equal(result.fetch_mode, 'not_executed');
+    assert.equal(result.candidate_count, 0);
+});
+
+test('fake fetchLeagueFixtures 可返回 normalized candidates 且受 maxTargets 限制', async t => {
+    installNoSideEffectGuards(t);
+    const { service, calls } = createService();
+    let fetchCalls = 0;
+
+    const result = await service.discoverCandidates(baseOptions(), {
+        networkKind: 'fake',
+        fetchLeagueFixtures: async request => {
+            fetchCalls += 1;
+            assert.equal(request.leagueId, 53);
+            assert.equal(request.season, '2025/2026');
+            assert.equal(request.date, '2026-05-10');
+            assert.match(request.sourceUrl, /fotmob\.com\/api\/data\/leagues/);
+            return fakePayload();
+        },
+    });
+
+    assert.equal(fetchCalls, 1);
+    assert.equal(result.fetch_mode, 'fake_injected_client');
+    assert.equal(result.external_network_used, false);
+    assert.equal(result.network_used, false);
+    assert.equal(result.raw_candidate_count, 2);
+    assert.equal(result.candidate_count, 1);
+    assert.equal(result.candidates.length, 1);
+    assert.equal(result.candidates[0].match_id, '53_20252026_123');
+    assert.equal(result.candidates[0].external_id, '123');
+    assert.equal(result.candidates[0].league, 'Ligue 1');
+    assert.equal(result.candidates[0].season, '2025/2026');
+    assert.equal(result.candidates[0].home, 'Paris SG');
+    assert.equal(result.candidates[0].away, 'Lyon');
+    assert.equal(result.candidates[0].match_date, '2026-05-10T19:00:00.000Z');
+    assert.equal(result.candidates[0].data_source, 'FotMob');
+    assert.equal(calls.persist, 0);
+    assert.equal(calls.browserInitialize, 0);
+    assert.equal(calls.proxyAcquire, 0);
+});
+
+test('fake network error 返回 controlled error 且不 retry', async t => {
+    installNoSideEffectGuards(t);
+    const { service, calls } = createService();
+    let fetchCalls = 0;
+
+    await assert.rejects(
+        () =>
+            service.discoverCandidates(baseOptions(), {
+                networkKind: 'fake',
+                fetchLeagueFixtures: async () => {
+                    fetchCalls += 1;
+                    throw new Error('fake upstream down');
+                },
+            }),
+        error => {
+            assert.equal(error.code, 'L1_DISCOVERY_CANDIDATES_FETCH_FAILED');
+            assert.equal(error.retryCount, 0);
+            assert.match(error.message, /fake upstream down/);
+            return true;
+        }
+    );
+
+    assert.equal(fetchCalls, 1);
+    assert.equal(calls.persist, 0);
+    assert.equal(calls.browserInitialize, 0);
+    assert.equal(calls.proxyAcquire, 0);
+});

--- a/tests/unit/l1_discovery_safe_preview.test.js
+++ b/tests/unit/l1_discovery_safe_preview.test.js
@@ -94,10 +94,10 @@ function installExecutionGuards(t) {
     });
 }
 
-function runCli(gate, argv, dependencies = {}) {
+async function runCli(gate, argv, dependencies = {}) {
     let stdout = '';
     let stderr = '';
-    const status = gate.runCli(
+    const status = await gate.runCli(
         argv,
         {
             stdout: text => {
@@ -173,10 +173,25 @@ test('parseArgs 能解析 league_season_date 参数', () => {
     assert.equal(options.maxTargets, '1');
 });
 
-test('valid config_only_preview 成功', t => {
+test('parseArgs 能解析 controlled_candidates_preview 和 network authorization', () => {
+    const gate = loadModuleFresh();
+    const options = gate.parseArgs([
+        '--source=fotmob',
+        '--scope=controlled_candidates_preview',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--network-authorization=no',
+    ]);
+
+    assert.equal(options.scope, 'controlled_candidates_preview');
+    assert.equal(options.networkAuthorization, false);
+});
+
+test('valid config_only_preview 成功', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview'], buildDependencies());
+    const result = await runCli(gate, ['--source=fotmob', '--scope=config_only_preview'], buildDependencies());
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 0);
@@ -188,10 +203,10 @@ test('valid config_only_preview 成功', t => {
     assertSafePreviewFlags(payload);
 });
 
-test('valid league_season_date 成功', t => {
+test('valid league_season_date 成功', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         [
             '--source=fotmob',
@@ -218,10 +233,10 @@ test('valid league_season_date 成功', t => {
     assertSafePreviewFlags(payload);
 });
 
-test('valid league_season_window_preview 成功', t => {
+test('valid league_season_window_preview 成功', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         [
             '--source=fotmob',
@@ -256,50 +271,50 @@ test('valid league_season_window_preview 成功', t => {
     assertSafePreviewFlags(payload);
 });
 
-test('缺 source 失败', t => {
+test('缺 source 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--scope=config_only_preview'], buildDependencies());
+    const result = await runCli(gate, ['--scope=config_only_preview'], buildDependencies());
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 1);
     assert.match(payload.errors.join('\n'), /missing source/i);
 });
 
-test('source 不是 fotmob 失败', t => {
+test('source 不是 fotmob 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--source=other', '--scope=config_only_preview'], buildDependencies());
+    const result = await runCli(gate, ['--source=other', '--scope=config_only_preview'], buildDependencies());
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 1);
     assert.match(payload.errors.join('\n'), /unsupported source/i);
 });
 
-test('缺 scope 失败', t => {
+test('缺 scope 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--source=fotmob'], buildDependencies());
+    const result = await runCli(gate, ['--source=fotmob'], buildDependencies());
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 1);
     assert.match(payload.errors.join('\n'), /missing scope/i);
 });
 
-test('unsupported scope 失败', t => {
+test('unsupported scope 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--source=fotmob', '--scope=bulk'], buildDependencies());
+    const result = await runCli(gate, ['--source=fotmob', '--scope=bulk'], buildDependencies());
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 1);
     assert.match(payload.errors.join('\n'), /unsupported scope/i);
 });
 
-test('league scope 缺 league-id 失败', t => {
+test('league scope 缺 league-id 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=league_season_date', '--season=2025/2026', '--date=2026-05-10'],
         buildDependencies()
@@ -310,10 +325,10 @@ test('league scope 缺 league-id 失败', t => {
     assert.match(payload.errors.join('\n'), /missing league-id/i);
 });
 
-test('league scope 缺 season 失败', t => {
+test('league scope 缺 season 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--date=2026-05-10'],
         buildDependencies()
@@ -324,10 +339,10 @@ test('league scope 缺 season 失败', t => {
     assert.match(payload.errors.join('\n'), /missing season/i);
 });
 
-test('league_season_date 缺 date 失败', t => {
+test('league_season_date 缺 date 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--season=2025/2026'],
         buildDependencies()
@@ -338,10 +353,10 @@ test('league_season_date 缺 date 失败', t => {
     assert.match(payload.errors.join('\n'), /missing date/i);
 });
 
-test('concurrency > 1 失败', t => {
+test('concurrency > 1 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=config_only_preview', '--concurrency=2'],
         buildDependencies()
@@ -352,10 +367,10 @@ test('concurrency > 1 失败', t => {
     assert.match(payload.errors.join('\n'), /concurrency > 1/i);
 });
 
-test('max_targets > 1 失败', t => {
+test('max_targets > 1 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=config_only_preview', '--max-targets=2'],
         buildDependencies()
@@ -366,20 +381,20 @@ test('max_targets > 1 失败', t => {
     assert.match(payload.errors.join('\n'), /max_targets > 1/i);
 });
 
-test('--all 失败', t => {
+test('--all 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--all'], buildDependencies());
+    const result = await runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--all'], buildDependencies());
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 1);
     assert.match(payload.errors.join('\n'), /--all/i);
 });
 
-test('--all-leagues 失败', t => {
+test('--all-leagues 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=config_only_preview', '--all-leagues'],
         buildDependencies()
@@ -390,20 +405,24 @@ test('--all-leagues 失败', t => {
     assert.match(payload.errors.join('\n'), /--all-leagues/i);
 });
 
-test('--full-sync 失败', t => {
+test('--full-sync 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--full-sync'], buildDependencies());
+    const result = await runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--full-sync'],
+        buildDependencies()
+    );
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 1);
     assert.match(payload.errors.join('\n'), /--full-sync/i);
 });
 
-test('dry_run=false 失败', t => {
+test('dry_run=false 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=config_only_preview', '--dry-run=false'],
         buildDependencies()
@@ -414,10 +433,10 @@ test('dry_run=false 失败', t => {
     assert.match(payload.errors.join('\n'), /dry_run=false/i);
 });
 
-test('db_write=true 失败', t => {
+test('db_write=true 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=config_only_preview', '--db-write=true'],
         buildDependencies()
@@ -428,10 +447,10 @@ test('db_write=true 失败', t => {
     assert.match(payload.errors.join('\n'), /db_write=true/i);
 });
 
-test('browser=true 失败', t => {
+test('browser=true 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=config_only_preview', '--browser=true'],
         buildDependencies()
@@ -442,10 +461,10 @@ test('browser=true 失败', t => {
     assert.match(payload.errors.join('\n'), /browser=true/i);
 });
 
-test('proxy=true 失败', t => {
+test('proxy=true 失败', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(
+    const result = await runCli(
         gate,
         ['--source=fotmob', '--scope=config_only_preview', '--proxy=true'],
         buildDependencies()
@@ -456,10 +475,14 @@ test('proxy=true 失败', t => {
     assert.match(payload.errors.join('\n'), /proxy=true/i);
 });
 
-test('--commit blocked', t => {
+test('--commit blocked', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--commit'], buildDependencies());
+    const result = await runCli(
+        gate,
+        ['--source=fotmob', '--scope=config_only_preview', '--commit'],
+        buildDependencies()
+    );
     const payload = parseJsonOutput(result.stdout);
 
     assert.equal(result.status, 1);
@@ -468,10 +491,155 @@ test('--commit blocked', t => {
     assertSafePreviewFlags(payload);
 });
 
-test('buildL1DiscoveryPlanPreview 直接构建时仍保持 no-side-effect 摘要', t => {
+test('controlled_candidates_preview scope 使用 fake discovery service 成功', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const payload = gate.buildL1DiscoveryPlanPreview(
+    let discoverCalls = 0;
+    let closeCalls = 0;
+    const result = await runCli(
+        gate,
+        [
+            '--source=fotmob',
+            '--scope=controlled_candidates_preview',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--date=2026-05-10',
+            '--concurrency=1',
+            '--max-targets=1',
+            '--network-authorization=no',
+        ],
+        {
+            ...buildDependencies(),
+            createDiscoveryService: () => ({
+                discoverCandidates: async options => {
+                    discoverCalls += 1;
+                    assert.equal(options.source, 'fotmob');
+                    assert.equal(options.scope, 'controlled_candidates_preview');
+                    assert.equal(options.allowNetwork, true);
+                    assert.equal(options.writeDb, false);
+                    return {
+                        source: 'fotmob',
+                        scope: 'controlled_candidates_preview',
+                        league_id: '53',
+                        season: '2025/2026',
+                        date: '2026-05-10',
+                        preview_only: true,
+                        network_used: false,
+                        external_network_used: false,
+                        browser_used: false,
+                        proxy_used: false,
+                        db_written: false,
+                        matches_written: false,
+                        raw_match_data_written: false,
+                        source_url_template:
+                            'https://www.fotmob.com/api/data/leagues?id={providerLeagueId}&season={season}',
+                        source_url_candidate: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+                        candidate_count: 1,
+                        candidates: [
+                            {
+                                match_id: '53_20252026_123',
+                                external_id: '123',
+                                league: 'Ligue 1',
+                                season: '2025/2026',
+                                home: 'Paris SG',
+                                away: 'Lyon',
+                                match_date: '2026-05-10T19:00:00.000Z',
+                                data_source: 'FotMob',
+                            },
+                        ],
+                        safety_summary: {
+                            would_write_db: false,
+                            would_call_persist: false,
+                            would_launch_browser: false,
+                            would_use_proxy: false,
+                        },
+                    };
+                },
+                close: async () => {
+                    closeCalls += 1;
+                },
+            }),
+            allowFakeNetwork: true,
+        }
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(discoverCalls, 1);
+    assert.equal(closeCalls, 1);
+    assert.equal(payload.scope, 'controlled_candidates_preview');
+    assert.equal(payload.candidates_preview_available, true);
+    assert.equal(payload.discover_candidates_available, true);
+    assert.equal(payload.network_execution_allowed, false);
+    assert.equal(payload.external_network_used, false);
+    assert.equal(payload.candidate_count, 1);
+    assert.equal(payload.candidates[0].match_id, '53_20252026_123');
+    assert.equal(payload.candidate_preview.fetch_mode, 'discover_candidates');
+    assert.equal(payload.safety_summary.would_call_persist, false);
+    assertSafePreviewFlags(payload);
+});
+
+test('controlled_candidates_preview 默认真实 CLI plan-only 且 no external network', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(
+        gate,
+        [
+            '--source=fotmob',
+            '--scope=controlled_candidates_preview',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--date=2026-05-10',
+            '--concurrency=1',
+            '--max-targets=1',
+            '--network-authorization=no',
+        ],
+        {
+            ...buildDependencies(),
+            allowDiscoveryServiceImport: false,
+        }
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.candidates_preview_available, true);
+    assert.equal(payload.discover_candidates_available, true);
+    assert.equal(payload.external_network_used, false);
+    assert.equal(payload.candidate_count, 0);
+    assert.deepEqual(payload.candidates, []);
+    assert.equal(payload.candidate_preview.fetch_mode, 'plan_only_no_service_import');
+    assertSafePreviewFlags(payload);
+});
+
+test('network-authorization=yes 在 Phase 5.04L1 仍 blocked', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(
+        gate,
+        [
+            '--source=fotmob',
+            '--scope=controlled_candidates_preview',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--date=2026-05-10',
+            '--network-authorization=yes',
+        ],
+        buildDependencies()
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 1);
+    assert.equal(payload.mode, 'blocked-network-authorization');
+    assert.equal(payload.external_network_used, false);
+    assert.equal(payload.network_execution_allowed, false);
+    assert.match(payload.blocked_reason, /later authorized phase/i);
+    assertSafePreviewFlags(payload);
+});
+
+test('buildL1DiscoveryPlanPreview 直接构建时仍保持 no-side-effect 摘要', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const payload = await gate.buildL1DiscoveryPlanPreview(
         {
             source: 'fotmob',
             scope: 'league_season_date',
@@ -485,7 +653,7 @@ test('buildL1DiscoveryPlanPreview 直接构建时仍保持 no-side-effect 摘要
         buildDependencies()
     );
 
-    assert.equal(payload.phase, 'PHASE5_03L1_L1_DISCOVERY_SAFE_PREVIEW_WRAPPER');
+    assert.equal(payload.phase, 'PHASE5_04L1_L1_DISCOVERY_CANDIDATES_EXTRACTION');
     assert.equal(payload.candidate_preview.estimated_target_limit, 1);
     assert.equal(payload.registry_reference.engine_id, 'titan_discovery');
     assert.equal(payload.registry_reference.accesses_network, true);
@@ -497,13 +665,14 @@ test('buildL1DiscoveryPlanPreview 直接构建时仍保持 no-side-effect 摘要
 test('Makefile preview target 已注册', () => {
     const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
     assert.match(makefile, /^data-l1-discovery-preview:/m);
+    assert.match(makefile, /^data-l1-discovery-candidates-preview:/m);
     assert.match(makefile, /scripts\/ops\/l1_discovery_safe_preview\.js/);
 });
 
 test('Makefile commit target blocked 文案存在', () => {
     const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
     assert.match(makefile, /^data-l1-discovery-commit:/m);
-    assert.match(makefile, /BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5\.03L1\./);
+    assert.match(makefile, /BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5\.04L1\./);
 });
 
 test('测试不在仓库内创建随机目录', () => {


### PR DESCRIPTION
## Summary

Adds Phase 5.04L1 controlled L1 candidates extraction.

Scope:
- Adds discoverCandidates() / candidates-only path to existing L1 DiscoveryService
- Keeps titan_discovery blocked for agents
- Keeps FixtureRepository.persist isolated from preview path
- Adds controlled_candidates_preview to L1 safe wrapper
- Keeps network execution blocked by default
- Keeps matches/raw_match_data/DB writes blocked
- Adds fake dependency injection tests
- Updates Makefile, AGENTS.md, and report

Safety:
- No external FotMob access
- No network dry-run
- No browser automation
- No proxy runtime
- No titan_discovery execution
- No DiscoveryService.discover execution
- No FixtureRepository.persist execution
- No harvest / ingest
- No matches writes
- No raw_match_data writes
- No DB writes
- No training / prediction

Validation:
- discoverCandidates tests passed
- L1 safe preview wrapper tests passed
- Makefile candidates preview passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally because browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed