### PR TITLE
feat(data): add L1 matches seed commit execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@
 - 如果命令已经封装为 `npm script`，优先使用脚本入口。
 - 如果 `npm script` 指向缺失文件，先修正文档或脚本，再继续依赖该入口。
 - 不直接运行 `scripts/ops/titan_discovery.js`。L1 discovery 默认只能通过 `make data-l1-discovery-preview` / `make data-l1-discovery-candidates-preview` 的 safe preview 路径进入；显式授权的 L1 外网候选预览只能通过 `make data-l1-discovery-candidates-network-preview`。
-- L1 matches seed commit 不能由 AI / Codex 直接执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning；Phase 5.07L1 仅允许 `make data-l1-matches-seed-commit-authorization` 输出 stdout authorization summary；Phase 5.08L1 仅允许 `make data-l1-matches-seed-commit-execution-preflight` 输出 stdout preflight summary 和 SELECT-only affected rows preview。
+- L1 matches seed commit 不能由 AI / Codex 直接走旧 commit 大入口执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning；Phase 5.07L1 仅允许 `make data-l1-matches-seed-commit-authorization` 输出 stdout authorization summary；Phase 5.08L1 仅允许 `make data-l1-matches-seed-commit-execution-preflight` 输出 stdout preflight summary 和 SELECT-only affected rows preview；Phase 5.09L1 仅允许 `make data-l1-matches-seed-commit-execute` 在最终确认后、按 exact scope 事务写入 `matches`。
 
 ### 2.3 禁止行为
 
@@ -221,6 +221,7 @@ AI / Codex 默认只能执行：
 - 仅做 matches seed commit planning、不触网、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no`
 - 用户明确授权、只记录 stdout authorization summary、不触网、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-authorization SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 USER_AUTHORIZED_MATCHES_SEED_COMMIT=yes ALLOW_MATCHES_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes`
 - 用户明确授权、仅做 execution preflight、允许 safe exact candidates + SELECT-only affected matches、不写 DB、不写 matches/raw_match_data 的 `make data-l1-matches-seed-commit-execution-preflight SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 FINAL_DB_WRITE_CONFIRMATION=no ALLOW_DB_WRITE_NOW=no ALLOW_MATCHES_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no`
+- 用户明确授权、Phase 5.09L1 exact scope 下唯一允许的 matches 写入入口：`make data-l1-matches-seed-commit-execute SOURCE=fotmob SCOPE=league_season_date LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CANDIDATE_COUNT=8 CONTAINS_TARGET_MATCH_ID=4830746 CONTAINS_TARGET_LABEL="Angers vs Strasbourg" MAX_SEED_ROWS=10 FINAL_DB_WRITE_CONFIRMATION=yes ALLOW_DB_WRITE_NOW=yes ALLOW_MATCHES_WRITE_NOW=yes ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no`；仅允许事务写 `matches`，不得写 `raw_match_data`
 - 用户明确授权的 `make data-local-dry-run`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
 - 用户明确授权且仅使用本地 fixture 的 `make data-l3-write-dry-run SAMPLE_RAW=<local fixture> MATCH_ID=<id>`
@@ -411,6 +412,17 @@ Phase 5.08L1 补充约定：
 - preflight 结束后仍必须要求最终 DB-write confirmation。
 - raw_match_data ingest 必须与 matches seed commit 分离，不得合并执行。
 - matches seed 各阶段不得训练、不得预测、不得加载或生成模型 artifact。
+
+Phase 5.09L1 补充约定：
+
+- controlled matches seed commit execution 只能走 `make data-l1-matches-seed-commit-execute`。
+- 该入口只允许 exact `source=fotmob`、`league_id=53`、`season=2025/2026`、`date=2026-05-10`、`candidate_count=8`、`contains_target_match_id=4830746`、`contains_target_label=Angers vs Strasbourg`。
+- 必须要求 `FINAL_DB_WRITE_CONFIRMATION=yes`、`ALLOW_DB_WRITE_NOW=yes`、`ALLOW_MATCHES_WRITE_NOW=yes`。
+- 只允许事务写 `matches`；不得写 `raw_match_data`、bookmaker odds、features、training、predictions。
+- 不得调用 `FixtureRepository.persist()`。
+- 不得运行 `titan_discovery.js`，不得调用 `DiscoveryService.discover()`。
+- 不得训练，不得预测。
+- L2 raw JSON acquisition 仍属于后续独立阶段。
 
 执行 `make data-l3-dry-run` 的前提：
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
         data-dataset-status data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
-        data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit \
+        data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -316,6 +316,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l1-matches-seed-commit-plan SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 COMMIT=no  # Phase 5.06L1 planning-only, no network/DB/matches/raw writes"
 	@echo "  make data-l1-matches-seed-commit-authorization SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 USER_AUTHORIZED_MATCHES_SEED_COMMIT=yes ALLOW_MATCHES_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes  # Phase 5.07L1 authorization-only, stdout-only, no DB/matches/raw writes"
 	@echo "  make data-l1-matches-seed-commit-execution-preflight SOURCE=fotmob SCOPE=<league_season_date|controlled_candidates_preview> LEAGUE_ID=<id> SEASON=<season> DATE=<yyyy-mm-dd> CANDIDATE_COUNT=<n> MAX_SEED_ROWS<=10 FINAL_DB_WRITE_CONFIRMATION=no ALLOW_DB_WRITE_NOW=no ALLOW_MATCHES_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.08L1 execution preflight only, safe exact candidates + SELECT-only affected matches, no DB writes"
+	@echo "  make data-l1-matches-seed-commit-execute SOURCE=fotmob SCOPE=league_season_date LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CANDIDATE_COUNT=8 CONTAINS_TARGET_MATCH_ID=4830746 CONTAINS_TARGET_LABEL=\"Angers vs Strasbourg\" MAX_SEED_ROWS=10 FINAL_DB_WRITE_CONFIRMATION=yes ALLOW_DB_WRITE_NOW=yes ALLOW_MATCHES_WRITE_NOW=yes ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.09L1 exact controlled execution only, matches-only transaction"
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -563,10 +564,37 @@ data-l1-matches-seed-commit-execution-preflight: ## L1 matches seed commit execu
 		$(if $(CANDIDATES_JSON),--candidates-json='$(CANDIDATES_JSON)') \
 		$(if $(EXISTING_MATCHES_JSON),--existing-matches-json='$(EXISTING_MATCHES_JSON)')
 
+data-l1-matches-seed-commit-execute: ## L1 matches seed commit execution. Phase 5.09L1. Exact 2026-05-10 FotMob Ligue 1 candidates only, matches-only transaction.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(SCOPE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(SEASON)" ] || [ -z "$(DATE)" ] || [ -z "$(CANDIDATE_COUNT)" ] || [ -z "$(CONTAINS_TARGET_MATCH_ID)" ] || [ -z "$(CONTAINS_TARGET_LABEL)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob SCOPE=league_season_date LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 CANDIDATE_COUNT=8 CONTAINS_TARGET_MATCH_ID=4830746 CONTAINS_TARGET_LABEL=<label>"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l1_matches_seed_commit_execute.js \
+		--source="$(SOURCE)" \
+		--scope="$(SCOPE)" \
+		--league-id="$(LEAGUE_ID)" \
+		--season="$(SEASON)" \
+		--date="$(DATE)" \
+		--candidate-count="$(CANDIDATE_COUNT)" \
+		--contains-target-match-id="$(CONTAINS_TARGET_MATCH_ID)" \
+		--contains-target-label="$(CONTAINS_TARGET_LABEL)" \
+		--max-seed-rows="$(or $(MAX_SEED_ROWS),10)" \
+		--final-db-write-confirmation="$(or $(FINAL_DB_WRITE_CONFIRMATION),no)" \
+		--allow-db-write-now="$(or $(ALLOW_DB_WRITE_NOW),no)" \
+		--allow-matches-write-now="$(or $(ALLOW_MATCHES_WRITE_NOW),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--bulk="$(or $(BULK),no)" \
+		$(if $(CANDIDATES_JSON),--candidates-json='$(CANDIDATES_JSON)') \
+		$(if $(EXISTING_MATCHES_JSON),--existing-matches-json='$(EXISTING_MATCHES_JSON)')
+
 data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blocked in Phase 5.08L1.
 	@echo "BLOCKED: L1 matches seed commit is not executable in Phase 5.06L1 planning."
-	@echo "  L1 matches seed commit remains authorization-only in Phase 5.07L1 and execution-preflight-only in Phase 5.08L1."
-	@echo "  Use data-l1-matches-seed-commit-plan, data-l1-matches-seed-commit-authorization, and data-l1-matches-seed-commit-execution-preflight for stdout-only planning/preflight."
+	@echo "  L1 matches seed commit remains authorization-only in Phase 5.07L1, execution-preflight-only in Phase 5.08L1, and exact execute-only via data-l1-matches-seed-commit-execute in Phase 5.09L1."
+	@echo "  Use data-l1-matches-seed-commit-plan, data-l1-matches-seed-commit-authorization, data-l1-matches-seed-commit-execution-preflight, and the exact-scope data-l1-matches-seed-commit-execute gate."
 	@echo "  Even with CONFIRM_L1_MATCHES_SEED_COMMIT=1, matches/DB/raw writes remain blocked."
 	@exit 1
 

--- a/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PHASE5_09L1.md
+++ b/docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PHASE5_09L1.md
@@ -1,0 +1,93 @@
+# L1 Controlled Matches Seed Commit Execution - Phase 5.09L1
+
+## 1. Executive summary
+
+Phase 5.09L1 是 controlled matches seed commit execution 阶段。
+
+本阶段在用户最终确认后允许写 `matches`，但范围只限 exact 8 个 `2026-05-10` FotMob Ligue 1 candidates。
+
+本阶段只写 `matches`，不写 `raw_match_data`，不训练，不预测。
+
+## 2. Background
+
+Phase 5.05L1 发现了 8 个 controlled candidates。
+
+Phase 5.08L1 execution preflight 显示：
+
+- `would_insert=8`
+- `would_update=0`
+- `would_skip=0`
+
+`raw_match_data.match_id` 依赖 `matches(match_id)` 外键，所以后续 raw JSON 入库前需要先完成 matches seed。
+
+## 3. Implemented files
+
+- `scripts/ops/l1_matches_seed_commit_execute.js`
+- `tests/unit/l1_matches_seed_commit_execute.test.js`
+- `Makefile`
+- `AGENTS.md`
+- `docs/_reports/L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION_PHASE5_09L1.md`
+
+## 4. Execution boundary
+
+- exact scope only
+- rows `<= 10`
+- only `matches` table
+- no `raw_match_data`
+- no features / predictions
+- no `titan_discovery`
+- no `FixtureRepository.persist`
+
+## 5. Validation before actual DB write
+
+本阶段在真实 DB write 前需要完成：
+
+- unit tests
+- `npm test`
+- `npm run test:coverage`
+- `git diff --check`
+- `eslint / prettier`
+- DB baseline read-only check
+- exact candidate recapture
+- affected `SELECT`
+
+## 6. Actual DB write result
+
+本节用于记录合并后、main CI 绿灯后的受控执行结果：
+
+- matches row count before / after
+- inserted_count
+- updated_count
+- skipped_count
+- affected match_ids
+- contains `4830746`
+- raw_match_data unchanged
+- features unchanged
+- predictions unchanged
+- transaction committed
+
+## 7. Recommended next phase
+
+推荐进入 Phase 5.10L2：controlled raw JSON acquisition planning。
+
+要求：
+
+- 使用 newly seeded matches
+- 只抓 match detail raw JSON
+- 规划 `raw_match_data` ingest
+- 不训练
+- 不预测
+
+## 8. Explicit non-execution
+
+本阶段明确不执行：
+
+- `titan_discovery` execution
+- `DiscoveryService.discover` execution
+- `FixtureRepository.persist`
+- `raw_match_data` writes
+- feature writes
+- prediction writes
+- harvest / ingest beyond controlled matches write
+- training / prediction
+- file deletion

--- a/scripts/ops/l1_matches_seed_commit_execute.js
+++ b/scripts/ops/l1_matches_seed_commit_execute.js
@@ -1,0 +1,1162 @@
+#!/usr/bin/env node
+/* eslint-disable complexity, max-lines */
+'use strict';
+
+const PHASE = 'PHASE5_09L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION';
+const SAFE_SOURCE = 'fotmob';
+const SAFE_SCOPES = new Set(['league_season_date', 'controlled_candidates_preview']);
+const EXACT_LEAGUE_ID = '53';
+const EXACT_SEASON = '2025/2026';
+const EXACT_DATE = '2026-05-10';
+const EXACT_CANDIDATE_COUNT = 8;
+const EXACT_TARGET_MATCH_ID = '4830746';
+const MAX_SEED_ROWS_LIMIT = 10;
+const DEFAULT_MAX_SEED_ROWS = 10;
+const PREVIEW_SCOPE = 'controlled_candidates_preview';
+const SAFE_NETWORK_CONCURRENCY = 1;
+const SAFE_NETWORK_MAX_TARGETS = 10;
+const SAFE_NETWORK_TIMEOUT_MS = 15000;
+const NEXT_REQUIRED_PHASE = 'Phase 5.10L2 controlled raw JSON acquisition planning';
+const ALLOWED_INSERT_COLUMNS = [
+    'match_id',
+    'external_id',
+    'league_name',
+    'season',
+    'home_team',
+    'away_team',
+    'match_date',
+    'status',
+    'is_finished',
+    'data_source',
+];
+const COUNT_TABLES = [
+    'matches',
+    'bookmaker_odds_history',
+    'raw_match_data',
+    'l3_features',
+    'match_features_training',
+    'predictions',
+];
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isInteger(parsed) ? parsed : Number.NaN;
+}
+
+function normalizeOptionalText(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    return String(value).trim();
+}
+
+function normalizeTargetLabel(value) {
+    return String(value || '')
+        .trim()
+        .toLowerCase();
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        scope: null,
+        leagueId: null,
+        season: null,
+        date: null,
+        candidateCount: null,
+        containsTargetMatchId: null,
+        containsTargetLabel: null,
+        maxSeedRows: null,
+        finalDbWriteConfirmation: false,
+        allowDbWriteNow: false,
+        allowMatchesWriteNow: false,
+        allowRawMatchDataWrite: false,
+        allowTraining: false,
+        allowPrediction: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        bulk: false,
+        candidatesJson: null,
+        existingMatchesJson: null,
+        help: false,
+    };
+
+    const keyMap = {
+        source: 'source',
+        scope: 'scope',
+        'league-id': 'leagueId',
+        league_id: 'leagueId',
+        season: 'season',
+        date: 'date',
+        'candidate-count': 'candidateCount',
+        candidate_count: 'candidateCount',
+        'contains-target-match-id': 'containsTargetMatchId',
+        contains_target_match_id: 'containsTargetMatchId',
+        'contains-target-label': 'containsTargetLabel',
+        contains_target_label: 'containsTargetLabel',
+        'max-seed-rows': 'maxSeedRows',
+        max_seed_rows: 'maxSeedRows',
+        'final-db-write-confirmation': 'finalDbWriteConfirmation',
+        final_db_write_confirmation: 'finalDbWriteConfirmation',
+        'allow-db-write-now': 'allowDbWriteNow',
+        allow_db_write_now: 'allowDbWriteNow',
+        'allow-matches-write-now': 'allowMatchesWriteNow',
+        allow_matches_write_now: 'allowMatchesWriteNow',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        prediction: 'allowPrediction',
+        'allow-browser-runtime': 'allowBrowserRuntime',
+        allow_browser_runtime: 'allowBrowserRuntime',
+        'allow-proxy-runtime': 'allowProxyRuntime',
+        allow_proxy_runtime: 'allowProxyRuntime',
+        bulk: 'bulk',
+        'candidates-json': 'candidatesJson',
+        candidates_json: 'candidatesJson',
+        'existing-matches-json': 'existingMatchesJson',
+        existing_matches_json: 'existingMatchesJson',
+        help: 'help',
+        h: 'help',
+    };
+
+    const booleanOptions = new Set([
+        'finalDbWriteConfirmation',
+        'allowDbWriteNow',
+        'allowMatchesWriteNow',
+        'allowRawMatchDataWrite',
+        'allowTraining',
+        'allowPrediction',
+        'allowBrowserRuntime',
+        'allowProxyRuntime',
+        'bulk',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (!arg.startsWith('--')) {
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        if (!optionKey) {
+            continue;
+        }
+
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (booleanOptions.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function normalizeExecutionInput(input = {}) {
+    return {
+        source: typeof input.source === 'string' ? input.source.trim().toLowerCase() : '',
+        scope: typeof input.scope === 'string' ? input.scope.trim() : '',
+        leagueId: normalizeOptionalText(input.leagueId),
+        season: typeof input.season === 'string' ? input.season.trim() : null,
+        date: typeof input.date === 'string' ? input.date.trim() : null,
+        candidateCount: parseInteger(input.candidateCount, null),
+        containsTargetMatchId: normalizeOptionalText(input.containsTargetMatchId),
+        containsTargetLabel: normalizeOptionalText(input.containsTargetLabel),
+        maxSeedRows: parseInteger(input.maxSeedRows, DEFAULT_MAX_SEED_ROWS),
+        finalDbWriteConfirmation: normalizeBooleanFlag(input.finalDbWriteConfirmation, false),
+        allowDbWriteNow: normalizeBooleanFlag(input.allowDbWriteNow, false),
+        allowMatchesWriteNow: normalizeBooleanFlag(input.allowMatchesWriteNow, false),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, false),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, false),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, false),
+        allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, false),
+        allowProxyRuntime: normalizeBooleanFlag(input.allowProxyRuntime, false),
+        bulk: normalizeBooleanFlag(input.bulk, false),
+        candidatesJson: typeof input.candidatesJson === 'string' ? input.candidatesJson : null,
+        existingMatchesJson: typeof input.existingMatchesJson === 'string' ? input.existingMatchesJson : null,
+    };
+}
+
+function validateExecutionInput(input = {}) {
+    const value = normalizeExecutionInput(input);
+    const errors = [];
+
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== SAFE_SOURCE) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+
+    if (!value.scope) {
+        errors.push('missing scope: provide --scope=league_season_date or --scope=controlled_candidates_preview');
+    } else if (!SAFE_SCOPES.has(value.scope)) {
+        errors.push(`unsupported scope: ${value.scope}`);
+    }
+
+    if (!value.leagueId) {
+        errors.push('missing league-id');
+    } else if (value.leagueId !== EXACT_LEAGUE_ID) {
+        errors.push(`league-id must be ${EXACT_LEAGUE_ID} in Phase 5.09L1`);
+    }
+
+    if (!value.season) {
+        errors.push('missing season');
+    } else if (value.season !== EXACT_SEASON) {
+        errors.push(`season must be ${EXACT_SEASON} in Phase 5.09L1`);
+    }
+
+    if (!value.date) {
+        errors.push('missing date');
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(value.date)) {
+        errors.push('invalid date: provide YYYY-MM-DD');
+    } else if (value.date !== EXACT_DATE) {
+        errors.push(`date must be ${EXACT_DATE} in Phase 5.09L1`);
+    }
+
+    if (!Number.isInteger(value.candidateCount)) {
+        errors.push('invalid candidate-count: provide an integer');
+    } else if (value.candidateCount !== EXACT_CANDIDATE_COUNT) {
+        errors.push(`candidate-count must be exactly ${EXACT_CANDIDATE_COUNT}`);
+    }
+
+    if (!Number.isInteger(value.maxSeedRows) || value.maxSeedRows < 1) {
+        errors.push('invalid max-seed-rows: provide a positive integer');
+    } else if (value.maxSeedRows > MAX_SEED_ROWS_LIMIT) {
+        errors.push(`max-seed-rows > ${MAX_SEED_ROWS_LIMIT} is blocked in Phase 5.09L1`);
+    }
+
+    if (
+        Number.isInteger(value.candidateCount) &&
+        Number.isInteger(value.maxSeedRows) &&
+        value.candidateCount > value.maxSeedRows
+    ) {
+        errors.push('candidate-count must be <= max-seed-rows');
+    }
+
+    if (!value.containsTargetMatchId) {
+        errors.push('missing contains-target-match-id');
+    } else if (value.containsTargetMatchId !== EXACT_TARGET_MATCH_ID) {
+        errors.push(`contains-target-match-id must be ${EXACT_TARGET_MATCH_ID}`);
+    }
+
+    const normalizedLabel = normalizeTargetLabel(value.containsTargetLabel);
+    if (!value.containsTargetLabel) {
+        errors.push('missing contains-target-label');
+    } else {
+        if (!normalizedLabel.includes('angers')) {
+            errors.push('contains-target-label must contain Angers');
+        }
+        if (!normalizedLabel.includes('strasbourg')) {
+            errors.push('contains-target-label must contain Strasbourg');
+        }
+    }
+
+    if (value.finalDbWriteConfirmation !== true) {
+        errors.push('final-db-write-confirmation must be yes');
+    }
+    if (value.allowDbWriteNow !== true) {
+        errors.push('allow-db-write-now must be yes');
+    }
+    if (value.allowMatchesWriteNow !== true) {
+        errors.push('allow-matches-write-now must be yes');
+    }
+    if (value.allowRawMatchDataWrite !== false) {
+        errors.push('allow-raw-match-data-write=yes is blocked in Phase 5.09L1');
+    }
+    if (value.allowTraining !== false) {
+        errors.push('allow-training=yes is blocked in Phase 5.09L1');
+    }
+    if (value.allowPrediction !== false) {
+        errors.push('allow-prediction=yes is blocked in Phase 5.09L1');
+    }
+    if (value.allowBrowserRuntime !== false) {
+        errors.push('allow-browser-runtime=yes is blocked in Phase 5.09L1');
+    }
+    if (value.allowProxyRuntime !== false) {
+        errors.push('allow-proxy-runtime=yes is blocked in Phase 5.09L1');
+    }
+    if (value.bulk !== false) {
+        errors.push('bulk=yes is blocked in Phase 5.09L1');
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function parseJsonText(text, label) {
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        throw new Error(`${label} is not valid JSON: ${error.message}`);
+    }
+}
+
+function normalizeDateText(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.toISOString();
+    }
+
+    const text = String(value).trim();
+    if (!text) {
+        return null;
+    }
+    const parsed = new Date(text);
+    return Number.isNaN(parsed.getTime()) ? text : parsed.toISOString();
+}
+
+function normalizeStatus(value) {
+    const text = String(value || '')
+        .trim()
+        .toLowerCase();
+    return text || 'scheduled';
+}
+
+function normalizeDataSource(value) {
+    const text = String(value || '').trim();
+    return text || 'FotMob';
+}
+
+function normalizeCandidates(input) {
+    const candidates = Array.isArray(input)
+        ? input
+        : Array.isArray(input?.candidates)
+          ? input.candidates
+          : input?.candidates_preview;
+    if (!Array.isArray(candidates)) {
+        throw new Error('candidate payload must be an array or expose candidates/candidates_preview');
+    }
+
+    return candidates.map((candidate, index) => {
+        const matchId = normalizeOptionalText(candidate?.match_id ?? candidate?.matchId);
+        const externalId = normalizeOptionalText(
+            candidate?.external_id ?? candidate?.externalId ?? candidate?.id ?? matchId
+        );
+        const leagueName = normalizeOptionalText(candidate?.league_name ?? candidate?.league);
+        const season = normalizeOptionalText(candidate?.season);
+        const homeTeam = normalizeOptionalText(candidate?.home_team ?? candidate?.home);
+        const awayTeam = normalizeOptionalText(candidate?.away_team ?? candidate?.away);
+        const matchDate = normalizeDateText(candidate?.match_date ?? candidate?.matchDate);
+        const status = normalizeStatus(candidate?.status);
+        const dataSource = normalizeDataSource(candidate?.data_source ?? candidate?.dataSource);
+        const isFinished = candidate?.is_finished === true || candidate?.isFinished === true || status === 'finished';
+
+        const missing = [];
+        if (!matchId) missing.push('match_id');
+        if (!externalId) missing.push('external_id');
+        if (!leagueName) missing.push('league_name');
+        if (!season) missing.push('season');
+        if (!homeTeam) missing.push('home_team');
+        if (!awayTeam) missing.push('away_team');
+        if (!matchDate) missing.push('match_date');
+        if (missing.length > 0) {
+            throw new Error(`candidate[${index}] missing required fields: ${missing.join(', ')}`);
+        }
+
+        return {
+            match_id: matchId,
+            external_id: externalId,
+            league_name: leagueName,
+            season,
+            home_team: homeTeam,
+            away_team: awayTeam,
+            match_date: matchDate,
+            status,
+            is_finished: isFinished,
+            data_source: dataSource,
+        };
+    });
+}
+
+function normalizeExistingMatches(rows) {
+    const list = Array.isArray(rows)
+        ? rows
+        : Array.isArray(rows?.rows)
+          ? rows.rows
+          : Array.isArray(rows?.existing_matches)
+            ? rows.existing_matches
+            : [];
+
+    return list.map(row => ({
+        match_id: normalizeOptionalText(row?.match_id ?? row?.matchId),
+        external_id: normalizeOptionalText(row?.external_id ?? row?.externalId),
+        league_name: normalizeOptionalText(row?.league_name ?? row?.leagueName),
+        season: normalizeOptionalText(row?.season),
+        home_team: normalizeOptionalText(row?.home_team ?? row?.homeTeam),
+        away_team: normalizeOptionalText(row?.away_team ?? row?.awayTeam),
+        match_date: normalizeDateText(row?.match_date ?? row?.matchDate),
+        status: normalizeStatus(row?.status),
+        is_finished:
+            row?.is_finished === true || row?.isFinished === true || normalizeStatus(row?.status) === 'finished',
+        data_source: normalizeDataSource(row?.data_source ?? row?.dataSource),
+    }));
+}
+
+function normalizeTeamToken(value) {
+    return String(value || '')
+        .toLowerCase()
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-z0-9]+/g, '');
+}
+
+function candidateMatchesTargetId(candidates, targetId) {
+    return normalizeCandidates(candidates).some(candidate =>
+        [candidate.match_id, candidate.external_id].some(value => String(value || '').includes(String(targetId || '')))
+    );
+}
+
+function candidateMatchesTargetLabel(candidates, targetLabel) {
+    const expectedHome = normalizeTargetLabel(targetLabel).includes('angers');
+    const expectedAway = normalizeTargetLabel(targetLabel).includes('strasbourg');
+    if (!expectedHome || !expectedAway) {
+        return false;
+    }
+
+    return normalizeCandidates(candidates).some(candidate => {
+        const home = normalizeTeamToken(candidate.home_team);
+        const away = normalizeTeamToken(candidate.away_team);
+        return (
+            (home.includes('angers') && away.includes('strasbourg')) ||
+            (home.includes('strasbourg') && away.includes('angers'))
+        );
+    });
+}
+
+function buildAffectedMatchIds(candidates) {
+    return [...new Set(normalizeCandidates(candidates).map(candidate => candidate.match_id))];
+}
+
+function buildInsertRows(candidates) {
+    return normalizeCandidates(candidates).map(candidate => ({
+        match_id: candidate.match_id,
+        external_id: candidate.external_id,
+        league_name: candidate.league_name,
+        season: candidate.season,
+        home_team: candidate.home_team,
+        away_team: candidate.away_team,
+        match_date: candidate.match_date,
+        status: candidate.status,
+        is_finished: candidate.is_finished === true,
+        data_source: candidate.data_source,
+    }));
+}
+
+function buildUpsertSqlPlan(rows) {
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new Error('rows are required for buildUpsertSqlPlan');
+    }
+
+    const values = [];
+    const placeholders = rows.map((row, index) => {
+        const offset = index * ALLOWED_INSERT_COLUMNS.length;
+        ALLOWED_INSERT_COLUMNS.forEach(column => {
+            values.push(row[column]);
+        });
+        return `(${ALLOWED_INSERT_COLUMNS.map((_, columnIndex) => `$${offset + columnIndex + 1}`).join(', ')})`;
+    });
+
+    return {
+        table: 'matches',
+        columns: [...ALLOWED_INSERT_COLUMNS],
+        rowCount: rows.length,
+        values,
+        text: `
+            INSERT INTO matches (
+                ${ALLOWED_INSERT_COLUMNS.join(', ')}
+            )
+            VALUES ${placeholders.join(', ')}
+            ON CONFLICT (match_id) DO UPDATE SET
+                external_id = EXCLUDED.external_id,
+                league_name = EXCLUDED.league_name,
+                season = EXCLUDED.season,
+                home_team = EXCLUDED.home_team,
+                away_team = EXCLUDED.away_team,
+                match_date = EXCLUDED.match_date,
+                status = EXCLUDED.status,
+                is_finished = EXCLUDED.is_finished,
+                data_source = EXCLUDED.data_source,
+                updated_at = NOW()
+            RETURNING match_id, (xmax = 0) AS inserted;
+        `,
+    };
+}
+
+function buildSelectExistingMatchesQuery(matchIds) {
+    return {
+        text: `
+            SELECT match_id, external_id, league_name, season, home_team, away_team, match_date, status, is_finished, data_source
+            FROM matches
+            WHERE match_id = ANY($1::text[])
+            ORDER BY match_date, match_id;
+        `,
+        values: [matchIds],
+    };
+}
+
+function buildCountQuery() {
+    return {
+        text: `
+            SELECT 'matches' AS table_name, COUNT(*)::int AS rows FROM matches
+            UNION ALL
+            SELECT 'bookmaker_odds_history', COUNT(*)::int FROM bookmaker_odds_history
+            UNION ALL
+            SELECT 'raw_match_data', COUNT(*)::int FROM raw_match_data
+            UNION ALL
+            SELECT 'l3_features', COUNT(*)::int FROM l3_features
+            UNION ALL
+            SELECT 'match_features_training', COUNT(*)::int FROM match_features_training
+            UNION ALL
+            SELECT 'predictions', COUNT(*)::int FROM predictions;
+        `,
+        values: [],
+    };
+}
+
+function mapCountRows(rows) {
+    const counts = Object.fromEntries(COUNT_TABLES.map(tableName => [tableName, null]));
+    (rows || []).forEach(row => {
+        counts[String(row.table_name)] = Number(row.rows);
+    });
+    return counts;
+}
+
+function diffControlledFields(candidate, existingRow) {
+    return [
+        'external_id',
+        'league_name',
+        'season',
+        'home_team',
+        'away_team',
+        'match_date',
+        'status',
+        'is_finished',
+        'data_source',
+    ].filter(field => {
+        const left = candidate[field] ?? null;
+        const right = existingRow[field] ?? null;
+        return left !== right;
+    });
+}
+
+function buildAffectedPreview(candidates, existingMatches) {
+    const existingMap = new Map(
+        normalizeExistingMatches(existingMatches)
+            .filter(row => row.match_id)
+            .map(row => [row.match_id, row])
+    );
+
+    return normalizeCandidates(candidates).map(candidate => {
+        const existingRow = existingMap.get(candidate.match_id) || null;
+        if (!existingRow) {
+            return {
+                match_id: candidate.match_id,
+                external_id: candidate.external_id,
+                home_team: candidate.home_team,
+                away_team: candidate.away_team,
+                match_date: candidate.match_date,
+                league_name: candidate.league_name,
+                season: candidate.season,
+                status: candidate.status,
+                existing_row_found: false,
+                decision: 'would_insert',
+                reason: 'match_id not found in matches',
+            };
+        }
+
+        const differingFields = diffControlledFields(candidate, existingRow);
+        if (differingFields.length === 0) {
+            return {
+                match_id: candidate.match_id,
+                external_id: candidate.external_id,
+                home_team: candidate.home_team,
+                away_team: candidate.away_team,
+                match_date: candidate.match_date,
+                league_name: candidate.league_name,
+                season: candidate.season,
+                status: candidate.status,
+                existing_row_found: true,
+                decision: 'would_skip',
+                reason: 'existing matches row already matches controlled seed fields',
+            };
+        }
+
+        return {
+            match_id: candidate.match_id,
+            external_id: candidate.external_id,
+            home_team: candidate.home_team,
+            away_team: candidate.away_team,
+            match_date: candidate.match_date,
+            league_name: candidate.league_name,
+            season: candidate.season,
+            status: candidate.status,
+            existing_row_found: true,
+            decision: 'would_update',
+            reason: `existing matches row differs on: ${differingFields.join(', ')}`,
+        };
+    });
+}
+
+function countDecisions(affectedPreview, decision) {
+    return affectedPreview.filter(item => item.decision === decision).length;
+}
+
+async function readStdinText(io = {}, dependencies = {}) {
+    if (typeof dependencies.stdinText === 'string') {
+        return dependencies.stdinText;
+    }
+
+    const stdin = io.stdin || process.stdin;
+    if (!stdin || typeof stdin.on !== 'function') {
+        return '';
+    }
+
+    return new Promise(resolve => {
+        let buffer = '';
+        stdin.setEncoding?.('utf8');
+        stdin.on('data', chunk => {
+            buffer += chunk;
+        });
+        stdin.on('end', () => resolve(buffer));
+        stdin.on('error', () => resolve(''));
+        if (stdin.readableEnded === true) {
+            resolve(buffer);
+        }
+    });
+}
+
+async function resolveCandidatesFromSafePreview(input, dependencies = {}) {
+    const safePreview = dependencies.safePreviewModule || require('./l1_discovery_safe_preview');
+    const payload = await safePreview.buildL1DiscoveryPlanPreview(
+        {
+            source: input.source,
+            scope: PREVIEW_SCOPE,
+            leagueId: input.leagueId,
+            season: input.season,
+            date: input.date,
+            concurrency: SAFE_NETWORK_CONCURRENCY,
+            maxTargets: SAFE_NETWORK_MAX_TARGETS,
+            dryRun: true,
+            networkPreview: true,
+            networkAuthorization: true,
+            allowBrowserRuntime: false,
+            allowProxyRuntime: false,
+            allowDbWrite: false,
+        },
+        {
+            fetch: dependencies.fetch,
+            timeoutMs: dependencies.timeoutMs || SAFE_NETWORK_TIMEOUT_MS,
+        }
+    );
+
+    return {
+        candidates: payload.candidates_preview || payload.candidates || [],
+        exactCandidateSetSource: 'safe_controlled_network_preview',
+        sourceUrlUsed: payload.source_url_used || null,
+        networkUsed: payload.external_network_used === true,
+    };
+}
+
+async function resolveCandidates(input, stdinText, dependencies = {}) {
+    if (Array.isArray(dependencies.candidates)) {
+        return {
+            candidates: dependencies.candidates,
+            exactCandidateSetSource: 'dependency_candidates',
+            sourceUrlUsed: dependencies.sourceUrlUsed || null,
+            networkUsed: false,
+        };
+    }
+
+    if (typeof dependencies.resolveCandidates === 'function') {
+        return dependencies.resolveCandidates({ input, stdinText });
+    }
+
+    if (input.candidatesJson) {
+        return {
+            candidates: parseJsonText(input.candidatesJson, 'candidates-json'),
+            exactCandidateSetSource: 'candidates_json_argument',
+            sourceUrlUsed: null,
+            networkUsed: false,
+        };
+    }
+
+    const trimmedStdin = String(stdinText || '').trim();
+    if (trimmedStdin) {
+        return {
+            candidates: parseJsonText(trimmedStdin, 'stdin candidates payload'),
+            exactCandidateSetSource: 'stdin_candidates_payload',
+            sourceUrlUsed: null,
+            networkUsed: false,
+        };
+    }
+
+    return resolveCandidatesFromSafePreview(input, dependencies);
+}
+
+async function resolveExistingMatches(input, affectedMatchIds, dependencies = {}) {
+    if (Array.isArray(dependencies.existingMatches)) {
+        return dependencies.existingMatches;
+    }
+
+    if (typeof dependencies.selectExistingMatches === 'function') {
+        return dependencies.selectExistingMatches({ input, matchIds: affectedMatchIds });
+    }
+
+    if (input.existingMatchesJson) {
+        return parseJsonText(input.existingMatchesJson, 'existing-matches-json');
+    }
+
+    return null;
+}
+
+function createPgPool() {
+    const { Pool } = require('pg');
+    return new Pool({
+        host: process.env.DB_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || '5432', 10),
+        database: process.env.DB_NAME || 'football_db',
+        user: process.env.DB_USER || 'football_user',
+        password: process.env.DB_PASSWORD || 'football_pass',
+        application_name: 'l1_matches_seed_commit_execute',
+        max: 2,
+        idleTimeoutMillis: 5000,
+        connectionTimeoutMillis: 5000,
+    });
+}
+
+async function selectProtectedRowCounts(client, dependencies = {}) {
+    if (typeof dependencies.selectProtectedRowCounts === 'function') {
+        return dependencies.selectProtectedRowCounts(client);
+    }
+
+    const query = buildCountQuery();
+    const result = await client.query(query.text, query.values);
+    return mapCountRows(result.rows);
+}
+
+async function selectExistingMatchesWithinTransaction(client, affectedMatchIds, dependencies = {}) {
+    if (typeof dependencies.selectExistingMatchesWithinTransaction === 'function') {
+        return dependencies.selectExistingMatchesWithinTransaction(client, affectedMatchIds);
+    }
+
+    const query = buildSelectExistingMatchesQuery(affectedMatchIds);
+    const result = await client.query(query.text, query.values);
+    return result.rows || [];
+}
+
+function buildPostCommitVerification(beforeCounts = {}, afterCounts = {}) {
+    const l3FeaturesUnchanged = beforeCounts.l3_features === afterCounts.l3_features;
+    const trainingFeaturesUnchanged = beforeCounts.match_features_training === afterCounts.match_features_training;
+
+    return {
+        matches_row_count_before: beforeCounts.matches ?? null,
+        matches_row_count_after: afterCounts.matches ?? null,
+        bookmaker_odds_history_unchanged: beforeCounts.bookmaker_odds_history === afterCounts.bookmaker_odds_history,
+        raw_match_data_unchanged: beforeCounts.raw_match_data === afterCounts.raw_match_data,
+        l3_features_unchanged: l3FeaturesUnchanged,
+        match_features_training_unchanged: trainingFeaturesUnchanged,
+        features_unchanged: l3FeaturesUnchanged && trainingFeaturesUnchanged,
+        predictions_unchanged: beforeCounts.predictions === afterCounts.predictions,
+    };
+}
+
+function buildControlledExecutionResult(details = {}) {
+    const verification = buildPostCommitVerification(details.beforeCounts, details.afterCounts);
+    return {
+        phase: PHASE,
+        execution_completed: true,
+        source: details.input.source,
+        scope: details.input.scope,
+        league_id: details.input.leagueId,
+        season: details.input.season,
+        date: details.input.date,
+        candidate_count: details.input.candidateCount,
+        max_seed_rows: details.input.maxSeedRows,
+        contains_target_match_id: details.input.containsTargetMatchId,
+        contains_target_label: details.input.containsTargetLabel,
+        final_db_write_confirmation: true,
+        db_write_executed: true,
+        matches_write_executed: true,
+        raw_match_data_write_executed: false,
+        inserted_count: details.insertedCount,
+        updated_count: details.updatedCount,
+        skipped_count: details.skippedCount,
+        affected_match_ids: details.affectedMatchIds,
+        exact_candidate_set_source: details.exactCandidateSetSource,
+        source_url_used: details.sourceUrlUsed || null,
+        existing_affected_matches_count: details.existingAffectedMatchesCount,
+        affected_preview: details.affectedPreview,
+        transaction: details.transaction,
+        post_commit_verification: verification,
+        safety_summary: {
+            called_titan_discovery: false,
+            called_discovery_service_discover: false,
+            called_fixture_repository_persist: false,
+            wrote_matches: true,
+            wrote_raw_match_data: false,
+            trained: false,
+            predicted: false,
+        },
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function buildControlledErrorPayload(input = {}, errors = [], details = {}) {
+    const value = normalizeExecutionInput(input);
+    const beforeCounts = details.beforeCounts || {};
+    const afterCounts = details.afterCounts || beforeCounts;
+    const transaction = details.transaction || {
+        began: false,
+        committed: false,
+        rolled_back: false,
+    };
+
+    return {
+        phase: PHASE,
+        execution_completed: false,
+        source: value.source || null,
+        scope: value.scope || null,
+        league_id: value.leagueId,
+        season: value.season,
+        date: value.date,
+        candidate_count: value.candidateCount,
+        max_seed_rows: value.maxSeedRows,
+        contains_target_match_id: value.containsTargetMatchId,
+        contains_target_label: value.containsTargetLabel,
+        final_db_write_confirmation: value.finalDbWriteConfirmation === true,
+        db_write_executed: false,
+        matches_write_executed: false,
+        raw_match_data_write_executed: false,
+        inserted_count: 0,
+        updated_count: 0,
+        skipped_count: 0,
+        affected_match_ids: details.affectedMatchIds || [],
+        exact_candidate_set_source: details.exactCandidateSetSource || null,
+        source_url_used: details.sourceUrlUsed || null,
+        existing_affected_matches_count: details.existingAffectedMatchesCount ?? null,
+        affected_preview: details.affectedPreview || [],
+        transaction,
+        post_commit_verification: buildPostCommitVerification(beforeCounts, afterCounts),
+        safety_summary: {
+            called_titan_discovery: false,
+            called_discovery_service_discover: false,
+            called_fixture_repository_persist: false,
+            wrote_matches: false,
+            wrote_raw_match_data: false,
+            trained: false,
+            predicted: false,
+        },
+        errors: Array.isArray(errors) ? errors : [String(errors)],
+        next_required_phase: null,
+    };
+}
+
+async function executeMatchesSeedTransaction(input = {}, dependencies = {}) {
+    const validation = validateExecutionInput(input);
+    if (!validation.ok) {
+        const error = new Error(validation.errors[0]);
+        error.validationErrors = validation.errors;
+        throw error;
+    }
+
+    const value = validation.value;
+    const stdinText = typeof dependencies.stdinText === 'string' ? dependencies.stdinText : '';
+    const candidateResolution = await resolveCandidates(value, stdinText, dependencies);
+    const candidates = normalizeCandidates(candidateResolution.candidates);
+
+    if (candidates.length !== value.candidateCount) {
+        throw new Error(
+            `exact candidate set count mismatch: expected ${value.candidateCount}, got ${candidates.length}`
+        );
+    }
+    if (candidates.length > value.maxSeedRows) {
+        throw new Error(`exact candidate set exceeds max-seed-rows=${value.maxSeedRows}`);
+    }
+    if (!candidateMatchesTargetId(candidates, value.containsTargetMatchId)) {
+        throw new Error(`target match id candidate not found: ${value.containsTargetMatchId}`);
+    }
+    if (!candidateMatchesTargetLabel(candidates, value.containsTargetLabel)) {
+        throw new Error(`target label candidate not found: ${value.containsTargetLabel}`);
+    }
+
+    const affectedMatchIds = buildAffectedMatchIds(candidates);
+    const externalExisting = normalizeExistingMatches(
+        (await resolveExistingMatches(value, affectedMatchIds, dependencies)) || []
+    );
+    const externalPreview = buildAffectedPreview(candidates, externalExisting);
+    const externalInsertCount = countDecisions(externalPreview, 'would_insert');
+    const externalUpdateCount = countDecisions(externalPreview, 'would_update');
+    const externalSkipCount = countDecisions(externalPreview, 'would_skip');
+
+    if (
+        externalInsertCount !== EXACT_CANDIDATE_COUNT ||
+        externalUpdateCount !== 0 ||
+        externalSkipCount !== 0 ||
+        externalExisting.length !== 0
+    ) {
+        throw new Error(
+            `preflight mismatch detected before transaction: existing=${externalExisting.length}, would_insert=${externalInsertCount}, would_update=${externalUpdateCount}, would_skip=${externalSkipCount}`
+        );
+    }
+
+    const pool = dependencies.pool || createPgPool();
+    const ownsPool = !dependencies.pool;
+    const transaction = {
+        began: false,
+        committed: false,
+        rolled_back: false,
+    };
+
+    let client = null;
+    let beforeCounts = null;
+    let afterCounts = null;
+    let transactionPreview = externalPreview;
+    let transactionExistingMatches = externalExisting;
+    let insertedCount = 0;
+    let updatedCount = 0;
+    let skippedCount = 0;
+
+    try {
+        client = dependencies.client || (await pool.connect());
+        transaction.began = true;
+        await client.query('BEGIN');
+
+        beforeCounts = await selectProtectedRowCounts(client, dependencies);
+        transactionExistingMatches = normalizeExistingMatches(
+            await selectExistingMatchesWithinTransaction(client, affectedMatchIds, dependencies)
+        );
+        transactionPreview = buildAffectedPreview(candidates, transactionExistingMatches);
+
+        const wouldInsertCount = countDecisions(transactionPreview, 'would_insert');
+        const wouldUpdateCount = countDecisions(transactionPreview, 'would_update');
+        const wouldSkipCount = countDecisions(transactionPreview, 'would_skip');
+
+        if (
+            transactionExistingMatches.length !== 0 ||
+            wouldInsertCount !== EXACT_CANDIDATE_COUNT ||
+            wouldUpdateCount !== 0 ||
+            wouldSkipCount !== 0
+        ) {
+            throw new Error(
+                `execution preflight mismatch inside transaction: existing=${transactionExistingMatches.length}, would_insert=${wouldInsertCount}, would_update=${wouldUpdateCount}, would_skip=${wouldSkipCount}`
+            );
+        }
+
+        const rows = buildInsertRows(candidates);
+        const sqlPlan = buildUpsertSqlPlan(rows);
+        const queryResult = await client.query(sqlPlan.text, sqlPlan.values);
+        const resultRows = Array.isArray(queryResult.rows) ? queryResult.rows : [];
+        insertedCount = resultRows.filter(row => row.inserted === true).length;
+        updatedCount = resultRows.length - insertedCount;
+        skippedCount = 0;
+
+        if (insertedCount !== EXACT_CANDIDATE_COUNT || updatedCount !== 0 || skippedCount !== 0) {
+            throw new Error(
+                `transaction write result mismatch: inserted=${insertedCount}, updated=${updatedCount}, skipped=${skippedCount}`
+            );
+        }
+
+        afterCounts = await selectProtectedRowCounts(client, dependencies);
+        const verification = buildPostCommitVerification(beforeCounts, afterCounts);
+
+        if (afterCounts.matches !== beforeCounts.matches + EXACT_CANDIDATE_COUNT) {
+            throw new Error(
+                `matches row count delta mismatch: before=${beforeCounts.matches}, after=${afterCounts.matches}`
+            );
+        }
+        if (
+            verification.bookmaker_odds_history_unchanged !== true ||
+            verification.raw_match_data_unchanged !== true ||
+            verification.features_unchanged !== true ||
+            verification.predictions_unchanged !== true
+        ) {
+            throw new Error('post-commit verification failed: protected tables changed unexpectedly');
+        }
+
+        await client.query('COMMIT');
+        transaction.committed = true;
+
+        return buildControlledExecutionResult({
+            input: value,
+            exactCandidateSetSource: candidateResolution.exactCandidateSetSource,
+            sourceUrlUsed: candidateResolution.sourceUrlUsed || null,
+            existingAffectedMatchesCount: transactionExistingMatches.length,
+            affectedPreview: transactionPreview,
+            insertedCount,
+            updatedCount,
+            skippedCount,
+            affectedMatchIds,
+            transaction,
+            beforeCounts,
+            afterCounts,
+        });
+    } catch (error) {
+        if (transaction.began && transaction.committed !== true && client) {
+            try {
+                await client.query('ROLLBACK');
+                transaction.rolled_back = true;
+            } catch (rollbackError) {
+                error.rollbackError = rollbackError;
+            }
+        }
+
+        if (client && beforeCounts) {
+            try {
+                afterCounts = await selectProtectedRowCounts(client, dependencies);
+            } catch (countError) {
+                error.afterCountError = countError;
+            }
+        }
+
+        error.controlledPayload = buildControlledErrorPayload(value, error.validationErrors || [error.message], {
+            transaction,
+            beforeCounts: beforeCounts || {},
+            afterCounts: afterCounts || beforeCounts || {},
+            affectedMatchIds,
+            affectedPreview: transactionPreview,
+            exactCandidateSetSource: candidateResolution.exactCandidateSetSource,
+            sourceUrlUsed: candidateResolution.sourceUrlUsed || null,
+            existingAffectedMatchesCount: transactionExistingMatches.length,
+        });
+        throw error;
+    } finally {
+        if (!dependencies.client && client && typeof client.release === 'function') {
+            client.release();
+        }
+        if (ownsPool && typeof pool.end === 'function') {
+            await pool.end();
+        }
+    }
+}
+
+function showHelp(io = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    stdout(
+        [
+            'Usage:',
+            '  node scripts/ops/l1_matches_seed_commit_execute.js --source=fotmob --scope=league_season_date --league-id=53 --season=2025/2026 --date=2026-05-10 --candidate-count=8 --contains-target-match-id=4830746 --contains-target-label="Angers vs Strasbourg" --max-seed-rows=10 --final-db-write-confirmation=yes --allow-db-write-now=yes --allow-matches-write-now=yes --allow-raw-match-data-write=no --allow-training=no --allow-prediction=no',
+            '',
+            'Optional:',
+            "  --candidates-json='[...]'",
+            "  --existing-matches-json='[...]'",
+            '  stdin JSON array/object for candidates',
+            '',
+            'Phase 5.09L1: controlled execution only, exact 2026-05-10 FotMob Ligue 1 candidates, matches-only transaction.',
+        ].join('\n')
+    );
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const stdout = io.stdout || (text => process.stdout.write(text));
+    const stderr = io.stderr || (text => process.stderr.write(text));
+    const options = parseArgs(argv);
+    const dependenciesProvideCandidates =
+        Array.isArray(dependencies.candidates) || typeof dependencies.resolveCandidates === 'function';
+    const shouldReadStdin =
+        Object.prototype.hasOwnProperty.call(dependencies, 'stdinText') ||
+        typeof io.stdin?.on === 'function' ||
+        (!options.candidatesJson && !dependenciesProvideCandidates);
+
+    if (options.help) {
+        showHelp({ stdout });
+        return 0;
+    }
+
+    try {
+        const stdinText = shouldReadStdin ? await readStdinText(io, dependencies) : '';
+        const payload = await executeMatchesSeedTransaction(
+            options,
+            Object.prototype.hasOwnProperty.call(dependencies, 'stdinText')
+                ? dependencies
+                : { ...dependencies, stdinText }
+        );
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 0;
+    } catch (error) {
+        const payload =
+            error.controlledPayload || buildControlledErrorPayload(options, error.validationErrors || [error.message]);
+        stderr(`${payload.errors[0]}\n`);
+        stdout(`${JSON.stringify(payload, null, 2)}\n`);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    runCli().then(code => {
+        process.exitCode = code;
+    });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validateExecutionInput,
+    normalizeCandidates,
+    normalizeExistingMatches,
+    buildAffectedPreview,
+    buildAffectedMatchIds,
+    buildInsertRows,
+    buildUpsertSqlPlan,
+    executeMatchesSeedTransaction,
+    buildPostCommitVerification,
+    buildControlledExecutionResult,
+    runCli,
+};

--- a/tests/unit/l1_matches_seed_commit_execute.test.js
+++ b/tests/unit/l1_matches_seed_commit_execute.test.js
@@ -1,0 +1,1134 @@
+'use strict';
+/* eslint-disable max-lines */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l1_matches_seed_commit_execute.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function installNoSideEffectGuards(t) {
+    const originalFetch = global.fetch;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalNetConnect = net.connect;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l1_matches_seed_commit_execute`);
+    };
+
+    global.fetch = fail('global.fetch');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    net.connect = fail('net.connect');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (['redis', 'ioredis', 'playwright', 'playwright-core'].includes(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/FixtureRepository|titan_discovery/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/DiscoveryService/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        net.connect = originalNetConnect;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        Module._load = originalLoad;
+    });
+}
+
+function validCandidates() {
+    return [
+        {
+            match_id: '53_20252026_4830746',
+            external_id: '4830746',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Angers',
+            away_team: 'Strasbourg',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830747',
+            external_id: '4830747',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Auxerre',
+            away_team: 'Nice',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830748',
+            external_id: '4830748',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Le Havre',
+            away_team: 'Marseille',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830750',
+            external_id: '4830750',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Metz',
+            away_team: 'Lorient',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830751',
+            external_id: '4830751',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Monaco',
+            away_team: 'Lille',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830752',
+            external_id: '4830752',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Paris Saint-Germain',
+            away_team: 'Brest',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830753',
+            external_id: '4830753',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Rennes',
+            away_team: 'Paris FC',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+        {
+            match_id: '53_20252026_4830754',
+            external_id: '4830754',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Toulouse',
+            away_team: 'Lyon',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+            data_source: 'FotMob',
+        },
+    ];
+}
+
+function validArgv(overrides = []) {
+    return [
+        '--source=fotmob',
+        '--scope=league_season_date',
+        '--league-id=53',
+        '--season=2025/2026',
+        '--date=2026-05-10',
+        '--candidate-count=8',
+        '--contains-target-match-id=4830746',
+        '--contains-target-label=Angers vs Strasbourg',
+        '--max-seed-rows=10',
+        '--final-db-write-confirmation=yes',
+        '--allow-db-write-now=yes',
+        '--allow-matches-write-now=yes',
+        '--allow-raw-match-data-write=no',
+        '--allow-training=no',
+        '--allow-prediction=no',
+        ...overrides,
+    ];
+}
+
+function createFakeStdin(chunks, options = {}) {
+    const values = Array.isArray(chunks) ? chunks : [chunks];
+    return {
+        readableEnded: options.readableEnded === true,
+        setEncoding() {},
+        on(event, handler) {
+            if (event === 'data') {
+                values.forEach(chunk => handler(chunk));
+            }
+            if (event === 'error' && options.emitError) {
+                handler(new Error('stdin error'));
+            }
+            if (event === 'end') {
+                handler();
+            }
+        },
+    };
+}
+
+function createFakePool({
+    countsBefore,
+    countsAfter,
+    existingMatches = [],
+    failOnInsert = false,
+    insertedRows,
+    rollbackFails = false,
+    failCountAfterRollback = false,
+} = {}) {
+    const queryLog = [];
+    let inTransaction = false;
+    let writeApplied = false;
+    let rolledBack = false;
+    let committed = false;
+    let rollbackAttempted = false;
+    const before = {
+        matches: 2,
+        bookmaker_odds_history: 2,
+        raw_match_data: 2,
+        l3_features: 2,
+        match_features_training: 2,
+        predictions: 2,
+        ...(countsBefore || {}),
+    };
+    const after = {
+        matches: 10,
+        bookmaker_odds_history: 2,
+        raw_match_data: 2,
+        l3_features: 2,
+        match_features_training: 2,
+        predictions: 2,
+        ...(countsAfter || {}),
+    };
+
+    const client = {
+        async query(text, values = []) {
+            queryLog.push(String(text).trim());
+            if (/^BEGIN$/i.test(String(text).trim())) {
+                inTransaction = true;
+                return { rows: [] };
+            }
+            if (/^COMMIT$/i.test(String(text).trim())) {
+                committed = true;
+                inTransaction = false;
+                return { rows: [] };
+            }
+            if (/^ROLLBACK$/i.test(String(text).trim())) {
+                rollbackAttempted = true;
+                if (rollbackFails) {
+                    throw new Error('forced rollback failure');
+                }
+                rolledBack = true;
+                inTransaction = false;
+                writeApplied = false;
+                return { rows: [] };
+            }
+            if (String(text).includes("SELECT 'matches' AS table_name")) {
+                if (rollbackAttempted && failCountAfterRollback) {
+                    throw new Error('forced count failure after rollback');
+                }
+                const current = writeApplied ? after : before;
+                return {
+                    rows: Object.entries(current).map(([table_name, rows]) => ({ table_name, rows })),
+                };
+            }
+            if (String(text).includes('FROM matches') && String(text).includes('WHERE match_id = ANY')) {
+                return { rows: existingMatches };
+            }
+            if (String(text).includes('INSERT INTO matches')) {
+                assert.equal(inTransaction, true);
+                assert.equal(Array.isArray(values), true);
+                if (failOnInsert) {
+                    throw new Error('forced insert failure');
+                }
+                writeApplied = true;
+                return {
+                    rows:
+                        insertedRows ||
+                        validCandidates().map(candidate => ({
+                            match_id: candidate.match_id,
+                            inserted: true,
+                        })),
+                };
+            }
+            throw new Error(`unexpected query: ${text}`);
+        },
+        release() {},
+    };
+
+    return {
+        queryLog,
+        pool: {
+            async connect() {
+                return client;
+            },
+            async end() {},
+        },
+        getState() {
+            return { rolledBack, committed, writeApplied, rollbackAttempted };
+        },
+    };
+}
+
+async function runCli(gate, argv, dependencies = {}) {
+    let stdout = '';
+    let stderr = '';
+    const status = await gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: text => {
+                stderr += text;
+            },
+        },
+        dependencies
+    );
+    return { status, stdout, stderr };
+}
+
+function parseJsonOutput(stdout) {
+    const payload = String(stdout || '').trim();
+    assert.notEqual(payload, '', 'expected JSON payload');
+    return JSON.parse(payload);
+}
+
+function validInput(overrides = {}) {
+    return {
+        source: 'fotmob',
+        scope: 'league_season_date',
+        leagueId: '53',
+        season: '2025/2026',
+        date: '2026-05-10',
+        candidateCount: '8',
+        containsTargetMatchId: '4830746',
+        containsTargetLabel: 'Angers vs Strasbourg',
+        maxSeedRows: '10',
+        finalDbWriteConfirmation: 'yes',
+        allowDbWriteNow: 'yes',
+        allowMatchesWriteNow: 'yes',
+        allowRawMatchDataWrite: 'no',
+        allowTraining: 'no',
+        allowPrediction: 'no',
+        ...overrides,
+    };
+}
+
+test('valid execution input succeeds', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+    const result = await runCli(gate, validArgv(), {
+        candidates: validCandidates(),
+        existingMatches: [],
+        pool: fakeDb.pool,
+    });
+    const payload = parseJsonOutput(result.stdout);
+
+    assert.equal(result.status, 0);
+    assert.equal(payload.phase, 'PHASE5_09L1_CONTROLLED_MATCHES_SEED_COMMIT_EXECUTION');
+    assert.equal(payload.execution_completed, true);
+    assert.equal(payload.db_write_executed, true);
+    assert.equal(payload.matches_write_executed, true);
+    assert.equal(payload.raw_match_data_write_executed, false);
+    assert.equal(payload.inserted_count, 8);
+    assert.equal(payload.updated_count, 0);
+    assert.equal(payload.skipped_count, 0);
+    assert.deepEqual(payload.transaction, {
+        began: true,
+        committed: true,
+        rolled_back: false,
+    });
+    assert.equal(payload.post_commit_verification.matches_row_count_before, 2);
+    assert.equal(payload.post_commit_verification.matches_row_count_after, 10);
+    assert.equal(payload.post_commit_verification.raw_match_data_unchanged, true);
+    assert.equal(payload.post_commit_verification.features_unchanged, true);
+    assert.equal(payload.post_commit_verification.predictions_unchanged, true);
+    assert.equal(payload.safety_summary.called_fixture_repository_persist, false);
+    assert.equal(payload.safety_summary.called_discovery_service_discover, false);
+    assert.equal(payload.safety_summary.called_titan_discovery, false);
+});
+
+test('validation failures and blocked flags are rejected', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const cases = [
+        { argv: validArgv().filter(arg => !arg.startsWith('--source=')), pattern: /missing source/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--source=')), '--source=other'],
+            pattern: /unsupported source/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--scope=')), pattern: /missing scope/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--scope=')), '--scope=bulk'],
+            pattern: /unsupported scope/i,
+        },
+        { argv: validArgv().filter(arg => !arg.startsWith('--league-id=')), pattern: /missing league-id/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--season=')), pattern: /missing season/i },
+        { argv: validArgv().filter(arg => !arg.startsWith('--date=')), pattern: /missing date/i },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--candidate-count=')), '--candidate-count=7'],
+            pattern: /candidate-count must be exactly 8/i,
+        },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--max-seed-rows=')), '--max-seed-rows=7'],
+            pattern: /candidate-count must be <= max-seed-rows/i,
+        },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--max-seed-rows=')), '--max-seed-rows=11'],
+            pattern: /max-seed-rows > 10/i,
+        },
+        {
+            argv: validArgv().filter(arg => !arg.startsWith('--contains-target-match-id=')),
+            pattern: /missing contains-target-match-id/i,
+        },
+        {
+            argv: [
+                ...validArgv().filter(arg => !arg.startsWith('--contains-target-match-id=')),
+                '--contains-target-match-id=123',
+            ],
+            pattern: /contains-target-match-id must be 4830746/i,
+        },
+        {
+            argv: [
+                ...validArgv().filter(arg => !arg.startsWith('--contains-target-label=')),
+                '--contains-target-label=Strasbourg only',
+            ],
+            pattern: /must contain Angers/i,
+        },
+        {
+            argv: [
+                ...validArgv().filter(arg => !arg.startsWith('--contains-target-label=')),
+                '--contains-target-label=Angers only',
+            ],
+            pattern: /must contain Strasbourg/i,
+        },
+        {
+            argv: [
+                ...validArgv().filter(arg => !arg.startsWith('--final-db-write-confirmation=')),
+                '--final-db-write-confirmation=no',
+            ],
+            pattern: /final-db-write-confirmation must be yes/i,
+        },
+        {
+            argv: [...validArgv().filter(arg => !arg.startsWith('--allow-db-write-now=')), '--allow-db-write-now=no'],
+            pattern: /allow-db-write-now must be yes/i,
+        },
+        {
+            argv: [
+                ...validArgv().filter(arg => !arg.startsWith('--allow-matches-write-now=')),
+                '--allow-matches-write-now=no',
+            ],
+            pattern: /allow-matches-write-now must be yes/i,
+        },
+        { argv: [...validArgv(), '--allow-raw-match-data-write=yes'], pattern: /allow-raw-match-data-write=yes/i },
+        { argv: [...validArgv(), '--allow-training=yes'], pattern: /allow-training=yes/i },
+        { argv: [...validArgv(), '--allow-prediction=yes'], pattern: /allow-prediction=yes/i },
+        { argv: [...validArgv(), '--allow-browser-runtime=yes'], pattern: /allow-browser-runtime=yes/i },
+        { argv: [...validArgv(), '--allow-proxy-runtime=yes'], pattern: /allow-proxy-runtime=yes/i },
+        { argv: [...validArgv(), '--bulk=yes'], pattern: /bulk=yes/i },
+    ];
+
+    for (const { argv, pattern } of cases) {
+        const result = await runCli(gate, argv, {
+            candidates: validCandidates(),
+            existingMatches: [],
+        });
+        const payload = parseJsonOutput(result.stdout);
+        assert.equal(result.status, 1);
+        assert.match(payload.errors.join('\n'), pattern);
+        assert.equal(payload.execution_completed, false);
+        assert.equal(payload.db_write_executed, false);
+        assert.equal(payload.matches_write_executed, false);
+        assert.equal(payload.raw_match_data_write_executed, false);
+    }
+});
+
+test('normalizeBooleanFlag and parseArgs cover fallback and split-value branches', () => {
+    const gate = loadModuleFresh();
+
+    assert.equal(gate.normalizeBooleanFlag('maybe', 'fallback'), 'fallback');
+
+    const parsed = gate.parseArgs([
+        '--source',
+        'fotmob',
+        'ignored-positional',
+        '--scope',
+        'league_season_date',
+        '--help',
+        '--candidate-count',
+        '8',
+        '--unknown=value',
+    ]);
+
+    assert.equal(parsed.source, 'fotmob');
+    assert.equal(parsed.scope, 'league_season_date');
+    assert.equal(parsed.help, true);
+    assert.equal(parsed.candidateCount, '8');
+});
+
+test('validateExecutionInput covers exact scope mismatches and invalid numeric/date branches', () => {
+    const gate = loadModuleFresh();
+
+    const invalid = gate.validateExecutionInput(
+        validInput({
+            leagueId: '99',
+            season: '2024/2025',
+            date: '2026/05/10',
+            candidateCount: 'abc',
+            maxSeedRows: '0',
+            containsTargetMatchId: '1',
+            containsTargetLabel: '',
+            finalDbWriteConfirmation: 'no',
+            allowDbWriteNow: 'no',
+            allowMatchesWriteNow: 'no',
+        })
+    );
+
+    assert.equal(invalid.ok, false);
+    assert.match(invalid.errors.join('\n'), /league-id must be 53/i);
+    assert.match(invalid.errors.join('\n'), /season must be 2025\/2026/i);
+    assert.match(invalid.errors.join('\n'), /invalid date/i);
+    assert.match(invalid.errors.join('\n'), /invalid candidate-count/i);
+    assert.match(invalid.errors.join('\n'), /invalid max-seed-rows/i);
+    assert.match(invalid.errors.join('\n'), /contains-target-match-id must be 4830746/i);
+    assert.match(invalid.errors.join('\n'), /missing contains-target-label/i);
+});
+
+test('candidate normalization works', () => {
+    const gate = loadModuleFresh();
+    const normalized = gate.normalizeCandidates({
+        candidates_preview: [
+            {
+                match_id: '53_20252026_4830746',
+                external_id: '4830746',
+                league: 'Ligue 1',
+                season: '2025/2026',
+                home: 'Angers',
+                away: 'Strasbourg',
+                match_date: '2026-05-10T19:00:00.000Z',
+                status: 'Finished',
+            },
+        ],
+    });
+
+    assert.equal(normalized.length, 1);
+    assert.equal(normalized[0].league_name, 'Ligue 1');
+    assert.equal(normalized[0].status, 'finished');
+    assert.equal(normalized[0].is_finished, true);
+    assert.equal(normalized[0].data_source, 'FotMob');
+});
+
+test('normalizeCandidates rejects invalid payloads and missing fields', () => {
+    const gate = loadModuleFresh();
+
+    assert.throws(() => gate.normalizeCandidates({ invalid: true }), /candidate payload must be an array/i);
+    assert.throws(
+        () =>
+            gate.normalizeCandidates([
+                {
+                    external_id: '4830746',
+                    league_name: 'Ligue 1',
+                    season: '2025/2026',
+                    home_team: 'Angers',
+                    away_team: 'Strasbourg',
+                    match_date: '2026-05-10T19:00:00.000Z',
+                },
+            ]),
+        /missing required fields: match_id/i
+    );
+});
+
+test('normalizeCandidates keeps unparseable date text and defaults scheduled/data source', () => {
+    const gate = loadModuleFresh();
+    const normalized = gate.normalizeCandidates([
+        {
+            matchId: '53_20252026_4830746',
+            externalId: '4830746',
+            league_name: 'Ligue 1',
+            season: '2025/2026',
+            home_team: 'Angers',
+            away_team: 'Strasbourg',
+            matchDate: 'not-a-date',
+        },
+    ]);
+
+    assert.equal(normalized[0].match_date, 'not-a-date');
+    assert.equal(normalized[0].status, 'scheduled');
+    assert.equal(normalized[0].data_source, 'FotMob');
+});
+
+test('normalizeExistingMatches and buildAffectedPreview cover insert/skip/update branches', () => {
+    const gate = loadModuleFresh();
+    const candidates = validCandidates().slice(0, 3);
+    const existing = gate.normalizeExistingMatches({
+        existing_matches: [
+            {
+                match_id: candidates[1].match_id,
+                external_id: candidates[1].external_id,
+                league_name: candidates[1].league_name,
+                season: candidates[1].season,
+                home_team: candidates[1].home_team,
+                away_team: candidates[1].away_team,
+                match_date: candidates[1].match_date,
+                status: candidates[1].status,
+                data_source: candidates[1].data_source,
+            },
+            {
+                match_id: candidates[2].match_id,
+                external_id: candidates[2].external_id,
+                league_name: candidates[2].league_name,
+                season: candidates[2].season,
+                home_team: candidates[2].home_team,
+                away_team: candidates[2].away_team,
+                match_date: candidates[2].match_date,
+                status: 'scheduled',
+                data_source: candidates[2].data_source,
+            },
+        ],
+    });
+    const preview = gate.buildAffectedPreview(candidates, existing);
+
+    assert.equal(preview[0].decision, 'would_insert');
+    assert.equal(preview[1].decision, 'would_skip');
+    assert.equal(preview[2].decision, 'would_update');
+    assert.match(preview[2].reason, /status/i);
+});
+
+test('build affected match ids works', () => {
+    const gate = loadModuleFresh();
+    assert.deepEqual(
+        gate.buildAffectedMatchIds(validCandidates()),
+        validCandidates().map(item => item.match_id)
+    );
+});
+
+test('build insert rows maps allowed fields only', () => {
+    const gate = loadModuleFresh();
+    const rows = gate.buildInsertRows([
+        {
+            ...validCandidates()[0],
+            extra_field: 'blocked',
+        },
+    ]);
+
+    assert.deepEqual(Object.keys(rows[0]).sort(), [
+        'away_team',
+        'data_source',
+        'external_id',
+        'home_team',
+        'is_finished',
+        'league_name',
+        'match_date',
+        'match_id',
+        'season',
+        'status',
+    ]);
+});
+
+test('generated SQL plan touches only matches', () => {
+    const gate = loadModuleFresh();
+    const sqlPlan = gate.buildUpsertSqlPlan(gate.buildInsertRows(validCandidates()));
+    assert.equal(sqlPlan.table, 'matches');
+    assert.match(sqlPlan.text, /INSERT INTO matches/i);
+});
+
+test('generated SQL plan contains no raw_match_data or predictions/features writes', () => {
+    const gate = loadModuleFresh();
+    const sqlPlan = gate.buildUpsertSqlPlan(gate.buildInsertRows(validCandidates()));
+    assert.doesNotMatch(sqlPlan.text, /raw_match_data/i);
+    assert.doesNotMatch(sqlPlan.text, /predictions/i);
+    assert.doesNotMatch(sqlPlan.text, /l3_features/i);
+    assert.doesNotMatch(sqlPlan.text, /match_features_training/i);
+});
+
+test('buildUpsertSqlPlan rejects empty rows', () => {
+    const gate = loadModuleFresh();
+    assert.throws(() => gate.buildUpsertSqlPlan([]), /rows are required/i);
+});
+
+test('transaction success commits', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+    const payload = await gate.executeMatchesSeedTransaction(
+        {
+            source: 'fotmob',
+            scope: 'league_season_date',
+            leagueId: '53',
+            season: '2025/2026',
+            date: '2026-05-10',
+            candidateCount: '8',
+            containsTargetMatchId: '4830746',
+            containsTargetLabel: 'Angers vs Strasbourg',
+            maxSeedRows: '10',
+            finalDbWriteConfirmation: 'yes',
+            allowDbWriteNow: 'yes',
+            allowMatchesWriteNow: 'yes',
+            allowRawMatchDataWrite: 'no',
+            allowTraining: 'no',
+            allowPrediction: 'no',
+        },
+        {
+            candidates: validCandidates(),
+            existingMatches: [],
+            pool: fakeDb.pool,
+        }
+    );
+
+    assert.equal(payload.transaction.committed, true);
+    assert.equal(fakeDb.getState().committed, true);
+});
+
+test('transaction failure rolls back', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool({ failOnInsert: true });
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(
+            {
+                source: 'fotmob',
+                scope: 'league_season_date',
+                leagueId: '53',
+                season: '2025/2026',
+                date: '2026-05-10',
+                candidateCount: '8',
+                containsTargetMatchId: '4830746',
+                containsTargetLabel: 'Angers vs Strasbourg',
+                maxSeedRows: '10',
+                finalDbWriteConfirmation: 'yes',
+                allowDbWriteNow: 'yes',
+                allowMatchesWriteNow: 'yes',
+                allowRawMatchDataWrite: 'no',
+                allowTraining: 'no',
+                allowPrediction: 'no',
+            },
+            {
+                candidates: validCandidates(),
+                existingMatches: [],
+                pool: fakeDb.pool,
+            }
+        ),
+        /forced insert failure/i
+    );
+
+    assert.equal(fakeDb.getState().rolledBack, true);
+});
+
+test('executeMatchesSeedTransaction covers candidatesJson and existingMatchesJson branches', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+    const payload = await gate.executeMatchesSeedTransaction(
+        validInput({
+            candidatesJson: JSON.stringify(validCandidates()),
+            existingMatchesJson: JSON.stringify([]),
+        }),
+        {
+            pool: fakeDb.pool,
+        }
+    );
+
+    assert.equal(payload.inserted_count, 8);
+    assert.equal(payload.exact_candidate_set_source, 'candidates_json_argument');
+});
+
+test('executeMatchesSeedTransaction covers dependency resolveCandidates and selectExistingMatches branches', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+    const payload = await gate.executeMatchesSeedTransaction(validInput(), {
+        pool: fakeDb.pool,
+        resolveCandidates: async () => ({
+            candidates: validCandidates(),
+            exactCandidateSetSource: 'custom_resolver',
+            sourceUrlUsed: 'https://example.test/candidates',
+            networkUsed: false,
+        }),
+        selectExistingMatches: async () => [],
+    });
+
+    assert.equal(payload.exact_candidate_set_source, 'custom_resolver');
+    assert.equal(payload.source_url_used, 'https://example.test/candidates');
+});
+
+test('executeMatchesSeedTransaction covers safe preview candidate recapture branch', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+    const payload = await gate.executeMatchesSeedTransaction(validInput(), {
+        pool: fakeDb.pool,
+        safePreviewModule: {
+            async buildL1DiscoveryPlanPreview() {
+                return {
+                    candidates_preview: validCandidates(),
+                    source_url_used: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+                    external_network_used: true,
+                };
+            },
+        },
+    });
+
+    assert.equal(payload.exact_candidate_set_source, 'safe_controlled_network_preview');
+    assert.match(payload.source_url_used, /fotmob\.com\/api\/data\/leagues/);
+});
+
+test('executeMatchesSeedTransaction rejects exact candidate mismatches before transaction', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(
+            validInput({ candidatesJson: JSON.stringify(validCandidates().slice(0, 7)) }),
+            { pool: fakeDb.pool }
+        ),
+        /exact candidate set count mismatch/i
+    );
+});
+
+test('executeMatchesSeedTransaction rejects target match or label mismatches before transaction', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+    const nonTargetCandidates = validCandidates().map(candidate =>
+        candidate.external_id === '4830746'
+            ? {
+                  ...candidate,
+                  external_id: '9999999',
+                  match_id: '53_20252026_9999999',
+                  home_team: 'Lens',
+                  away_team: 'Nantes',
+              }
+            : candidate
+    );
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(validInput({ candidatesJson: JSON.stringify(nonTargetCandidates) }), {
+            pool: fakeDb.pool,
+        }),
+        /target match id candidate not found/i
+    );
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(
+            validInput({
+                candidatesJson: JSON.stringify([
+                    { ...validCandidates()[0], home_team: 'Lens' },
+                    ...validCandidates().slice(1),
+                ]),
+            }),
+            { pool: fakeDb.pool }
+        ),
+        /target label candidate not found/i
+    );
+});
+
+test('executeMatchesSeedTransaction rejects preflight mismatch when existing rows already appear before transaction', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool();
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(validInput(), {
+            candidates: validCandidates(),
+            existingMatches: [validCandidates()[0]],
+            pool: fakeDb.pool,
+        }),
+        /preflight mismatch detected before transaction/i
+    );
+});
+
+test('executeMatchesSeedTransaction rejects in-transaction mismatch when affected rows drift', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool({ existingMatches: [validCandidates()[0]] });
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(validInput(), {
+            candidates: validCandidates(),
+            existingMatches: [],
+            pool: fakeDb.pool,
+        }),
+        /execution preflight mismatch inside transaction/i
+    );
+});
+
+test('executeMatchesSeedTransaction rejects write-result mismatch and post-commit verification mismatch', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(validInput(), {
+            candidates: validCandidates(),
+            existingMatches: [],
+            pool: createFakePool({
+                insertedRows: validCandidates().map((candidate, index) => ({
+                    match_id: candidate.match_id,
+                    inserted: index !== 0,
+                })),
+            }).pool,
+        }),
+        /transaction write result mismatch/i
+    );
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(validInput(), {
+            candidates: validCandidates(),
+            existingMatches: [],
+            pool: createFakePool({
+                countsAfter: {
+                    matches: 10,
+                    raw_match_data: 3,
+                },
+            }).pool,
+        }),
+        /post-commit verification failed/i
+    );
+});
+
+test('executeMatchesSeedTransaction rejects matches count delta mismatch after write', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool({
+        countsAfter: {
+            matches: 9,
+        },
+    });
+
+    await assert.rejects(
+        gate.executeMatchesSeedTransaction(validInput(), {
+            candidates: validCandidates(),
+            existingMatches: [],
+            pool: fakeDb.pool,
+        }),
+        /matches row count delta mismatch/i
+    );
+});
+
+test('executeMatchesSeedTransaction error path records rollback and tolerates rollback/count follow-up failures', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+    const fakeDb = createFakePool({
+        failOnInsert: true,
+        rollbackFails: true,
+        failCountAfterRollback: true,
+    });
+
+    await assert.rejects(async () => {
+        try {
+            await gate.executeMatchesSeedTransaction(validInput(), {
+                candidates: validCandidates(),
+                existingMatches: [],
+                pool: fakeDb.pool,
+            });
+        } catch (error) {
+            assert.equal(error.controlledPayload.execution_completed, false);
+            assert.equal(error.controlledPayload.transaction.began, true);
+            assert.equal(error.controlledPayload.db_write_executed, false);
+            assert.equal(error.controlledPayload.raw_match_data_write_executed, false);
+            assert.match(error.rollbackError.message, /forced rollback failure/i);
+            assert.match(error.afterCountError.message, /forced count failure after rollback/i);
+            throw error;
+        }
+    }, /forced insert failure/i);
+});
+
+test('post commit verification checks protected tables', () => {
+    const gate = loadModuleFresh();
+    const verification = gate.buildPostCommitVerification(
+        {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        {
+            matches: 10,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        }
+    );
+
+    assert.equal(verification.raw_match_data_unchanged, true);
+    assert.equal(verification.features_unchanged, true);
+    assert.equal(verification.predictions_unchanged, true);
+});
+
+test('output builder keeps required flags on fake success', () => {
+    const gate = loadModuleFresh();
+    const payload = gate.buildControlledExecutionResult({
+        input: {
+            source: 'fotmob',
+            scope: 'league_season_date',
+            leagueId: '53',
+            season: '2025/2026',
+            date: '2026-05-10',
+            candidateCount: 8,
+            maxSeedRows: 10,
+            containsTargetMatchId: '4830746',
+            containsTargetLabel: 'Angers vs Strasbourg',
+        },
+        exactCandidateSetSource: 'dependency_candidates',
+        sourceUrlUsed: null,
+        existingAffectedMatchesCount: 0,
+        affectedPreview: [],
+        insertedCount: 8,
+        updatedCount: 0,
+        skippedCount: 0,
+        affectedMatchIds: validCandidates().map(item => item.match_id),
+        transaction: {
+            began: true,
+            committed: true,
+            rolled_back: false,
+        },
+        beforeCounts: {
+            matches: 2,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        afterCounts: {
+            matches: 10,
+            bookmaker_odds_history: 2,
+            raw_match_data: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+    });
+
+    assert.equal(payload.execution_completed, true);
+    assert.equal(payload.inserted_count, 8);
+    assert.equal(payload.raw_match_data_write_executed, false);
+    assert.equal(payload.safety_summary.called_fixture_repository_persist, false);
+});
+
+test('runCli handles stdin candidates, explicit stdinText, and invalid JSON errors', async t => {
+    installNoSideEffectGuards(t);
+    const gate = loadModuleFresh();
+
+    const helpResult = await runCli(gate, ['--help']);
+    assert.equal(helpResult.status, 0);
+    assert.match(helpResult.stdout, /Usage:/);
+
+    let stdout = '';
+    const stdinStatus = await gate.runCli(
+        validArgv(),
+        {
+            stdin: createFakeStdin(JSON.stringify(validCandidates())),
+            stdout: text => {
+                stdout += text;
+            },
+            stderr: () => {},
+        },
+        {
+            pool: createFakePool().pool,
+            existingMatches: [],
+        }
+    );
+    assert.equal(stdinStatus, 0);
+    assert.equal(parseJsonOutput(stdout).inserted_count, 8);
+
+    const explicitStdin = await runCli(gate, validArgv(), {
+        stdinText: JSON.stringify(validCandidates()),
+        pool: createFakePool().pool,
+        existingMatches: [],
+    });
+    assert.equal(explicitStdin.status, 0);
+    assert.equal(parseJsonOutput(explicitStdin.stdout).inserted_count, 8);
+
+    const invalidCandidatesJson = await runCli(gate, [...validArgv(), '--candidates-json={invalid'], {
+        pool: createFakePool().pool,
+        existingMatches: [],
+    });
+    assert.equal(invalidCandidatesJson.status, 1);
+    assert.match(invalidCandidatesJson.stderr, /candidates-json is not valid JSON/i);
+
+    const invalidExistingJson = await runCli(
+        gate,
+        [...validArgv(), '--candidates-json=' + JSON.stringify(validCandidates()), '--existing-matches-json={invalid'],
+        { pool: createFakePool().pool }
+    );
+    assert.equal(invalidExistingJson.status, 1);
+    assert.match(invalidExistingJson.stderr, /existing-matches-json is not valid JSON/i);
+
+    const stdinErrorResult = await gate.runCli(
+        validArgv(),
+        {
+            stdin: createFakeStdin('', { emitError: true }),
+            stdout: () => {},
+            stderr: () => {},
+        },
+        {
+            candidates: validCandidates(),
+            existingMatches: [],
+            pool: createFakePool().pool,
+        }
+    );
+    assert.equal(stdinErrorResult, 0);
+});
+
+test('Makefile execute target is registered and points to controlled script', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l1-matches-seed-commit-execute:/m);
+    assert.match(makefile, /scripts\/ops\/l1_matches_seed_commit_execute\.js/);
+    assert.match(makefile, /FINAL_DB_WRITE_CONFIRMATION=yes/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.09L1 controlled matches seed commit execution.

Scope:
- Adds controlled execution script for exact 2026-05-10 Ligue 1 FotMob candidates
- Requires final DB write confirmation
- Writes only matches table when executed
- Keeps raw_match_data/features/predictions blocked
- Avoids titan_discovery, DiscoveryService.discover, and FixtureRepository.persist
- Adds unit tests and report

Safety:
- No raw_match_data writes
- No feature writes
- No prediction writes
- No training/prediction
- No titan_discovery execution
- No DiscoveryService.discover execution
- No FixtureRepository.persist

Validation before merge:
- Unit tests passed
- npm test passed
- npm run test:coverage passed
- DB unchanged before execution
- eslint / prettier / git diff --check passed