### PR TITLE
feat(data): add L1 matches seed execution preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@
 - 如果命令已经封装为 `npm script`，优先使用脚本入口。
 - 如果 `npm script` 指向缺失文件，先修正文档或脚本，再继续依赖该入口。
 - 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` / `make data-l1-discovery-candidates-preview` 的 safe preview 路径进入；显式授权的 L1 外网候选预览只能通过 `make data-l1-discovery-candidates-network-preview`。
-- L1 matches seed commit 不能由 AI / Codex 直接执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning；Phase 5.07L1 仅允许 `make data-l1-matches-seed-commit-authorization` 输出 stdout authorization summary。
+- L1 matches seed commit 不能由 AI / Codex 直接执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning；Phase 5.07L1 仅允许 `make data-l1-matches-seed-commit-authorization` 输出 stdout authorization summary；Phase 5.08L1 仅允许 `make data-l1-matches-seed-commit-execution-preflight` 输出 stdout preflight summary 和 SELECT-only affected rows preview。
 
 ### 2.3 禁止行为
 
@@ -220,6 +220,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权、仅做 candidates stdout summary、不写 DB/不启动 browser/proxy 的 `make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no`
 - 仅做 matches seed commit planning、不触网、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no`
 - 用户明确授权、只记录 stdout authorization summary、不触网、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-authorization SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 USER_AUTHORIZED_MATCHES_SEED_COMMIT=yes ALLOW_MATCHES_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes`
+- 用户明确授权、仅做 execution preflight、允许 safe exact candidates + SELECT-only affected matches、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-execution-preflight SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 FINAL_DB_WRITE_CONFIRMATION=no ALLOW_DB_WRITE_NOW=no ALLOW_MATCHES_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
@@ -400,6 +401,15 @@ Phase 5.07L1 补充约定：
 - `data-l1-matches-seed-commit-authorization` 只允许记录 stdout authorization summary，不得触网，不得写 DB，不得写 `matches`，不得写 `raw_match_data`。
 - `make data-l1-matches-seed-commit` 继续 blocked，直到 Phase 5.08L1 或后续单独执行阶段再次确认。
 - matches seed commit execution 必须与 raw_match_data ingest 分离，不得合并执行。
+- matches seed 各阶段不得训练、不得预测、不得加载或生成模型 artifact。
+
+Phase 5.08L1 补充约定：
+
+- L1 matches seed commit execution preflight 只能走 `make data-l1-matches-seed-commit-execution-preflight`。
+- `data-l1-matches-seed-commit-execution-preflight` 允许 safe exact candidates preview 和 `matches` 的 SELECT-only affected rows 预览；不得写 DB，不得写 `matches`，不得写 `raw_match_data`，不得调用 `FixtureRepository.persist()`。
+- `make data-l1-matches-seed-commit` 继续 blocked，直到后续单独 execution phase。
+- preflight 结束后仍必须要求最终 DB-write confirmation。
+- raw_match_data ingest 必须与 matches seed commit 分离，不得合并执行。
 - matches seed 各阶段不得训练、不得预测、不得加载或生成模型 artifact。
 
 执行 `make data-l3-dry-run` 的前提：

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
-        data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit \
+        data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -315,6 +315,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l1-discovery-candidates-network-preview SOURCE=fotmob SCOPE=controlled_candidates_preview LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CONCURRENCY=1 MAX_TARGETS<=10 NETWORK_AUTHORIZATION=yes ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no ALLOW_DB_WRITE=no  # Phase 5.05L1 controlled external network candidates preview only"
 	@echo "  make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no  # Phase 5.06L1 planning-only, no network/DB/matches/raw writes"
 	@echo "  make data-l1-matches-seed-commit-authorization SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 USER_AUTHORIZED_MATCHES_SEED_COMMIT=yes ALLOW_MATCHES_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes  # Phase 5.07L1 authorization-only, stdout-only, no DB/matches/raw writes"
+	@echo "  make data-l1-matches-seed-commit-execution-preflight SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 FINAL_DB_WRITE_CONFIRMATION=no ALLOW_DB_WRITE_NOW=no ALLOW_MATCHES_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.08L1 execution preflight only, safe exact candidates + SELECT-only affected matches, no DB writes"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -538,10 +539,34 @@ data-l1-matches-seed-commit-authorization: ## L1 matches seed commit authorizati
 		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
 		--final-human-confirmation="$(or $(FINAL_HUMAN_CONFIRMATION),no)"
 
-data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blocked in Phase 5.07L1.
-	@echo "BLOCKED: L1 matches seed commit is not executable in Phase 5.06L1 planning."
-	@echo "  L1 matches seed commit remains authorization-only in Phase 5.07L1."
-	@echo "  Use data-l1-matches-seed-commit-plan and data-l1-matches-seed-commit-authorization for stdout-only planning/authorization."
+data-l1-matches-seed-commit-execution-preflight: ## L1 matches seed commit execution preflight. Phase 5.08L1. Preflight-only, exact candidates + SELECT-only affected matches, no DB writes.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(SCOPE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(SEASON)" ] || [ -z "$(DATE)" ] || [ -z "$(CANDIDATE_COUNT)" ] || [ -z "$(CONTAINS_TARGET_MATCH_ID)" ] || [ -z "$(CONTAINS_TARGET_LABEL)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> CONTAINS_TARGET_MATCH_ID=<id> CONTAINS_TARGET_LABEL=<label>"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_matches_seed_commit_execution_preflight.js \
+		--source="$(SOURCE)" \
+		--scope="$(SCOPE)" \
+		--league-id="$(LEAGUE_ID)" \
+		--season="$(SEASON)" \
+		--date="$(DATE)" \
+		--candidate-count="$(CANDIDATE_COUNT)" \
+		--contains-target-match-id="$(CONTAINS_TARGET_MATCH_ID)" \
+		--contains-target-label="$(CONTAINS_TARGET_LABEL)" \
+		--max-seed-rows="$(or $(MAX_SEED_ROWS),10)" \
+		--final-db-write-confirmation="$(or $(FINAL_DB_WRITE_CONFIRMATION),no)" \
+		--allow-db-write-now="$(or $(ALLOW_DB_WRITE_NOW),no)" \
+		--allow-matches-write-now="$(or $(ALLOW_MATCHES_WRITE_NOW),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		$(if $(CANDIDATES_JSON),--candidates-json='$(CANDIDATES_JSON)') \
+		$(if $(EXISTING_MATCHES_JSON),--existing-matches-json='$(EXISTING_MATCHES_JSON)')
+
+data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blocked in Phase 5.08L1.
+	@echo "BLOCKED: L1 matches seed commit is not executable in Phase 5.08L1 execution preflight."
+	@echo "  L1 matches seed commit remains authorization-only in Phase 5.07L1 and execution-preflight-only in Phase 5.08L1."
+	@echo "  Use data-l1-matches-seed-commit-plan, data-l1-matches-seed-commit-authorization, and data-l1-matches-seed-commit-execution-preflight for stdout-only planning/preflight."
 	@echo "  Even with CONFIRM_L1_MATCHES_SEED_COMMIT=1, matches/DB/raw writes remain blocked."
 	@exit 1
 

--- a/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PREFLIGHT_PHASE5_08L1.md
+++ b/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PREFLIGHT_PHASE5_08L1.md
@@ -1,0 +1,154 @@
+# L1 Controlled Matches Seed Commit Execution Preflight - Phase 5.08L1
+
+## 1. Executive summary
+
+Phase 5.08L1 是 controlled matches seed commit execution preflight 阶段。
+
+本阶段展示 `would_insert` / `would_update` / `would_skip`，但仍不写 DB，不写 `matches`，不写 `raw_match_data`。真实 DB commit 必须在后续 Phase 5.09L1 或单独执行阶段再次确认。
+
+## 2. Background
+
+Phase 5.05L1 找到 8 个 FotMob Ligue 1 candidates。
+
+Phase 5.06L1 完成 candidate -> matches mapping、upsert、backup 和 rollback planning。
+
+Phase 5.07L1 已记录 controlled matches seed commit authorization。
+
+`raw_match_data.match_id` FK 到 `matches(match_id)`，所以后续 raw JSON 入库前必须先有对应 `matches` seed。
+
+## 3. Implemented files
+
+- `scripts/ops/l1_matches_seed_commit_execution_preflight.js`
+- `tests/unit/l1_matches_seed_commit_execution_preflight.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PREFLIGHT_PHASE5_08L1.md`
+
+## 4. Exact candidate set
+
+本阶段实际使用 safe controlled candidates preview path 重新捕获 exact candidate set。
+
+- exact candidate source: `safe_controlled_network_preview`
+- source_url: `https://www.fotmob.com/api/data/leagues?id=53&season=20252026`
+- candidate_count: `8`
+- candidate ids:
+    - `53_20252026_4830746`
+    - `53_20252026_4830747`
+    - `53_20252026_4830748`
+    - `53_20252026_4830750`
+    - `53_20252026_4830751`
+    - `53_20252026_4830752`
+    - `53_20252026_4830753`
+    - `53_20252026_4830754`
+- contains `4830746`: `true`
+- contains `Angers vs Strasbourg`: `true`
+
+candidate preview summary:
+
+- `4830746`: Angers vs Strasbourg
+- `4830747`: Auxerre vs Nice
+- `4830748`: Le Havre vs Marseille
+- `4830750`: Metz vs Lorient
+- `4830751`: Monaco vs Lille
+- `4830752`: Paris Saint-Germain vs Brest
+- `4830753`: Rennes vs Paris FC
+- `4830754`: Toulouse vs Lyon
+
+## 5. Affected rows preflight
+
+execution preflight 会：
+
+- 对 exact candidate set 做 normalization
+- 对 `matches` 执行 SELECT-only affected rows 查询
+- 计算 `would_insert_count`
+- 计算 `would_update_count`
+- 计算 `would_skip_count`
+- 输出 `affected_preview`
+
+本阶段实际 preflight 结果：
+
+- existing affected matches SELECT result summary: `0 rows`
+- existing affected matches count: `0`
+- would_insert_count: `8`
+- would_update_count: `0`
+- would_skip_count: `0`
+
+affected_preview summary:
+
+- `53_20252026_4830746` Angers vs Strasbourg, `status=finished`, `decision=would_insert`
+- `53_20252026_4830747` Auxerre vs Nice, `status=finished`, `decision=would_insert`
+- `53_20252026_4830748` Le Havre vs Marseille, `status=finished`, `decision=would_insert`
+- `53_20252026_4830750` Metz vs Lorient, `status=finished`, `decision=would_insert`
+- `53_20252026_4830751` Monaco vs Lille, `status=finished`, `decision=would_insert`
+- `53_20252026_4830752` Paris Saint-Germain vs Brest, `status=finished`, `decision=would_insert`
+- `53_20252026_4830753` Rennes vs Paris FC, `status=finished`, `decision=would_insert`
+- `53_20252026_4830754` Toulouse vs Lyon, `status=finished`, `decision=would_insert`
+
+## 6. Transaction / backup / rollback policy
+
+- transaction required
+- rows <= 10
+- only `matches` table
+- no `raw_match_data`
+- no features / predictions
+- rollback on error
+- backup / affected rows snapshot before commit
+- no `pg_dump` / file write this phase
+
+## 7. Authorization boundary
+
+本阶段 preflight 不等于执行。
+
+- `commit_allowed_this_phase=false`
+- `data-l1-matches-seed-commit` 仍 blocked
+- 下一阶段必须让用户看到 `would_insert` / `would_update` / `would_skip` 后再次确认
+- 用户必须最终确认才能写 DB
+
+## 8. Validation
+
+本阶段本地验证结果：
+
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/l1_matches_seed_commit_execution_preflight.test.js` passed
+- `make data-l1-matches-seed-commit-execution-preflight ...` passed
+- `make data-l1-matches-seed-commit ...` remained blocked as expected
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test` passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage` passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npx eslint scripts/ops/l1_matches_seed_commit_execution_preflight.js tests/unit/l1_matches_seed_commit_execution_preflight.test.js --no-cache` passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md Makefile scripts/ops/l1_matches_seed_commit_execution_preflight.js tests/unit/l1_matches_seed_commit_execution_preflight.test.js docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PREFLIGHT_PHASE5_08L1.md` passed
+- `git diff --check` passed
+- DB row counts unchanged
+- `tests/fixtures/l1-config-*` absent
+- `docs/_staging_preview` absent
+- local integration was not separately expanded beyond repository test gates where browser/runtime safety boundaries would be violated
+
+## 9. Recommended next phase
+
+推荐进入 Phase 5.09L1：controlled matches seed commit execution。
+
+要求：
+
+- 用户明确最终 DB-write confirmation
+- 只处理 preflight 展示的 exact candidates
+- rows <= 10
+- 只写 `matches`
+- 不写 `raw_match_data`
+- 不训练
+- 不预测
+- 事务执行
+- post-commit verification
+
+## 10. Explicit non-execution
+
+本阶段明确未执行：
+
+- `titan_discovery` execution
+- `DiscoveryService.discover` execution
+- `FixtureRepository.persist`
+- DB writes
+- matches writes
+- `raw_match_data` writes
+- feature writes
+- prediction writes
+- harvest / ingest
+- training / prediction
+- file deletion

--- a/scripts/ops/l1_matches_seed_commit_execution_preflight.js
+++ b/scripts/ops/l1_matches_seed_commit_execution_preflight.js
@@ -1,0 +1,911 @@
+#!/usr/bin/env node
+/* eslint-disable complexity, max-lines */
+'use strict';
+
+const PHASE = 'PHASE5_08L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PREFLIGHT';
+const SAFE_SOURCE = 'fotmob';
+const SAFE_SCOPES = new Set(['league_season_date', 'controlled_candidates_preview']);
+const MAX_SEED_ROWS_LIMIT = 10;
+const DEFAULT_MAX_SEED_ROWS = 10;
+const BLOCKED_COMMIT_MESSAGE = 'BLOCKED: L1 matches seed commit execution remains preflight-only in Phase 5.08L1.';
+const NEXT_REQUIRED_PHASE = 'Phase 5.09L1 controlled matches seed commit execution';
+const PREVIEW_SCOPE = 'controlled_candidates_preview';
+const SAFE_NETWORK_CONCURRENCY = 1;
+const SAFE_NETWORK_MAX_TARGETS = 10;
+const SAFE_NETWORK_TIMEOUT_MS = 15000;
+const CONTROLLED_FIELD_NAMES = [
+    'external_id',
+    'league_name',
+    'season',
+    'home_team',
+    'away_team',
+    'match_date',
+    'status',
+    'data_source',
+];
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isInteger(parsed) ? parsed : Number.NaN;
+}
+
+function normalizeOptionalText(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    return String(value).trim();
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        scope: null,
+        leagueId: null,
+        season: null,
+        date: null,
+        candidateCount: null,
+        containsTargetMatchId: null,
+        containsTargetLabel: null,
+        maxSeedRows: null,
+        finalDbWriteConfirmation: false,
+        allowDbWriteNow: false,
+        allowMatchesWriteNow: false,
+        allowRawMatchDataWrite: false,
+        allowTraining: false,
+        allowPrediction: false,
+        commit: false,
+        execute: false,
+        candidatesJson: null,
+        existingMatchesJson: null,
+        help: false,
+    };
+
+    const keyMap = {
+        source: 'source',
+        scope: 'scope',
+        'league-id': 'leagueId',
+        league_id: 'leagueId',
+        season: 'season',
+        date: 'date',
+        'candidate-count': 'candidateCount',
+        candidate_count: 'candidateCount',
+        'contains-target-match-id': 'containsTargetMatchId',
+        contains_target_match_id: 'containsTargetMatchId',
+        'contains-target-label': 'containsTargetLabel',
+        contains_target_label: 'containsTargetLabel',
+        'max-seed-rows': 'maxSeedRows',
+        max_seed_rows: 'maxSeedRows',
+        'final-db-write-confirmation': 'finalDbWriteConfirmation',
+        final_db_write_confirmation: 'finalDbWriteConfirmation',
+        'allow-db-write-now': 'allowDbWriteNow',
+        allow_db_write_now: 'allowDbWriteNow',
+        'allow-matches-write-now': 'allowMatchesWriteNow',
+        allow_matches_write_now: 'allowMatchesWriteNow',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        prediction: 'allowPrediction',
+        commit: 'commit',
+        execute: 'execute',
+        'candidates-json': 'candidatesJson',
+        candidates_json: 'candidatesJson',
+        'existing-matches-json': 'existingMatchesJson',
+        existing_matches_json: 'existingMatchesJson',
+        help: 'help',
+        h: 'help',
+    };
+
+    const booleanOptions = new Set([
+        'finalDbWriteConfirmation',
+        'allowDbWriteNow',
+        'allowMatchesWriteNow',
+        'allowRawMatchDataWrite',
+        'allowTraining',
+        'allowPrediction',
+        'commit',
+        'execute',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (!arg.startsWith('--')) {
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        if (!optionKey) {
+            continue;
+        }
+
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (booleanOptions.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function normalizeExecutionPreflightInput(input = {}) {
+    return {
+        source: typeof input.source === 'string' ? input.source.trim().toLowerCase() : '',
+        scope: typeof input.scope === 'string' ? input.scope.trim() : '',
+        leagueId: normalizeOptionalText(input.leagueId),
+        season: typeof input.season === 'string' ? input.season.trim() : null,
+        date: typeof input.date === 'string' ? input.date.trim() : null,
+        candidateCount: parseInteger(input.candidateCount, null),
+        containsTargetMatchId: normalizeOptionalText(input.containsTargetMatchId),
+        containsTargetLabel: normalizeOptionalText(input.containsTargetLabel),
+        maxSeedRows: parseInteger(input.maxSeedRows, DEFAULT_MAX_SEED_ROWS),
+        finalDbWriteConfirmation: normalizeBooleanFlag(input.finalDbWriteConfirmation, false),
+        allowDbWriteNow: normalizeBooleanFlag(input.allowDbWriteNow, false),
+        allowMatchesWriteNow: normalizeBooleanFlag(input.allowMatchesWriteNow, false),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, false),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, false),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, false),
+        commit: normalizeBooleanFlag(input.commit, false),
+        execute: normalizeBooleanFlag(input.execute, false),
+        candidatesJson: typeof input.candidatesJson === 'string' ? input.candidatesJson : null,
+        existingMatchesJson: typeof input.existingMatchesJson === 'string' ? input.existingMatchesJson : null,
+    };
+}
+
+function validateSourceScope(value, errors) {
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== SAFE_SOURCE) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+
+    if (!value.scope) {
+        errors.push('missing scope: provide --scope=league_season_date or --scope=controlled_candidates_preview');
+    } else if (!SAFE_SCOPES.has(value.scope)) {
+        errors.push(`unsupported scope: ${value.scope}`);
+    }
+}
+
+function validateRequiredFields(value, errors) {
+    if (!value.leagueId) {
+        errors.push('missing league-id');
+    }
+    if (!value.season) {
+        errors.push('missing season');
+    }
+    if (!value.date) {
+        errors.push('missing date');
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(value.date)) {
+        errors.push('invalid date: provide YYYY-MM-DD');
+    }
+    if (!value.containsTargetMatchId) {
+        errors.push('missing contains-target-match-id');
+    }
+    if (!value.containsTargetLabel) {
+        errors.push('missing contains-target-label');
+    }
+}
+
+function validateLimits(value, errors) {
+    if (!Number.isInteger(value.candidateCount) || value.candidateCount < 0) {
+        errors.push('invalid candidate-count: provide a non-negative integer');
+    }
+    if (!Number.isInteger(value.maxSeedRows) || value.maxSeedRows < 1) {
+        errors.push('invalid max-seed-rows: provide a positive integer');
+    } else if (value.maxSeedRows > MAX_SEED_ROWS_LIMIT) {
+        errors.push(`max-seed-rows > ${MAX_SEED_ROWS_LIMIT} is blocked in Phase 5.08L1`);
+    }
+    if (
+        Number.isInteger(value.candidateCount) &&
+        Number.isInteger(value.maxSeedRows) &&
+        value.candidateCount > value.maxSeedRows
+    ) {
+        errors.push('candidate-count must be <= max-seed-rows');
+    }
+}
+
+function validateBlockedFlags(value, errors) {
+    if (value.finalDbWriteConfirmation === true) {
+        errors.push('final-db-write-confirmation=yes is blocked in Phase 5.08L1');
+    }
+    if (value.allowDbWriteNow === true) {
+        errors.push('allow-db-write-now=yes is blocked in Phase 5.08L1');
+    }
+    if (value.allowMatchesWriteNow === true) {
+        errors.push('allow-matches-write-now=yes is blocked in Phase 5.08L1');
+    }
+    if (value.allowRawMatchDataWrite === true) {
+        errors.push('allow-raw-match-data-write=yes is blocked in Phase 5.08L1');
+    }
+    if (value.allowTraining === true) {
+        errors.push('allow-training=yes is blocked in Phase 5.08L1');
+    }
+    if (value.allowPrediction === true) {
+        errors.push('allow-prediction=yes is blocked in Phase 5.08L1');
+    }
+    if (value.commit === true) {
+        errors.push(BLOCKED_COMMIT_MESSAGE);
+    }
+    if (value.execute === true) {
+        errors.push('execute=yes is blocked in Phase 5.08L1');
+    }
+}
+
+function validateExecutionPreflightInput(input = {}) {
+    const value = normalizeExecutionPreflightInput(input);
+    const errors = [];
+
+    validateSourceScope(value, errors);
+    validateRequiredFields(value, errors);
+    validateLimits(value, errors);
+    validateBlockedFlags(value, errors);
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function parseJsonText(text, label) {
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        throw new Error(`${label} is not valid JSON: ${error.message}`);
+    }
+}
+
+function normalizeDateText(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.toISOString();
+    }
+
+    const text = String(value).trim();
+    if (!text) {
+        return null;
+    }
+    const parsed = new Date(text);
+    return Number.isNaN(parsed.getTime()) ? text : parsed.toISOString();
+}
+
+function normalizeStatus(value) {
+    const text = String(value || '')
+        .trim()
+        .toLowerCase();
+    return text || 'scheduled';
+}
+
+function normalizeDataSource(value) {
+    const text = String(value || '').trim();
+    return text || 'FotMob';
+}
+
+function normalizeCandidates(input) {
+    const candidates = Array.isArray(input)
+        ? input
+        : Array.isArray(input?.candidates)
+          ? input.candidates
+          : input?.candidates_preview;
+    if (!Array.isArray(candidates)) {
+        throw new Error('candidate payload must be an array or expose candidates/candidates_preview');
+    }
+
+    return candidates.map((candidate, index) => {
+        const matchId = normalizeOptionalText(candidate?.match_id ?? candidate?.matchId);
+        const externalId = normalizeOptionalText(
+            candidate?.external_id ?? candidate?.externalId ?? candidate?.id ?? matchId
+        );
+        const leagueName = normalizeOptionalText(candidate?.league_name ?? candidate?.league);
+        const season = normalizeOptionalText(candidate?.season);
+        const homeTeam = normalizeOptionalText(candidate?.home_team ?? candidate?.home);
+        const awayTeam = normalizeOptionalText(candidate?.away_team ?? candidate?.away);
+        const matchDate = normalizeDateText(candidate?.match_date ?? candidate?.matchDate);
+        const status = normalizeStatus(candidate?.status);
+        const dataSource = normalizeDataSource(candidate?.data_source ?? candidate?.dataSource);
+
+        const missing = [];
+        if (!matchId) missing.push('match_id');
+        if (!externalId) missing.push('external_id');
+        if (!leagueName) missing.push('league_name');
+        if (!season) missing.push('season');
+        if (!homeTeam) missing.push('home_team');
+        if (!awayTeam) missing.push('away_team');
+        if (!matchDate) missing.push('match_date');
+        if (missing.length > 0) {
+            throw new Error(`candidate[${index}] missing required fields: ${missing.join(', ')}`);
+        }
+
+        return {
+            match_id: matchId,
+            external_id: externalId,
+            league_name: leagueName,
+            season,
+            home_team: homeTeam,
+            away_team: awayTeam,
+            match_date: matchDate,
+            status,
+            data_source: dataSource,
+        };
+    });
+}
+
+function normalizeExistingMatches(rows) {
+    const list = Array.isArray(rows)
+        ? rows
+        : Array.isArray(rows?.rows)
+          ? rows.rows
+          : Array.isArray(rows?.existing_matches)
+            ? rows.existing_matches
+            : [];
+
+    return list.map(row => ({
+        match_id: normalizeOptionalText(row?.match_id ?? row?.matchId),
+        external_id: normalizeOptionalText(row?.external_id ?? row?.externalId),
+        league_name: normalizeOptionalText(row?.league_name ?? row?.leagueName),
+        season: normalizeOptionalText(row?.season),
+        home_team: normalizeOptionalText(row?.home_team ?? row?.homeTeam),
+        away_team: normalizeOptionalText(row?.away_team ?? row?.awayTeam),
+        match_date: normalizeDateText(row?.match_date ?? row?.matchDate),
+        status: normalizeStatus(row?.status),
+        data_source: normalizeDataSource(row?.data_source ?? row?.dataSource),
+    }));
+}
+
+function diffControlledFields(candidate, existingRow) {
+    return CONTROLLED_FIELD_NAMES.filter(field => {
+        const left = candidate[field] ?? null;
+        const right = existingRow[field] ?? null;
+        return left !== right;
+    });
+}
+
+function buildAffectedPreview(candidates, existingMatches) {
+    const existingMap = new Map(
+        normalizeExistingMatches(existingMatches)
+            .filter(row => row.match_id)
+            .map(row => [row.match_id, row])
+    );
+
+    return normalizeCandidates(candidates).map(candidate => {
+        const existingRow = existingMap.get(candidate.match_id) || null;
+        if (!existingRow) {
+            return {
+                match_id: candidate.match_id,
+                external_id: candidate.external_id,
+                home_team: candidate.home_team,
+                away_team: candidate.away_team,
+                match_date: candidate.match_date,
+                league_name: candidate.league_name,
+                season: candidate.season,
+                status: candidate.status,
+                existing_row_found: false,
+                decision: 'would_insert',
+                reason: 'match_id not found in matches',
+            };
+        }
+
+        const differingFields = diffControlledFields(candidate, existingRow);
+        if (differingFields.length === 0) {
+            return {
+                match_id: candidate.match_id,
+                external_id: candidate.external_id,
+                home_team: candidate.home_team,
+                away_team: candidate.away_team,
+                match_date: candidate.match_date,
+                league_name: candidate.league_name,
+                season: candidate.season,
+                status: candidate.status,
+                existing_row_found: true,
+                decision: 'would_skip',
+                reason: 'existing matches row already matches controlled seed fields',
+            };
+        }
+
+        return {
+            match_id: candidate.match_id,
+            external_id: candidate.external_id,
+            home_team: candidate.home_team,
+            away_team: candidate.away_team,
+            match_date: candidate.match_date,
+            league_name: candidate.league_name,
+            season: candidate.season,
+            status: candidate.status,
+            existing_row_found: true,
+            decision: 'would_update',
+            reason: `existing matches row differs on: ${differingFields.join(', ')}`,
+        };
+    });
+}
+
+function buildTransactionPlan(input) {
+    return {
+        begin: 'BEGIN',
+        row_limit: `rows <= ${input.maxSeedRows}`,
+        row_limit_enforced: true,
+        allowed_table: 'matches',
+        forbidden_tables: ['raw_match_data', 'l3_features', 'match_features_training', 'predictions'],
+        upsert_strategy: 'upsert by match_id',
+        raw_match_data_write_allowed: false,
+        feature_write_allowed: false,
+        prediction_write_allowed: false,
+        rollback_on_error: 'ROLLBACK on error',
+        commit_condition: 'COMMIT only after final confirmation in next phase',
+        steps: [
+            'BEGIN',
+            `validate rows <= ${input.maxSeedRows}`,
+            'operate on matches only',
+            'upsert by match_id',
+            'ROLLBACK on error',
+            'COMMIT only after final confirmation in next phase',
+        ],
+    };
+}
+
+function buildBackupPlan() {
+    return {
+        execute_backup_this_phase: false,
+        select_existing_affected_rows_before_commit: true,
+        include_baseline_counts: true,
+        baseline_count_tables: ['matches', 'raw_match_data', 'l3_features', 'match_features_training', 'predictions'],
+        pg_dump_allowed_this_phase: false,
+        backup_file_write_allowed_this_phase: false,
+        future_backup_artifact_requires_separate_user_authorization: true,
+    };
+}
+
+function buildRollbackPlan() {
+    return {
+        execute_rollback_this_phase: false,
+        transaction_rollback_on_failure: true,
+        affected_rows_snapshot_required_for_later_compensation: true,
+        later_restore_requires_authorization: true,
+        delete_allowed_this_phase: false,
+        rollback_file_write_allowed_this_phase: false,
+    };
+}
+
+function buildPostCommitVerificationPlan() {
+    return {
+        matches_row_count_delta_expected: true,
+        affected_match_ids_exist: true,
+        raw_match_data_unchanged: true,
+        l3_features_unchanged: true,
+        match_features_training_unchanged: true,
+        predictions_unchanged: true,
+        no_training_prediction_executed: true,
+    };
+}
+
+function candidateMatchesTargetId(candidates, targetId) {
+    return normalizeCandidates(candidates).some(candidate =>
+        [candidate.match_id, candidate.external_id].some(value => String(value || '').includes(String(targetId || '')))
+    );
+}
+
+function candidateMatchesTargetLabel(candidates, targetLabel) {
+    const label = String(targetLabel || '')
+        .trim()
+        .toLowerCase();
+    if (!label) {
+        return false;
+    }
+
+    return normalizeCandidates(candidates).some(candidate => {
+        const pair = `${candidate.home_team} vs ${candidate.away_team}`.toLowerCase();
+        const reversePair = `${candidate.away_team} vs ${candidate.home_team}`.toLowerCase();
+        return pair === label || reversePair === label;
+    });
+}
+
+async function resolveCandidatesFromSafePreview(input, dependencies = {}) {
+    const safePreview = dependencies.safePreviewModule || require('./l1_discovery_safe_preview');
+    const payload = await safePreview.buildL1DiscoveryPlanPreview(
+        {
+            source: input.source,
+            scope: PREVIEW_SCOPE,
+            leagueId: input.leagueId,
+            season: input.season,
+            date: input.date,
+            concurrency: SAFE_NETWORK_CONCURRENCY,
+            maxTargets: SAFE_NETWORK_MAX_TARGETS,
+            dryRun: true,
+            networkPreview: true,
+            networkAuthorization: true,
+            allowBrowserRuntime: false,
+            allowProxyRuntime: false,
+            allowDbWrite: false,
+        },
+        {
+            fetch: dependencies.fetch,
+            timeoutMs: dependencies.timeoutMs || SAFE_NETWORK_TIMEOUT_MS,
+        }
+    );
+
+    return {
+        candidates: payload.candidates_preview || payload.candidates || [],
+        exact_candidate_set_source: 'safe_controlled_network_preview',
+        source_url_used: payload.source_url_used || null,
+        network_used: payload.external_network_used === true,
+        contains_target_match_id_candidate: payload.contains_target_match_id_candidate === true,
+        contains_angers_strasbourg_candidate:
+            payload.contains_angers_strasbourg_candidate === true ||
+            payload.contains_anglers_strasbourg_candidate === true,
+    };
+}
+
+async function readStdinText(io = {}, dependencies = {}) {
+    if (typeof dependencies.stdinText === 'string') {
+        return dependencies.stdinText;
+    }
+
+    const stdin = io.stdin || process.stdin;
+    if (!stdin || typeof stdin.on !== 'function') {
+        return '';
+    }
+
+    return new Promise(resolve => {
+        let buffer = '';
+        stdin.setEncoding?.('utf8');
+        stdin.on('data', chunk => {
+            buffer += chunk;
+        });
+        stdin.on('end', () => resolve(buffer));
+        stdin.on('error', () => resolve(''));
+        if (stdin.readableEnded === true) {
+            resolve(buffer);
+        }
+    });
+}
+
+async function resolveCandidates(input, stdinText, dependencies = {}) {
+    if (Array.isArray(dependencies.candidates)) {
+        return {
+            candidates: dependencies.candidates,
+            exact_candidate_set_source: 'dependency_candidates',
+            source_url_used: dependencies.sourceUrlUsed || null,
+            network_used: false,
+        };
+    }
+
+    if (typeof dependencies.resolveCandidates === 'function') {
+        return dependencies.resolveCandidates({ input, stdinText });
+    }
+
+    if (input.candidatesJson) {
+        return {
+            candidates: parseJsonText(input.candidatesJson, 'candidates-json'),
+            exact_candidate_set_source: 'candidates_json_argument',
+            source_url_used: null,
+            network_used: false,
+        };
+    }
+
+    const trimmedStdin = String(stdinText || '').trim();
+    if (trimmedStdin) {
+        return {
+            candidates: parseJsonText(trimmedStdin, 'stdin candidates payload'),
+            exact_candidate_set_source: 'stdin_candidates_payload',
+            source_url_used: null,
+            network_used: false,
+        };
+    }
+
+    return resolveCandidatesFromSafePreview(input, dependencies);
+}
+
+function buildSelectExistingMatchesQuery(matchIds) {
+    return {
+        text: `
+            SELECT match_id, external_id, league_name, season, home_team, away_team, match_date, status, data_source
+            FROM matches
+            WHERE match_id = ANY($1::text[])
+            ORDER BY match_date, match_id;
+        `,
+        values: [matchIds],
+    };
+}
+
+async function defaultSelectExistingMatches(matchIds) {
+    if (!Array.isArray(matchIds) || matchIds.length === 0) {
+        return [];
+    }
+
+    const { Pool } = require('pg');
+    const pool = new Pool({
+        host: process.env.DB_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || '5432', 10),
+        database: process.env.DB_NAME || 'football_db',
+        user: process.env.DB_USER || 'football_user',
+        password: process.env.DB_PASSWORD || 'football_pass',
+        application_name: 'l1_matches_seed_execution_preflight',
+        max: 2,
+        idleTimeoutMillis: 5000,
+        connectionTimeoutMillis: 5000,
+    });
+
+    try {
+        const query = buildSelectExistingMatchesQuery(matchIds);
+        const result = await pool.query(query.text, query.values);
+        return result.rows || [];
+    } finally {
+        await pool.end();
+    }
+}
+
+async function resolveExistingMatches(input, candidates, dependencies = {}) {
+    if (Array.isArray(dependencies.existingMatches)) {
+        return dependencies.existingMatches;
+    }
+
+    if (typeof dependencies.selectExistingMatches === 'function') {
+        return dependencies.selectExistingMatches({
+            input,
+            matchIds: normalizeCandidates(candidates).map(candidate => candidate.match_id),
+        });
+    }
+
+    if (input.existingMatchesJson) {
+        return parseJsonText(input.existingMatchesJson, 'existing-matches-json');
+    }
+
+    return defaultSelectExistingMatches(normalizeCandidates(candidates).map(candidate => candidate.match_id));
+}
+
+function countDecisions(affectedPreview, decision) {
+    return affectedPreview.filter(item => item.decision === decision).length;
+}
+
+async function buildMatchesSeedExecutionPreflight(input = {}, dependencies = {}) {
+    const validation = validateExecutionPreflightInput(input);
+    if (!validation.ok) {
+        const error = new Error(validation.errors[0]);
+        error.validationErrors = validation.errors;
+        throw error;
+    }
+
+    const value = validation.value;
+    const stdinText = typeof dependencies.stdinText === 'string' ? dependencies.stdinText : '';
+    const candidateResolution = await resolveCandidates(value, stdinText, dependencies);
+    const candidates = normalizeCandidates(candidateResolution.candidates);
+
+    if (candidates.length !== value.candidateCount) {
+        throw new Error(
+            `exact candidate set count mismatch: expected ${value.candidateCount}, got ${candidates.length}`
+        );
+    }
+    if (candidates.length > value.maxSeedRows) {
+        throw new Error(`exact candidate set exceeds max-seed-rows=${value.maxSeedRows}`);
+    }
+    if (!candidateMatchesTargetId(candidates, value.containsTargetMatchId)) {
+        throw new Error(`target match id candidate not found: ${value.containsTargetMatchId}`);
+    }
+    if (!candidateMatchesTargetLabel(candidates, value.containsTargetLabel)) {
+        throw new Error(`target label candidate not found: ${value.containsTargetLabel}`);
+    }
+
+    const existingMatches = normalizeExistingMatches(await resolveExistingMatches(value, candidates, dependencies));
+    const affectedPreview = buildAffectedPreview(candidates, existingMatches);
+
+    return {
+        phase: PHASE,
+        execution_preflight_only: true,
+        source: value.source,
+        scope: value.scope,
+        league_id: value.leagueId,
+        season: value.season,
+        date: value.date,
+        candidate_count: value.candidateCount,
+        max_seed_rows: value.maxSeedRows,
+        contains_target_match_id: value.containsTargetMatchId,
+        contains_target_label: value.containsTargetLabel,
+        exact_candidate_set_captured: true,
+        exact_candidate_set_source: candidateResolution.exact_candidate_set_source || 'unknown',
+        source_url_used: candidateResolution.source_url_used || null,
+        candidate_match_ids: candidates.map(candidate => candidate.match_id),
+        contains_target_match_id_candidate:
+            candidateResolution.contains_target_match_id_candidate === true ||
+            candidateMatchesTargetId(candidates, value.containsTargetMatchId),
+        contains_angers_strasbourg_candidate:
+            candidateResolution.contains_angers_strasbourg_candidate === true ||
+            candidateMatchesTargetLabel(candidates, value.containsTargetLabel),
+        affected_matches_selected: true,
+        existing_affected_matches_count: existingMatches.length,
+        would_insert_count: countDecisions(affectedPreview, 'would_insert'),
+        would_update_count: countDecisions(affectedPreview, 'would_update'),
+        would_skip_count: countDecisions(affectedPreview, 'would_skip'),
+        affected_preview: affectedPreview,
+        transaction_plan: buildTransactionPlan(value),
+        backup_plan: buildBackupPlan(),
+        rollback_plan: buildRollbackPlan(),
+        post_commit_verification_plan: buildPostCommitVerificationPlan(),
+        final_db_write_confirmation_required: true,
+        commit_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed_this_phase: false,
+        raw_match_data_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        would_write_matches: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_call_fixture_repository_persist: false,
+        would_call_discovery_service_discover: false,
+        would_run_titan_discovery: false,
+        would_train: false,
+        would_predict: false,
+        commit_gate: 'blocked_this_phase',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildErrorPayload(options, errors) {
+    const value = normalizeExecutionPreflightInput(options);
+    return {
+        phase: PHASE,
+        execution_preflight_only: true,
+        ok: false,
+        errors: Array.isArray(errors) ? errors : [String(errors)],
+        source: value.source || null,
+        scope: value.scope || null,
+        league_id: value.leagueId,
+        season: value.season,
+        date: value.date,
+        candidate_count: value.candidateCount,
+        max_seed_rows: value.maxSeedRows,
+        contains_target_match_id: value.containsTargetMatchId,
+        contains_target_label: value.containsTargetLabel,
+        exact_candidate_set_captured: false,
+        affected_matches_selected: false,
+        would_insert_count: 0,
+        would_update_count: 0,
+        would_skip_count: 0,
+        affected_preview: [],
+        transaction_plan: buildTransactionPlan(value),
+        backup_plan: buildBackupPlan(),
+        rollback_plan: buildRollbackPlan(),
+        post_commit_verification_plan: buildPostCommitVerificationPlan(),
+        final_db_write_confirmation_required: true,
+        commit_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed_this_phase: false,
+        raw_match_data_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        would_write_matches: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_call_fixture_repository_persist: false,
+        would_call_discovery_service_discover: false,
+        would_run_titan_discovery: false,
+        would_train: false,
+        would_predict: false,
+        commit_gate: 'blocked_this_phase',
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function showHelp(io = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    stdout(
+        [
+            'Usage:',
+            '  node scripts/ops/l1_matches_seed_commit_execution_preflight.js --source=fotmob --scope=league_season_date --league-id=53 --season=2025/2026 --date=2026-05-10 --candidate-count=8 --contains-target-match-id=4830746 --contains-target-label="Angers vs Strasbourg" --max-seed-rows=10 --final-db-write-confirmation=no --allow-db-write-now=no --allow-matches-write-now=no --allow-raw-match-data-write=no --allow-training=no --allow-prediction=no',
+            '',
+            'Optional:',
+            "  --candidates-json='[...]'",
+            "  --existing-matches-json='[...]'",
+            '  stdin JSON array/object for candidates',
+            '',
+            'Phase 5.08L1: execution preflight only, SELECT-only, no DB writes, no matches/raw writes.',
+        ].join('\n')
+    );
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+    const options = parseArgs(argv);
+    const dependenciesProvideCandidates =
+        Array.isArray(dependencies.candidates) || typeof dependencies.resolveCandidates === 'function';
+    const shouldReadStdin =
+        Object.prototype.hasOwnProperty.call(dependencies, 'stdinText') ||
+        typeof io.stdin?.on === 'function' ||
+        (!options.candidatesJson && !dependenciesProvideCandidates);
+
+    if (options.help) {
+        showHelp({ stdout });
+        return 0;
+    }
+
+    try {
+        const stdinText = shouldReadStdin ? await readStdinText(io, dependencies) : '';
+        const payload = await buildMatchesSeedExecutionPreflight(
+            options,
+            Object.prototype.hasOwnProperty.call(dependencies, 'stdinText')
+                ? dependencies
+                : { ...dependencies, stdinText }
+        );
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 0;
+    } catch (error) {
+        const payload = buildErrorPayload(options, error.validationErrors || [error.message]);
+        stderr(`${payload.errors[0]}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    runCli().then(code => {
+        process.exitCode = code;
+    });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validateExecutionPreflightInput,
+    normalizeCandidates,
+    normalizeExistingMatches,
+    buildAffectedPreview,
+    buildTransactionPlan,
+    buildBackupPlan,
+    buildRollbackPlan,
+    buildPostCommitVerificationPlan,
+    buildMatchesSeedExecutionPreflight,
+    runCli,
+};

--- a/tests/unit/l1_matches_seed_commit_execution_preflight.test.js
+++ b/tests/unit/l1_matches_seed_commit_execution_preflight.test.js
@@ -1,0 +1,419 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l1_matches_seed_commit_execution_preflight.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function installNoSideEffectGuards(t) {
+    const originalFetch = global.fetch;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalNetConnect = net.connect;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l1_matches_seed_commit_execution_preflight`);
+    };
+
+    global.fetch = fail('global.fetch');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    net.connect = fail('net.connect');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (['redis', 'ioredis', 'playwright', 'playwright-core'].includes(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/FixtureRepository|titan_discovery/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (request === 'pg') {
+            return {
+                Pool: class FakePool {
+                    async query(text) {
+                        if (!/^\s*SELECT\b/i.test(String(text || ''))) {
+                            throw new Error('pg write query is blocked in unit tests');
+                        }
+                        return { rows: [] };
+                    }
+                    async end() {}
+                },
+            };
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        net.connect = originalNetConnect;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+async function runCli(gate, argv, dependencies = {}) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function parseJsonOutput(stdout) {
+    const payload = String(stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload');
+    return JSON.parse(payload);
+}
+
+function validArgv(overrides = []) {
+    return [
+        '--source=fotmob',
+        '--scope=league_season_date',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--candidate-count=2',
+        '--contains-target-match-id=4830746',
+        '--contains-target-label=Angers vs Strasbourg',
+        '--max-seed-rows=10',
+        '--final-db-write-confirmation=no',
+        '--allow-db-write-now=no',
+        '--allow-matches-write-now=no',
+        '--allow-raw-match-data-write=no',
+        '--allow-training=no',
+        '--allow-prediction=no',
+        ...overrides,
+    ];
+}
+
+function validCandidates() {
+    return [
+        {
+            match_id: '53_20252026_4830746',
+            external_id: '4830746',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Angers',
+            away_team: 'Strasbourg',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'scheduled',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830747',
+            external_id: '4830747',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Brest',
+            away_team: 'Nice',
+            match_date: '2026-05-10T21:00:00.000Z',
+            status: 'scheduled',
+            data_source: 'FotMob',
+        },
+    ];
+}
+
+test('valid execution preflight input succeeds', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, validArgv(), {
+        candidates: validCandidates(),
+        existingMatches: [],
+    });
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.phase, 'PHASE5_08L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PREFLIGHT');
+    assert.equal(payload.execution_preflight_only, true);
+    assert.equal(payload.final_db_write_confirmation_required, true);
+    assert.equal(payload.commit_allowed_this_phase, false);
+    assert.equal(payload.db_write_allowed_this_phase, false);
+    assert.equal(payload.matches_write_allowed_this_phase, false);
+    assert.equal(payload.raw_match_data_write_allowed, false);
+    assert.equal(payload.would_write_matches, false);
+    assert.equal(payload.would_write_raw_match_data, false);
+    assert.equal(payload.would_write_db, false);
+    assert.equal(payload.would_call_fixture_repository_persist, false);
+    assert.equal(payload.would_call_discovery_service_discover, false);
+    assert.equal(payload.would_run_titan_discovery, false);
+    assert.equal(payload.exact_candidate_set_captured, true);
+    assert.equal(payload.affected_matches_selected, true);
+    assert.equal(payload.would_insert_count, 2);
+    assert.equal(payload.would_update_count, 0);
+    assert.equal(payload.would_skip_count, 0);
+    assert.equal(payload.affected_preview.length, 2);
+    assert.equal(payload.affected_preview[0].decision, 'would_insert');
+    assert.match(JSON.stringify(payload.transaction_plan), /BEGIN/);
+    assert.match(JSON.stringify(payload.transaction_plan), /COMMIT only after final confirmation in next phase/);
+    assert.match(JSON.stringify(payload.transaction_plan), /ROLLBACK on error/);
+    assert.equal(payload.backup_plan.pg_dump_allowed_this_phase, false);
+    assert.equal(payload.backup_plan.backup_file_write_allowed_this_phase, false);
+    assert.equal(payload.rollback_plan.delete_allowed_this_phase, false);
+    assert.equal(payload.rollback_plan.rollback_file_write_allowed_this_phase, false);
+    assert.equal(payload.post_commit_verification_plan.raw_match_data_unchanged, true);
+    assert.equal(payload.post_commit_verification_plan.l3_features_unchanged, true);
+    assert.equal(payload.post_commit_verification_plan.match_features_training_unchanged, true);
+    assert.equal(payload.post_commit_verification_plan.predictions_unchanged, true);
+});
+
+test('validation failures and blocked flags are rejected', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const cases = [
+        { argv: validArgv().filter(arg => !arg.startsWith('--source=')), pattern: /missing source/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--source=')), '--source=other'],
+            pattern: /unsupported source/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--scope=')), pattern: /missing scope/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--scope=')), '--scope=bulk'],
+            pattern: /unsupported scope/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--league-id=')), pattern: /missing league-id/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--season=')), pattern: /missing season/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--date=')), pattern: /missing date/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--candidate-count=')), '--candidate-count=11'],
+            pattern: /candidate-count must be <= max-seed-rows/i,
+        },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--max-seed-rows=')), '--max-seed-rows=11'],
+            pattern: /max-seed-rows > 10/i,
+        },
+        {
+            argv: validArgv().filter(arg => !arg.startsWith('--contains-target-match-id=')),
+            pattern: /missing contains-target-match-id/i,
+        },
+        {
+            argv: validArgv().filter(arg => !arg.startsWith('--contains-target-label=')),
+            pattern: /missing contains-target-label/i,
+        },
+        { argv: [...validArgv(), '--final-db-write-confirmation=yes'], pattern: /final-db-write-confirmation=yes/i },
+        { argv: [...validArgv(), '--allow-db-write-now=yes'], pattern: /allow-db-write-now=yes/i },
+        {
+            argv: [...validArgv(), '--allow-matches-write-now=yes'],
+            pattern: /allow-matches-write-now=yes/i,
+        },
+        {
+            argv: [...validArgv(), '--allow-raw-match-data-write=yes'],
+            pattern: /allow-raw-match-data-write=yes/i,
+        },
+        { argv: [...validArgv(), '--allow-training=yes'], pattern: /allow-training=yes/i },
+        { argv: [...validArgv(), '--allow-prediction=yes'], pattern: /allow-prediction=yes/i },
+        { argv: [...validArgv(), '--commit=yes'], pattern: /preflight-only/i },
+        { argv: [...validArgv(), '--execute=yes'], pattern: /execute=yes/i },
+    ];
+
+    for (const { argv, pattern } of cases) {
+        const result = await runCli(gate, argv, {
+            candidates: validCandidates(),
+            existingMatches: [],
+        });
+        const payload = parseJsonOutput(result.stdout);
+        assert.equal(result.status, 1);
+        assert.match(payload.errors.join('\n'), pattern);
+        assert.equal(payload.execution_preflight_only, true);
+        assert.equal(payload.would_write_matches, false);
+        assert.equal(payload.would_write_raw_match_data, false);
+        assert.equal(payload.would_write_db, false);
+        assert.equal(payload.would_call_fixture_repository_persist, false);
+        assert.equal(payload.would_call_discovery_service_discover, false);
+        assert.equal(payload.would_run_titan_discovery, false);
+    }
+});
+
+test('candidate normalization, existing matches normalization and affected preview decisions work', () => {
+    const gate = loadModuleFresh();
+    const candidates = gate.normalizeCandidates([
+        {
+            match_id: '53_20252026_4830746',
+            external_id: '4830746',
+            league: 'Ligue 1',
+            season: '2025/2026',
+            home: 'Angers',
+            away: 'Strasbourg',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'Scheduled',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830747',
+            external_id: '4830747',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Brest',
+            away_team: 'Nice',
+            match_date: '2026-05-10T21:00:00.000Z',
+            status: 'scheduled',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830748',
+            external_id: '4830748',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Lille',
+            away_team: 'Monaco',
+            match_date: '2026-05-10T22:00:00.000Z',
+            status: 'scheduled',
+            data_source: 'FotMob',
+        },
+    ]);
+    const existingMatches = gate.normalizeExistingMatches([
+        {
+            match_id: '53_20252026_4830747',
+            external_id: '4830747',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Brest',
+            away_team: 'Nice',
+            match_date: '2026-05-10T21:00:00.000Z',
+            status: 'scheduled',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830748',
+            external_id: '4830748',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Lille',
+            away_team: 'Monaco',
+            match_date: '2026-05-10T22:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+    ]);
+    const preview = gate.buildAffectedPreview(candidates, existingMatches);
+
+    assert.equal(candidates[0].status, 'scheduled');
+    assert.equal(existingMatches[0].match_id, '53_20252026_4830747');
+    assert.equal(preview[0].decision, 'would_insert');
+    assert.equal(preview[0].existing_row_found, false);
+    assert.equal(preview[1].decision, 'would_skip');
+    assert.equal(preview[1].existing_row_found, true);
+    assert.equal(preview[2].decision, 'would_update');
+    assert.match(preview[2].reason, /status/);
+});
+
+test('counts and policy builders expose expected values', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const result = await gate.buildMatchesSeedExecutionPreflight(
+        {
+            source: 'fotmob',
+            scope: 'league_season_date',
+            leagueId: '53',
+            season: '2025/2026',
+            date: '2026-05-10',
+            candidateCount: '2',
+            containsTargetMatchId: '4830746',
+            containsTargetLabel: 'Angers vs Strasbourg',
+            maxSeedRows: '10',
+            finalDbWriteConfirmation: 'no',
+            allowDbWriteNow: 'no',
+            allowMatchesWriteNow: 'no',
+            allowRawMatchDataWrite: 'no',
+            allowTraining: 'no',
+            allowPrediction: 'no',
+        },
+        {
+            candidates: validCandidates(),
+            existingMatches: [
+                {
+                    match_id: '53_20252026_4830747',
+                    external_id: '4830747',
+                    league_name: 'Ligue 1',
+                    season: '2025/2026',
+                    home_team: 'Brest',
+                    away_team: 'Nice',
+                    match_date: '2026-05-10T21:00:00.000Z',
+                    status: 'finished',
+                    data_source: 'FotMob',
+                },
+            ],
+        }
+    );
+
+    assert.equal(result.would_insert_count, 1);
+    assert.equal(result.would_update_count, 1);
+    assert.equal(result.would_skip_count, 0);
+    assert.equal(result.execution_preflight_only, true);
+    assert.equal(result.final_db_write_confirmation_required, true);
+    assert.equal(result.commit_allowed_this_phase, false);
+    assert.equal(result.db_write_allowed_this_phase, false);
+    assert.equal(result.matches_write_allowed_this_phase, false);
+    assert.equal(result.raw_match_data_write_allowed, false);
+    assert.equal(result.would_write_matches, false);
+    assert.equal(result.would_write_raw_match_data, false);
+    assert.equal(result.would_write_db, false);
+    assert.equal(result.would_call_fixture_repository_persist, false);
+    assert.equal(result.would_call_discovery_service_discover, false);
+    assert.equal(result.would_run_titan_discovery, false);
+    assert.match(JSON.stringify(gate.buildTransactionPlan({ maxSeedRows: 10 })), /BEGIN/);
+    assert.match(
+        JSON.stringify(gate.buildTransactionPlan({ maxSeedRows: 10 })),
+        /COMMIT only after final confirmation in next phase/
+    );
+    assert.match(JSON.stringify(gate.buildBackupPlan()), /pg_dump_allowed_this_phase/);
+    assert.match(JSON.stringify(gate.buildRollbackPlan()), /delete_allowed_this_phase/);
+    assert.match(JSON.stringify(gate.buildPostCommitVerificationPlan()), /raw_match_data_unchanged/);
+});
+
+test('Makefile preflight target is registered and commit target remains blocked', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l1-matches-seed-commit-execution-preflight:/m);
+    assert.match(makefile, /scripts\/ops\/l1_matches_seed_commit_execution_preflight\.js/);
+    assert.match(makefile, /^data-l1-matches-seed-commit:/m);
+    assert.match(makefile, /authorization-only in Phase 5\.07L1|execution preflight/i);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.08L1 controlled matches seed commit execution preflight.

Scope:
- Adds execution preflight script for future matches seed commit
- Computes would_insert / would_update / would_skip
- Defines transaction, backup, rollback, and post-commit verification plans
- Keeps final DB write confirmation required
- Keeps DB writes blocked this phase
- Keeps matches/raw_match_data writes blocked
- Adds Makefile preflight target
- Adds no-side-effect unit tests
- Updates AGENTS.md
- Adds Phase 5.08L1 report

Safety:
- No titan_discovery execution
- No DiscoveryService.discover execution
- No FixtureRepository.persist
- No DB writes
- No matches writes
- No raw_match_data writes
- No harvest / ingest
- No training / prediction

Validation:
- execution preflight tests passed
- Makefile preflight passed
- commit gate blocked
- npm test passed
- npm run test:coverage passed
- integration tests skipped locally if browser automation would be required
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed