### PR TITLE
feat(data): add controlled L1 network candidates preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
 - 开始修改前先确认当前 Git 分支；如果是 `main`，先切出工作分支。
 - 如果命令已经封装为 `npm script`，优先使用脚本入口。
 - 如果 `npm script` 指向缺失文件，先修正文档或脚本，再继续依赖该入口。
-- 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` / `make data-l1-discovery-candidates-preview` 的 safe preview 路径进入，除非用户后续显式授权受控网络阶段。
+- 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` / `make data-l1-discovery-candidates-preview` 的 safe preview 路径进入；显式授权的 L1 外网候选预览只能通过 `make data-l1-discovery-candidates-network-preview`。
 
 ### 2.3 禁止行为
 
@@ -216,6 +216,7 @@ AI / Codex 默认只能执行：
 - `make data-check`
 - `make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...`
 - `make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no ...`
+- 用户明确授权、仅做 candidates stdout summary、不写 DB/不启动 browser/proxy 的 `make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
@@ -366,6 +367,19 @@ Phase 5.04L1 补充约定：
 - 不得启动 browser / proxy runtime。
 - 真实 L1 network preview 必须后续阶段另行授权。
 - matches seed commit 必须后续阶段另行授权。
+
+Phase 5.05L1 补充约定：
+
+- L1 external network candidate preview 只能走 `make data-l1-discovery-candidates-network-preview`。
+- 该入口必须调用 `discoverCandidates()`，不得运行 `titan_discovery.js`。
+- 不得调用 `DiscoveryService.discover()`。
+- 不得调用 `FixtureRepository.persist()`。
+- 不得写 `matches`、`raw_match_data` 或任何 DB 表。
+- 不得启动 browser / proxy runtime，除非未来单独阶段另行授权。
+- 参数必须显式包含 source / scope / league / season / date / concurrency / maxTargets。
+- 仅允许 `SOURCE=fotmob`、`SCOPE=controlled_candidates_preview`、`CONCURRENCY=1`、`MAX_TARGETS<=10`。
+- 网络错误、403、429、captcha 或 block 信号必须立即停止。
+- 不得自动 retry，不得降级到 browser/proxy，不得降级到 `titan_discovery.js`。
 
 执行 `make data-l3-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
         data-prediction-write-dry-run data-prediction-write-commit \
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
-        data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-commit \
+        data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -309,8 +309,9 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
-	@echo "  make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...  # Phase 5.04L1 preview-only, no network/browser/proxy/DB, no titan_discovery/DiscoveryService.discover/FixtureRepository.persist"
-	@echo "  make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no  # Phase 5.04L1 candidates preview, no external network/browser/proxy/DB, no matches/raw writes"
+	@echo "  make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...  # Phase 5.05L1 preview-only, no network/browser/proxy/DB, no titan_discovery/DiscoveryService.discover/FixtureRepository.persist"
+	@echo "  make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no  # Phase 5.05L1 candidates preview, no external network/browser/proxy/DB, no matches/raw writes"
+	@echo "  make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no  # Phase 5.05L1 controlled external network candidates preview only"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -361,7 +362,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-packet-file-preauth-closure CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path>"
 	@echo "  make data-football-data-packet-file-preauth-closure-commit CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_PREAUTH_CLOSURE=1  # blocked in Phase 4.76C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
-	@echo "  make data-l1-discovery-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_DISCOVERY_COMMIT=1  # blocked in Phase 5.04L1"
+	@echo "  make data-l1-discovery-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_DISCOVERY_COMMIT=1  # blocked in Phase 5.05L1"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
 	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
@@ -425,12 +426,12 @@ data-check: ## Read-only data environment check
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/csv_bulk_loader.js --help >/tmp/fp_data_csv_loader_help.txt
 	@echo "OK: read-only data environment check completed."
 
-data-l1-discovery-preview: ## L1 safe preview wrapper. Phase 5.04L1. Preview-only, no network, no DB, no browser/proxy.
+data-l1-discovery-preview: ## L1 safe preview wrapper. Phase 5.05L1. Preview-only, no network, no DB, no browser/proxy.
 	@if [ -z "$(SOURCE)" ] || [ -z "$(SCOPE)" ]; then \
 		echo "ERROR: provide SOURCE=fotmob and SCOPE=<config_only_preview|league_season_date|league_season_window_preview|controlled_candidates_preview>"; \
 		exit 1; \
 	fi
-	$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
 		--source="$(SOURCE)" \
 		--scope="$(SCOPE)" \
 		$(if $(LEAGUE_ID),--league-id="$(LEAGUE_ID)") \
@@ -442,12 +443,12 @@ data-l1-discovery-preview: ## L1 safe preview wrapper. Phase 5.04L1. Preview-onl
 		$(if $(LOOKAHEAD),--lookahead="$(LOOKAHEAD)") \
 		--dry-run=true
 
-data-l1-discovery-candidates-preview: ## L1 controlled candidates preview. Phase 5.04L1. Default no external network, no DB, no browser/proxy.
+data-l1-discovery-candidates-preview: ## L1 controlled candidates preview. Phase 5.05L1. Default no external network, no DB, no browser/proxy.
 	@if [ -z "$(SOURCE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(SEASON)" ] || [ -z "$(DATE)" ]; then \
 		echo "ERROR: provide SOURCE=fotmob LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd>"; \
 		exit 1; \
 	fi
-	$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
 		--source="$(SOURCE)" \
 		--scope="$(or $(SCOPE),controlled_candidates_preview)" \
 		--league-id="$(LEAGUE_ID)" \
@@ -460,8 +461,30 @@ data-l1-discovery-candidates-preview: ## L1 controlled candidates preview. Phase
 		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
 		--dry-run=true
 
-data-l1-discovery-commit: ## Blocked L1 safe preview commit gate. Remains blocked in Phase 5.04L1.
-	@echo "BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.04L1."
+data-l1-discovery-candidates-network-preview: ## L1 controlled external network candidates preview. Phase 5.05L1. No DB, no browser/proxy.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(SEASON)" ] || [ -z "$(DATE)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd>"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_discovery_safe_preview.js \
+		--network-preview=true \
+		--source="$(SOURCE)" \
+		--scope="$(or $(SCOPE),controlled_candidates_preview)" \
+		--league-id="$(LEAGUE_ID)" \
+		--season="$(SEASON)" \
+		--date="$(DATE)" \
+		--concurrency="$(or $(CONCURRENCY),1)" \
+		--max-targets="$(or $(MAX_TARGETS),10)" \
+		$(if $(LOOKBACK),--lookback="$(LOOKBACK)") \
+		$(if $(LOOKAHEAD),--lookahead="$(LOOKAHEAD)") \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--dry-run=true
+
+data-l1-discovery-commit: ## Blocked L1 safe preview commit gate. Remains blocked in Phase 5.05L1.
+	@echo "BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.05L1."
 	@echo "  No titan_discovery direct call, no DiscoveryService.discover call, no FixtureRepository.persist call."
 	@echo "  Even with CONFIRM_L1_DISCOVERY_COMMIT=1, network execution and DB writes remain blocked."
 	@exit 1

--- a/docs/_reports/L1_CONTROLLED_NETWORK_CANDIDATES_PREVIEW_PHASE5_05L1.md
+++ b/docs/_reports/L1_CONTROLLED_NETWORK_CANDIDATES_PREVIEW_PHASE5_05L1.md
@@ -1,0 +1,85 @@
+# L1 Controlled Network Candidates Preview - Phase 5.05L1
+
+## 1. Executive summary
+
+Phase 5.05L1 将 L1 candidates preview 从 no-network plan-only 提升为显式授权后的 controlled external network preview。
+
+本阶段仍不运行 `titan_discovery.js`，不调用 `DiscoveryService.discover()`，不调用 `FixtureRepository.persist()`，不写 DB，不写 `matches` / `raw_match_data`，不启动 browser / proxy。
+
+## 2. Implemented files
+
+- `src/infrastructure/services/DiscoveryService.js`
+- `scripts/ops/l1_discovery_safe_preview.js`
+- `tests/unit/DiscoveryService.discoverCandidates.test.js`
+- `tests/unit/l1_discovery_safe_preview.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/L1_CONTROLLED_NETWORK_CANDIDATES_PREVIEW_PHASE5_05L1.md`
+
+## 3. Why this is safe
+
+- `discoverCandidates()` 与 `FixtureRepository.persist()` 保持分离，候选发现只返回 candidates。
+- 外网 preview 必须显式传入 `NETWORK_AUTHORIZATION=yes`，且只能通过 `data-l1-discovery-candidates-network-preview`。
+- scope 固定为 `controlled_candidates_preview`，source 固定为 `fotmob`。
+- `CONCURRENCY=1`，`MAX_TARGETS<=10`。
+- DB write、matches write、raw_match_data write 全部固定为 false。
+- browser / proxy runtime 固定 disabled。
+- `data-l1-discovery-commit` 仍 blocked。
+- 网络错误、403、429、captcha 或 block 信号停止，不自动 retry。
+
+## 4. Validation
+
+本地验证通过：
+
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/DiscoveryService.discoverCandidates.test.js`
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/l1_discovery_safe_preview.test.js`
+- `make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CONCURRENCY=1 MAX_TARGETS=1 NETWORK_AUTHORIZATION=no`
+- `make data-l1-discovery-commit SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CONCURRENCY=1 MAX_TARGETS=1 CONFIRM_L1_DISCOVERY_COMMIT=1 || true`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`
+- `git diff --check`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx eslint src/infrastructure/services/DiscoveryService.js scripts/ops/l1_discovery_safe_preview.js tests/unit/l1_discovery_safe_preview.test.js tests/unit/DiscoveryService.discoverCandidates.test.js --no-cache`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md Makefile src/infrastructure/services/DiscoveryService.js scripts/ops/l1_discovery_safe_preview.js tests/unit/l1_discovery_safe_preview.test.js tests/unit/DiscoveryService.discoverCandidates.test.js docs/_reports/L1_CONTROLLED_NETWORK_CANDIDATES_PREVIEW_PHASE5_05L1.md`
+
+No-network preview returned `external_network_used=false`, `candidate_count=0`, and all DB / persist / browser / proxy write indicators false.
+
+Commit gate remained blocked.
+
+Safety review passed:
+
+- no `tests/fixtures/l1-config-*` residue
+- no `docs/_staging_preview` directory
+- DB row counts unchanged: `matches=2`, `bookmaker_odds_history=2`, `raw_match_data=2`, `l3_features=2`, `match_features_training=2`, `predictions=2`
+
+## 5. Actual controlled network preview result
+
+本阶段代码合并前不执行真实外网 preview。若 PR 合并且 main push CI 成功，将在 main 上按授权范围执行一次：
+
+- source: `fotmob`
+- league_id: `53`
+- season: `2025/2026`
+- date: `2026-05-10`
+- concurrency: `1`
+- max_targets: `10`
+
+合并前实际结果：未执行真实外网 preview；原因是本阶段要求真实 network preview 仅在 PR 合并、main push CI 成功、main 工作区 clean 且 DB 行数复核通过后执行。
+
+## 6. Recommended next step
+
+如果 preview 成功发现目标 candidates，推荐 Phase 5.06L1：controlled matches seed commit planning。
+
+Phase 5.06L1 仍不写 `raw_match_data`，只规划是否将 candidates 写入 `matches` seed；需要用户明确授权，并需要 backup / rollback / upsert policy。
+
+如果 preview 失败，则停止，不绕过，不启用 browser/proxy，由用户决定是否调整范围、retry 或单独授权后续能力。
+
+## 7. Explicit non-execution
+
+- no titan_discovery execution
+- no DiscoveryService.discover execution
+- no FixtureRepository.persist
+- no DB writes
+- no matches writes
+- no raw_match_data writes
+- no browser/proxy
+- no harvest/ingest
+- no training/prediction

--- a/scripts/ops/l1_discovery_safe_preview.js
+++ b/scripts/ops/l1_discovery_safe_preview.js
@@ -7,7 +7,7 @@ const path = require('node:path');
 
 const { L1ConfigManager } = require('../../src/infrastructure/services/L1ConfigManager');
 
-const PHASE = 'PHASE5_04L1_L1_DISCOVERY_CANDIDATES_EXTRACTION';
+const PHASE = 'PHASE5_05L1_CONTROLLED_L1_EXTERNAL_NETWORK_CANDIDATES_PREVIEW';
 const SAFE_SOURCE = 'fotmob';
 const CONTROLLED_CANDIDATES_SCOPE = 'controlled_candidates_preview';
 const SAFE_SCOPES = new Set([
@@ -18,11 +18,13 @@ const SAFE_SCOPES = new Set([
 ]);
 const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_MAX_TARGETS = 1;
+const MAX_CONTROLLED_NETWORK_TARGETS = 10;
 const DEFAULT_LOOKBACK = 30;
 const DEFAULT_LOOKAHEAD = 7;
-const NEXT_REQUIRED_PHASE = 'controlled L1 external network preview with explicit user authorization';
-const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.04L1.';
+const NEXT_REQUIRED_PHASE = 'controlled matches seed commit planning with explicit user authorization';
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.05L1.';
 const REGISTRY_PATH = path.resolve(__dirname, '../../config/acquisition_engines.phase454.json');
+const TARGET_MATCH_ID_CANDIDATE = '4830746';
 
 function parseBooleanLike(value, fallback = undefined) {
     if (typeof value === 'boolean') {
@@ -127,6 +129,10 @@ function parseArgs(argv = process.argv.slice(2)) {
         allLeagues: false,
         fullSync: false,
         networkAuthorization: false,
+        networkPreview: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        allowDbWrite: false,
         help: false,
         json: true,
     };
@@ -157,6 +163,16 @@ function parseArgs(argv = process.argv.slice(2)) {
         full_sync: 'fullSync',
         'network-authorization': 'networkAuthorization',
         network_authorization: 'networkAuthorization',
+        'network-preview': 'networkPreview',
+        network_preview: 'networkPreview',
+        'allow-network': 'networkPreview',
+        allow_network: 'networkPreview',
+        'allow-browser-runtime': 'allowBrowserRuntime',
+        allow_browser_runtime: 'allowBrowserRuntime',
+        'allow-proxy-runtime': 'allowProxyRuntime',
+        allow_proxy_runtime: 'allowProxyRuntime',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
         help: 'help',
         h: 'help',
         json: 'json',
@@ -189,6 +205,10 @@ function parseArgs(argv = process.argv.slice(2)) {
                 'allLeagues',
                 'fullSync',
                 'networkAuthorization',
+                'networkPreview',
+                'allowBrowserRuntime',
+                'allowProxyRuntime',
+                'allowDbWrite',
                 'help',
                 'json',
             ].includes(optionKey)
@@ -237,6 +257,10 @@ function normalizeSafePreviewInput(input = {}) {
         dbWrite: parseBooleanLike(input.dbWrite, false),
         browser: parseBooleanLike(input.browser, false),
         proxy: parseBooleanLike(input.proxy, false),
+        networkPreview: parseBooleanLike(input.networkPreview, false),
+        allowBrowserRuntime: parseBooleanLike(input.allowBrowserRuntime, false),
+        allowProxyRuntime: parseBooleanLike(input.allowProxyRuntime, false),
+        allowDbWrite: parseBooleanLike(input.allowDbWrite, false),
         all: parseBooleanLike(input.all, false),
         allLeagues: parseBooleanLike(input.allLeagues, false),
         fullSync: parseBooleanLike(input.fullSync, false),
@@ -267,27 +291,30 @@ function validateSourceAndScope(input, errors) {
 }
 
 function validateBlockedFlags(input, errors) {
-    pushIf(input.all, errors, 'bulk flag not allowed: --all is blocked in Phase 5.04L1');
-    pushIf(input.allLeagues, errors, 'bulk flag not allowed: --all-leagues is blocked in Phase 5.04L1');
-    pushIf(input.fullSync, errors, 'bulk flag not allowed: --full-sync is blocked in Phase 5.04L1');
+    pushIf(input.all, errors, 'bulk flag not allowed: --all is blocked in Phase 5.05L1');
+    pushIf(input.allLeagues, errors, 'bulk flag not allowed: --all-leagues is blocked in Phase 5.05L1');
+    pushIf(input.fullSync, errors, 'bulk flag not allowed: --full-sync is blocked in Phase 5.05L1');
     pushIf(input.commit, errors, BLOCKED_COMMIT_MESSAGE);
     pushIf(input.dryRun !== true, errors, 'dry_run=false is not allowed: preview wrapper is fixed to dry-run mode');
-    pushIf(input.dbWrite === true, errors, 'db_write=true is not allowed in Phase 5.04L1');
-    pushIf(input.browser === true, errors, 'browser=true is not allowed in Phase 5.04L1');
-    pushIf(input.proxy === true, errors, 'proxy=true is not allowed in Phase 5.04L1');
+    pushIf(input.dbWrite === true, errors, 'db_write=true is not allowed in Phase 5.05L1');
+    pushIf(input.allowDbWrite === true, errors, 'ALLOW_DB_WRITE=yes is not allowed in Phase 5.05L1');
+    pushIf(input.browser === true, errors, 'browser=true is not allowed in Phase 5.05L1');
+    pushIf(input.allowBrowserRuntime === true, errors, 'ALLOW_BROWSER_RUNTIME=yes is not allowed in Phase 5.05L1');
+    pushIf(input.proxy === true, errors, 'proxy=true is not allowed in Phase 5.05L1');
+    pushIf(input.allowProxyRuntime === true, errors, 'ALLOW_PROXY_RUNTIME=yes is not allowed in Phase 5.05L1');
 }
 
 function validateLimits(input, errors) {
     if (!Number.isInteger(input.concurrency) || input.concurrency < 1) {
         errors.push('invalid concurrency: provide a positive integer');
     } else if (input.concurrency > 1) {
-        errors.push('concurrency > 1 is blocked in Phase 5.04L1');
+        errors.push('concurrency > 1 is blocked in Phase 5.05L1');
     }
 
     if (!Number.isInteger(input.maxTargets) || input.maxTargets < 1) {
         errors.push('invalid max_targets: provide a positive integer');
-    } else if (input.maxTargets > 1) {
-        errors.push('max_targets > 1 is blocked in Phase 5.04L1');
+    } else if (input.maxTargets > MAX_CONTROLLED_NETWORK_TARGETS) {
+        errors.push(`max_targets > ${MAX_CONTROLLED_NETWORK_TARGETS} is blocked in Phase 5.05L1`);
     }
 
     if (!Number.isInteger(input.lookback) || input.lookback < 0) {
@@ -327,6 +354,28 @@ function validateLeagueScope(input, errors) {
     }
 }
 
+function validateNetworkPreview(input, errors) {
+    if (!input.networkPreview) {
+        return;
+    }
+
+    if (input.source !== SAFE_SOURCE) {
+        return;
+    }
+    if (input.scope !== CONTROLLED_CANDIDATES_SCOPE) {
+        errors.push('network preview requires scope=controlled_candidates_preview');
+    }
+    if (input.networkAuthorization !== true) {
+        errors.push('network preview requires NETWORK_AUTHORIZATION=yes');
+    }
+    if (input.concurrency !== 1) {
+        errors.push('network preview requires CONCURRENCY=1');
+    }
+    if (input.maxTargets > MAX_CONTROLLED_NETWORK_TARGETS) {
+        errors.push(`network preview requires MAX_TARGETS<=${MAX_CONTROLLED_NETWORK_TARGETS}`);
+    }
+}
+
 function validateSafePreviewInput(input) {
     const errors = [];
     const normalized = normalizeSafePreviewInput(input);
@@ -335,6 +384,7 @@ function validateSafePreviewInput(input) {
     validateBlockedFlags(normalized, errors);
     validateLimits(normalized, errors);
     validateLeagueScope(normalized, errors);
+    validateNetworkPreview(normalized, errors);
 
     return {
         ok: errors.length === 0,
@@ -350,6 +400,10 @@ function validateSafePreviewInput(input) {
             dbWrite: false,
             browser: false,
             proxy: false,
+            networkPreview: normalized.networkPreview,
+            allowBrowserRuntime: false,
+            allowProxyRuntime: false,
+            allowDbWrite: false,
             all: false,
             allLeagues: false,
             fullSync: false,
@@ -406,7 +460,9 @@ function buildSafetySummary(input, metadata = {}) {
         bulk_allowed: false,
         full_sync_allowed: false,
         all_leagues_allowed: false,
-        network_execution_allowed: false,
+        network_execution_allowed: input.networkPreview === true && input.networkAuthorization === true,
+        controlled_external_network_preview_allowed:
+            input.networkPreview === true && input.networkAuthorization === true,
         browser_runtime_allowed: false,
         proxy_runtime_allowed: false,
         db_write_allowed: false,
@@ -416,13 +472,16 @@ function buildSafetySummary(input, metadata = {}) {
         discover_candidates_available: true,
         training_allowed: false,
         prediction_allowed: false,
-        would_access_network: false,
+        would_access_network: input.networkPreview === true,
         external_network_used: false,
+        network_authorization_used: false,
+        source_url_used: null,
         would_launch_browser: false,
         would_use_proxy: false,
         would_call_titan_discovery: false,
         would_call_discovery_service_discover: false,
         would_call_fixture_repository_persist: false,
+        would_call_persist: false,
         would_write_matches: false,
         would_write_raw_match_data: false,
         would_write_db: false,
@@ -431,9 +490,13 @@ function buildSafetySummary(input, metadata = {}) {
         would_create_files: false,
         would_spawn_child_process: false,
         network_authorization_requested: input.networkAuthorization === true,
-        network_authorization_effective: false,
+        network_authorization_effective: input.networkPreview === true && input.networkAuthorization === true,
         network_authorization_status:
-            input.networkAuthorization === true ? 'blocked_phase_5_04l1_plan_only' : 'not_requested',
+            input.networkAuthorization === true && input.networkPreview === true
+                ? 'authorized_phase_5_05l1_controlled_network_preview'
+                : input.networkAuthorization === true
+                  ? 'blocked_without_network_preview_target'
+                  : 'not_requested',
         candidate_count: 0,
         candidates: [],
         safety_classification: 'safe_preview_only',
@@ -480,6 +543,137 @@ function buildWindowPreview(input, seasonWindow, dependencies = {}) {
     };
 }
 
+function assertFotMobLeagueApiUrl(sourceUrl) {
+    let parsed;
+    try {
+        parsed = new URL(sourceUrl);
+    } catch (error) {
+        throw new Error(`invalid FotMob source URL: ${error.message}`);
+    }
+
+    if (
+        parsed.protocol !== 'https:' ||
+        parsed.hostname !== 'www.fotmob.com' ||
+        parsed.pathname !== '/api/data/leagues'
+    ) {
+        throw new Error('blocked source URL: only https://www.fotmob.com/api/data/leagues is allowed');
+    }
+
+    if (!parsed.searchParams.get('id') || !parsed.searchParams.get('season')) {
+        throw new Error('blocked source URL: FotMob league API requires id and season');
+    }
+}
+
+function classifyBlockText(bodyText) {
+    const normalized = String(bodyText || '').toLowerCase();
+    return ['captcha', 'cloudflare', 'access denied', 'too many requests', 'blocked', 'rate limit'].some(pattern =>
+        normalized.includes(pattern)
+    );
+}
+
+function buildNetworkError(message, context = {}) {
+    const error = new Error(message);
+    error.statusCode = context.statusCode || null;
+    error.code = context.code || null;
+    error.sourceUrl = context.sourceUrl || null;
+    return error;
+}
+
+function createSafeFotMobNetworkClient(dependencies = {}) {
+    const fetchImpl = dependencies.fetch || global.fetch;
+    const timeoutMs = Number.parseInt(String(dependencies.timeoutMs || 15000), 10);
+
+    return async request => {
+        assertFotMobLeagueApiUrl(request.sourceUrl);
+        if (request.source !== SAFE_SOURCE) {
+            throw new Error(`unsupported source for safe network client: ${request.source}`);
+        }
+        if (request.concurrency !== 1) {
+            throw new Error('safe network client requires concurrency=1');
+        }
+        if (
+            !Number.isInteger(Number(request.maxTargets)) ||
+            Number(request.maxTargets) > MAX_CONTROLLED_NETWORK_TARGETS
+        ) {
+            throw new Error(`safe network client requires maxTargets<=${MAX_CONTROLLED_NETWORK_TARGETS}`);
+        }
+        if (request.networkAuthorization !== true) {
+            throw new Error('safe network client requires networkAuthorization=true');
+        }
+        if (typeof fetchImpl !== 'function') {
+            throw new Error('global fetch is unavailable for controlled network preview');
+        }
+
+        const controller = typeof AbortController === 'function' ? new AbortController() : null;
+        const timeout = controller
+            ? setTimeout(() => {
+                  controller.abort();
+              }, timeoutMs)
+            : null;
+
+        try {
+            const response = await fetchImpl(request.sourceUrl, {
+                method: 'GET',
+                headers: {
+                    accept: 'application/json,text/plain;q=0.9,*/*;q=0.8',
+                    'user-agent': 'FootballPrediction-L1CandidatesPreview/5.05',
+                },
+                signal: controller?.signal,
+            });
+            const statusCode = Number(response.status);
+            const bodyText = await response.text();
+
+            if (statusCode === 403 || statusCode === 429 || classifyBlockText(bodyText)) {
+                throw buildNetworkError(`FotMob controlled network preview blocked with status ${statusCode}`, {
+                    statusCode,
+                    code: 'L1_DISCOVERY_CANDIDATES_NETWORK_BLOCKED',
+                    sourceUrl: request.sourceUrl,
+                });
+            }
+            if (!response.ok) {
+                throw buildNetworkError(`FotMob controlled network preview failed with status ${statusCode}`, {
+                    statusCode,
+                    code: 'L1_DISCOVERY_CANDIDATES_FETCH_FAILED',
+                    sourceUrl: request.sourceUrl,
+                });
+            }
+
+            return JSON.parse(bodyText);
+        } finally {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+        }
+    };
+}
+
+function normalizeTeamName(value) {
+    return String(value || '')
+        .toLowerCase()
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-z0-9]+/g, '');
+}
+
+function containsTargetMatchIdCandidate(candidates, targetId = TARGET_MATCH_ID_CANDIDATE) {
+    return (Array.isArray(candidates) ? candidates : []).some(candidate =>
+        [candidate?.external_id, candidate?.externalId, candidate?.id, candidate?.match_id, candidate?.matchId].some(
+            value => String(value || '').includes(targetId)
+        )
+    );
+}
+
+function containsAngersStrasbourgCandidate(candidates) {
+    return (Array.isArray(candidates) ? candidates : []).some(candidate => {
+        const home = normalizeTeamName(candidate?.home || candidate?.home_team);
+        const away = normalizeTeamName(candidate?.away || candidate?.away_team);
+        return (
+            (home.includes('angers') && away.includes('strasbourg')) ||
+            (home.includes('strasbourg') && away.includes('angers'))
+        );
+    });
+}
+
 function resolveDiscoveryServiceFactory(dependencies = {}) {
     if (dependencies.discoveryService) {
         return () => dependencies.discoveryService;
@@ -513,9 +707,9 @@ async function buildControlledCandidatesPreview(input, context, dependencies = {
     basePreview.mode = 'controlled_candidates_preview';
     basePreview.plan_summary = {
         preview_kind: CONTROLLED_CANDIDATES_SCOPE,
-        network_execution: 'blocked_by_default',
+        network_execution: input.networkPreview ? 'authorized_controlled_external_preview' : 'blocked_by_default',
         network_authorization_requested: input.networkAuthorization === true,
-        network_authorization_effective: false,
+        network_authorization_effective: input.networkPreview === true && input.networkAuthorization === true,
         persistence: 'blocked',
         browser_runtime: 'blocked',
         proxy_runtime: 'blocked',
@@ -523,6 +717,8 @@ async function buildControlledCandidatesPreview(input, context, dependencies = {
     basePreview.discover_candidates_available = true;
     basePreview.candidates_preview_available = true;
     basePreview.external_network_used = false;
+    basePreview.network_authorization_used = false;
+    basePreview.source_url_used = null;
     basePreview.candidate_count = 0;
     basePreview.candidates = [];
 
@@ -534,6 +730,15 @@ async function buildControlledCandidatesPreview(input, context, dependencies = {
         };
     }
 
+    const fetchLeagueFixtures =
+        dependencies.fetchLeagueFixtures ||
+        (input.networkPreview
+            ? createSafeFotMobNetworkClient({
+                  fetch: dependencies.fetch,
+                  timeoutMs: dependencies.timeoutMs,
+              })
+            : null);
+    const networkKind = dependencies.networkKind || (input.networkPreview ? 'external' : 'none');
     const service = createDiscoveryService({ input, context, dependencies });
     if (!service || typeof service.discoverCandidates !== 'function') {
         throw new Error('discoverCandidates provider is not available');
@@ -552,20 +757,20 @@ async function buildControlledCandidatesPreview(input, context, dependencies = {
                 concurrency: input.concurrency,
                 maxTargets: input.maxTargets,
                 dryRun: true,
-                allowNetwork: dependencies.allowFakeNetwork === true,
+                allowNetwork: input.networkPreview === true || dependencies.allowFakeNetwork === true,
+                networkAuthorization: input.networkAuthorization === true || dependencies.allowFakeNetwork === true,
                 allowBrowserFallback: false,
                 allowProxy: false,
                 writeDb: false,
                 previewOnly: true,
             },
             {
-                fetchLeagueFixtures: dependencies.fetchLeagueFixtures,
-                httpClient: dependencies.httpClient,
+                fetchLeagueFixtures,
                 parser: dependencies.parser,
                 logger: dependencies.logger,
                 repository: dependencies.repository,
                 browserProvider: dependencies.browserProvider,
-                networkKind: dependencies.allowFakeNetwork === true ? 'fake' : 'none',
+                networkKind: dependencies.allowFakeNetwork === true ? 'fake' : networkKind,
             }
         );
 
@@ -574,6 +779,9 @@ async function buildControlledCandidatesPreview(input, context, dependencies = {
             : [];
         basePreview.fetch_mode = candidateResult.fetch_mode || 'discover_candidates';
         basePreview.source_url_candidate = candidateResult.source_url_candidate || basePreview.source_url_template;
+        basePreview.source_url_used = candidateResult.source_url_used || null;
+        basePreview.external_network_used = candidateResult.external_network_used === true;
+        basePreview.network_authorization_used = candidateResult.network_authorization_used === true;
         basePreview.candidate_count = Number(candidateResult.candidate_count) || candidates.length;
         basePreview.candidates = candidates;
         basePreview.safety_summary = candidateResult.safety_summary || null;
@@ -720,14 +928,20 @@ async function buildL1DiscoveryPlanPreview(input, dependencies = {}) {
         ...payload,
         candidates_preview_available: true,
         discover_candidates_available: true,
-        external_network_used: false,
+        external_network_used: controlledPreview.preview.external_network_used === true,
+        network_authorization_used: controlledPreview.preview.network_authorization_used === true,
         candidate_count: Number(controlledPreview.preview.candidate_count) || candidates.length,
         candidates,
+        candidates_preview: candidates,
+        contains_target_match_id_candidate: containsTargetMatchIdCandidate(candidates),
+        contains_anglers_strasbourg_candidate: containsAngersStrasbourgCandidate(candidates),
+        contains_angers_strasbourg_candidate: containsAngersStrasbourgCandidate(candidates),
         source_url_template:
             controlledPreview.preview.source_url_template || buildSourceUrlPreview(configManager, normalizedInput),
         source_url_candidate:
             controlledPreview.preview.source_url_candidate || buildSourceUrlPreview(configManager, normalizedInput),
-        network_used: false,
+        source_url_used: controlledPreview.preview.source_url_used || null,
+        network_used: controlledPreview.preview.external_network_used === true || candidateResult.network_used === true,
         browser_used: false,
         proxy_used: false,
         db_written: false,
@@ -753,6 +967,10 @@ function buildErrorPayload(options, errors, mode = 'validation-error') {
         dbWrite: false,
         browser: false,
         proxy: false,
+        networkPreview: options.networkPreview,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        allowDbWrite: false,
         all: false,
         allLeagues: false,
         fullSync: false,
@@ -764,6 +982,9 @@ function buildErrorPayload(options, errors, mode = 'validation-error') {
         ok: false,
         mode,
         errors: Array.isArray(errors) ? errors : [String(errors)],
+        contains_target_match_id_candidate: false,
+        contains_anglers_strasbourg_candidate: false,
+        contains_angers_strasbourg_candidate: false,
     };
 }
 
@@ -775,6 +996,7 @@ function showHelp(io = {}) {
             '',
             '用法:',
             '  node scripts/ops/l1_discovery_safe_preview.js --source=fotmob --scope=league_season_date --league-id=53 --season=2025/2026 --date=2026-05-10 --concurrency=1 --max-targets=1',
+            '  node scripts/ops/l1_discovery_safe_preview.js --network-preview=true --source=fotmob --scope=controlled_candidates_preview --league-id=53 --season=2025/2026 --date=2026-05-10 --concurrency=1 --max-targets=10 --network-authorization=yes',
             '',
             '允许 scope:',
             '  config_only_preview',
@@ -782,9 +1004,9 @@ function showHelp(io = {}) {
             '  league_season_window_preview',
             '  controlled_candidates_preview',
             '',
-            'Phase 5.04L1 约束:',
+            'Phase 5.05L1 约束:',
             '  preview-only',
-            '  no network',
+            '  network only when --network-preview=true and --network-authorization=yes',
             '  no browser',
             '  no proxy',
             '  no DB write',
@@ -820,13 +1042,14 @@ async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) 
         return 1;
     }
 
-    if (validation.value.networkAuthorization === true) {
+    if (validation.value.networkAuthorization === true && validation.value.networkPreview !== true) {
         const payload = buildErrorPayload(
             options,
-            ['BLOCKED: external L1 network execution requires a later authorized phase.'],
+            ['BLOCKED: external L1 network execution requires data-l1-discovery-candidates-network-preview.'],
             'blocked-network-authorization'
         );
-        payload.blocked_reason = 'BLOCKED: external L1 network execution requires a later authorized phase.';
+        payload.blocked_reason =
+            'BLOCKED: external L1 network execution requires data-l1-discovery-candidates-network-preview.';
         payload.candidates_preview_available = validation.value.scope === CONTROLLED_CANDIDATES_SCOPE;
         payload.discover_candidates_available = true;
         payload.external_network_used = false;
@@ -841,7 +1064,18 @@ async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) 
         stdout(`${JSON.stringify(payload, null, 2)}\n`);
         return 0;
     } catch (error) {
-        const payload = buildErrorPayload(options, error.validationErrors || [error.message]);
+        const mode =
+            error.code === 'L1_DISCOVERY_CANDIDATES_NETWORK_BLOCKED'
+                ? 'controlled-network-blocked'
+                : error.code === 'L1_DISCOVERY_CANDIDATES_FETCH_FAILED'
+                  ? 'controlled-network-error'
+                  : 'validation-error';
+        const payload = buildErrorPayload(options, error.validationErrors || [error.message], mode);
+        payload.external_network_used = error.externalNetworkUsed === true;
+        payload.network_authorization_used = error.networkAuthorizationUsed === true;
+        payload.source_url_used = error.sourceUrl || null;
+        payload.status_code = error.statusCode || null;
+        payload.retry_count = Number.isInteger(error.retryCount) ? error.retryCount : 0;
         stderr(`${error.message}\n`);
         stdout(`${JSON.stringify(payload, null, 2)}\n`);
         return 1;
@@ -867,5 +1101,8 @@ module.exports = {
     loadSeasonWindowSafe,
     buildSafetySummary,
     buildControlledCandidatesPreview,
+    createSafeFotMobNetworkClient,
+    containsTargetMatchIdCandidate,
+    containsAngersStrasbourgCandidate,
     runCli,
 };

--- a/src/infrastructure/services/DiscoveryService.js
+++ b/src/infrastructure/services/DiscoveryService.js
@@ -31,6 +31,9 @@ const { L1ConfigManager } = require('./L1ConfigManager');
 
 require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
 
+const DISCOVERY_CANDIDATE_SCOPES = new Set(['controlled_candidates_preview', 'league_season_date']);
+const MAX_CONTROLLED_CANDIDATE_TARGETS = 10;
+
 function loadPool() {
     return require('pg').Pool;
 }
@@ -348,17 +351,20 @@ class DiscoveryService {
     }
 
     /**
-     * Phase 5.04L1: candidates-only preview path.
-     * 只做 fetch provider 注入、parse、normalize，不调用 persist，不写 DB。
+     * Phase 5.05L1: candidates-only preview path.
+     * 只做 safe network client 注入、parse、normalize，不调用 persist，不写 DB。
      */
     async discoverCandidates(options = {}, deps = {}) {
         const input = this._normalizeDiscoverCandidatesOptions(options);
         const target = this._resolveCandidateTarget(input);
-        const sourceUrl = target ? this._buildCandidateSourceUrl(target) : this._buildCandidateSourceUrlTemplate();
+        const sourceUrl = this._buildCandidateSourceUrl(target);
         const fetchLeagueFixtures = this._resolveCandidateFetch(input, deps);
         const basePayload = this._buildDiscoverCandidatesPayload(input, target, sourceUrl);
 
         if (!fetchLeagueFixtures) {
+            if (input.allowNetwork) {
+                throw new Error('safe network client is required when allowNetwork=true');
+            }
             return {
                 ...basePayload,
                 fetch_mode: 'not_executed',
@@ -372,30 +378,18 @@ class DiscoveryService {
         try {
             const fetchRequest = {
                 source: input.source,
-                leagueId: target?.id || null,
-                providerLeagueId: target ? target.providerId || target.id : null,
-                season: target?.season || input.season,
+                leagueId: target.id,
+                providerLeagueId: target.providerId || target.id,
+                season: target.season,
                 formattedSeason: this._formatCandidateSeason(target),
                 date: input.date,
                 sourceUrl,
                 target,
+                networkAuthorization: input.networkAuthorization,
+                maxTargets: input.maxTargets,
+                concurrency: input.concurrency,
             };
             const response = await fetchLeagueFixtures(fetchRequest);
-            if (!target) {
-                return {
-                    ...basePayload,
-                    ok: true,
-                    fetch_mode: deps.networkKind === 'fake' ? 'fake_injected_client' : 'injected_client',
-                    raw_candidate_count: 0,
-                    candidate_count: 0,
-                    candidates: [],
-                    response_preview_available: Boolean(response),
-                    safety_summary: {
-                        ...basePayload.safety_summary,
-                        network_client_injected: true,
-                    },
-                };
-            }
             const parser = deps.parser || this.parser;
             const isHistorical = this._isHistoricalSeason(target.season);
             const parsedFixtures = parser.parse(response, target.id, target.season, isHistorical, {
@@ -412,19 +406,35 @@ class DiscoveryService {
             return {
                 ...basePayload,
                 ok: true,
-                fetch_mode: deps.networkKind === 'fake' ? 'fake_injected_client' : 'injected_client',
+                fetch_mode: deps.networkKind === 'fake' ? 'fake_injected_client' : 'safe_injected_client',
+                network_used: true,
+                external_network_used: deps.networkKind === 'external',
+                network_authorization_used: input.networkAuthorization,
+                source_url_used: sourceUrl,
                 raw_candidate_count: datedFixtures.length,
                 candidate_count: candidates.length,
                 candidates,
                 safety_summary: {
                     ...basePayload.safety_summary,
                     network_client_injected: true,
+                    external_network_used: deps.networkKind === 'external',
+                    network_authorization_used: input.networkAuthorization,
                 },
             };
         } catch (error) {
             const controlledError = new Error(`L1 discovery candidates fetch failed: ${error.message}`);
-            controlledError.code = 'L1_DISCOVERY_CANDIDATES_FETCH_FAILED';
+            const statusCode = Number(error.statusCode || error.status || 0) || null;
+            const blocked =
+                statusCode === 403 || statusCode === 429 || error.code === 'L1_DISCOVERY_CANDIDATES_NETWORK_BLOCKED';
+            controlledError.code = blocked
+                ? 'L1_DISCOVERY_CANDIDATES_NETWORK_BLOCKED'
+                : 'L1_DISCOVERY_CANDIDATES_FETCH_FAILED';
             controlledError.retryCount = 0;
+            controlledError.statusCode = statusCode;
+            controlledError.blocked = blocked;
+            controlledError.sourceUrl = sourceUrl;
+            controlledError.externalNetworkUsed = deps.networkKind === 'external';
+            controlledError.networkAuthorizationUsed = input.networkAuthorization;
             controlledError.cause = error;
             throw controlledError;
         }
@@ -434,11 +444,16 @@ class DiscoveryService {
         const source = String(options.source || '')
             .trim()
             .toLowerCase();
+        const scope = String(options.scope || 'controlled_candidates_preview').trim();
         const concurrency = Number.parseInt(String(options.concurrency ?? 1), 10);
         const maxTargets = Number.parseInt(String(options.maxTargets ?? options.max_targets ?? 1), 10);
         const lookback = Number.parseInt(String(options.lookback ?? 30), 10);
         const lookahead = Number.parseInt(String(options.lookahead ?? 7), 10);
         const leagueId = options.leagueId ?? options.league_id ?? null;
+        const season = typeof options.season === 'string' ? options.season.trim() : options.season || null;
+        const date = typeof options.date === 'string' ? options.date.trim() : options.date || null;
+        const allowNetwork = options.allowNetwork === true || options.allow_network === true;
+        const networkAuthorization = options.networkAuthorization === true || options.network_authorization === true;
 
         if (!source) {
             throw new Error('missing source: discoverCandidates requires source=fotmob');
@@ -446,36 +461,62 @@ class DiscoveryService {
         if (source !== 'fotmob') {
             throw new Error('unsupported source: discoverCandidates currently only allows fotmob');
         }
-        if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 1) {
-            throw new Error('concurrency > 1 is blocked for discoverCandidates in Phase 5.04L1');
+        if (!DISCOVERY_CANDIDATE_SCOPES.has(scope)) {
+            throw new Error(
+                'unsupported scope: discoverCandidates only allows controlled_candidates_preview or league_season_date'
+            );
         }
-        if (!Number.isInteger(maxTargets) || maxTargets < 1 || maxTargets > 1) {
-            throw new Error('maxTargets > 1 is blocked for discoverCandidates in Phase 5.04L1');
+        if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 1) {
+            throw new Error('concurrency > 1 is blocked for discoverCandidates in Phase 5.05L1');
+        }
+        if (!Number.isInteger(maxTargets) || maxTargets < 1 || maxTargets > MAX_CONTROLLED_CANDIDATE_TARGETS) {
+            throw new Error(
+                `maxTargets > ${MAX_CONTROLLED_CANDIDATE_TARGETS} is blocked for discoverCandidates in Phase 5.05L1`
+            );
+        }
+        if (leagueId === null || leagueId === undefined || leagueId === '') {
+            throw new Error('missing leagueId: discoverCandidates requires explicit leagueId');
+        }
+        if (!season) {
+            throw new Error('missing season: discoverCandidates requires explicit season');
+        }
+        if (!date) {
+            throw new Error('missing date: discoverCandidates requires explicit date');
+        }
+        if (allowNetwork && !networkAuthorization) {
+            throw new Error('networkAuthorization=true is required when allowNetwork=true');
         }
         if (options.writeDb === true || options.write_db === true) {
             throw new Error('writeDb=true is not allowed in discoverCandidates');
         }
         if (options.allowBrowserFallback === true || options.allow_browser_fallback === true) {
-            throw new Error('allowBrowserFallback=true is not allowed in Phase 5.04L1');
+            throw new Error('allowBrowserFallback=true is not allowed in Phase 5.05L1');
         }
         if (options.allowProxy === true || options.allow_proxy === true) {
-            throw new Error('allowProxy=true is not allowed in Phase 5.04L1');
+            throw new Error('allowProxy=true is not allowed in Phase 5.05L1');
+        }
+        if (options.dryRun === false || options.dry_run === false) {
+            throw new Error('dryRun=false is not allowed in discoverCandidates');
+        }
+        if (options.previewOnly === false || options.preview_only === false) {
+            throw new Error('previewOnly=false is not allowed in discoverCandidates');
         }
 
         return {
             source,
-            scope: options.scope || 'controlled_candidates_preview',
+            scope,
             league: options.league || null,
             leagueId: leagueId === null || leagueId === undefined || leagueId === '' ? null : String(leagueId),
-            season: options.season || null,
-            date: options.date || null,
+            season,
+            date,
             lookback,
             lookahead,
             concurrency,
             maxTargets,
             dryRun: options.dryRun !== false && options.dry_run !== false,
             previewOnly: options.previewOnly !== false && options.preview_only !== false,
-            allowNetwork: options.allowNetwork === true || options.allow_network === true,
+            allowNetwork,
+            networkAuthorization,
             allowBrowserFallback: false,
             allowProxy: false,
             writeDb: false,
@@ -519,25 +560,29 @@ class DiscoveryService {
     }
 
     _resolveCandidateFetch(input, deps = {}) {
-        const fakeClientAllowed = deps.networkKind === 'fake';
-        if (!input.allowNetwork && !fakeClientAllowed) {
+        if (!input.allowNetwork) {
             return null;
         }
         if (typeof deps.fetchLeagueFixtures === 'function') {
             return deps.fetchLeagueFixtures;
         }
-        if (deps.httpClient && typeof deps.httpClient.request === 'function') {
-            return ({ sourceUrl, providerLeagueId }) =>
-                deps.httpClient.request(sourceUrl, {
-                    expectedLeagueId: Number(providerLeagueId),
-                });
+        if (typeof deps.safeNetworkClient === 'function') {
+            return deps.safeNetworkClient;
         }
         return null;
     }
 
     _buildDiscoverCandidatesPayload(input, target, sourceUrl) {
         const safetySummary = {
+            wrote_db: false,
+            wrote_matches: false,
+            wrote_raw_match_data: false,
+            called_persist: false,
+            launched_browser: false,
+            used_proxy: false,
             would_write_db: false,
+            would_write_matches: false,
+            would_write_raw_match_data: false,
             would_call_persist: false,
             would_launch_browser: false,
             would_use_proxy: false,
@@ -556,6 +601,7 @@ class DiscoveryService {
             preview_only: true,
             dry_run: true,
             allow_network: input.allowNetwork,
+            network_authorization_used: false,
             network_used: false,
             external_network_used: false,
             browser_used: false,
@@ -565,6 +611,7 @@ class DiscoveryService {
             raw_match_data_written: false,
             source_url_template: this._buildCandidateSourceUrlTemplate(),
             source_url_candidate: sourceUrl,
+            source_url_used: null,
             raw_candidate_count: 0,
             candidate_count: 0,
             candidates: [],

--- a/tests/unit/DiscoveryService.discoverCandidates.test.js
+++ b/tests/unit/DiscoveryService.discoverCandidates.test.js
@@ -165,28 +165,24 @@ function createService() {
     return { service, calls };
 }
 
-function fakePayload() {
+function fakeMatch(id, home, away, utcTime = '2026-05-10T19:00:00.000Z') {
+    return {
+        id,
+        home: { name: home },
+        away: { name: away },
+        status: {
+            scheduled: true,
+            utcTime,
+        },
+    };
+}
+
+function fakePayload(matches = null) {
     return {
         fixtures: {
-            allMatches: [
-                {
-                    id: 123,
-                    home: { name: 'Paris SG' },
-                    away: { name: 'Lyon' },
-                    status: {
-                        scheduled: true,
-                        utcTime: '2026-05-10T19:00:00.000Z',
-                    },
-                },
-                {
-                    id: 124,
-                    home: { name: 'Marseille' },
-                    away: { name: 'Nice' },
-                    status: {
-                        scheduled: true,
-                        utcTime: '2026-05-10T21:00:00.000Z',
-                    },
-                },
+            allMatches: matches || [
+                fakeMatch(123, 'Paris SG', 'Lyon', '2026-05-10T19:00:00.000Z'),
+                fakeMatch(124, 'Marseille', 'Nice', '2026-05-10T21:00:00.000Z'),
             ],
         },
     };
@@ -201,15 +197,32 @@ function baseOptions(overrides = {}) {
         date: '2026-05-10',
         concurrency: 1,
         maxTargets: 1,
+        allowNetwork: false,
+        networkAuthorization: false,
         ...overrides,
     };
+}
+
+function assertSafetySummaryAllFalse(result) {
+    assert.equal(result.safety_summary.wrote_db, false);
+    assert.equal(result.safety_summary.wrote_matches, false);
+    assert.equal(result.safety_summary.wrote_raw_match_data, false);
+    assert.equal(result.safety_summary.called_persist, false);
+    assert.equal(result.safety_summary.launched_browser, false);
+    assert.equal(result.safety_summary.used_proxy, false);
+    assert.equal(result.safety_summary.would_write_db, false);
+    assert.equal(result.safety_summary.would_write_matches, false);
+    assert.equal(result.safety_summary.would_write_raw_match_data, false);
+    assert.equal(result.safety_summary.would_call_persist, false);
+    assert.equal(result.safety_summary.would_launch_browser, false);
+    assert.equal(result.safety_summary.would_use_proxy, false);
 }
 
 test('discoverCandidates 存在并默认 safe preview/no network/no DB', async t => {
     installNoSideEffectGuards(t);
     const { service, calls } = createService();
 
-    const result = await service.discoverCandidates({ source: 'fotmob' });
+    const result = await service.discoverCandidates(baseOptions());
 
     assert.equal(typeof service.discoverCandidates, 'function');
     assert.equal(result.preview_only, true);
@@ -223,6 +236,7 @@ test('discoverCandidates 存在并默认 safe preview/no network/no DB', async t
     assert.equal(calls.browserInitialize, 0);
     assert.equal(calls.proxyAcquire, 0);
     assert.equal(calls.httpRequest, 0);
+    assertSafetySummaryAllFalse(result);
 });
 
 test('discoverCandidates source 缺失或非 fotmob 会失败', async t => {
@@ -231,6 +245,7 @@ test('discoverCandidates source 缺失或非 fotmob 会失败', async t => {
 
     await assert.rejects(() => service.discoverCandidates({}), /missing source/i);
     await assert.rejects(() => service.discoverCandidates({ source: 'other' }), /unsupported source/i);
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ scope: 'bulk' })), /unsupported scope/i);
 });
 
 test('discoverCandidates 拒绝并发、批量、写库、browser fallback 和 proxy', async t => {
@@ -238,13 +253,32 @@ test('discoverCandidates 拒绝并发、批量、写库、browser fallback 和 p
     const { service } = createService();
 
     await assert.rejects(() => service.discoverCandidates(baseOptions({ concurrency: 2 })), /concurrency > 1/i);
-    await assert.rejects(() => service.discoverCandidates(baseOptions({ maxTargets: 2 })), /maxTargets > 1/i);
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ maxTargets: 11 })), /maxTargets > 10/i);
     await assert.rejects(() => service.discoverCandidates(baseOptions({ writeDb: true })), /writeDb=true/i);
     await assert.rejects(
         () => service.discoverCandidates(baseOptions({ allowBrowserFallback: true })),
         /allowBrowserFallback=true/i
     );
     await assert.rejects(() => service.discoverCandidates(baseOptions({ allowProxy: true })), /allowProxy=true/i);
+});
+
+test('discoverCandidates 要求显式 leagueId/season/date', async t => {
+    installNoSideEffectGuards(t);
+    const { service } = createService();
+
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ leagueId: null })), /missing leagueId/i);
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ season: null })), /missing season/i);
+    await assert.rejects(() => service.discoverCandidates(baseOptions({ date: null })), /missing date/i);
+});
+
+test('allowNetwork=true 但 networkAuthorization=false 失败', async t => {
+    installNoSideEffectGuards(t);
+    const { service } = createService();
+
+    await assert.rejects(
+        () => service.discoverCandidates(baseOptions({ allowNetwork: true, networkAuthorization: false })),
+        /networkAuthorization=true is required/i
+    );
 });
 
 test('allowNetwork=false 时不调用注入的真实 fetch', async t => {
@@ -262,14 +296,16 @@ test('allowNetwork=false 时不调用注入的真实 fetch', async t => {
     assert.equal(fetchCalls, 0);
     assert.equal(result.fetch_mode, 'not_executed');
     assert.equal(result.candidate_count, 0);
+    assert.equal(result.external_network_used, false);
+    assert.equal(result.network_authorization_used, false);
 });
 
-test('fake fetchLeagueFixtures 可返回 normalized candidates 且受 maxTargets 限制', async t => {
+test('allowNetwork=true 且 networkAuthorization=true 时调用 fake client 并返回 normalized candidates', async t => {
     installNoSideEffectGuards(t);
     const { service, calls } = createService();
     let fetchCalls = 0;
 
-    const result = await service.discoverCandidates(baseOptions(), {
+    const result = await service.discoverCandidates(baseOptions({ allowNetwork: true, networkAuthorization: true }), {
         networkKind: 'fake',
         fetchLeagueFixtures: async request => {
             fetchCalls += 1;
@@ -284,7 +320,9 @@ test('fake fetchLeagueFixtures 可返回 normalized candidates 且受 maxTargets
     assert.equal(fetchCalls, 1);
     assert.equal(result.fetch_mode, 'fake_injected_client');
     assert.equal(result.external_network_used, false);
-    assert.equal(result.network_used, false);
+    assert.equal(result.network_used, true);
+    assert.equal(result.network_authorization_used, true);
+    assert.equal(result.source_url_used, 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026');
     assert.equal(result.raw_candidate_count, 2);
     assert.equal(result.candidate_count, 1);
     assert.equal(result.candidates.length, 1);
@@ -299,6 +337,28 @@ test('fake fetchLeagueFixtures 可返回 normalized candidates 且受 maxTargets
     assert.equal(calls.persist, 0);
     assert.equal(calls.browserInitialize, 0);
     assert.equal(calls.proxyAcquire, 0);
+    assert.equal(calls.httpRequest, 0);
+    assertSafetySummaryAllFalse(result);
+});
+
+test('candidates 受 maxTargets=10 限制', async t => {
+    installNoSideEffectGuards(t);
+    const { service } = createService();
+    const matches = Array.from({ length: 12 }, (_, index) =>
+        fakeMatch(200 + index, `Home ${index}`, `Away ${index}`, '2026-05-10T12:00:00.000Z')
+    );
+
+    const result = await service.discoverCandidates(
+        baseOptions({ allowNetwork: true, networkAuthorization: true, maxTargets: 10 }),
+        {
+            networkKind: 'fake',
+            fetchLeagueFixtures: async () => fakePayload(matches),
+        }
+    );
+
+    assert.equal(result.raw_candidate_count, 12);
+    assert.equal(result.candidate_count, 10);
+    assert.equal(result.candidates.length, 10);
 });
 
 test('fake network error 返回 controlled error 且不 retry', async t => {
@@ -308,7 +368,7 @@ test('fake network error 返回 controlled error 且不 retry', async t => {
 
     await assert.rejects(
         () =>
-            service.discoverCandidates(baseOptions(), {
+            service.discoverCandidates(baseOptions({ allowNetwork: true, networkAuthorization: true }), {
                 networkKind: 'fake',
                 fetchLeagueFixtures: async () => {
                     fetchCalls += 1;
@@ -318,6 +378,8 @@ test('fake network error 返回 controlled error 且不 retry', async t => {
         error => {
             assert.equal(error.code, 'L1_DISCOVERY_CANDIDATES_FETCH_FAILED');
             assert.equal(error.retryCount, 0);
+            assert.equal(error.externalNetworkUsed, false);
+            assert.equal(error.networkAuthorizationUsed, true);
             assert.match(error.message, /fake upstream down/);
             return true;
         }
@@ -327,4 +389,5 @@ test('fake network error 返回 controlled error 且不 retry', async t => {
     assert.equal(calls.persist, 0);
     assert.equal(calls.browserInitialize, 0);
     assert.equal(calls.proxyAcquire, 0);
+    assert.equal(calls.httpRequest, 0);
 });

--- a/tests/unit/l1_discovery_safe_preview.test.js
+++ b/tests/unit/l1_discovery_safe_preview.test.js
@@ -152,9 +152,9 @@ function buildDependencies() {
     };
 }
 
-test('parseArgs 能解析 league_season_date 参数', () => {
+test('parseArgs 能解析 preview 与 controlled network 参数', () => {
     const gate = loadModuleFresh();
-    const options = gate.parseArgs([
+    const dateOptions = gate.parseArgs([
         '--source=fotmob',
         '--scope=league_season_date',
         '--league-id=53',
@@ -164,18 +164,15 @@ test('parseArgs 能解析 league_season_date 参数', () => {
         '--max-targets=1',
     ]);
 
-    assert.equal(options.source, 'fotmob');
-    assert.equal(options.scope, 'league_season_date');
-    assert.equal(options.leagueId, '53');
-    assert.equal(options.season, '2025/2026');
-    assert.equal(options.date, '2026-05-10');
-    assert.equal(options.concurrency, '1');
-    assert.equal(options.maxTargets, '1');
-});
+    assert.equal(dateOptions.source, 'fotmob');
+    assert.equal(dateOptions.scope, 'league_season_date');
+    assert.equal(dateOptions.leagueId, '53');
+    assert.equal(dateOptions.season, '2025/2026');
+    assert.equal(dateOptions.date, '2026-05-10');
+    assert.equal(dateOptions.concurrency, '1');
+    assert.equal(dateOptions.maxTargets, '1');
 
-test('parseArgs 能解析 controlled_candidates_preview 和 network authorization', () => {
-    const gate = loadModuleFresh();
-    const options = gate.parseArgs([
+    const candidateOptions = gate.parseArgs([
         '--source=fotmob',
         '--scope=controlled_candidates_preview',
         '--league-id=53',
@@ -184,8 +181,30 @@ test('parseArgs 能解析 controlled_candidates_preview 和 network authorizatio
         '--network-authorization=no',
     ]);
 
-    assert.equal(options.scope, 'controlled_candidates_preview');
-    assert.equal(options.networkAuthorization, false);
+    assert.equal(candidateOptions.scope, 'controlled_candidates_preview');
+    assert.equal(candidateOptions.networkAuthorization, false);
+
+    const networkOptions = gate.parseArgs([
+        '--network-preview=true',
+        '--source=fotmob',
+        '--scope=controlled_candidates_preview',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--concurrency=1',
+        '--max-targets=10',
+        '--network-authorization=yes',
+        '--allow-browser-runtime=no',
+        '--allow-proxy-runtime=no',
+        '--allow-db-write=no',
+    ]);
+
+    assert.equal(networkOptions.networkPreview, true);
+    assert.equal(networkOptions.maxTargets, '10');
+    assert.equal(networkOptions.networkAuthorization, true);
+    assert.equal(networkOptions.allowBrowserRuntime, false);
+    assert.equal(networkOptions.allowProxyRuntime, false);
+    assert.equal(networkOptions.allowDbWrite, false);
 });
 
 test('valid config_only_preview 成功', async t => {
@@ -271,208 +290,37 @@ test('valid league_season_window_preview 成功', async t => {
     assertSafePreviewFlags(payload);
 });
 
-test('缺 source 失败', async t => {
+test('参数校验失败场景保持 blocked', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = await runCli(gate, ['--scope=config_only_preview'], buildDependencies());
-    const payload = parseJsonOutput(result.stdout);
+    const cases = [
+        [['--scope=config_only_preview'], /missing source/i],
+        [['--source=other', '--scope=config_only_preview'], /unsupported source/i],
+        [['--source=fotmob'], /missing scope/i],
+        [['--source=fotmob', '--scope=bulk'], /unsupported scope/i],
+        [
+            ['--source=fotmob', '--scope=league_season_date', '--season=2025/2026', '--date=2026-05-10'],
+            /missing league-id/i,
+        ],
+        [['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--date=2026-05-10'], /missing season/i],
+        [['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--season=2025/2026'], /missing date/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--concurrency=2'], /concurrency > 1/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--max-targets=11'], /max_targets > 10/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--all'], /--all/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--all-leagues'], /--all-leagues/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--full-sync'], /--full-sync/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--dry-run=false'], /dry_run=false/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--db-write=true'], /db_write=true/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--browser=true'], /browser=true/i],
+        [['--source=fotmob', '--scope=config_only_preview', '--proxy=true'], /proxy=true/i],
+    ];
 
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /missing source/i);
-});
-
-test('source 不是 fotmob 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(gate, ['--source=other', '--scope=config_only_preview'], buildDependencies());
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /unsupported source/i);
-});
-
-test('缺 scope 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(gate, ['--source=fotmob'], buildDependencies());
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /missing scope/i);
-});
-
-test('unsupported scope 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(gate, ['--source=fotmob', '--scope=bulk'], buildDependencies());
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /unsupported scope/i);
-});
-
-test('league scope 缺 league-id 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=league_season_date', '--season=2025/2026', '--date=2026-05-10'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /missing league-id/i);
-});
-
-test('league scope 缺 season 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--date=2026-05-10'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /missing season/i);
-});
-
-test('league_season_date 缺 date 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=league_season_date', '--league-id=53', '--season=2025/2026'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /missing date/i);
-});
-
-test('concurrency > 1 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--concurrency=2'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /concurrency > 1/i);
-});
-
-test('max_targets > 1 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--max-targets=2'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /max_targets > 1/i);
-});
-
-test('--all 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(gate, ['--source=fotmob', '--scope=config_only_preview', '--all'], buildDependencies());
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /--all/i);
-});
-
-test('--all-leagues 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--all-leagues'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /--all-leagues/i);
-});
-
-test('--full-sync 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--full-sync'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /--full-sync/i);
-});
-
-test('dry_run=false 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--dry-run=false'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /dry_run=false/i);
-});
-
-test('db_write=true 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--db-write=true'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /db_write=true/i);
-});
-
-test('browser=true 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--browser=true'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /browser=true/i);
-});
-
-test('proxy=true 失败', async t => {
-    installExecutionGuards(t);
-    const gate = loadModuleFresh();
-    const result = await runCli(
-        gate,
-        ['--source=fotmob', '--scope=config_only_preview', '--proxy=true'],
-        buildDependencies()
-    );
-    const payload = parseJsonOutput(result.stdout);
-
-    assert.equal(result.status, 1);
-    assert.match(payload.errors.join('\n'), /proxy=true/i);
+    for (const [argv, pattern] of cases) {
+        const result = await runCli(gate, argv, buildDependencies());
+        const payload = parseJsonOutput(result.stdout);
+        assert.equal(result.status, 1);
+        assert.match(payload.errors.join('\n'), pattern);
+    }
 });
 
 test('--commit blocked', async t => {
@@ -611,7 +459,7 @@ test('controlled_candidates_preview 默认真实 CLI plan-only 且 no external n
     assertSafePreviewFlags(payload);
 });
 
-test('network-authorization=yes 在 Phase 5.04L1 仍 blocked', async t => {
+test('旧 candidates preview target network-authorization=yes 仍 blocked', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
     const result = await runCli(
@@ -632,8 +480,184 @@ test('network-authorization=yes 在 Phase 5.04L1 仍 blocked', async t => {
     assert.equal(payload.mode, 'blocked-network-authorization');
     assert.equal(payload.external_network_used, false);
     assert.equal(payload.network_execution_allowed, false);
-    assert.match(payload.blocked_reason, /later authorized phase/i);
+    assert.match(payload.blocked_reason, /data-l1-discovery-candidates-network-preview/i);
     assertSafePreviewFlags(payload);
+});
+
+test('controlled network preview 参数校验通过并输出安全摘要', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    let discoverCalls = 0;
+    const result = await runCli(
+        gate,
+        [
+            '--network-preview=true',
+            '--source=fotmob',
+            '--scope=controlled_candidates_preview',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--date=2026-05-10',
+            '--concurrency=1',
+            '--max-targets=10',
+            '--network-authorization=yes',
+            '--allow-browser-runtime=no',
+            '--allow-proxy-runtime=no',
+            '--allow-db-write=no',
+        ],
+        {
+            ...buildDependencies(),
+            createDiscoveryService: () => ({
+                discoverCandidates: async options => {
+                    discoverCalls += 1;
+                    assert.equal(options.source, 'fotmob');
+                    assert.equal(options.scope, 'controlled_candidates_preview');
+                    assert.equal(options.leagueId, '53');
+                    assert.equal(options.season, '2025/2026');
+                    assert.equal(options.date, '2026-05-10');
+                    assert.equal(options.concurrency, 1);
+                    assert.equal(options.maxTargets, 10);
+                    assert.equal(options.allowNetwork, true);
+                    assert.equal(options.networkAuthorization, true);
+                    assert.equal(options.writeDb, false);
+                    assert.equal(options.allowBrowserFallback, false);
+                    assert.equal(options.allowProxy, false);
+                    return {
+                        source: 'fotmob',
+                        scope: 'controlled_candidates_preview',
+                        league_id: '53',
+                        season: '2025/2026',
+                        date: '2026-05-10',
+                        preview_only: true,
+                        network_used: true,
+                        external_network_used: true,
+                        network_authorization_used: true,
+                        browser_used: false,
+                        proxy_used: false,
+                        db_written: false,
+                        matches_written: false,
+                        raw_match_data_written: false,
+                        source_url_template:
+                            'https://www.fotmob.com/api/data/leagues?id={providerLeagueId}&season={season}',
+                        source_url_candidate: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+                        source_url_used: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+                        candidate_count: 1,
+                        candidates: [
+                            {
+                                match_id: '53_20252026_4830746',
+                                external_id: '4830746',
+                                league: 'Ligue 1',
+                                season: '2025/2026',
+                                home: 'Angers',
+                                away: 'Strasbourg',
+                                match_date: '2026-05-10T19:00:00.000Z',
+                                data_source: 'FotMob',
+                            },
+                        ],
+                        safety_summary: {
+                            wrote_db: false,
+                            wrote_matches: false,
+                            wrote_raw_match_data: false,
+                            called_persist: false,
+                            launched_browser: false,
+                            used_proxy: false,
+                            would_write_db: false,
+                            would_write_matches: false,
+                            would_write_raw_match_data: false,
+                            would_call_persist: false,
+                            would_launch_browser: false,
+                            would_use_proxy: false,
+                        },
+                    };
+                },
+                close: async () => {},
+            }),
+        }
+    );
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(discoverCalls, 1);
+    assert.equal(payload.phase, 'PHASE5_05L1_CONTROLLED_L1_EXTERNAL_NETWORK_CANDIDATES_PREVIEW');
+    assert.equal(payload.source, 'fotmob');
+    assert.equal(payload.league_id, '53');
+    assert.equal(payload.season, '2025/2026');
+    assert.equal(payload.date, '2026-05-10');
+    assert.equal(payload.concurrency, 1);
+    assert.equal(payload.max_targets, 10);
+    assert.equal(payload.external_network_used, true);
+    assert.equal(payload.network_authorization_used, true);
+    assert.equal(payload.candidate_count, 1);
+    assert.equal(payload.candidates_preview[0].external_id, '4830746');
+    assert.equal(payload.contains_target_match_id_candidate, true);
+    assert.equal(payload.contains_anglers_strasbourg_candidate, true);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_call_persist, false);
+    assert.equal(payload.would_call_fixture_repository_persist, false);
+    assert.equal(payload.would_launch_browser, false);
+    assert.equal(payload.would_use_proxy, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+});
+
+test('controlled network preview 拒绝 DB/browser/proxy runtime', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const baseArgv = [
+        '--network-preview=true',
+        '--source=fotmob',
+        '--scope=controlled_candidates_preview',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--network-authorization=yes',
+    ];
+
+    const dbWrite = await runCli(gate, [...baseArgv, '--allow-db-write=yes'], buildDependencies());
+    const browser = await runCli(gate, [...baseArgv, '--allow-browser-runtime=yes'], buildDependencies());
+    const proxy = await runCli(gate, [...baseArgv, '--allow-proxy-runtime=yes'], buildDependencies());
+
+    assert.equal(dbWrite.status, 1);
+    assert.match(parseJsonOutput(dbWrite.stdout).errors.join('\n'), /ALLOW_DB_WRITE=yes/i);
+    assert.equal(browser.status, 1);
+    assert.match(parseJsonOutput(browser.stdout).errors.join('\n'), /ALLOW_BROWSER_RUNTIME=yes/i);
+    assert.equal(proxy.status, 1);
+    assert.match(parseJsonOutput(proxy.stdout).errors.join('\n'), /ALLOW_PROXY_RUNTIME=yes/i);
+});
+
+test('controlled network preview 拒绝 maxTargets > 10 和缺 date', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const maxTargets = await runCli(
+        gate,
+        [
+            '--network-preview=true',
+            '--source=fotmob',
+            '--scope=controlled_candidates_preview',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--date=2026-05-10',
+            '--max-targets=11',
+            '--network-authorization=yes',
+        ],
+        buildDependencies()
+    );
+    const missingDate = await runCli(
+        gate,
+        [
+            '--network-preview=true',
+            '--source=fotmob',
+            '--scope=controlled_candidates_preview',
+            '--league-id=53',
+            '--season=2025/2026',
+            '--network-authorization=yes',
+        ],
+        buildDependencies()
+    );
+
+    assert.equal(maxTargets.status, 1);
+    assert.match(parseJsonOutput(maxTargets.stdout).errors.join('\n'), /max_targets > 10/i);
+    assert.equal(missingDate.status, 1);
+    assert.match(parseJsonOutput(missingDate.stdout).errors.join('\n'), /missing date/i);
 });
 
 test('buildL1DiscoveryPlanPreview 直接构建时仍保持 no-side-effect 摘要', async t => {
@@ -653,7 +677,7 @@ test('buildL1DiscoveryPlanPreview 直接构建时仍保持 no-side-effect 摘要
         buildDependencies()
     );
 
-    assert.equal(payload.phase, 'PHASE5_04L1_L1_DISCOVERY_CANDIDATES_EXTRACTION');
+    assert.equal(payload.phase, 'PHASE5_05L1_CONTROLLED_L1_EXTERNAL_NETWORK_CANDIDATES_PREVIEW');
     assert.equal(payload.candidate_preview.estimated_target_limit, 1);
     assert.equal(payload.registry_reference.engine_id, 'titan_discovery');
     assert.equal(payload.registry_reference.accesses_network, true);
@@ -666,13 +690,14 @@ test('Makefile preview target 已注册', () => {
     const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
     assert.match(makefile, /^data-l1-discovery-preview:/m);
     assert.match(makefile, /^data-l1-discovery-candidates-preview:/m);
+    assert.match(makefile, /^data-l1-discovery-candidates-network-preview:/m);
     assert.match(makefile, /scripts\/ops\/l1_discovery_safe_preview\.js/);
 });
 
 test('Makefile commit target blocked 文案存在', () => {
     const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
     assert.match(makefile, /^data-l1-discovery-commit:/m);
-    assert.match(makefile, /BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5\.04L1\./);
+    assert.match(makefile, /BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5\.05L1\./);
 });
 
 test('测试不在仓库内创建随机目录', () => {


### PR DESCRIPTION
## Summary

Adds Phase 5.05L1 controlled L1 external network candidates preview support.

Scope:
- Extends discoverCandidates() for explicit controlled network preview
- Keeps titan_discovery blocked
- Keeps DiscoveryService.discover blocked for agents
- Keeps FixtureRepository.persist isolated
- Adds data-l1-discovery-candidates-network-preview
- Keeps browser/proxy disabled
- Keeps matches/raw_match_data/DB writes blocked
- Adds fake network dependency-injection tests
- Updates Makefile, AGENTS.md, and report

Safety:
- No DB writes
- No matches writes
- No raw_match_data writes
- No FixtureRepository.persist
- No titan_discovery execution
- No DiscoveryService.discover execution
- No browser/proxy
- No harvest/ingest
- No training/prediction

Validation:
- discoverCandidates tests passed
- L1 safe preview tests passed
- no-network preview passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally if browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed