### PR TITLE
docs(data): add L1 matches seed commit authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@
 - 如果命令已经封装为 `npm script`，优先使用脚本入口。
 - 如果 `npm script` 指向缺失文件，先修正文档或脚本，再继续依赖该入口。
 - 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` / `make data-l1-discovery-candidates-preview` 的 safe preview 路径进入；显式授权的 L1 外网候选预览只能通过 `make data-l1-discovery-candidates-network-preview`。
-- L1 matches seed commit 不能由 AI / Codex 直接执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning。
+- L1 matches seed commit 不能由 AI / Codex 直接执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning；Phase 5.07L1 仅允许 `make data-l1-matches-seed-commit-authorization` 输出 stdout authorization summary。
 
 ### 2.3 禁止行为
 
@@ -219,6 +219,7 @@ AI / Codex 默认只能执行：
 - `make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no ...`
 - 用户明确授权、仅做 candidates stdout summary、不写 DB/不启动 browser/proxy 的 `make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no`
 - 仅做 matches seed commit planning、不触网、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no`
+- 用户明确授权、只记录 stdout authorization summary、不触网、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-authorization SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 USER_AUTHORIZED_MATCHES_SEED_COMMIT=yes ALLOW_MATCHES_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
@@ -392,6 +393,14 @@ Phase 5.06L1 补充约定：
 - raw_match_data ingest 必须与 matches seed commit 分离，不得合并执行。
 - matches seed 阶段不得训练、不得预测、不得加载或生成模型 artifact。
 - 任何 DB write 前必须先复核 candidate mapping、upsert policy、backup policy、rollback policy。
+
+Phase 5.07L1 补充约定：
+
+- L1 matches seed commit authorization 只能走 `make data-l1-matches-seed-commit-authorization`。
+- `data-l1-matches-seed-commit-authorization` 只允许记录 stdout authorization summary，不得触网，不得写 DB，不得写 `matches`，不得写 `raw_match_data`。
+- `make data-l1-matches-seed-commit` 继续 blocked，直到 Phase 5.08L1 或后续单独执行阶段再次确认。
+- matches seed commit execution 必须与 raw_match_data ingest 分离，不得合并执行。
+- matches seed 各阶段不得训练、不得预测、不得加载或生成模型 artifact。
 
 执行 `make data-l3-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
-        data-l1-matches-seed-commit-plan data-l1-matches-seed-commit \
+        data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -314,6 +314,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l1-discovery-candidates-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> NETWORK_AUTHORIZATION=no  # Phase 5.05L1 candidates preview, no external network/browser/proxy/DB, no matches/raw writes"
 	@echo "  make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no  # Phase 5.05L1 controlled external network candidates preview only"
 	@echo "  make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no  # Phase 5.06L1 planning-only, no network/DB/matches/raw writes"
+	@echo "  make data-l1-matches-seed-commit-authorization SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 USER_AUTHORIZED_MATCHES_SEED_COMMIT=yes ALLOW_MATCHES_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes  # Phase 5.07L1 authorization-only, stdout-only, no DB/matches/raw writes"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -365,7 +366,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-football-data-packet-file-preauth-closure-commit CLOSURE_TEMPLATE=<path> CONSOLIDATION_TEMPLATE=<path> DRAFT_TEMPLATE=<path> READINESS_CHECKLIST=<path> AUTH_FORM=<path> SOURCE_MANIFEST=<path> LOCAL_CSV=<path> APPROVAL_FORM=<path> RUNBOOK_TEMPLATE=<path> CONFIRM_FOOTBALL_DATA_PACKET_FILE_PREAUTH_CLOSURE=1  # blocked in Phase 4.76C"
 	@echo "  make data-training-dataset-export CONFIRM_DATASET_EXPORT=1  # blocked in Phase 4.36"
 	@echo "  make data-l1-discovery-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_DISCOVERY_COMMIT=1  # blocked in Phase 5.05L1"
-	@echo "  make data-l1-matches-seed-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_MATCHES_SEED_COMMIT=1  # blocked in Phase 5.06L1"
+	@echo "  make data-l1-matches-seed-commit SOURCE=fotmob SCOPE=<scope> CONFIRM_L1_MATCHES_SEED_COMMIT=1  # blocked in Phase 5.07L1"
 	@echo "  make data-prediction-write-commit MATCH_ID=<id> CONFIRM_PREDICTION_WRITE=1  # blocked in Phase 4.32"
 	@echo "  make data-training-feature-commit MATCH_ID=<id> CONFIRM_TRAINING_FEATURE=1  # blocked in Phase 4.30"
 	@echo "  make data-training-commit CONFIRM_TRAINING=1  # blocked in Phase 4.29"
@@ -514,9 +515,33 @@ data-l1-matches-seed-commit-plan: ## L1 matches seed commit planning. Phase 5.06
 		--training=no \
 		--prediction=no
 
-data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blocked in Phase 5.06L1.
+data-l1-matches-seed-commit-authorization: ## L1 matches seed commit authorization. Phase 5.07L1. Authorization-only, no network/DB writes.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(SCOPE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(SEASON)" ] || [ -z "$(DATE)" ] || [ -z "$(CANDIDATE_COUNT)" ] || [ -z "$(CONTAINS_TARGET_MATCH_ID)" ] || [ -z "$(CONTAINS_TARGET_LABEL)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> CONTAINS_TARGET_MATCH_ID=<id> CONTAINS_TARGET_LABEL=<label>"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_matches_seed_commit_authorization.js \
+		--source="$(SOURCE)" \
+		--scope="$(SCOPE)" \
+		--league-id="$(LEAGUE_ID)" \
+		--season="$(SEASON)" \
+		--date="$(DATE)" \
+		--candidate-count="$(CANDIDATE_COUNT)" \
+		--contains-target-match-id="$(CONTAINS_TARGET_MATCH_ID)" \
+		--contains-target-label="$(CONTAINS_TARGET_LABEL)" \
+		--max-seed-rows="$(or $(MAX_SEED_ROWS),10)" \
+		--user-authorized-matches-seed-commit="$(or $(USER_AUTHORIZED_MATCHES_SEED_COMMIT),no)" \
+		--allow-matches-write-next-phase="$(or $(ALLOW_MATCHES_WRITE_NEXT_PHASE),no)" \
+		--allow-db-write-now="$(or $(ALLOW_DB_WRITE_NOW),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--final-human-confirmation="$(or $(FINAL_HUMAN_CONFIRMATION),no)"
+
+data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blocked in Phase 5.07L1.
 	@echo "BLOCKED: L1 matches seed commit is not executable in Phase 5.06L1 planning."
-	@echo "  Use data-l1-matches-seed-commit-plan for stdout planning only."
+	@echo "  L1 matches seed commit remains authorization-only in Phase 5.07L1."
+	@echo "  Use data-l1-matches-seed-commit-plan and data-l1-matches-seed-commit-authorization for stdout-only planning/authorization."
 	@echo "  Even with CONFIRM_L1_MATCHES_SEED_COMMIT=1, matches/DB/raw writes remain blocked."
 	@exit 1
 

--- a/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_AUTHORIZATION_PHASE5_07L1.md
+++ b/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_AUTHORIZATION_PHASE5_07L1.md
@@ -1,0 +1,97 @@
+# L1 Controlled Matches Seed Commit Authorization - Phase 5.07L1
+
+## 1. Executive summary
+
+Phase 5.07L1 是 controlled matches seed commit authorization 阶段。
+
+用户已授权进入 matches seed commit 的下一阶段，但本阶段仍不写 DB，不写 `matches`，不写 `raw_match_data`。真实 DB commit 必须在 Phase 5.08L1 或单独执行阶段再次确认。
+
+## 2. Background
+
+Phase 5.05L1 找到 8 个 FotMob Ligue 1 candidates，范围为 `source=fotmob`、`league_id=53`、`season=2025/2026`、`date=2026-05-10`。
+
+结果包含 `Angers vs Strasbourg`，目标 candidate match id 为 `4830746`。
+
+Phase 5.06L1 已完成 candidate -> matches mapping、upsert、backup 和 rollback planning。
+
+`raw_match_data.match_id` FK 到 `matches(match_id)`，所以后续 raw JSON 入库前必须先完成受控 `matches` seed。
+
+## 3. Implemented files
+
+- `scripts/ops/l1_matches_seed_commit_authorization.js`
+- `tests/unit/l1_matches_seed_commit_authorization.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_AUTHORIZATION_PHASE5_07L1.md`
+
+## 4. Authorization scope
+
+- `source=fotmob`
+- `league_id=53`
+- `season=2025/2026`
+- `date=2026-05-10`
+- `candidate_count=8`
+- `max_seed_rows=10`
+- `contains_target_match_id=4830746`
+- `contains_target_label=Angers vs Strasbourg`
+- `allow matches write next phase=true`
+- `allow DB write this phase=false`
+- `allow raw_match_data write=false`
+- `allow training=false`
+- `allow prediction=false`
+
+## 5. Authorization boundary
+
+本阶段授权不等于执行。
+
+- `commit_allowed_this_phase=false`
+- `data-l1-matches-seed-commit` 仍 blocked
+- 下一阶段必须再次展示 affected rows / `would_insert` / `would_update` / transaction / rollback plan
+- 用户必须再次确认才能写 DB
+
+## 6. Validation
+
+本阶段本地验证记录包括：
+
+- `tests/unit/l1_matches_seed_commit_authorization.test.js`
+- `make data-l1-matches-seed-commit-authorization ...`
+- `make data-l1-matches-seed-commit ...` 仍 blocked
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx eslint scripts/ops/l1_matches_seed_commit_authorization.js tests/unit/l1_matches_seed_commit_authorization.test.js --no-cache`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md Makefile scripts/ops/l1_matches_seed_commit_authorization.js tests/unit/l1_matches_seed_commit_authorization.test.js docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_AUTHORIZATION_PHASE5_07L1.md`
+- `git diff --check`
+- DB row counts unchanged
+- `tests/fixtures/l1-config-*` absent
+- `docs/_staging_preview` absent
+
+## 7. Recommended next phase
+
+推荐进入 Phase 5.08L1：controlled matches seed commit execution preflight / actual commit split。
+
+建议仍先做 execution preflight：
+
+- reload / capture exact candidate set
+- SELECT existing affected matches
+- show `would_insert` / `would_update` / `would_skip`
+- verify rows <= 10
+- then ask user for final DB-write confirmation
+- only after final confirmation execute transaction
+
+## 8. Explicit non-execution
+
+本阶段明确未执行：
+
+- external FotMob access
+- network dry-run
+- `titan_discovery` execution
+- `DiscoveryService.discover` execution
+- `FixtureRepository.persist`
+- DB writes
+- matches writes
+- `raw_match_data` writes
+- feature writes
+- prediction writes
+- harvest / ingest
+- training / prediction
+- file deletion

--- a/scripts/ops/l1_matches_seed_commit_authorization.js
+++ b/scripts/ops/l1_matches_seed_commit_authorization.js
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+'use strict';
+
+const PHASE = 'PHASE5_07L1_CONTROLLED_MATCHES_SEED_COMMIT_AUTHORIZATION';
+const SAFE_SOURCE = 'fotmob';
+const SAFE_SCOPES = new Set(['league_season_date', 'controlled_candidates_preview']);
+const MAX_SEED_ROWS_LIMIT = 10;
+const DEFAULT_MAX_SEED_ROWS = 10;
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 matches seed commit remains authorization-only in Phase 5.07L1.';
+const NEXT_REQUIRED_PHASE = 'Phase 5.08L1 controlled matches seed commit execution';
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isInteger(parsed) ? parsed : Number.NaN;
+}
+
+function normalizeOptionalText(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    return String(value).trim();
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        scope: null,
+        leagueId: null,
+        season: null,
+        date: null,
+        candidateCount: null,
+        containsTargetMatchId: null,
+        containsTargetLabel: null,
+        maxSeedRows: null,
+        userAuthorizedMatchesSeedCommit: false,
+        allowMatchesWriteNextPhase: false,
+        allowDbWriteNow: false,
+        allowRawMatchDataWrite: false,
+        allowTraining: false,
+        allowPrediction: false,
+        finalHumanConfirmation: false,
+        commit: false,
+        execute: false,
+        help: false,
+    };
+
+    const keyMap = {
+        source: 'source',
+        scope: 'scope',
+        'league-id': 'leagueId',
+        league_id: 'leagueId',
+        season: 'season',
+        date: 'date',
+        'candidate-count': 'candidateCount',
+        candidate_count: 'candidateCount',
+        'contains-target-match-id': 'containsTargetMatchId',
+        contains_target_match_id: 'containsTargetMatchId',
+        'contains-target-label': 'containsTargetLabel',
+        contains_target_label: 'containsTargetLabel',
+        'max-seed-rows': 'maxSeedRows',
+        max_seed_rows: 'maxSeedRows',
+        'user-authorized-matches-seed-commit': 'userAuthorizedMatchesSeedCommit',
+        user_authorized_matches_seed_commit: 'userAuthorizedMatchesSeedCommit',
+        'allow-matches-write-next-phase': 'allowMatchesWriteNextPhase',
+        allow_matches_write_next_phase: 'allowMatchesWriteNextPhase',
+        'allow-db-write-now': 'allowDbWriteNow',
+        allow_db_write_now: 'allowDbWriteNow',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        prediction: 'allowPrediction',
+        'final-human-confirmation': 'finalHumanConfirmation',
+        final_human_confirmation: 'finalHumanConfirmation',
+        commit: 'commit',
+        execute: 'execute',
+        help: 'help',
+        h: 'help',
+    };
+
+    const booleanOptions = new Set([
+        'userAuthorizedMatchesSeedCommit',
+        'allowMatchesWriteNextPhase',
+        'allowDbWriteNow',
+        'allowRawMatchDataWrite',
+        'allowTraining',
+        'allowPrediction',
+        'finalHumanConfirmation',
+        'commit',
+        'execute',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (!arg.startsWith('--')) {
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        if (!optionKey) {
+            continue;
+        }
+
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (booleanOptions.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function normalizeAuthorizationInput(input = {}) {
+    return {
+        source: typeof input.source === 'string' ? input.source.trim().toLowerCase() : '',
+        scope: typeof input.scope === 'string' ? input.scope.trim() : '',
+        leagueId: normalizeOptionalText(input.leagueId),
+        season: typeof input.season === 'string' ? input.season.trim() : null,
+        date: typeof input.date === 'string' ? input.date.trim() : null,
+        candidateCount: parseInteger(input.candidateCount, null),
+        containsTargetMatchId: normalizeOptionalText(input.containsTargetMatchId),
+        containsTargetLabel: normalizeOptionalText(input.containsTargetLabel),
+        maxSeedRows: parseInteger(input.maxSeedRows, DEFAULT_MAX_SEED_ROWS),
+        userAuthorizedMatchesSeedCommit: normalizeBooleanFlag(input.userAuthorizedMatchesSeedCommit, false),
+        allowMatchesWriteNextPhase: normalizeBooleanFlag(input.allowMatchesWriteNextPhase, false),
+        allowDbWriteNow: normalizeBooleanFlag(input.allowDbWriteNow, false),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, false),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, false),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, false),
+        finalHumanConfirmation: normalizeBooleanFlag(input.finalHumanConfirmation, false),
+        commit: normalizeBooleanFlag(input.commit, false),
+        execute: normalizeBooleanFlag(input.execute, false),
+    };
+}
+
+function validateSourceScope(value, errors) {
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== SAFE_SOURCE) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+
+    if (!value.scope) {
+        errors.push('missing scope: provide --scope=league_season_date or --scope=controlled_candidates_preview');
+    } else if (!SAFE_SCOPES.has(value.scope)) {
+        errors.push(`unsupported scope: ${value.scope}`);
+    }
+}
+
+function validateRequiredFields(value, errors) {
+    if (!value.leagueId) {
+        errors.push('missing league-id');
+    }
+    if (!value.season) {
+        errors.push('missing season');
+    }
+    if (!value.date) {
+        errors.push('missing date');
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(value.date)) {
+        errors.push('invalid date: provide YYYY-MM-DD');
+    }
+    if (!value.containsTargetMatchId) {
+        errors.push('missing contains-target-match-id');
+    }
+    if (!value.containsTargetLabel) {
+        errors.push('missing contains-target-label');
+    }
+}
+
+function validateLimits(value, errors) {
+    if (!Number.isInteger(value.candidateCount) || value.candidateCount < 0) {
+        errors.push('invalid candidate-count: provide a non-negative integer');
+    }
+    if (!Number.isInteger(value.maxSeedRows) || value.maxSeedRows < 1) {
+        errors.push('invalid max-seed-rows: provide a positive integer');
+    } else if (value.maxSeedRows > MAX_SEED_ROWS_LIMIT) {
+        errors.push(`max-seed-rows > ${MAX_SEED_ROWS_LIMIT} is blocked in Phase 5.07L1`);
+    }
+    if (
+        Number.isInteger(value.candidateCount) &&
+        Number.isInteger(value.maxSeedRows) &&
+        value.candidateCount > value.maxSeedRows
+    ) {
+        errors.push('candidate-count must be <= max-seed-rows');
+    }
+}
+
+function validateAuthorizationFlags(value, errors) {
+    if (value.userAuthorizedMatchesSeedCommit !== true) {
+        errors.push('user-authorized-matches-seed-commit must be yes in Phase 5.07L1');
+    }
+    if (value.allowMatchesWriteNextPhase !== true) {
+        errors.push('allow-matches-write-next-phase must be yes in Phase 5.07L1');
+    }
+    if (value.allowDbWriteNow === true) {
+        errors.push('allow-db-write-now=yes is blocked in Phase 5.07L1');
+    }
+    if (value.allowRawMatchDataWrite === true) {
+        errors.push('allow-raw-match-data-write=yes is blocked in Phase 5.07L1');
+    }
+    if (value.allowTraining === true) {
+        errors.push('allow-training=yes is blocked in Phase 5.07L1');
+    }
+    if (value.allowPrediction === true) {
+        errors.push('allow-prediction=yes is blocked in Phase 5.07L1');
+    }
+    if (value.finalHumanConfirmation !== true) {
+        errors.push('final-human-confirmation must be yes in Phase 5.07L1');
+    }
+    if (value.commit === true) {
+        errors.push(BLOCKED_COMMIT_MESSAGE);
+    }
+    if (value.execute === true) {
+        errors.push('execute=yes is blocked in Phase 5.07L1');
+    }
+}
+
+function validateAuthorizationInput(input = {}) {
+    const value = normalizeAuthorizationInput(input);
+    const errors = [];
+
+    validateSourceScope(value, errors);
+    validateRequiredFields(value, errors);
+    validateLimits(value, errors);
+    validateAuthorizationFlags(value, errors);
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function buildAffectedScope(value) {
+    return {
+        source: value.source,
+        league_id: value.leagueId,
+        season: value.season,
+        date: value.date,
+        max_rows: value.maxSeedRows,
+    };
+}
+
+function buildPreCommitBaselineRequirements(value) {
+    return [
+        'main CI green',
+        'clean worktree',
+        'DB row counts baseline',
+        'affected candidate set reloaded or explicitly supplied',
+        'affected existing matches SELECT',
+        `rows <= ${value.maxSeedRows}`,
+        `source=${value.source}`,
+        `league_id=${value.leagueId}`,
+        `season=${value.season}`,
+        `date=${value.date}`,
+        'no raw_match_data write',
+        'no feature/prediction write',
+        'rollback plan acknowledged',
+        'post-commit verification plan acknowledged',
+    ];
+}
+
+function buildAuthorizationGates(value) {
+    return [
+        `user_authorized_matches_seed_commit=${value.userAuthorizedMatchesSeedCommit === true}`,
+        `final_human_confirmation=${value.finalHumanConfirmation === true}`,
+        `allow_db_write_now=${value.allowDbWriteNow === true}`,
+        `allow_matches_write_next_phase=${value.allowMatchesWriteNextPhase === true}`,
+        `allow_raw_match_data_write=${value.allowRawMatchDataWrite === true}`,
+        `allow_training=${value.allowTraining === true}`,
+        `allow_prediction=${value.allowPrediction === true}`,
+        'commit_this_phase=false',
+    ];
+}
+
+function buildBlockedActionsThisPhase() {
+    return [
+        'execute_db_write',
+        'write_matches',
+        'write_raw_match_data',
+        'call_fixture_repository_persist',
+        'run_titan_discovery',
+        'run_discovery_service_discover',
+        'harvest',
+        'ingest',
+        'training',
+        'prediction',
+    ];
+}
+
+function buildNextPhaseRequirements() {
+    return [
+        'regenerate exact candidate set or use captured candidate payload',
+        'SELECT existing affected match rows',
+        'show would_insert / would_update / would_skip',
+        'require user final execution confirmation',
+        'execute in transaction',
+        'verify matches row delta / affected rows',
+        'verify raw_match_data unchanged',
+        'verify features/predictions unchanged',
+    ];
+}
+
+function buildMatchesSeedCommitAuthorization(input = {}) {
+    const validation = validateAuthorizationInput(input);
+    if (!validation.ok) {
+        const error = new Error(validation.errors[0]);
+        error.validationErrors = validation.errors;
+        throw error;
+    }
+
+    const value = validation.value;
+    return {
+        phase: PHASE,
+        authorization_only: true,
+        authorization_status: 'authorized_for_next_phase_only',
+        source: value.source,
+        scope: value.scope,
+        league_id: value.leagueId,
+        season: value.season,
+        date: value.date,
+        candidate_count: value.candidateCount,
+        max_seed_rows: value.maxSeedRows,
+        contains_target_match_id: value.containsTargetMatchId,
+        contains_target_label: value.containsTargetLabel,
+        user_authorized_matches_seed_commit: true,
+        matches_seed_commit_authorization_recorded: true,
+        matches_seed_commit_ready_for_next_phase: true,
+        commit_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed_this_phase: false,
+        matches_write_allowed_next_phase: true,
+        raw_match_data_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        final_human_confirmation: true,
+        affected_scope: buildAffectedScope(value),
+        pre_commit_baseline_requirements: buildPreCommitBaselineRequirements(value),
+        authorization_gates: buildAuthorizationGates(value),
+        blocked_actions_this_phase: buildBlockedActionsThisPhase(),
+        next_phase_requirements: buildNextPhaseRequirements(value),
+        would_write_matches: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_call_fixture_repository_persist: false,
+        would_call_discovery_service_discover: false,
+        would_run_titan_discovery: false,
+        would_train: false,
+        would_predict: false,
+        commit_gate: 'blocked_this_phase',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildErrorPayload(options, errors) {
+    const value = normalizeAuthorizationInput(options);
+    return {
+        phase: PHASE,
+        authorization_only: true,
+        authorization_status: 'blocked',
+        ok: false,
+        errors: Array.isArray(errors) ? errors : [String(errors)],
+        source: value.source || null,
+        scope: value.scope || null,
+        league_id: value.leagueId,
+        season: value.season,
+        date: value.date,
+        candidate_count: value.candidateCount,
+        max_seed_rows: value.maxSeedRows,
+        contains_target_match_id: value.containsTargetMatchId,
+        contains_target_label: value.containsTargetLabel,
+        user_authorized_matches_seed_commit: value.userAuthorizedMatchesSeedCommit === true,
+        matches_seed_commit_authorization_recorded: false,
+        matches_seed_commit_ready_for_next_phase: false,
+        commit_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed_this_phase: false,
+        matches_write_allowed_next_phase: value.allowMatchesWriteNextPhase === true,
+        raw_match_data_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        final_human_confirmation: value.finalHumanConfirmation === true,
+        affected_scope: buildAffectedScope(value),
+        pre_commit_baseline_requirements: buildPreCommitBaselineRequirements(value),
+        authorization_gates: buildAuthorizationGates(value),
+        blocked_actions_this_phase: buildBlockedActionsThisPhase(),
+        next_phase_requirements: buildNextPhaseRequirements(value),
+        would_write_matches: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_call_fixture_repository_persist: false,
+        would_call_discovery_service_discover: false,
+        would_run_titan_discovery: false,
+        would_train: false,
+        would_predict: false,
+        commit_gate: 'blocked_this_phase',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function showHelp(io = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    stdout(
+        [
+            'Usage:',
+            '  node scripts/ops/l1_matches_seed_commit_authorization.js --source=fotmob --scope=league_season_date --league-id=53 --season=2025/2026 --date=2026-05-10 --candidate-count=8 --contains-target-match-id=4830746 --contains-target-label="Angers vs Strasbourg" --max-seed-rows=10 --user-authorized-matches-seed-commit=yes --allow-matches-write-next-phase=yes --allow-db-write-now=no --allow-raw-match-data-write=no --allow-training=no --allow-prediction=no --final-human-confirmation=yes',
+            '',
+            'Phase 5.07L1: authorization-only, stdout-only, no DB writes, no matches/raw writes.',
+        ].join('\n')
+    );
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+    const options = parseArgs(argv);
+
+    if (options.help) {
+        showHelp({ stdout });
+        return 0;
+    }
+
+    try {
+        const payload = buildMatchesSeedCommitAuthorization(options);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 0;
+    } catch (error) {
+        const payload = buildErrorPayload(options, error.validationErrors || [error.message]);
+        stderr(`${payload.errors[0]}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    runCli().then(code => {
+        process.exitCode = code;
+    });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validateAuthorizationInput,
+    buildAffectedScope,
+    buildPreCommitBaselineRequirements,
+    buildAuthorizationGates,
+    buildBlockedActionsThisPhase,
+    buildNextPhaseRequirements,
+    buildMatchesSeedCommitAuthorization,
+    runCli,
+};

--- a/tests/unit/l1_matches_seed_commit_authorization.test.js
+++ b/tests/unit/l1_matches_seed_commit_authorization.test.js
@@ -1,0 +1,357 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l1_matches_seed_commit_authorization.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function installNoSideEffectGuards(t) {
+    const originalFetch = global.fetch;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalNetConnect = net.connect;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l1_matches_seed_commit_authorization`);
+    };
+
+    global.fetch = fail('global.fetch');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    net.connect = fail('net.connect');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (['pg', 'redis', 'ioredis', 'playwright', 'playwright-core'].includes(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/FixtureRepository|titan_discovery|DiscoveryService/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        net.connect = originalNetConnect;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+async function runCli(gate, argv) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.runCli(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+        stderr: text => {
+            stderr += text;
+        },
+    });
+    return { status, stdout, stderr };
+}
+
+function parseJsonOutput(stdout) {
+    const payload = String(stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload');
+    return JSON.parse(payload);
+}
+
+function validArgv(overrides = []) {
+    return [
+        '--source=fotmob',
+        '--scope=league_season_date',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--candidate-count=8',
+        '--contains-target-match-id=4830746',
+        '--contains-target-label=Angers vs Strasbourg',
+        '--max-seed-rows=10',
+        '--user-authorized-matches-seed-commit=yes',
+        '--allow-matches-write-next-phase=yes',
+        '--allow-db-write-now=no',
+        '--allow-raw-match-data-write=no',
+        '--allow-training=no',
+        '--allow-prediction=no',
+        '--final-human-confirmation=yes',
+        ...overrides,
+    ];
+}
+
+test('valid authorization input succeeds and emits authorization-only payload', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, validArgv());
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.phase, 'PHASE5_07L1_CONTROLLED_MATCHES_SEED_COMMIT_AUTHORIZATION');
+    assert.equal(payload.authorization_only, true);
+    assert.equal(payload.authorization_status, 'authorized_for_next_phase_only');
+    assert.equal(payload.source, 'fotmob');
+    assert.equal(payload.scope, 'league_season_date');
+    assert.equal(payload.league_id, '53');
+    assert.equal(payload.season, '2025/2026');
+    assert.equal(payload.date, '2026-05-10');
+    assert.equal(payload.candidate_count, 8);
+    assert.equal(payload.max_seed_rows, 10);
+    assert.equal(payload.contains_target_match_id, '4830746');
+    assert.equal(payload.contains_target_label, 'Angers vs Strasbourg');
+    assert.equal(payload.user_authorized_matches_seed_commit, true);
+    assert.equal(payload.matches_seed_commit_authorization_recorded, true);
+    assert.equal(payload.matches_seed_commit_ready_for_next_phase, true);
+    assert.equal(payload.commit_allowed_this_phase, false);
+    assert.equal(payload.db_write_allowed_this_phase, false);
+    assert.equal(payload.matches_write_allowed_this_phase, false);
+    assert.equal(payload.matches_write_allowed_next_phase, true);
+    assert.equal(payload.raw_match_data_write_allowed, false);
+    assert.equal(payload.training_allowed, false);
+    assert.equal(payload.prediction_allowed, false);
+    assert.equal(payload.final_human_confirmation, true);
+    assert.deepEqual(payload.affected_scope, {
+        source: 'fotmob',
+        league_id: '53',
+        season: '2025/2026',
+        date: '2026-05-10',
+        max_rows: 10,
+    });
+    assert.ok(payload.pre_commit_baseline_requirements.includes('main CI green'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('clean worktree'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('DB row counts baseline'));
+    assert.ok(
+        payload.pre_commit_baseline_requirements.includes('affected candidate set reloaded or explicitly supplied')
+    );
+    assert.ok(payload.pre_commit_baseline_requirements.includes('affected existing matches SELECT'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('rows <= 10'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('source=fotmob'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('league_id=53'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('season=2025/2026'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('date=2026-05-10'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('no raw_match_data write'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('no feature/prediction write'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('rollback plan acknowledged'));
+    assert.ok(payload.pre_commit_baseline_requirements.includes('post-commit verification plan acknowledged'));
+    assert.ok(payload.authorization_gates.includes('user_authorized_matches_seed_commit=true'));
+    assert.ok(payload.authorization_gates.includes('final_human_confirmation=true'));
+    assert.ok(payload.authorization_gates.includes('allow_db_write_now=false'));
+    assert.ok(payload.authorization_gates.includes('allow_matches_write_next_phase=true'));
+    assert.ok(payload.authorization_gates.includes('allow_raw_match_data_write=false'));
+    assert.ok(payload.authorization_gates.includes('allow_training=false'));
+    assert.ok(payload.authorization_gates.includes('allow_prediction=false'));
+    assert.ok(payload.authorization_gates.includes('commit_this_phase=false'));
+    assert.ok(payload.blocked_actions_this_phase.includes('write_matches'));
+    assert.ok(payload.blocked_actions_this_phase.includes('execute_db_write'));
+    assert.ok(payload.blocked_actions_this_phase.includes('write_raw_match_data'));
+    assert.ok(payload.blocked_actions_this_phase.includes('call_fixture_repository_persist'));
+    assert.ok(payload.blocked_actions_this_phase.includes('run_titan_discovery'));
+    assert.ok(payload.blocked_actions_this_phase.includes('run_discovery_service_discover'));
+    assert.ok(payload.blocked_actions_this_phase.includes('harvest'));
+    assert.ok(payload.blocked_actions_this_phase.includes('ingest'));
+    assert.ok(payload.blocked_actions_this_phase.includes('training'));
+    assert.ok(payload.blocked_actions_this_phase.includes('prediction'));
+    assert.ok(
+        payload.next_phase_requirements.includes('regenerate exact candidate set or use captured candidate payload')
+    );
+    assert.ok(payload.next_phase_requirements.includes('SELECT existing affected match rows'));
+    assert.ok(payload.next_phase_requirements.includes('show would_insert / would_update / would_skip'));
+    assert.ok(payload.next_phase_requirements.includes('require user final execution confirmation'));
+    assert.ok(payload.next_phase_requirements.includes('execute in transaction'));
+    assert.ok(payload.next_phase_requirements.includes('verify matches row delta / affected rows'));
+    assert.ok(payload.next_phase_requirements.includes('verify raw_match_data unchanged'));
+    assert.ok(payload.next_phase_requirements.includes('verify features/predictions unchanged'));
+    assert.equal(payload.would_write_matches, false);
+    assert.equal(payload.would_write_raw_match_data, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_call_fixture_repository_persist, false);
+    assert.equal(payload.would_call_discovery_service_discover, false);
+    assert.equal(payload.would_run_titan_discovery, false);
+    assert.equal(payload.would_train, false);
+    assert.equal(payload.would_predict, false);
+    assert.equal(payload.commit_gate, 'blocked_this_phase');
+    assert.equal(payload.next_required_phase, 'Phase 5.08L1 controlled matches seed commit execution');
+});
+
+test('validation failures and blocked flags are rejected', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const cases = [
+        { argv: validArgv().filter(arg => !arg.startsWith('--source=')), pattern: /missing source/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--source=')), '--source=other'],
+            pattern: /unsupported source/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--scope=')), pattern: /missing scope/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--scope=')), '--scope=bulk'],
+            pattern: /unsupported scope/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--league-id=')), pattern: /missing league-id/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--season=')), pattern: /missing season/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--date=')), pattern: /missing date/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--candidate-count=')), '--candidate-count=11'],
+            pattern: /candidate-count must be <= max-seed-rows/i,
+        },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--max-seed-rows=')), '--max-seed-rows=11'],
+            pattern: /max-seed-rows > 10/i,
+        },
+        {
+            argv: validArgv().filter(arg => !arg.startsWith('--contains-target-match-id=')),
+            pattern: /missing contains-target-match-id/i,
+        },
+        {
+            argv: validArgv().filter(arg => !arg.startsWith('--contains-target-label=')),
+            pattern: /missing contains-target-label/i,
+        },
+        {
+            argv: [
+                ...validArgv().filter(arg => !arg.startsWith('--user-authorized-matches-seed-commit=')),
+                '--user-authorized-matches-seed-commit=no',
+            ],
+            pattern: /user-authorized-matches-seed-commit must be yes/i,
+        },
+        {
+            argv: [
+                ...validArgv().filter(arg => !arg.startsWith('--final-human-confirmation=')),
+                '--final-human-confirmation=no',
+            ],
+            pattern: /final-human-confirmation must be yes/i,
+        },
+        { argv: [...validArgv(), '--allow-db-write-now=yes'], pattern: /allow-db-write-now=yes/i },
+        {
+            argv: [...validArgv(), '--allow-raw-match-data-write=yes'],
+            pattern: /allow-raw-match-data-write=yes/i,
+        },
+        { argv: [...validArgv(), '--allow-training=yes'], pattern: /allow-training=yes/i },
+        { argv: [...validArgv(), '--allow-prediction=yes'], pattern: /allow-prediction=yes/i },
+        { argv: [...validArgv(), '--commit=yes'], pattern: /authorization-only/i },
+        { argv: [...validArgv(), '--execute=yes'], pattern: /execute=yes/i },
+    ];
+
+    for (const { argv, pattern } of cases) {
+        const result = await runCli(gate, argv);
+        const payload = parseJsonOutput(result.stdout);
+        assert.equal(result.status, 1);
+        assert.match(payload.errors.join('\n'), pattern);
+        assert.equal(payload.authorization_only, true);
+        assert.equal(payload.would_write_matches, false);
+        assert.equal(payload.would_write_raw_match_data, false);
+        assert.equal(payload.would_write_db, false);
+        assert.equal(payload.would_call_fixture_repository_persist, false);
+        assert.equal(payload.would_call_discovery_service_discover, false);
+        assert.equal(payload.would_run_titan_discovery, false);
+    }
+});
+
+test('helpers normalize inputs and build expected authorization metadata', () => {
+    const gate = loadModuleFresh();
+    const options = gate.parseArgs([
+        '--source=fotmob',
+        '--scope=controlled_candidates_preview',
+        '--league-id',
+        '53',
+        '--candidate-count',
+        '8',
+        '--contains-target-match-id',
+        '4830746',
+        '--contains-target-label',
+        'Angers vs Strasbourg',
+        '--user-authorized-matches-seed-commit=yes',
+        '--allow-matches-write-next-phase=yes',
+        '--allow-db-write-now=no',
+        '--allow-raw-match-data-write=no',
+        '--allow-training=no',
+        '--allow-prediction=no',
+        '--final-human-confirmation=yes',
+        '--commit=no',
+        '--execute=no',
+    ]);
+
+    assert.equal(options.scope, 'controlled_candidates_preview');
+    assert.equal(options.leagueId, '53');
+    assert.equal(options.userAuthorizedMatchesSeedCommit, true);
+    assert.equal(gate.normalizeBooleanFlag('yes'), true);
+    assert.equal(gate.normalizeBooleanFlag('no'), false);
+
+    const validation = gate.validateAuthorizationInput({
+        ...options,
+        season: '2025/2026',
+        date: '2026-05-10',
+        maxSeedRows: '10',
+    });
+    assert.equal(validation.ok, true);
+    assert.deepEqual(gate.buildAffectedScope(validation.value), {
+        source: 'fotmob',
+        league_id: '53',
+        season: '2025/2026',
+        date: '2026-05-10',
+        max_rows: 10,
+    });
+    assert.ok(gate.buildAuthorizationGates(validation.value).includes('commit_this_phase=false'));
+    assert.ok(gate.buildBlockedActionsThisPhase().includes('write_matches'));
+    assert.ok(gate.buildNextPhaseRequirements().includes('execute in transaction'));
+    assert.ok(gate.buildNextPhaseRequirements().includes('verify raw_match_data unchanged'));
+});
+
+test('script stays side-effect free on success and failure paths', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+
+    const success = await runCli(gate, validArgv());
+    const blocked = await runCli(gate, [...validArgv(), '--execute=yes']);
+
+    assert.equal(success.status, 0);
+    assert.equal(blocked.status, 1);
+});
+
+test('Makefile authorization target is registered and commit target remains blocked', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+
+    assert.match(makefile, /^data-l1-matches-seed-commit-authorization:/m);
+    assert.match(makefile, /scripts\/ops\/l1_matches_seed_commit_authorization\.js/);
+    assert.match(makefile, /^data-l1-matches-seed-commit:/m);
+    assert.match(makefile, /authorization-only in Phase 5\.07L1/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.07L1 controlled matches seed commit authorization.

Scope:
- Adds authorization-only script for future controlled matches seed commit
- Records user-authorized scope for 2026-05-10 Ligue 1 FotMob candidates
- Keeps commit blocked this phase
- Keeps DB writes blocked this phase
- Keeps matches/raw_match_data writes blocked
- Adds Makefile authorization target
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 5.07L1 report

Safety:
- No external FotMob access
- No network dry-run
- No titan_discovery execution
- No DiscoveryService.discover execution
- No FixtureRepository.persist
- No DB writes
- No matches writes
- No raw_match_data writes
- No harvest / ingest
- No training / prediction

Validation:
- matches seed authorization tests passed
- Makefile authorization passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally if browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed