### PR TITLE
feat(data): add L2 raw detail preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@
 - L1 matches seed commit 不能由 AI / Codex 直接走旧 commit 大入口执行；Phase 5.06L1 仅允许 `make data-l1-matches-seed-commit-plan` 输出 stdout planning；Phase 5.07L1 仅允许 `make data-l1-matches-seed-commit-authorization` 输出 stdout authorization summary；Phase 5.08L1 仅允许 `make data-l1-matches-seed-commit-execution-preflight` 输出 stdout preflight summary 和 SELECT-only affected rows preview；Phase 5.09L1 仅允许 `make data-l1-matches-seed-commit-execute` 在最终确认后、按 exact scope 事务写入 `matches`。
 - legacy L1 / data entrypoints 对 agents 视为 deprecated：admin / 人工兼容入口可以保留，但 AI / Codex 不得直接运行 `titan_discovery.js`、`run_production.js`、`batch_historical_backfill.js`、`total_war_pipeline.js`、生产 harvest 入口或 raw ingest commit 入口；L1 discovery 与 matches seed 操作必须走 `data-l1-*` safe targets。
 - L2 raw JSON acquisition 当前仍未授权执行。AI / Codex 不得运行 legacy raw backfill、production harvest、`raw_match_data` commit 或任何会抓取 FotMob match detail / 写 `raw_match_data` 的入口；后续必须先走 Phase 5.10L2+ controlled planning / preview / authorization / preflight，且 `raw_match_data` 写入必须与训练、预测分离并单独授权。
+- Phase 5.11L2 raw detail preview 仅允许 preview-only：除非未来用户扩大授权，只能目标 `53_20252026_4830746` / `external_id=4830746`；不得写 `raw_match_data` 或任何 DB，不得打印或保存完整 body，不得启 browser/proxy，不得调用 `ProductionHarvester` 或 legacy raw backfill；`raw_match_data` 写入必须等待后续 planning / authorization / preflight。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 
@@ -224,6 +225,7 @@ AI / Codex 默认只能执行：
 
 - legacy L1/data entrypoints 对 agents 视为 deprecated：admin / 人工兼容可以继续保留，但默认不得直接运行；L1 discovery 和 matches seed 默认必须走 `data-l1-*` safe workflow。
 - L2 raw JSON acquisition 仍处于 planning 阶段，默认不得触网、不得抓取 FotMob match detail、不得写 `raw_match_data`；后续必须走 controlled preview / authorization / preflight。
+- Phase 5.11L2 仅允许用户明确授权的 `make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg NETWORK_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no`；只输出 stdout metadata/hash/markers，不写 DB，不写 `raw_match_data`，不保存或打印完整 body。
 - `make data-help`
 - `make data-check`
 - `make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...`

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
+        data-l2-raw-detail-preview \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -330,7 +331,10 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "L2 raw JSON acquisition is under planning:"
 	@echo "  Do not run legacy raw backfill / production harvest as an agent workflow."
 	@echo "  Do not write raw_match_data until a separate controlled authorization/preflight phase."
-	@echo "  Future preferred path will be data-l2-* controlled targets."
+	@echo "  make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg NETWORK_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # Phase 5.11L2 single-target preview only"
+	@echo "  L2 raw detail preview is preview-only: no raw_match_data write, no DB write, no browser/proxy, no full body print/save."
+	@echo "  raw_match_data write requires future authorization/preflight."
+	@echo "  Future preferred path will continue as data-l2-* controlled targets."
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
 	@echo "  make data-fotmob-stdout-network-dry-run-authorization-packet-preview PACKET=<path>  # Phase 4.99F template-only, stdout-only, no network/staging/DB/runtime packet write"
 	@echo "  make data-fotmob-stdout-network-dry-run-execution-plan-preview PLAN=<path> PACKET=<path>  # Phase 5.00F template-only, stdout-only, no network/staging/DB/runtime execution plan write"
@@ -611,6 +615,27 @@ data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blo
 	@echo "  Use data-l1-matches-seed-commit-plan, data-l1-matches-seed-commit-authorization, data-l1-matches-seed-commit-execution-preflight, and the exact-scope data-l1-matches-seed-commit-execute gate."
 	@echo "  Even with CONFIRM_L1_MATCHES_SEED_COMMIT=1, matches/DB/raw writes remain blocked."
 	@exit 1
+
+data-l2-raw-detail-preview: ## L2 raw detail preview. Phase 5.11L2. Single target, stdout metadata only, no DB/raw write/browser/proxy/body save.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(MATCH_ID)" ] || [ -z "$(EXTERNAL_ID)" ] || [ -z "$(HOME_TEAM)" ] || [ -z "$(AWAY_TEAM)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l2_raw_detail_preview.js \
+		--source="$(SOURCE)" \
+		--match-id="$(MATCH_ID)" \
+		--external-id="$(EXTERNAL_ID)" \
+		--home-team="$(HOME_TEAM)" \
+		--away-team="$(AWAY_TEAM)" \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--concurrency="$(or $(CONCURRENCY),1)" \
+		--retry="$(or $(RETRY),0)" \
+		--print-body="$(or $(PRINT_BODY),no)" \
+		--save-body="$(or $(SAVE_BODY),no)"
 
 data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.
 	@if [ -n "$(SAMPLE_HTML)" ]; then \

--- a/docs/_reports/L2_RAW_DETAIL_ACQUISITION_PREVIEW_PHASE5_11L2.md
+++ b/docs/_reports/L2_RAW_DETAIL_ACQUISITION_PREVIEW_PHASE5_11L2.md
@@ -1,0 +1,134 @@
+# L2 Raw Detail Acquisition Preview - Phase 5.11L2
+
+## 1. Executive summary
+
+Phase 5.11L2 adds a controlled raw detail acquisition preview for one already seeded FotMob match:
+
+- `match_id=53_20252026_4830746`
+- `external_id=4830746`
+- Angers vs Strasbourg
+
+This phase is preview-only. It can perform one explicitly authorized external FotMob match detail request after merge and green main CI, then prints only response metadata, hash, markers, and structural signals to stdout.
+
+It does not write `raw_match_data`, does not write any DB table, does not save or print the full body, does not use browser/proxy runtime, and does not run parser, feature, training, or prediction pipelines.
+
+## 2. Background
+
+Phase 5.09L1 seeded 8 Ligue 1 matches for 2026-05-10 into `matches`. Phase 5.10L2 confirmed that `raw_match_data` has an FK to `matches(match_id)` and that the next safe step should be a single-target raw detail preview before any ingest planning or DB write.
+
+The current preview target exists in `matches`:
+
+| match_id              | external_id | fixture              | status   |
+| --------------------- | ----------- | -------------------- | -------- |
+| `53_20252026_4830746` | `4830746`   | Angers vs Strasbourg | finished |
+
+`raw_match_data` had no existing row for this target before implementation.
+
+## 3. Implemented files
+
+| file                                                             | purpose                                         |
+| ---------------------------------------------------------------- | ----------------------------------------------- |
+| `scripts/ops/l2_raw_detail_preview.js`                           | Phase 5.11L2 safe preview wrapper               |
+| `tests/unit/l2_raw_detail_preview.test.js`                       | Unit tests with fake fetch and execution guards |
+| `Makefile`                                                       | Adds `data-l2-raw-detail-preview` and help text |
+| `AGENTS.md`                                                      | Adds Phase 5.11L2 agent safety rules            |
+| `docs/_reports/L2_RAW_DETAIL_ACQUISITION_PREVIEW_PHASE5_11L2.md` | This report                                     |
+
+## 4. Safety boundary
+
+The wrapper enforces:
+
+- exact source: `fotmob`
+- exact match: `53_20252026_4830746`
+- exact external id: `4830746`
+- `NETWORK_AUTHORIZATION=yes`
+- `ALLOW_DB_WRITE=no`
+- `ALLOW_RAW_MATCH_DATA_WRITE=no`
+- `ALLOW_BROWSER_RUNTIME=no`
+- `ALLOW_PROXY_RUNTIME=no`
+- `CONCURRENCY=1`
+- `RETRY=0`
+- `PRINT_BODY=no`
+- `SAVE_BODY=no`
+- `bulk=yes` blocked
+
+The wrapper does not import `ProductionHarvester`, `FotMobStrategy`, raw ingest scripts, `pg`, Playwright, proxy runtime, or child process modules. It does not call file write APIs.
+
+## 5. Local validation
+
+Local validation completed for this phase:
+
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/l2_raw_detail_preview.test.js` passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test` passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage` passed
+- `git diff --check` passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npx eslint scripts/ops/l2_raw_detail_preview.js tests/unit/l2_raw_detail_preview.test.js --no-cache` passed
+- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md Makefile scripts/ops/l2_raw_detail_preview.js tests/unit/l2_raw_detail_preview.test.js docs/_reports/L2_RAW_DETAIL_ACQUISITION_PREVIEW_PHASE5_11L2.md` passed
+- DB row counts unchanged before commit:
+    - `matches=10`
+    - `raw_match_data=2`
+    - `bookmaker_odds_history=2`
+    - `l3_features=2`
+    - `match_features_training=2`
+    - `predictions=2`
+- `l1-config-*` residue absent
+- `docs/_staging_preview` absent
+
+Integration browser automation is intentionally not run in this phase.
+
+## 6. Actual controlled preview result
+
+To be recorded after PR merge, green main CI, and final local safety baseline:
+
+| field                              | result  |
+| ---------------------------------- | ------- |
+| request_url                        | pending |
+| final_url                          | pending |
+| http_status                        | pending |
+| content_type                       | pending |
+| body_byte_length                   | pending |
+| body_sha256                        | pending |
+| contains `4830746`                 | pending |
+| contains `Angers`                  | pending |
+| contains `Strasbourg`              | pending |
+| json_parse_ok / hydration_parse_ok | pending |
+| top_level_keys                     | pending |
+| candidate_raw_data_paths           | pending |
+| looks_like_valid_match_detail      | pending |
+| body_printed                       | `false` |
+| body_saved                         | `false` |
+| DB unchanged                       | pending |
+
+If FotMob returns 403, 429, captcha, or another block signal, the wrapper must stop, not retry, not launch browser/proxy, and report only the controlled error summary.
+
+## 7. Recommended next phase
+
+Recommended next phase:
+
+Phase 5.12L2: raw_match_data ingest planning.
+
+That phase should use the preview result to define:
+
+- `raw_data` storage shape
+- `data_hash` SHA-256 policy
+- `data_version`
+- `collected_at` / fetched-at mapping
+- upsert and dedup policy
+- protected table verification
+- no features / predictions / training
+
+It should remain no-write unless a later authorization phase explicitly permits `raw_match_data` writes.
+
+## 8. Explicit non-execution
+
+During implementation and local validation, this phase does not execute:
+
+- `raw_match_data` writes
+- DB writes
+- harvest / ingest
+- production harvester
+- legacy raw backfill
+- training / prediction
+- browser / proxy runtime
+- full body save / print
+- file deletion

--- a/scripts/ops/l2_raw_detail_preview.js
+++ b/scripts/ops/l2_raw_detail_preview.js
@@ -1,0 +1,670 @@
+#!/usr/bin/env node
+/* eslint-disable complexity */
+'use strict';
+
+const crypto = require('node:crypto');
+
+const PHASE = 'PHASE5_11L2_CONTROLLED_RAW_DETAIL_ACQUISITION_PREVIEW';
+const NEXT_REQUIRED_PHASE = 'Phase 5.12L2 raw_match_data ingest planning';
+const DEFAULT_TIMEOUT_MS = 20000;
+const FOTMOB_DETAIL_URL = 'https://www.fotmob.com/api/data/matchDetails';
+const TARGET = Object.freeze({
+    source: 'fotmob',
+    matchId: '53_20252026_4830746',
+    externalId: '4830746',
+    homeTeam: 'Angers',
+    awayTeam: 'Strasbourg',
+});
+const BLOCK_SIGNAL_PATTERNS = Object.freeze([
+    /captcha/i,
+    /cloudflare/i,
+    /cf-challenge/i,
+    /access denied/i,
+    /too many requests/i,
+    /rate limit/i,
+]);
+const CANDIDATE_KEYS = new Set([
+    'content',
+    'general',
+    'header',
+    'lineup',
+    'matchFacts',
+    'matchDetails',
+    'stats',
+    'shotmap',
+    'teamColors',
+    'teams',
+]);
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    return Number.parseInt(normalized, 10);
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return {
+            value: nextArg,
+            consumedNext: true,
+        };
+    }
+
+    return {
+        value: true,
+        consumedNext: false,
+    };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        matchId: null,
+        externalId: null,
+        homeTeam: null,
+        awayTeam: null,
+        networkAuthorization: null,
+        allowDbWrite: null,
+        allowRawMatchDataWrite: null,
+        allowBrowserRuntime: null,
+        allowProxyRuntime: null,
+        concurrency: null,
+        retry: null,
+        printBody: null,
+        saveBody: null,
+        bulk: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        'match-id': 'matchId',
+        match_id: 'matchId',
+        'external-id': 'externalId',
+        external_id: 'externalId',
+        'home-team': 'homeTeam',
+        home_team: 'homeTeam',
+        'away-team': 'awayTeam',
+        away_team: 'awayTeam',
+        'network-authorization': 'networkAuthorization',
+        network_authorization: 'networkAuthorization',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-browser-runtime': 'allowBrowserRuntime',
+        allow_browser_runtime: 'allowBrowserRuntime',
+        'allow-proxy-runtime': 'allowProxyRuntime',
+        allow_proxy_runtime: 'allowProxyRuntime',
+        concurrency: 'concurrency',
+        retry: 'retry',
+        'print-body': 'printBody',
+        print_body: 'printBody',
+        'save-body': 'saveBody',
+        save_body: 'saveBody',
+        bulk: 'bulk',
+        help: 'help',
+        h: 'help',
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (!String(arg).startsWith('--')) {
+            options.unknown.push(String(arg));
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+
+        if (
+            [
+                'networkAuthorization',
+                'allowDbWrite',
+                'allowRawMatchDataWrite',
+                'allowBrowserRuntime',
+                'allowProxyRuntime',
+                'printBody',
+                'saveBody',
+                'bulk',
+                'help',
+            ].includes(optionKey)
+        ) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function normalizeText(value) {
+    return String(value || '').trim();
+}
+
+function includesText(value, expected) {
+    return normalizeText(value).toLowerCase().includes(normalizeText(expected).toLowerCase());
+}
+
+function pushRequiredBooleanError(errors, value, flagName, expected) {
+    if (value === expected) {
+        return;
+    }
+    if (value === true) {
+        errors.push(`${flagName}=yes is blocked in Phase 5.11L2`);
+        return;
+    }
+    if (value === false) {
+        errors.push(`${flagName}=no is required in Phase 5.11L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=${expected ? 'yes' : 'no'}`);
+}
+
+function normalizePreviewInput(input = {}) {
+    return {
+        source: normalizeText(input.source).toLowerCase(),
+        matchId: normalizeText(input.matchId),
+        externalId: normalizeText(input.externalId),
+        homeTeam: normalizeText(input.homeTeam),
+        awayTeam: normalizeText(input.awayTeam),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, undefined),
+        allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
+        allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, undefined),
+        allowProxyRuntime: normalizeBooleanFlag(input.allowProxyRuntime, undefined),
+        concurrency: parseInteger(input.concurrency, null),
+        retry: parseInteger(input.retry, null),
+        printBody: normalizeBooleanFlag(input.printBody, undefined),
+        saveBody: normalizeBooleanFlag(input.saveBody, undefined),
+        bulk: normalizeBooleanFlag(input.bulk, false),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function validatePreviewInput(input = {}) {
+    const value = normalizePreviewInput(input);
+    const errors = [];
+
+    if (value.unknown.length > 0) {
+        errors.push(`unknown arguments: ${value.unknown.join(', ')}`);
+    }
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== TARGET.source) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+    if (!value.matchId) {
+        errors.push('missing match-id');
+    } else if (value.matchId !== TARGET.matchId) {
+        errors.push(`match-id must be ${TARGET.matchId} in Phase 5.11L2`);
+    }
+    if (!value.externalId) {
+        errors.push('missing external-id');
+    } else if (value.externalId !== TARGET.externalId) {
+        errors.push(`external-id must be ${TARGET.externalId} in Phase 5.11L2`);
+    }
+    if (!value.homeTeam) {
+        errors.push('missing home-team');
+    } else if (!includesText(value.homeTeam, TARGET.homeTeam)) {
+        errors.push(`home-team must contain ${TARGET.homeTeam}`);
+    }
+    if (!value.awayTeam) {
+        errors.push('missing away-team');
+    } else if (!includesText(value.awayTeam, TARGET.awayTeam)) {
+        errors.push(`away-team must contain ${TARGET.awayTeam}`);
+    }
+
+    pushRequiredBooleanError(errors, value.networkAuthorization, 'network-authorization', true);
+    pushRequiredBooleanError(errors, value.allowDbWrite, 'allow-db-write', false);
+    pushRequiredBooleanError(errors, value.allowRawMatchDataWrite, 'allow-raw-match-data-write', false);
+    pushRequiredBooleanError(errors, value.allowBrowserRuntime, 'allow-browser-runtime', false);
+    pushRequiredBooleanError(errors, value.allowProxyRuntime, 'allow-proxy-runtime', false);
+    pushRequiredBooleanError(errors, value.printBody, 'print-body', false);
+    pushRequiredBooleanError(errors, value.saveBody, 'save-body', false);
+
+    if (value.concurrency !== 1) {
+        errors.push(value.concurrency > 1 ? 'concurrency > 1 is blocked' : 'concurrency must be 1');
+    }
+    if (value.retry !== 0) {
+        errors.push(value.retry > 0 ? 'retry > 0 is blocked' : 'retry must be 0');
+    }
+    if (value.bulk === true) {
+        errors.push('bulk=yes is blocked in Phase 5.11L2');
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function buildFotMobDetailRequest(input = {}) {
+    const validation = validatePreviewInput(input);
+    if (!validation.ok) {
+        throw new Error(`INVALID_PREVIEW_INPUT:${validation.errors.join('; ')}`);
+    }
+
+    const url = new URL(FOTMOB_DETAIL_URL);
+    url.searchParams.set('matchId', validation.value.externalId);
+
+    return {
+        method: 'GET',
+        url: url.href,
+        headers: {
+            accept: 'application/json, text/plain, */*',
+            'accept-language': 'en-US,en;q=0.9',
+            'accept-encoding': 'identity',
+            referer: `https://www.fotmob.com/match/${validation.value.externalId}`,
+            'user-agent':
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+            'x-requested-with': 'XMLHttpRequest',
+        },
+    };
+}
+
+function getObjectKeys(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return [];
+    }
+    return Object.keys(value).sort();
+}
+
+function collectCandidatePaths(value, prefix = '', paths = new Set(), depth = 0) {
+    if (!value || typeof value !== 'object' || depth > 5) {
+        return paths;
+    }
+
+    for (const key of Object.keys(value)) {
+        const nextPath = prefix ? `${prefix}.${key}` : key;
+        if (CANDIDATE_KEYS.has(key)) {
+            paths.add(nextPath);
+        }
+        collectCandidatePaths(value[key], nextPath, paths, depth + 1);
+    }
+
+    return paths;
+}
+
+function parseJsonPayload(bodyText) {
+    try {
+        return {
+            ok: true,
+            value: JSON.parse(bodyText),
+        };
+    } catch (error) {
+        return {
+            ok: false,
+            error: error.message,
+            value: null,
+        };
+    }
+}
+
+function extractNextDataPayload(bodyText) {
+    const match = String(bodyText || '').match(/<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i);
+    if (!match) {
+        return {
+            ok: false,
+            value: null,
+            error: 'NEXT_DATA_NOT_FOUND',
+        };
+    }
+
+    const parsed = parseJsonPayload(match[1].trim());
+    return {
+        ...parsed,
+        error: parsed.ok ? null : parsed.error,
+    };
+}
+
+function detectBlockSignals(bodyText, httpStatus = null) {
+    const signals = [];
+    if ([403, 429].includes(Number(httpStatus))) {
+        signals.push(`HTTP_${httpStatus}`);
+    }
+    for (const pattern of BLOCK_SIGNAL_PATTERNS) {
+        if (pattern.test(bodyText)) {
+            signals.push(pattern.source.replace(/\\/g, ''));
+        }
+    }
+    return [...new Set(signals)].sort();
+}
+
+function extractJsonOrHydrationPreview(body, contentType = '', context = {}) {
+    const bodyText = String(body || '');
+    const markers = [];
+    const candidatePaths = new Set();
+    const contentTypeText = String(contentType || '').toLowerCase();
+    const likelyJson = contentTypeText.includes('json') || /^[\s\n\r]*[{[]/.test(bodyText);
+    let jsonParseOk = false;
+    let hydrationParseOk = false;
+    let parsedRoot = null;
+
+    if (likelyJson) {
+        const parsed = parseJsonPayload(bodyText);
+        jsonParseOk = parsed.ok;
+        if (parsed.ok) {
+            parsedRoot = parsed.value;
+            markers.push('json');
+            collectCandidatePaths(parsed.value, '', candidatePaths);
+        }
+    }
+
+    if (bodyText.includes('__NEXT_DATA__')) {
+        markers.push('__NEXT_DATA__');
+        const nextData = extractNextDataPayload(bodyText);
+        hydrationParseOk = nextData.ok;
+        if (nextData.ok) {
+            parsedRoot = nextData.value;
+            collectCandidatePaths(nextData.value, '__NEXT_DATA__', candidatePaths);
+        }
+    }
+
+    const topLevelKeys = getObjectKeys(parsedRoot);
+    const containsMatchId = bodyText.includes(String(context.externalId || TARGET.externalId));
+    const containsHomeTeam = includesText(bodyText, context.homeTeam || TARGET.homeTeam);
+    const containsAwayTeam = includesText(bodyText, context.awayTeam || TARGET.awayTeam);
+    const blockSignals = detectBlockSignals(bodyText, context.httpStatus);
+    const hasExpectedStructure = [...candidatePaths].some(path =>
+        /(content|general|header|matchDetails|matchFacts|lineup|stats)/i.test(path)
+    );
+
+    return {
+        contains_match_id: containsMatchId,
+        contains_home_team: containsHomeTeam,
+        contains_away_team: containsAwayTeam,
+        json_parse_ok: jsonParseOk,
+        hydration_parse_ok: hydrationParseOk,
+        hydration_or_json_markers: [...new Set(markers)].sort(),
+        top_level_keys: topLevelKeys,
+        candidate_raw_data_paths: [...candidatePaths].sort().slice(0, 30),
+        block_signals: blockSignals,
+        looks_like_valid_match_detail:
+            blockSignals.length === 0 && containsMatchId && (jsonParseOk || hydrationParseOk) && hasExpectedStructure,
+    };
+}
+
+function getHeaderValue(headers, name) {
+    if (!headers) {
+        return '';
+    }
+    if (typeof headers.get === 'function') {
+        return String(headers.get(name) || '');
+    }
+    const targetName = String(name).toLowerCase();
+    const foundKey = Object.keys(headers).find(key => key.toLowerCase() === targetName);
+    return foundKey ? String(headers[foundKey] || '') : '';
+}
+
+function sha256(bodyText) {
+    return crypto
+        .createHash('sha256')
+        .update(String(bodyText || ''), 'utf8')
+        .digest('hex');
+}
+
+function buildRawDetailPreviewSummary({ input, request, response = {}, body = '', extraction = null, error = null }) {
+    const normalized = normalizePreviewInput(input);
+    const bodyText = String(body || '');
+    const httpStatus = Number(response.status || response.statusCode || 0) || null;
+    const contentType = getHeaderValue(response.headers, 'content-type');
+    const preview =
+        extraction ||
+        extractJsonOrHydrationPreview(bodyText, contentType, {
+            externalId: normalized.externalId,
+            homeTeam: normalized.homeTeam,
+            awayTeam: normalized.awayTeam,
+            httpStatus,
+        });
+    const controlledError = error
+        ? String(error.message || error)
+        : preview.block_signals.length > 0
+          ? `CONTROLLED_BLOCK_SIGNAL:${preview.block_signals.join(',')}`
+          : null;
+    const isHttpOk = httpStatus !== null && httpStatus >= 200 && httpStatus < 300;
+    const ok = !controlledError && isHttpOk && preview.looks_like_valid_match_detail;
+
+    return {
+        phase: PHASE,
+        preview_only: true,
+        source: TARGET.source,
+        match_id: TARGET.matchId,
+        external_id: TARGET.externalId,
+        home_team: TARGET.homeTeam,
+        away_team: TARGET.awayTeam,
+        network_authorization_used: normalized.networkAuthorization === true,
+        external_network_used: error ? false : true,
+        request_url: request?.url || '',
+        final_url: response.url || request?.url || '',
+        http_status: httpStatus,
+        ok,
+        controlled_error: controlledError,
+        content_type: contentType,
+        body_byte_length: Buffer.byteLength(bodyText, 'utf8'),
+        body_sha256: sha256(bodyText),
+        contains_match_id: preview.contains_match_id,
+        contains_home_team: preview.contains_home_team,
+        contains_away_team: preview.contains_away_team,
+        looks_like_valid_match_detail: preview.looks_like_valid_match_detail,
+        json_parse_ok: preview.json_parse_ok,
+        hydration_parse_ok: preview.hydration_parse_ok,
+        hydration_or_json_markers: preview.hydration_or_json_markers,
+        top_level_keys: preview.top_level_keys,
+        candidate_raw_data_paths: preview.candidate_raw_data_paths,
+        raw_match_data_write_allowed: false,
+        db_write_allowed: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        browser_used: false,
+        proxy_used: false,
+        body_printed: false,
+        body_saved: false,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+async function fetchPreviewBody(request, dependencies = {}) {
+    const fetchImpl = dependencies.fetchImpl || global.fetch;
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('FETCH_UNAVAILABLE: native fetch is not available');
+    }
+
+    const timeoutMs = Number(dependencies.requestTimeoutMs || DEFAULT_TIMEOUT_MS);
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+    const timeout = controller
+        ? setTimeout(() => {
+              controller.abort();
+          }, timeoutMs)
+        : null;
+
+    try {
+        const response = await fetchImpl(request.url, {
+            method: request.method,
+            headers: request.headers,
+            redirect: 'follow',
+            signal: controller?.signal,
+        });
+        const body = typeof response.text === 'function' ? await response.text() : '';
+        return {
+            response,
+            body,
+        };
+    } finally {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+    }
+}
+
+function buildValidationFailureSummary(args, errors) {
+    return {
+        phase: PHASE,
+        preview_only: true,
+        ok: false,
+        errors,
+        source: args.source || null,
+        match_id: args.matchId || null,
+        external_id: args.externalId || null,
+        raw_match_data_write_allowed: false,
+        db_write_allowed: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        browser_used: false,
+        proxy_used: false,
+        body_printed: false,
+        body_saved: false,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l2_raw_detail_preview.js --source=fotmob --match-id=53_20252026_4830746 --external-id=4830746 --home-team=Angers --away-team=Strasbourg --network-authorization=yes --allow-db-write=no --allow-raw-match-data-write=no --allow-browser-runtime=no --allow-proxy-runtime=no --concurrency=1 --retry=0 --print-body=no --save-body=no',
+        '',
+        'Safety:',
+        '  Phase 5.11L2 is preview-only: no DB write, no raw_match_data write, no browser/proxy, no full body print/save.',
+    ].join('\n');
+}
+
+async function runCli(argv = process.argv.slice(2), streams = {}, dependencies = {}) {
+    const stdout = streams.stdout || (text => process.stdout.write(text));
+    const args = parseArgs(argv);
+
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    const validation = validatePreviewInput(args);
+    if (!validation.ok) {
+        stdout(`${JSON.stringify(buildValidationFailureSummary(args, validation.errors), null, 2)}\n`);
+        return 1;
+    }
+
+    const request = buildFotMobDetailRequest(args);
+    try {
+        const { response, body } = await fetchPreviewBody(request, dependencies);
+        const contentType = getHeaderValue(response.headers, 'content-type');
+        const extraction = extractJsonOrHydrationPreview(body, contentType, {
+            externalId: validation.value.externalId,
+            homeTeam: validation.value.homeTeam,
+            awayTeam: validation.value.awayTeam,
+            httpStatus: response.status,
+        });
+        const summary = buildRawDetailPreviewSummary({
+            input: args,
+            request,
+            response,
+            body,
+            extraction,
+        });
+        stdout(`${JSON.stringify(summary, null, 2)}\n`);
+        return summary.ok ? 0 : 1;
+    } catch (error) {
+        const summary = buildRawDetailPreviewSummary({
+            input: args,
+            request,
+            response: {
+                status: null,
+                url: request.url,
+                headers: {},
+            },
+            body: '',
+            error,
+        });
+        stdout(`${JSON.stringify(summary, null, 2)}\n`);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    runCli()
+        .then(status => {
+            process.exitCode = status;
+        })
+        .catch(error => {
+            console.error(
+                JSON.stringify(
+                    {
+                        phase: PHASE,
+                        preview_only: true,
+                        ok: false,
+                        error: error.message,
+                        raw_match_data_write_allowed: false,
+                        db_write_allowed: false,
+                        would_write_raw_match_data: false,
+                        would_write_db: false,
+                        would_train: false,
+                        would_predict: false,
+                        browser_used: false,
+                        proxy_used: false,
+                        body_printed: false,
+                        body_saved: false,
+                        next_required_phase: NEXT_REQUIRED_PHASE,
+                    },
+                    null,
+                    2
+                )
+            );
+            process.exitCode = 1;
+        });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validatePreviewInput,
+    buildFotMobDetailRequest,
+    extractJsonOrHydrationPreview,
+    buildRawDetailPreviewSummary,
+    runCli,
+};

--- a/tests/unit/l2_raw_detail_preview.test.js
+++ b/tests/unit/l2_raw_detail_preview.test.js
@@ -1,0 +1,634 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+const Module = require('node:module');
+const { pathToFileURL } = require('node:url');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l2_raw_detail_preview.js');
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function validArgs(overrides = {}) {
+    return {
+        source: 'fotmob',
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        homeTeam: 'Angers',
+        awayTeam: 'Strasbourg',
+        networkAuthorization: true,
+        allowDbWrite: false,
+        allowRawMatchDataWrite: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        concurrency: '1',
+        retry: '0',
+        printBody: false,
+        saveBody: false,
+        bulk: false,
+        ...overrides,
+    };
+}
+
+function cliArgs(overrides = {}) {
+    const args = validArgs(overrides);
+    const tokens = [
+        `--source=${args.source}`,
+        `--match-id=${args.matchId}`,
+        `--external-id=${args.externalId}`,
+        `--home-team=${args.homeTeam}`,
+        `--away-team=${args.awayTeam}`,
+        `--network-authorization=${args.networkAuthorization ? 'yes' : 'no'}`,
+        `--allow-db-write=${args.allowDbWrite ? 'yes' : 'no'}`,
+        `--allow-raw-match-data-write=${args.allowRawMatchDataWrite ? 'yes' : 'no'}`,
+        `--allow-browser-runtime=${args.allowBrowserRuntime ? 'yes' : 'no'}`,
+        `--allow-proxy-runtime=${args.allowProxyRuntime ? 'yes' : 'no'}`,
+        `--concurrency=${args.concurrency}`,
+        `--retry=${args.retry}`,
+        `--print-body=${args.printBody ? 'yes' : 'no'}`,
+        `--save-body=${args.saveBody ? 'yes' : 'no'}`,
+    ];
+    if (args.bulk) {
+        tokens.push('--bulk=yes');
+    }
+    return tokens;
+}
+
+function fakeJsonBody() {
+    return JSON.stringify({
+        general: {
+            matchId: 4830746,
+            homeTeam: { name: 'Angers' },
+            awayTeam: { name: 'Strasbourg' },
+        },
+        header: {
+            teams: [{ name: 'Angers' }, { name: 'Strasbourg' }],
+        },
+        content: {
+            matchFacts: {
+                matchId: 4830746,
+            },
+            stats: {
+                periods: [],
+            },
+            lineup: {
+                homeTeam: 'Angers',
+                awayTeam: 'Strasbourg',
+            },
+        },
+    });
+}
+
+function fakeHtmlBody() {
+    const nextData = {
+        props: {
+            pageProps: {
+                general: {
+                    matchId: 4830746,
+                    homeTeam: { name: 'Angers' },
+                    awayTeam: { name: 'Strasbourg' },
+                },
+                content: {
+                    matchDetails: {
+                        id: 4830746,
+                        fixture: 'Angers vs Strasbourg',
+                    },
+                },
+            },
+        },
+    };
+    return `<html><body><script id="__NEXT_DATA__" type="application/json">${JSON.stringify(nextData)}</script></body></html>`;
+}
+
+function createResponse(body, options = {}) {
+    const status = options.status || 200;
+    const url = options.url || 'https://www.fotmob.com/api/data/matchDetails?matchId=4830746';
+    const contentType = options.contentType || 'application/json; charset=utf-8';
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        url,
+        headers: {
+            get(name) {
+                return String(name).toLowerCase() === 'content-type' ? contentType : '';
+            },
+        },
+        async text() {
+            return body;
+        },
+    };
+}
+
+async function runCli(gate, argv, dependencies = {}) {
+    let stdout = '';
+    const status = await gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return {
+        status,
+        stdout,
+        payload: stdout.trim().startsWith('{') ? JSON.parse(stdout) : null,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l2_raw_detail_preview`);
+    };
+
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+            'child_process',
+            'node:child_process',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (
+            /ProductionHarvester|FotMobStrategy|raw_match_data_local_ingest|backfill_historical_raw_match_data/i.test(
+                request
+            )
+        ) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        Module._load = originalLoad;
+    });
+}
+
+test('valid input succeeds', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validatePreviewInput(validArgs());
+    assert.equal(validation.ok, true);
+});
+
+test('parseArgs maps dashed CLI flags', () => {
+    const gate = loadModuleFresh();
+    const parsed = gate.parseArgs(cliArgs());
+    assert.equal(parsed.source, 'fotmob');
+    assert.equal(parsed.matchId, '53_20252026_4830746');
+    assert.equal(parsed.externalId, '4830746');
+    assert.equal(parsed.homeTeam, 'Angers');
+    assert.equal(parsed.awayTeam, 'Strasbourg');
+    assert.equal(parsed.networkAuthorization, true);
+    assert.equal(parsed.allowDbWrite, false);
+    assert.equal(parsed.allowRawMatchDataWrite, false);
+});
+
+test('normalizeBooleanFlag supports yes/no forms', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.normalizeBooleanFlag('yes'), true);
+    assert.equal(gate.normalizeBooleanFlag('true'), true);
+    assert.equal(gate.normalizeBooleanFlag('no'), false);
+    assert.equal(gate.normalizeBooleanFlag('false'), false);
+    assert.equal(gate.normalizeBooleanFlag('', 'fallback'), 'fallback');
+    assert.equal(gate.normalizeBooleanFlag(null, 'fallback'), 'fallback');
+    assert.equal(gate.normalizeBooleanFlag('unknown', null), null);
+});
+
+test('parseArgs covers split values, positional unknown, and unknown flags', () => {
+    const gate = loadModuleFresh();
+    const parsed = gate.parseArgs([
+        '--source',
+        'fotmob',
+        '--match-id',
+        '53_20252026_4830746',
+        '--unknown-flag=yes',
+        'positional-value',
+        '--help',
+    ]);
+
+    assert.equal(parsed.source, 'fotmob');
+    assert.equal(parsed.matchId, '53_20252026_4830746');
+    assert.equal(parsed.help, true);
+    assert.deepEqual(parsed.unknown, ['unknown-flag', 'positional-value']);
+});
+
+const invalidInputCases = [
+    ['source missing fails', { source: null }, /missing source/],
+    ['source non-fotmob fails', { source: 'other' }, /unsupported source/],
+    ['match-id missing fails', { matchId: null }, /missing match-id/],
+    ['match-id not 53_20252026_4830746 fails', { matchId: '53_20252026_4830747' }, /match-id must be/],
+    ['external-id missing fails', { externalId: null }, /missing external-id/],
+    ['external-id not 4830746 fails', { externalId: '4830747' }, /external-id must be/],
+    ['missing home-team fails', { homeTeam: null }, /missing home-team/],
+    ['home-team mismatch fails', { homeTeam: 'Nice' }, /home-team must contain/],
+    ['missing away-team fails', { awayTeam: null }, /missing away-team/],
+    ['away-team mismatch fails', { awayTeam: 'Lyon' }, /away-team must contain/],
+    ['network-authorization=no fails for actual preview', { networkAuthorization: false }, /network-authorization=no/],
+    ['allow-db-write=yes blocked', { allowDbWrite: true }, /allow-db-write=yes/],
+    ['allow-raw-match-data-write=yes blocked', { allowRawMatchDataWrite: true }, /allow-raw-match-data-write=yes/],
+    ['allow-browser-runtime=yes blocked', { allowBrowserRuntime: true }, /allow-browser-runtime=yes/],
+    ['allow-proxy-runtime=yes blocked', { allowProxyRuntime: true }, /allow-proxy-runtime=yes/],
+    ['concurrency > 1 blocked', { concurrency: '2' }, /concurrency > 1/],
+    ['retry > 0 blocked', { retry: '1' }, /retry > 0/],
+    ['print-body=yes blocked', { printBody: true }, /print-body=yes/],
+    ['save-body=yes blocked', { saveBody: true }, /save-body=yes/],
+    ['bulk=yes blocked', { bulk: true }, /bulk=yes/],
+    ['invalid concurrency fails', { concurrency: 'abc' }, /concurrency must be 1/],
+    ['missing retry fails', { retry: null }, /retry must be 0/],
+    ['unknown arguments fail validation', { unknown: ['--bad'] }, /unknown arguments/],
+];
+
+for (const [name, override, pattern] of invalidInputCases) {
+    test(name, () => {
+        const gate = loadModuleFresh();
+        const validation = gate.validatePreviewInput(validArgs(override));
+        assert.equal(validation.ok, false);
+        assert.match(validation.errors.join('\n'), pattern);
+    });
+}
+
+test('build request URL contains 4830746', () => {
+    const gate = loadModuleFresh();
+    const request = gate.buildFotMobDetailRequest(validArgs());
+    assert.equal(request.method, 'GET');
+    assert.match(request.url, /matchDetails/);
+    assert.match(request.url, /matchId=4830746/);
+});
+
+test('build request rejects invalid input', () => {
+    const gate = loadModuleFresh();
+    assert.throws(() => gate.buildFotMobDetailRequest(validArgs({ externalId: '4830747' })), /INVALID_PREVIEW_INPUT/);
+});
+
+test('fake JSON response preview succeeds', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    let fetchCount = 0;
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async url => {
+            fetchCount += 1;
+            assert.match(url, /4830746/);
+            return createResponse(fakeJsonBody());
+        },
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(fetchCount, 1);
+    assert.equal(result.payload.http_status, 200);
+    assert.equal(result.payload.contains_match_id, true);
+    assert.equal(result.payload.contains_home_team, true);
+    assert.equal(result.payload.contains_away_team, true);
+    assert.equal(result.payload.json_parse_ok, true);
+    assert.equal(result.payload.looks_like_valid_match_detail, true);
+    assert.ok(result.payload.top_level_keys.includes('content'));
+    assert.ok(result.payload.candidate_raw_data_paths.includes('content.matchFacts'));
+});
+
+test('fake HTML __NEXT_DATA__ response preview succeeds', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeHtmlBody(), { contentType: 'text/html; charset=utf-8' }),
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.hydration_parse_ok, true);
+    assert.equal(result.payload.hydration_or_json_markers.includes('__NEXT_DATA__'), true);
+    assert.equal(result.payload.contains_match_id, true);
+    assert.equal(result.payload.contains_home_team, true);
+    assert.equal(result.payload.contains_away_team, true);
+    assert.equal(result.payload.looks_like_valid_match_detail, true);
+});
+
+test('invalid JSON response returns parse failure without printing body', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () =>
+            createResponse('{not-json Angers Strasbourg 4830746', {
+                contentType: 'application/json',
+            }),
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.json_parse_ok, false);
+    assert.equal(result.payload.hydration_parse_ok, false);
+    assert.equal(result.payload.body_printed, false);
+});
+
+test('plain HTML without __NEXT_DATA__ is controlled invalid preview', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () =>
+            createResponse('<html>Angers vs Strasbourg 4830746</html>', {
+                contentType: 'text/html',
+            }),
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.hydration_parse_ok, false);
+    assert.equal(result.payload.looks_like_valid_match_detail, false);
+});
+
+test('extract preview handles null body and object headers', () => {
+    const gate = loadModuleFresh();
+    const extraction = gate.extractJsonOrHydrationPreview(null, '', {});
+    assert.equal(extraction.contains_match_id, false);
+    assert.equal(extraction.looks_like_valid_match_detail, false);
+
+    const summary = gate.buildRawDetailPreviewSummary({
+        input: validArgs(),
+        request: { url: 'https://example.test/detail?matchId=4830746' },
+        response: {
+            statusCode: 200,
+            url: 'https://example.test/final',
+            headers: { 'Content-Type': 'application/json' },
+        },
+        body: fakeJsonBody(),
+    });
+
+    assert.equal(summary.content_type, 'application/json');
+    assert.equal(summary.final_url, 'https://example.test/final');
+    assert.equal(summary.ok, true);
+});
+
+test('summary handles missing headers, missing request url, and explicit error', () => {
+    const gate = loadModuleFresh();
+    const summary = gate.buildRawDetailPreviewSummary({
+        input: validArgs({ networkAuthorization: false }),
+        request: {},
+        response: {},
+        body: '',
+        error: new Error('FETCH_FAILED'),
+    });
+
+    assert.equal(summary.external_network_used, false);
+    assert.equal(summary.request_url, '');
+    assert.equal(summary.final_url, '');
+    assert.equal(summary.http_status, null);
+    assert.equal(summary.content_type, '');
+    assert.equal(summary.controlled_error, 'FETCH_FAILED');
+    assert.equal(summary.network_authorization_used, false);
+});
+
+test('runCli --help prints usage and does not fetch', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, ['--help'], {
+        fetchImpl: async () => {
+            throw new Error('fetch should not be called for help');
+        },
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Usage:/);
+});
+
+test('runCli validation failure returns controlled summary', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs({ source: 'bad' }), {
+        fetchImpl: async () => {
+            throw new Error('fetch should not be called for invalid input');
+        },
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.ok, false);
+    assert.match(result.payload.errors.join('\n'), /unsupported source/);
+    assert.equal(result.payload.would_write_db, false);
+});
+
+test('fetch unavailable returns controlled error summary', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const originalFetch = global.fetch;
+    global.fetch = undefined;
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    const result = await runCli(gate, cliArgs());
+    assert.equal(result.status, 1);
+    assert.match(result.payload.controlled_error, /FETCH_UNAVAILABLE/);
+    assert.equal(result.payload.body_saved, false);
+});
+
+test('fetch error returns controlled error summary without retry', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    let fetchCount = 0;
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => {
+            fetchCount += 1;
+            throw new Error('NETWORK_DOWN');
+        },
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(fetchCount, 1);
+    assert.match(result.payload.controlled_error, /NETWORK_DOWN/);
+    assert.equal(result.payload.browser_used, false);
+});
+
+test('response without text method is handled as empty body', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => ({
+            status: 204,
+            ok: true,
+            url: 'https://www.fotmob.com/api/data/matchDetails?matchId=4830746',
+            headers: {},
+        }),
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.body_byte_length, 0);
+    assert.equal(result.payload.body_saved, false);
+});
+
+test('module can be imported as ESM URL without executing CLI main', async () => {
+    const imported = await import(pathToFileURL(SCRIPT_PATH).href);
+    assert.equal(typeof imported.default.runCli, 'function');
+});
+
+test('output safety flags remain false', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+
+    assert.equal(result.payload.body_printed, false);
+    assert.equal(result.payload.body_saved, false);
+    assert.equal(result.payload.would_write_raw_match_data, false);
+    assert.equal(result.payload.would_write_db, false);
+    assert.equal(result.payload.browser_used, false);
+    assert.equal(result.payload.proxy_used, false);
+    assert.equal(result.payload.raw_match_data_write_allowed, false);
+    assert.equal(result.payload.db_write_allowed, false);
+});
+
+test('output body_printed=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+    assert.equal(result.payload.body_printed, false);
+});
+
+test('output body_saved=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+    assert.equal(result.payload.body_saved, false);
+});
+
+test('output would_write_raw_match_data=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+    assert.equal(result.payload.would_write_raw_match_data, false);
+});
+
+test('output would_write_db=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+    assert.equal(result.payload.would_write_db, false);
+});
+
+test('output browser_used=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+    assert.equal(result.payload.browser_used, false);
+});
+
+test('output proxy_used=false', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+    assert.equal(result.payload.proxy_used, false);
+});
+
+test('controlled 403 error does not retry', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    let fetchCount = 0;
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => {
+            fetchCount += 1;
+            return createResponse('Access denied cloudflare captcha', {
+                status: 403,
+                contentType: 'text/html',
+            });
+        },
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(fetchCount, 1);
+    assert.equal(result.payload.http_status, 403);
+    assert.match(result.payload.controlled_error, /CONTROLLED_BLOCK_SIGNAL/);
+    assert.equal(result.payload.browser_used, false);
+    assert.equal(result.payload.proxy_used, false);
+});
+
+test('no fs.writeFile / mkdir or child_process operations during preview', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async () => createResponse(fakeJsonBody()),
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.body_saved, false);
+});
+
+test('source audit: no DB client write', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"]pg['"]/.test(source));
+    assert.ok(!/\bINSERT\b|\bUPDATE\b|\bDELETE\b|\bALTER\b|\bDROP\b|\bTRUNCATE\b/.test(source));
+});
+
+test('source audit: no child_process spawn', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(source));
+});
+
+test('source audit: no ProductionHarvester', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/ProductionHarvester/.test(source));
+});
+
+test('source audit: no FotMobStrategy live harvest', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/FotMobStrategy/.test(source));
+});
+
+test('source audit: no raw ingest commit', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/raw_match_data_local_ingest/.test(source));
+    assert.ok(!/backfill_historical_raw_match_data/.test(source));
+});
+
+test('source audit: no file writer calls', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/writeFile|createWriteStream|mkdir/.test(source));
+});
+
+test('source audit: no browser or proxy runtime imports', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/playwright|BrowserProvider|proxy runtime/i.test(source));
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.11L2 controlled raw detail acquisition preview.

Scope:
- Adds single-target FotMob raw detail preview for seeded match 53_20252026_4830746 / external_id 4830746
- Outputs response metadata/hash/markers only
- Does not print or save full body
- Does not write raw_match_data
- Does not write DB
- Does not use browser/proxy
- Adds Makefile target, tests, AGENTS.md rules, and report

Safety:
- No raw_match_data writes
- No DB writes
- No harvest / ingest
- No training / prediction
- No browser/proxy
- No file deletion

Validation:
- l2 raw detail preview tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed