### PR TITLE
docs(data): add L1 matches seed commit plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@
 - 如果命令已经封装为 `npm script`，优先使用脚本入口。
 - 如果 `npm script` 指向缺失文件，先修正文档或脚本，再继续依赖该入口。
 - 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` / `make data-l1-discovery-candidates-preview` 的 safe preview 路径进入；显式授权的 L1 外网候选预览只能通过 `make data-l1-discovery-candidates-network-preview`。
+- L1 matches seed commit 不能由 AI / Codex 直接执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning。
 
 ### 2.3 禁止行为
 
@@ -217,6 +218,7 @@ AI / Codex 默认只能执行：
 - `make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...`
 - `make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no ...`
 - 用户明确授权、仅做 candidates stdout summary、不写 DB/不启动 browser/proxy 的 `make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no`
+- 仅做 matches seed commit planning、不触网、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
@@ -380,6 +382,16 @@ Phase 5.05L1 补充约定：
 - 仅允许 `SOURCE=fotmob`、`SCOPE=controlled_candidates_preview`、`CONCURRENCY=1`、`MAX_TARGETS<=10`。
 - 网络错误、403、429、captcha 或 block 信号必须立即停止。
 - 不得自动 retry，不得降级到 browser/proxy，不得降级到 `titan_discovery.js`。
+
+Phase 5.06L1 补充约定：
+
+- L1 matches seed commit planning 只能走 `make data-l1-matches-seed-commit-plan`。
+- `data-l1-matches-seed-commit-plan` 只允许输出 stdout planning，不得触网，不得写 DB，不得写 `matches` / `raw_match_data`。
+- `make data-l1-matches-seed-commit` 固定 blocked，即使传入 `CONFIRM_L1_MATCHES_SEED_COMMIT=1`。
+- matches seed commit 必须等待未来单独用户明确授权阶段。
+- raw_match_data ingest 必须与 matches seed commit 分离，不得合并执行。
+- matches seed 阶段不得训练、不得预测、不得加载或生成模型 artifact。
+- 任何 DB write 前必须先复核 candidate mapping、upsert policy、backup policy、rollback policy。
 
 执行 `make data-l3-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
+        data-l1-matches-seed-commit-plan data-l1-matches-seed-commit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -312,6 +313,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...  # Phase 5.05L1 preview-only, no network/browser/proxy/DB, no titan_discovery/DiscoveryService.discover/FixtureRepository.persist"
 	@echo "  make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no  # Phase 5.05L1 candidates preview, no external network/browser/proxy/DB, no matches/raw writes"
 	@echo "  make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no  # Phase 5.05L1 controlled external network candidates preview only"
+	@echo "  make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no  # Phase 5.06L1 planning-only, no network/DB/matches/raw writes"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -363,6 +365,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-packet-file-preauth-closure-commit CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_PREAUTH_CLOSURE=1  # blocked in Phase 4.76C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-l1-discovery-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_DISCOVERY_COMMIT=1  # blocked in Phase 5.05L1"
+	@echo "  make data-l1-matches-seed-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_MATCHES_SEED_COMMIT=1  # blocked in Phase 5.06L1"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
 	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
@@ -487,6 +490,34 @@ data-l1-discovery-commit: ## Blocked L1 safe preview commit gate. Remains blocke
 	@echo "BLOCKED: L1 discovery safe preview wrapper does not execute writes in Phase 5.05L1."
 	@echo "  No titan_discovery direct call, no DiscoveryService.discover call, no FixtureRepository.persist call."
 	@echo "  Even with CONFIRM_L1_DISCOVERY_COMMIT=1, network execution and DB writes remain blocked."
+	@exit 1
+
+data-l1-matches-seed-commit-plan: ## L1 matches seed commit planning. Phase 5.06L1. Planning-only, no network/DB writes.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(SCOPE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(SEASON)" ] || [ -z "$(DATE)" ] || [ -z "$(CANDIDATE_COUNT)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n>"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_matches_seed_commit_plan.js \
+		--source="$(SOURCE)" \
+		--scope="$(SCOPE)" \
+		--league-id="$(LEAGUE_ID)" \
+		--season="$(SEASON)" \
+		--date="$(DATE)" \
+		--candidate-count="$(CANDIDATE_COUNT)" \
+		$(if $(CONTAINS_TARGET_MATCH_ID),--contains-target-match-id="$(CONTAINS_TARGET_MATCH_ID)") \
+		$(if $(CONTAINS_TARGET_LABEL),--contains-target-label="$(CONTAINS_TARGET_LABEL)") \
+		--max-seed-rows="$(or $(MAX_SEED_ROWS),10)" \
+		--commit="$(or $(COMMIT),no)" \
+		--allow-db-write=no \
+		--allow-matches-write=no \
+		--allow-raw-match-data-write=no \
+		--training=no \
+		--prediction=no
+
+data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blocked in Phase 5.06L1.
+	@echo "BLOCKED: L1 matches seed commit is not executable in Phase 5.06L1 planning."
+	@echo "  Use data-l1-matches-seed-commit-plan for stdout planning only."
+	@echo "  Even with CONFIRM_L1_MATCHES_SEED_COMMIT=1, matches/DB/raw writes remain blocked."
 	@exit 1
 
 data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.

--- a/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_PLANNING_PHASE5_06L1.md
+++ b/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_PLANNING_PHASE5_06L1.md
@@ -1,0 +1,144 @@
+# L1 Controlled Matches Seed Commit Planning - Phase 5.06L1
+
+## 1. Executive summary
+
+Phase 5.06L1 是 matches seed commit planning 阶段。
+
+本阶段不写 DB，不写 `matches`，不写 `raw_match_data`。目标是为后续受控 matches seed commit 定义 candidate -> matches mapping、upsert、backup 和 rollback policy。
+
+## 2. Background
+
+Phase 5.05L1 已通过受控 FotMob L1 external network candidates preview 找到 8 个 Ligue 1 candidates。
+
+结果包含 `Angers vs Strasbourg`，external id / match id candidate 为 `4830746`。
+
+`raw_match_data.match_id` FK 到 `matches(match_id)`，所以后续 raw JSON 入库前需要先有对应 `matches` seed。
+
+## 3. Implemented files
+
+- `scripts/ops/l1_matches_seed_commit_plan.js`
+- `tests/unit/l1_matches_seed_commit_plan.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_PLANNING_PHASE5_06L1.md`
+
+## 4. Mapping policy
+
+Candidate source fields:
+
+- `match_id`
+- `external_id`
+- `league_name`
+- `season`
+- `home_team`
+- `away_team`
+- `match_date`
+- `status`
+- `is_finished`
+- `data_source`
+
+Target `matches` fields:
+
+- `match_id`
+- `external_id`
+- `league_name`
+- `season`
+- `home_team`
+- `away_team`
+- `match_date`
+- `status`
+- `is_finished`
+- `data_source`
+
+Forbidden writes:
+
+- `raw_match_data`
+- `bookmaker_odds_history`
+- `l3_features`
+- `match_features_training`
+- `predictions`
+- feature / prediction fields
+- raw JSON payloads
+
+## 5. Upsert policy
+
+- Use `matches.match_id` as the identity key.
+- If `match_id` exists: no delete; planning only marks `would_update`; manual critical fields must not be overwritten unless a future phase explicitly authorizes it.
+- If `match_id` does not exist: planning only marks `would_insert`.
+- Future commit must run in a transaction.
+- Future commit must limit rows to `MAX_SEED_ROWS<=10`.
+- Future commit must process only the exact user-confirmed candidate set.
+- No `raw_match_data` write is allowed in the matches seed phase.
+
+## 6. Backup / rollback policy
+
+This phase only plans backup and rollback. It does not execute either.
+
+Backup planning:
+
+- Before a future commit, SELECT the exact affected `match_id` rows.
+- Affected rows must be output to stdout or to a future user-authorized backup artifact.
+- Backup file creation requires future user authorization.
+- `pg_dump` is not allowed in this phase.
+- Backup file writes are not allowed in this phase.
+
+Rollback planning:
+
+- Future commit must run in a transaction.
+- On failure, use `ROLLBACK`.
+- If a committed seed is later found wrong, use saved affected rows to prepare reviewed compensation SQL in a future authorized phase.
+- Runtime rollback file generation is not allowed in this phase.
+- DELETE execution is not allowed in this phase.
+
+## 7. Why this lowers risk
+
+This stage does not jump from candidates directly to writes. It first makes the write rules, affected rows, allowed fields, and rollback path explicit.
+
+The next phase can then authorize only a narrow `matches` seed write. `raw_match_data` stays separate, and training / prediction remain isolated.
+
+## 8. Validation
+
+Executed local validation:
+
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/l1_matches_seed_commit_plan.test.js` passed.
+- `make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=league_season_date LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CANDIDATE_COUNT=8 CONTAINS_TARGET_MATCH_ID=4830746 CONTAINS_TARGET_LABEL="Angers vs Strasbourg" MAX_SEED_ROWS=10 COMMIT=no` passed and emitted planning-only JSON.
+- `make data-l1-matches-seed-commit ... CONFIRM_L1_MATCHES_SEED_COMMIT=1` remained blocked.
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test` passed.
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage` passed.
+- `git diff --check` passed.
+- `docker compose -f docker-compose.dev.yml exec -T dev npx eslint scripts/ops/l1_matches_seed_commit_plan.js tests/unit/l1_matches_seed_commit_plan.test.js --no-cache` passed.
+- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md Makefile scripts/ops/l1_matches_seed_commit_plan.js tests/unit/l1_matches_seed_commit_plan.test.js docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_PLANNING_PHASE5_06L1.md` passed.
+- DB row counts were read-only checked after validation: `matches=2`, `bookmaker_odds_history=2`, `raw_match_data=2`, `l3_features=2`, `match_features_training=2`, `predictions=2`.
+- `tests/fixtures/l1-config-*` had no filesystem or tracked-file residue.
+- `docs/_staging_preview` was absent.
+
+## 9. Recommended next phase
+
+Phase 5.07L1: controlled matches seed commit authorization.
+
+Requirements:
+
+- user explicit authorization
+- only process 2026-05-10 Ligue 1 candidates
+- rows <= 10
+- only write `matches`
+- do not write `raw_match_data`
+- do not train
+- do not predict
+- before commit, confirm DB baseline, affected rows, and rollback plan again
+
+## 10. Explicit non-execution
+
+- no external FotMob access
+- no network dry-run
+- no titan_discovery execution
+- no DiscoveryService.discover execution
+- no FixtureRepository.persist
+- no DB writes
+- no matches writes
+- no raw_match_data writes
+- no feature writes
+- no prediction writes
+- no harvest / ingest
+- no training / prediction
+- no file deletion

--- a/scripts/ops/l1_matches_seed_commit_plan.js
+++ b/scripts/ops/l1_matches_seed_commit_plan.js
@@ -1,0 +1,521 @@
+#!/usr/bin/env node
+'use strict';
+
+const PHASE = 'PHASE5_06L1_CONTROLLED_MATCHES_SEED_COMMIT_PLANNING';
+const SAFE_SOURCE = 'fotmob';
+const SAFE_SCOPES = new Set(['league_season_date', 'controlled_candidates_preview']);
+const MAX_SEED_ROWS_LIMIT = 10;
+const DEFAULT_MAX_SEED_ROWS = 10;
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 matches seed commit is not executable in Phase 5.06L1 planning.';
+const NEXT_REQUIRED_PHASE = 'Phase 5.07L1 controlled matches seed commit authorization';
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isInteger(parsed) ? parsed : Number.NaN;
+}
+
+function normalizeOptionalText(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    return String(value).trim();
+}
+
+function normalizeEnvBoolean(inputValue, envValue) {
+    return normalizeBooleanFlag(inputValue, false) || normalizeBooleanFlag(envValue, false);
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        scope: null,
+        leagueId: null,
+        season: null,
+        date: null,
+        candidateCount: null,
+        containsTargetMatchId: null,
+        containsTargetLabel: null,
+        maxSeedRows: null,
+        commit: false,
+        allowDbWrite: false,
+        allowMatchesWrite: false,
+        allowRawMatchDataWrite: false,
+        training: false,
+        prediction: false,
+        help: false,
+    };
+
+    const keyMap = {
+        source: 'source',
+        scope: 'scope',
+        'league-id': 'leagueId',
+        league_id: 'leagueId',
+        season: 'season',
+        date: 'date',
+        'candidate-count': 'candidateCount',
+        candidate_count: 'candidateCount',
+        'contains-target-match-id': 'containsTargetMatchId',
+        contains_target_match_id: 'containsTargetMatchId',
+        'contains-target-label': 'containsTargetLabel',
+        contains_target_label: 'containsTargetLabel',
+        'max-seed-rows': 'maxSeedRows',
+        max_seed_rows: 'maxSeedRows',
+        commit: 'commit',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        training: 'training',
+        prediction: 'prediction',
+        help: 'help',
+        h: 'help',
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (!arg.startsWith('--')) {
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        if (!optionKey) {
+            continue;
+        }
+
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (
+            [
+                'commit',
+                'allowDbWrite',
+                'allowMatchesWrite',
+                'allowRawMatchDataWrite',
+                'training',
+                'prediction',
+                'help',
+            ].includes(optionKey)
+        ) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function normalizePlanningInput(input = {}, env = process.env) {
+    const candidateCount = parseInteger(input.candidateCount, null);
+    const maxSeedRows = parseInteger(input.maxSeedRows, DEFAULT_MAX_SEED_ROWS);
+
+    return {
+        source: typeof input.source === 'string' ? input.source.trim().toLowerCase() : '',
+        scope: typeof input.scope === 'string' ? input.scope.trim() : '',
+        leagueId: normalizeOptionalText(input.leagueId),
+        season: typeof input.season === 'string' ? input.season.trim() : null,
+        date: typeof input.date === 'string' ? input.date.trim() : null,
+        candidateCount,
+        containsTargetMatchId: normalizeOptionalText(input.containsTargetMatchId),
+        containsTargetLabel: normalizeOptionalText(input.containsTargetLabel),
+        maxSeedRows,
+        commit: normalizeBooleanFlag(input.commit, false),
+        allowDbWrite: normalizeEnvBoolean(input.allowDbWrite, env.DB_WRITE),
+        allowMatchesWrite: normalizeEnvBoolean(input.allowMatchesWrite, env.MATCHES_WRITE),
+        allowRawMatchDataWrite: normalizeEnvBoolean(input.allowRawMatchDataWrite, env.RAW_MATCH_DATA_WRITE),
+        training: normalizeEnvBoolean(input.training, env.TRAINING),
+        prediction: normalizeEnvBoolean(input.prediction, env.PREDICTION),
+    };
+}
+
+function validateSourceScope(value, errors) {
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== SAFE_SOURCE) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+
+    if (!value.scope) {
+        errors.push('missing scope: provide --scope=league_season_date or --scope=controlled_candidates_preview');
+    } else if (!SAFE_SCOPES.has(value.scope)) {
+        errors.push(`unsupported scope: ${value.scope}`);
+    }
+}
+
+function validateRequiredPlanningFields(value, errors) {
+    if (!value.leagueId) {
+        errors.push('missing league-id');
+    }
+    if (!value.season) {
+        errors.push('missing season');
+    }
+    if (!value.date) {
+        errors.push('missing date');
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(value.date)) {
+        errors.push('invalid date: provide YYYY-MM-DD');
+    }
+}
+
+function validatePlanningLimits(value, errors) {
+    if (!Number.isInteger(value.candidateCount) || value.candidateCount < 0) {
+        errors.push('invalid candidate-count: provide a non-negative integer');
+    }
+    if (!Number.isInteger(value.maxSeedRows) || value.maxSeedRows < 1) {
+        errors.push('invalid max-seed-rows: provide a positive integer');
+    } else if (value.maxSeedRows > MAX_SEED_ROWS_LIMIT) {
+        errors.push(`max-seed-rows > ${MAX_SEED_ROWS_LIMIT} is blocked in Phase 5.06L1`);
+    }
+    if (
+        Number.isInteger(value.candidateCount) &&
+        Number.isInteger(value.maxSeedRows) &&
+        value.candidateCount > value.maxSeedRows
+    ) {
+        errors.push('candidate-count must be <= max-seed-rows');
+    }
+}
+
+function validateBlockedPlanningFlags(value, errors) {
+    if (value.commit === true) {
+        errors.push(BLOCKED_COMMIT_MESSAGE);
+    }
+    if (value.allowDbWrite === true) {
+        errors.push('allow-db-write=yes is blocked in Phase 5.06L1');
+    }
+    if (value.allowMatchesWrite === true) {
+        errors.push('allow-matches-write=yes is blocked in Phase 5.06L1');
+    }
+    if (value.allowRawMatchDataWrite === true) {
+        errors.push('allow-raw-match-data-write=yes is blocked in Phase 5.06L1');
+    }
+    if (value.training === true) {
+        errors.push('training=yes is blocked in Phase 5.06L1');
+    }
+    if (value.prediction === true) {
+        errors.push('prediction=yes is blocked in Phase 5.06L1');
+    }
+}
+
+function validatePlanningInput(input = {}, env = process.env) {
+    const value = normalizePlanningInput(input, env);
+    const errors = [];
+
+    validateSourceScope(value, errors);
+    validateRequiredPlanningFields(value, errors);
+    validatePlanningLimits(value, errors);
+    validateBlockedPlanningFlags(value, errors);
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function buildCandidateToMatchesMappingPolicy() {
+    return {
+        source_candidate_fields: [
+            'match_id',
+            'external_id',
+            'league_name',
+            'season',
+            'home_team',
+            'away_team',
+            'match_date',
+            'status',
+            'is_finished',
+            'data_source',
+        ],
+        matches_target_fields: {
+            match_id: {
+                source: 'candidate.match_id',
+                required: true,
+                rule: 'primary key / identity key; must match matches.match_id varchar(50)',
+            },
+            external_id: { source: 'candidate.external_id', required: true },
+            league_name: { source: 'candidate.league_name or candidate.league', required: true },
+            season: { source: 'candidate.season', required: true, rule: 'must satisfy YYYY/YYYY check constraint' },
+            home_team: { source: 'candidate.home_team or candidate.home', required: true },
+            away_team: { source: 'candidate.away_team or candidate.away', required: true },
+            match_date: { source: 'candidate.match_date', required: true },
+            status: { source: 'candidate.status', required: false, rule: 'lowercase value required by schema' },
+            is_finished: { source: 'candidate.is_finished or normalized status', required: false },
+            data_source: { source: 'candidate.data_source', required: false, default: 'FotMob' },
+        },
+        allowed_matches_fields_for_future_commit: [
+            'match_id',
+            'external_id',
+            'league_name',
+            'season',
+            'home_team',
+            'away_team',
+            'match_date',
+            'status',
+            'is_finished',
+            'data_source',
+        ],
+        forbidden_tables: [
+            'raw_match_data',
+            'bookmaker_odds_history',
+            'l3_features',
+            'match_features_training',
+            'predictions',
+        ],
+        forbidden_field_families: ['features', 'predictions', 'odds history', 'raw JSON payloads'],
+    };
+}
+
+function buildUpsertPolicy(input) {
+    return {
+        identity_key: 'matches.match_id',
+        conflict_target: 'match_id',
+        if_match_id_exists: {
+            action: 'would_update_only_after_future_authorization',
+            delete_allowed: false,
+            preserve_manual_fields: true,
+            fields_not_to_overwrite_without_future_authorization: [
+                'actual_result',
+                'home_score',
+                'away_score',
+                'venue',
+                'referee',
+                'pipeline_status',
+                'manual review fields',
+            ],
+        },
+        if_match_id_missing: {
+            action: 'would_insert_only_after_future_authorization',
+        },
+        transaction_required_for_future_commit: true,
+        max_rows_per_future_commit: input.maxSeedRows,
+        only_user_confirmed_candidate_set: true,
+        delete_allowed: false,
+        raw_match_data_write_allowed: false,
+    };
+}
+
+function buildBackupPolicy(input) {
+    return {
+        planning_phase_executes_backup: false,
+        pg_dump_allowed_this_phase: false,
+        backup_file_write_allowed_this_phase: false,
+        future_commit_precheck:
+            'SELECT existing rows for the exact affected match_id set before any INSERT/UPDATE executes',
+        affected_rows_output: 'stdout or future user-authorized backup artifact only',
+        backup_artifact_requires_future_user_authorization: true,
+        max_rows: input.maxSeedRows,
+    };
+}
+
+function buildRollbackPolicy() {
+    return {
+        planning_phase_executes_rollback: false,
+        transaction_required_for_future_commit: true,
+        on_commit_failure: 'ROLLBACK transaction',
+        post_commit_compensation:
+            'Use saved affected rows to generate reviewed compensation SQL in a later authorized phase',
+        runtime_rollback_file_write_allowed_this_phase: false,
+        delete_execution_allowed_this_phase: false,
+        delete_allowed_without_future_authorization: false,
+    };
+}
+
+function buildPreCommitChecks(input) {
+    return [
+        'user explicit authorization required',
+        'PR/main CI green',
+        'clean worktree',
+        'DB row counts baseline captured',
+        'exact candidate set captured',
+        `max rows <= ${input.maxSeedRows}`,
+        'source=fotmob',
+        'league/date/season match user scope',
+        'no raw_match_data write',
+        'no feature/prediction write',
+        'rollback/backup plan acknowledged',
+    ];
+}
+
+function buildPostCommitChecks() {
+    return [
+        'matches row count delta expected',
+        'affected match_ids exist',
+        'raw_match_data unchanged',
+        'features unchanged',
+        'predictions unchanged',
+        'no training/prediction executed',
+    ];
+}
+
+function buildMatchesSeedCommitPlan(input = {}, env = process.env) {
+    const validation = validatePlanningInput(input, env);
+    if (!validation.ok) {
+        const error = new Error(validation.errors[0]);
+        error.validationErrors = validation.errors;
+        throw error;
+    }
+
+    const value = validation.value;
+    return {
+        phase: PHASE,
+        planning_only: true,
+        source: value.source,
+        scope: value.scope,
+        league_id: value.leagueId,
+        season: value.season,
+        date: value.date,
+        candidate_count_from_previous_preview: value.candidateCount,
+        max_seed_rows: value.maxSeedRows,
+        contains_target_match_id: value.containsTargetMatchId,
+        contains_target_label: value.containsTargetLabel,
+        matches_seed_commit_ready: false,
+        matches_seed_commit_authorized: false,
+        db_write_allowed: false,
+        matches_write_allowed: false,
+        raw_match_data_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        would_write_matches: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_call_fixture_repository_persist: false,
+        would_call_discovery_service_discover: false,
+        would_run_titan_discovery: false,
+        would_train: false,
+        would_predict: false,
+        commit_gate: 'blocked',
+        candidate_to_matches_mapping_policy: buildCandidateToMatchesMappingPolicy(value),
+        upsert_policy: buildUpsertPolicy(value),
+        backup_policy: buildBackupPolicy(value),
+        rollback_policy: buildRollbackPolicy(value),
+        pre_commit_checks: buildPreCommitChecks(value),
+        post_commit_checks: buildPostCommitChecks(value),
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildErrorPayload(options, errors) {
+    const normalized = normalizePlanningInput(options);
+    return {
+        phase: PHASE,
+        planning_only: true,
+        ok: false,
+        errors: Array.isArray(errors) ? errors : [String(errors)],
+        source: normalized.source || null,
+        scope: normalized.scope || null,
+        league_id: normalized.leagueId,
+        season: normalized.season,
+        date: normalized.date,
+        db_write_allowed: false,
+        matches_write_allowed: false,
+        raw_match_data_write_allowed: false,
+        would_write_matches: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_call_fixture_repository_persist: false,
+        would_call_discovery_service_discover: false,
+        would_run_titan_discovery: false,
+        would_train: false,
+        would_predict: false,
+        commit_gate: 'blocked',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function showHelp(io = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    stdout(
+        [
+            'Usage:',
+            '  node scripts/ops/l1_matches_seed_commit_plan.js --source=fotmob --scope=league_season_date --league-id=53 --season=2025/2026 --date=2026-05-10 --candidate-count=8 --contains-target-match-id=4830746 --contains-target-label="Angers vs Strasbourg" --max-seed-rows=10 --commit=no',
+            '',
+            'Phase 5.06L1: planning-only, no DB writes, no network, no browser/proxy.',
+        ].join('\n')
+    );
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+    const options = parseArgs(argv);
+
+    if (options.help) {
+        showHelp({ stdout });
+        return 0;
+    }
+
+    try {
+        const payload = buildMatchesSeedCommitPlan(options, dependencies.env || process.env);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 0;
+    } catch (error) {
+        const payload = buildErrorPayload(options, error.validationErrors || [error.message]);
+        stderr(`${payload.errors[0]}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    runCli().then(code => {
+        process.exitCode = code;
+    });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validatePlanningInput,
+    buildCandidateToMatchesMappingPolicy,
+    buildUpsertPolicy,
+    buildBackupPolicy,
+    buildRollbackPolicy,
+    buildPreCommitChecks,
+    buildPostCommitChecks,
+    buildMatchesSeedCommitPlan,
+    runCli,
+};

--- a/tests/unit/l1_matches_seed_commit_plan.test.js
+++ b/tests/unit/l1_matches_seed_commit_plan.test.js
@@ -1,0 +1,273 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l1_matches_seed_commit_plan.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function installNoSideEffectGuards(t) {
+    const originalFetch = global.fetch;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalNetConnect = net.connect;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l1_matches_seed_commit_plan`);
+    };
+
+    global.fetch = fail('global.fetch');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    net.connect = fail('net.connect');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (['pg', 'redis', 'ioredis', 'playwright', 'playwright-core'].includes(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/FixtureRepository|titan_discovery|DiscoveryService/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        net.connect = originalNetConnect;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+async function runCli(gate, argv, dependencies = {}) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function parseJsonOutput(stdout) {
+    const payload = String(stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload');
+    return JSON.parse(payload);
+}
+
+function validArgv(overrides = []) {
+    return [
+        '--source=fotmob',
+        '--scope=league_season_date',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--candidate-count=8',
+        '--contains-target-match-id=4830746',
+        '--contains-target-label=Angers vs Strasbourg',
+        '--max-seed-rows=10',
+        '--commit=no',
+        ...overrides,
+    ];
+}
+
+function assertNoWriteFlags(payload) {
+    assert.equal(payload.planning_only, true);
+    assert.equal(payload.matches_seed_commit_ready, false);
+    assert.equal(payload.matches_seed_commit_authorized, false);
+    assert.equal(payload.db_write_allowed, false);
+    assert.equal(payload.matches_write_allowed, false);
+    assert.equal(payload.raw_match_data_write_allowed, false);
+    assert.equal(payload.training_allowed, false);
+    assert.equal(payload.prediction_allowed, false);
+    assert.equal(payload.would_write_matches, false);
+    assert.equal(payload.would_write_raw_match_data, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_call_fixture_repository_persist, false);
+    assert.equal(payload.would_call_discovery_service_discover, false);
+    assert.equal(payload.would_run_titan_discovery, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.commit_gate, 'blocked');
+}
+
+test('valid planning input succeeds and emits no-write plan', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, validArgv(), { env: {} });
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.phase, 'PHASE5_06L1_CONTROLLED_MATCHES_SEED_COMMIT_PLANNING');
+    assert.equal(payload.source, 'fotmob');
+    assert.equal(payload.scope, 'league_season_date');
+    assert.equal(payload.league_id, '53');
+    assert.equal(payload.season, '2025/2026');
+    assert.equal(payload.date, '2026-05-10');
+    assert.equal(payload.candidate_count_from_previous_preview, 8);
+    assert.equal(payload.max_seed_rows, 10);
+    assert.equal(payload.contains_target_match_id, '4830746');
+    assert.equal(payload.contains_target_label, 'Angers vs Strasbourg');
+    assertNoWriteFlags(payload);
+});
+
+test('validation failures are blocked', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const cases = [
+        { argv: validArgv().filter(arg => !arg.startsWith('--source=')), pattern: /missing source/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--source=')), '--source=other'],
+            pattern: /unsupported source/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--scope=')), pattern: /missing scope/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--scope=')), '--scope=bulk'],
+            pattern: /unsupported scope/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--league-id=')), pattern: /missing league-id/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--season=')), pattern: /missing season/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--date=')), pattern: /missing date/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--candidate-count=')), '--candidate-count=11'],
+            pattern: /candidate-count must be <= max-seed-rows/i,
+        },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--max-seed-rows=')), '--max-seed-rows=11'],
+            pattern: /max-seed-rows > 10/i,
+        },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--commit=')), '--commit=yes'],
+            pattern: /not executable/i,
+        },
+        { argv: [...validArgv(), '--allow-db-write=yes'], pattern: /allow-db-write=yes/i },
+        { argv: [...validArgv(), '--allow-matches-write=yes'], pattern: /allow-matches-write=yes/i },
+        {
+            argv: [...validArgv(), '--allow-raw-match-data-write=yes'],
+            pattern: /allow-raw-match-data-write=yes/i,
+        },
+        { argv: [...validArgv(), '--training=yes'], pattern: /training=yes/i },
+        { argv: [...validArgv(), '--prediction=yes'], pattern: /prediction=yes/i },
+    ];
+
+    for (const { argv, pattern } of cases) {
+        const result = await runCli(gate, argv, { env: {} });
+        const payload = parseJsonOutput(result.stdout);
+        assert.equal(result.status, 1);
+        assert.match(payload.errors.join('\n'), pattern);
+        assert.equal(payload.would_write_db, false);
+        assert.equal(payload.would_write_matches, false);
+        assert.equal(payload.would_write_raw_match_data, false);
+    }
+});
+
+test('environment write and model flags are blocked', () => {
+    const gate = loadModuleFresh();
+    for (const [envKey, pattern] of [
+        ['DB_WRITE', /allow-db-write=yes/i],
+        ['RAW_MATCH_DATA_WRITE', /allow-raw-match-data-write=yes/i],
+        ['TRAINING', /training=yes/i],
+        ['PREDICTION', /prediction=yes/i],
+    ]) {
+        const result = gate.validatePlanningInput(gate.parseArgs(validArgv()), { [envKey]: 'yes' });
+        assert.equal(result.ok, false);
+        assert.match(result.errors.join('\n'), pattern);
+    }
+});
+
+test('mapping, upsert, backup, rollback and checks contain required controls', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const payload = gate.buildMatchesSeedCommitPlan(gate.parseArgs(validArgv()), {});
+    const mappingText = JSON.stringify(payload.candidate_to_matches_mapping_policy);
+
+    for (const field of ['match_id', 'external_id', 'home_team', 'away_team', 'match_date', 'status', 'data_source']) {
+        assert.match(mappingText, new RegExp(field));
+    }
+    assert.ok(payload.candidate_to_matches_mapping_policy.forbidden_tables.includes('raw_match_data'));
+    assert.ok(payload.candidate_to_matches_mapping_policy.forbidden_tables.includes('predictions'));
+    assert.equal(payload.upsert_policy.identity_key, 'matches.match_id');
+    assert.equal(payload.upsert_policy.transaction_required_for_future_commit, true);
+    assert.equal(payload.upsert_policy.delete_allowed, false);
+    assert.equal(payload.backup_policy.pg_dump_allowed_this_phase, false);
+    assert.equal(payload.backup_policy.backup_file_write_allowed_this_phase, false);
+    assert.equal(payload.rollback_policy.delete_execution_allowed_this_phase, false);
+    assert.equal(payload.rollback_policy.runtime_rollback_file_write_allowed_this_phase, false);
+    assert.ok(payload.pre_commit_checks.includes('user explicit authorization required'));
+    assert.ok(payload.post_commit_checks.includes('raw_match_data unchanged'));
+});
+
+test('parseArgs and boolean normalization support expected flags', () => {
+    const gate = loadModuleFresh();
+    const options = gate.parseArgs([
+        '--source=fotmob',
+        '--scope=controlled_candidates_preview',
+        '--league-id',
+        '53',
+        '--commit=no',
+        '--training=false',
+    ]);
+
+    assert.equal(options.source, 'fotmob');
+    assert.equal(options.scope, 'controlled_candidates_preview');
+    assert.equal(options.leagueId, '53');
+    assert.equal(options.commit, false);
+    assert.equal(options.training, false);
+    assert.equal(gate.normalizeBooleanFlag('yes'), true);
+    assert.equal(gate.normalizeBooleanFlag('no'), false);
+});
+
+test('Makefile plan and blocked commit targets are registered', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l1-matches-seed-commit-plan:/m);
+    assert.match(makefile, /scripts\/ops\/l1_matches_seed_commit_plan\.js/);
+    assert.match(makefile, /^data-l1-matches-seed-commit:/m);
+    assert.match(makefile, /L1 matches seed commit is not executable in Phase 5\.06L1/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.06L1 controlled matches seed commit planning.

Scope:
- Adds matches seed commit planning script
- Defines candidate-to-matches mapping policy
- Defines upsert policy
- Defines backup and rollback policy
- Adds Makefile plan target and blocked commit target
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 5.06L1 report

Safety:
- No external FotMob access
- No network dry-run
- No titan_discovery execution
- No DiscoveryService.discover execution
- No FixtureRepository.persist
- No DB writes
- No matches writes
- No raw_match_data writes
- No harvest / ingest
- No training / prediction

Validation:
- matches seed planning tests passed
- Makefile plan passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally if browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed