### PR TITLE
feat(data): add FotMob detail route selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@
 - L2 raw JSON acquisition 当前仍未授权执行。AI / Codex 不得运行 legacy raw backfill、production harvest、`raw_match_data` commit 或任何会抓取 FotMob match detail / 写 `raw_match_data` 的入口；后续必须先走 Phase 5.10L2+ controlled planning / preview / authorization / preflight，且 `raw_match_data` 写入必须与训练、预测分离并单独授权。
 - Phase 5.11L2 raw detail preview 仅允许 preview-only：除非未来用户扩大授权，只能目标 `53_20252026_4830746` / `external_id=4830746`；不得写 `raw_match_data` 或任何 DB，不得打印或保存完整 body，不得启 browser/proxy，不得调用 `ProductionHarvester` 或 legacy raw backfill；`raw_match_data` 写入必须等待后续 planning / authorization / preflight。
 - Phase 5.11L2 direct `matchDetails` endpoint 已返回 403。AI / Codex 不得擅自 retry、增加 headers、改走 browser/proxy 或尝试 alternate route；继续请求 raw detail 前必须先完成现有 L2 fetch path reconciliation 并取得明确授权，`raw_match_data` 写入仍未授权。
+- Phase 5.12L2B 新增 safe FotMob detail route selector，默认顺序为 `html_hydration` -> `api_match_details`，`alternate_route` 仅 plan-only；live external raw detail preview 仍默认 blocked，未经未来单独授权不得 retry Phase 5.11L2 direct API 403、不得加 headers/browser/proxy 绕过，`raw_match_data` 写入仍未授权。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
-        data-l2-raw-detail-preview \
+        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -331,10 +331,12 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "L2 raw JSON acquisition is under planning:"
 	@echo "  Do not run legacy raw backfill / production harvest as an agent workflow."
 	@echo "  Do not write raw_match_data until a separate controlled authorization/preflight phase."
-	@echo "  make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg NETWORK_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # Phase 5.11L2 single-target preview only"
+	@echo "  make data-l2-raw-detail-route-preview-plan  # Phase 5.12L2B route selector plan only, no network"
+	@echo "  make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg ROUTE=auto NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=no ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # route selector preview; live remains blocked without future authorization"
 	@echo "  L2 raw detail preview is preview-only: no raw_match_data write, no DB write, no browser/proxy, no full body print/save."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
-	@echo "  Use a future audited L2 route selector / safe adapter, not legacy harvest/backfill, for further raw detail access."
+	@echo "  Phase 5.12L2B route selector supports html_hydration before api_match_details; alternate_route remains plan-only."
+	@echo "  Live raw detail requests require future explicit authorization; use audited route selector / safe adapter, not legacy harvest/backfill."
 	@echo "  raw_match_data write requires future authorization/preflight."
 	@echo "  Future preferred path will continue as data-l2-* controlled targets."
 	@echo "  make data-fotmob-single-target-adapter-preflight TARGET_SOURCE=fotmob TARGET_SCOPE_TYPE=match_id TARGET_MATCH_ID=<id> ...  # Phase 4.98F hardening, stdout-only, no network/staging/DB/legacy runtime"
@@ -618,7 +620,22 @@ data-l1-matches-seed-commit: ## Blocked L1 matches seed commit gate. Remains blo
 	@echo "  Even with CONFIRM_L1_MATCHES_SEED_COMMIT=1, matches/DB/raw writes remain blocked."
 	@exit 1
 
-data-l2-raw-detail-preview: ## L2 raw detail preview. Phase 5.11L2. Single target, stdout metadata only, no DB/raw write/browser/proxy/body save.
+data-l2-raw-detail-route-preview-plan: ## L2 raw detail route selector plan. Phase 5.12L2B. Stdout only, no network/DB/raw write/browser/proxy.
+	@echo "{"
+	@echo "  \"phase\": \"PHASE5_12L2B_SAFE_FOTMOB_DETAIL_ROUTE_SELECTOR\","
+	@echo "  \"preview_only\": true,"
+	@echo "  \"plan_only\": true,"
+	@echo "  \"route_selector_enabled\": true,"
+	@echo "  \"default_route_order\": [\"html_hydration\", \"api_match_details\"],"
+	@echo "  \"alternate_route\": \"plan_only\","
+	@echo "  \"live_external_request_allowed\": false,"
+	@echo "  \"db_write_allowed\": false,"
+	@echo "  \"raw_match_data_write_allowed\": false,"
+	@echo "  \"browser_runtime_allowed\": false,"
+	@echo "  \"proxy_runtime_allowed\": false"
+	@echo "}"
+
+data-l2-raw-detail-preview: ## L2 raw detail preview. Phase 5.12L2B. Route selector, stdout metadata only, live blocked by default.
 	@if [ -z "$(SOURCE)" ] || [ -z "$(MATCH_ID)" ] || [ -z "$(EXTERNAL_ID)" ] || [ -z "$(HOME_TEAM)" ] || [ -z "$(AWAY_TEAM)" ]; then \
 		echo "ERROR: provide SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg"; \
 		exit 1; \
@@ -629,7 +646,9 @@ data-l2-raw-detail-preview: ## L2 raw detail preview. Phase 5.11L2. Single targe
 		--external-id="$(EXTERNAL_ID)" \
 		--home-team="$(HOME_TEAM)" \
 		--away-team="$(AWAY_TEAM)" \
+		--route="$(or $(ROUTE),auto)" \
 		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--live-preview-authorization="$(or $(LIVE_PREVIEW_AUTHORIZATION),no)" \
 		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
 		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
 		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \

--- a/docs/_reports/FOTMOB_DETAIL_ROUTE_SELECTOR_PHASE5_12L2B.md
+++ b/docs/_reports/FOTMOB_DETAIL_ROUTE_SELECTOR_PHASE5_12L2B.md
@@ -1,0 +1,192 @@
+# FotMob Detail Route Selector - Phase 5.12L2B
+
+## 1. Executive summary
+
+Phase 5.11L2 proved the safe preview boundary but the direct public API route returned `HTTP 403` for:
+
+```text
+https://www.fotmob.com/api/data/matchDetails?matchId=4830746
+```
+
+Phase 5.12L2A found existing project evidence for multiple FotMob detail access paths: API `matchDetails`, page HTML hydration through `__NEXT_DATA__`, and browser/session fallback in legacy harvest code.
+
+Phase 5.12L2B adds a safe route selector to the L2 raw detail preview wrapper. The default route order now favors `html_hydration` before `api_match_details`, while `alternate_route` remains planning-only. This phase uses fake-fetch / fixture-backed unit tests only.
+
+No live external FotMob request, DB write, `raw_match_data` write, full body save/print, browser/proxy runtime, harvest/ingest, training, prediction, or file deletion is performed.
+
+## 2. Implemented files
+
+| file                                                         | change                                                                                                                |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `scripts/ops/l2_raw_detail_preview.js`                       | Adds safe route selector, route summaries, plan-only default, existing-parser integration, and route metadata output. |
+| `src/infrastructure/services/FotMobDetailRouteSelector.js`   | Extracts pure route selector execution and summary helpers from the CLI wrapper.                                      |
+| `tests/unit/l2_raw_detail_preview.test.js`                   | Adds fake HTML hydration, fake API JSON, fake 403, plan-only, alternate route, and safety guard coverage.             |
+| `Makefile`                                                   | Adds `data-l2-raw-detail-route-preview-plan` and updates L2 help text / preview parameters.                           |
+| `AGENTS.md`                                                  | Adds Phase 5.12L2B route selector guardrails.                                                                         |
+| `docs/_reports/FOTMOB_DETAIL_ROUTE_SELECTOR_PHASE5_12L2B.md` | Adds this implementation report.                                                                                      |
+
+## 3. Route selector design
+
+Supported input routes:
+
+- `route=auto`
+- `route=html_hydration`
+- `route=api_match_details`
+
+Default `route=auto` order:
+
+1. `html_hydration`
+    - Candidate URL: `https://www.fotmob.com/match/4830746`
+    - Parses page HTML `__NEXT_DATA__`
+    - Uses the existing pure `NextDataParser.extractFromHtml()` and `transformToApiFormat()` helpers
+2. `api_match_details`
+    - Candidate URL: `https://www.fotmob.com/api/data/matchDetails?matchId=4830746`
+    - Uses a safe local request builder aligned with the existing API client route
+3. `alternate_route`
+    - Candidate URL: `https://www.fotmob.com/api/matchDetails?matchId=4830746`
+    - Included in plan output only
+    - Not executed by default
+
+Execution boundary:
+
+- CLI defaults to plan-only unless live preview authorization is explicitly supplied in a future phase.
+- Unit tests execute route selector paths only with injected fake fetch.
+- `allow_browser_runtime=yes`, `allow_proxy_runtime=yes`, `allow_db_write=yes`, `allow_raw_match_data_write=yes`, `print_body=yes`, `save_body=yes`, `concurrency>1`, and `retry>0` are blocked.
+
+## 4. Existing client integration
+
+What is reused or aligned:
+
+- Reuses `src/parsers/fotmob/NextDataParser.js` pure HTML `__NEXT_DATA__` parser.
+- Aligns `html_hydration` route ordering with `FotMobStrategy` compliance mode, which tries match page HTML before public JSON.
+- Aligns `api_match_details` URL with `FotMobApiClient.fetchMatchDetails()`.
+- Keeps `FotMobApiClient` import disabled because the current engine client can bootstrap browser cookies if no usable session exists.
+
+What is intentionally not used:
+
+- `ProductionHarvester` is not imported or executed.
+- `FotMobStrategy` runtime harvest paths are not imported or executed.
+- Legacy backfill, Marathon, raw ingest, browser/session/proxy fallback, and persistence paths are not used.
+
+Engine-core components remain available for future controlled integration:
+
+- `FotMobApiClient`
+- `FotMobStrategy`
+- `NextDataParser`
+- `ProductionHarvester`
+- raw persistence components
+
+## 5. Test evidence
+
+Unit tests cover:
+
+- `route=auto` builds `html_hydration` before `api_match_details`.
+- Fake HTML with `__NEXT_DATA__` parses through the existing parser and selects `html_hydration`.
+- Fake hydration candidate contains `4830746`, `Angers`, and `Strasbourg`.
+- Fake API JSON parses and selects `api_match_details`.
+- Fake API `HTTP 403` returns controlled block summary.
+- Auto route does not proceed past a controlled block.
+- Auto route may fall back from missing hydration to fake API JSON.
+- `alternate_route` is present as plan-only and not executed.
+- `body_printed=false` and `body_saved=false`.
+- DB/raw writes remain false.
+- Browser/proxy flags remain false.
+- Source audit guards block `pg`, file writes, child process, native HTTP clients, browser/proxy imports, ProductionHarvester, runtime FotMobStrategy harvest, raw ingest, and legacy backfill.
+
+## 6. Safety boundary
+
+This phase enforces:
+
+- no live external FotMob access
+- no live match detail request
+- no retry
+- no browser/proxy runtime
+- no DB write
+- no `raw_match_data` write
+- no `matches` write
+- no protected table write
+- no full body save
+- no full body print
+- no harvest/ingest/backfill
+- no training/prediction
+- no model artifact loading
+- no file deletion
+
+## 7. Recommended next phase
+
+Recommended:
+
+`Phase 5.12L2C: controlled raw detail preview via audited route selector`
+
+Requirements:
+
+- user explicitly authorizes exactly one live request
+- single target `53_20252026_4830746` / `external_id=4830746`
+- `route=auto` or `route=html_hydration` first
+- no DB write
+- no `raw_match_data` write
+- no full body save/print
+- no browser/proxy
+- no retry unless explicitly authorized
+- if HTML hydration fails, report the failure; do not automatically add headers, cookies, browser, proxy, or alternate live routes without a new authorization boundary
+
+## 8. Explicit non-execution
+
+This phase does not execute:
+
+- external FotMob access
+- live match detail request
+- retry
+- browser/proxy
+- DB writes
+- `raw_match_data` writes
+- harvest / ingest
+- batch backfill
+- bulk harvest
+- training / prediction
+- model artifact loading
+- full body save/print
+- file deletion
+
+## 9. Validation
+
+Validation commands:
+
+- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/l2_raw_detail_preview.test.js`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm test`
+- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx eslint scripts/ops/l2_raw_detail_preview.js tests/unit/l2_raw_detail_preview.test.js src/infrastructure/services/FotMobDetailRouteSelector.js --no-cache`
+- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md Makefile scripts/ops/l2_raw_detail_preview.js tests/unit/l2_raw_detail_preview.test.js src/infrastructure/services/FotMobDetailRouteSelector.js docs/_reports/FOTMOB_DETAIL_ROUTE_SELECTOR_PHASE5_12L2B.md`
+- `git diff --check`
+- `make data-l2-raw-detail-route-preview-plan`
+
+Safety checks:
+
+- DB row counts unchanged:
+    - `matches=10`
+    - `raw_match_data=2`
+    - `bookmaker_odds_history=2`
+    - `l3_features=2`
+    - `match_features_training=2`
+    - `predictions=2`
+- `l1-config-*` residue absent
+- `docs/_staging_preview` absent
+
+Results:
+
+- `node --test tests/unit/l2_raw_detail_preview.test.js`: passed, 64/64.
+- `npm test`: passed.
+- `npm run test:coverage`: passed with the existing 80/80/80 coverage gate.
+- `eslint`: passed for the wrapper, unit test, and route selector helper.
+- `prettier --check`: passed for all touched files.
+- `git diff --check`: passed.
+- `make data-l2-raw-detail-route-preview-plan`: passed and printed plan-only JSON.
+- DB row counts remained unchanged:
+    - `matches=10`
+    - `raw_match_data=2`
+    - `bookmaker_odds_history=2`
+    - `l3_features=2`
+    - `match_features_training=2`
+    - `predictions=2`
+- `l1-config-*` residue absent.
+- `docs/_staging_preview` absent.

--- a/scripts/ops/l2_raw_detail_preview.js
+++ b/scripts/ops/l2_raw_detail_preview.js
@@ -3,11 +3,15 @@
 'use strict';
 
 const crypto = require('node:crypto');
+const { extractFromHtml, transformToApiFormat } = require('../../src/parsers/fotmob/NextDataParser');
+const { createFotMobDetailRouteSelector } = require('../../src/infrastructure/services/FotMobDetailRouteSelector');
 
-const PHASE = 'PHASE5_11L2_CONTROLLED_RAW_DETAIL_ACQUISITION_PREVIEW';
-const NEXT_REQUIRED_PHASE = 'Phase 5.12L2 raw_match_data ingest planning';
+const PHASE = 'PHASE5_12L2B_SAFE_FOTMOB_DETAIL_ROUTE_SELECTOR';
+const NEXT_REQUIRED_PHASE = 'Phase 5.12L2C controlled raw detail preview via audited route selector';
 const DEFAULT_TIMEOUT_MS = 20000;
+const FOTMOB_BASE_URL = 'https://www.fotmob.com';
 const FOTMOB_DETAIL_URL = 'https://www.fotmob.com/api/data/matchDetails';
+const FOTMOB_ALTERNATE_DETAIL_URL = 'https://www.fotmob.com/api/matchDetails';
 const TARGET = Object.freeze({
     source: 'fotmob',
     matchId: '53_20252026_4830746',
@@ -15,6 +19,13 @@ const TARGET = Object.freeze({
     homeTeam: 'Angers',
     awayTeam: 'Strasbourg',
 });
+const ROUTES = Object.freeze({
+    AUTO: 'auto',
+    HTML_HYDRATION: 'html_hydration',
+    API_MATCH_DETAILS: 'api_match_details',
+    ALTERNATE_ROUTE: 'alternate_route',
+});
+const EXECUTABLE_ROUTES = new Set([ROUTES.HTML_HYDRATION, ROUTES.API_MATCH_DETAILS]);
 const BLOCK_SIGNAL_PATTERNS = Object.freeze([
     /captcha/i,
     /cloudflare/i,
@@ -94,7 +105,9 @@ function parseArgs(argv = process.argv.slice(2)) {
         externalId: null,
         homeTeam: null,
         awayTeam: null,
+        route: ROUTES.AUTO,
         networkAuthorization: null,
+        livePreviewAuthorization: null,
         allowDbWrite: null,
         allowRawMatchDataWrite: null,
         allowBrowserRuntime: null,
@@ -117,8 +130,11 @@ function parseArgs(argv = process.argv.slice(2)) {
         home_team: 'homeTeam',
         'away-team': 'awayTeam',
         away_team: 'awayTeam',
+        route: 'route',
         'network-authorization': 'networkAuthorization',
         network_authorization: 'networkAuthorization',
+        'live-preview-authorization': 'livePreviewAuthorization',
+        live_preview_authorization: 'livePreviewAuthorization',
         'allow-db-write': 'allowDbWrite',
         allow_db_write: 'allowDbWrite',
         'allow-raw-match-data-write': 'allowRawMatchDataWrite',
@@ -160,6 +176,7 @@ function parseArgs(argv = process.argv.slice(2)) {
         if (
             [
                 'networkAuthorization',
+                'livePreviewAuthorization',
                 'allowDbWrite',
                 'allowRawMatchDataWrite',
                 'allowBrowserRuntime',
@@ -193,11 +210,11 @@ function pushRequiredBooleanError(errors, value, flagName, expected) {
         return;
     }
     if (value === true) {
-        errors.push(`${flagName}=yes is blocked in Phase 5.11L2`);
+        errors.push(`${flagName}=yes is blocked in Phase 5.12L2B`);
         return;
     }
     if (value === false) {
-        errors.push(`${flagName}=no is required in Phase 5.11L2`);
+        errors.push(`${flagName}=no is required in Phase 5.12L2B`);
         return;
     }
     errors.push(`missing ${flagName}=${expected ? 'yes' : 'no'}`);
@@ -210,7 +227,15 @@ function normalizePreviewInput(input = {}) {
         externalId: normalizeText(input.externalId),
         homeTeam: normalizeText(input.homeTeam),
         awayTeam: normalizeText(input.awayTeam),
-        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, undefined),
+        route: normalizeText(input.route || ROUTES.AUTO).toLowerCase(),
+        networkAuthorization: normalizeBooleanFlag(
+            input.networkAuthorization,
+            normalizeBooleanFlag(process.env.NETWORK_AUTHORIZATION, false)
+        ),
+        livePreviewAuthorization: normalizeBooleanFlag(
+            input.livePreviewAuthorization,
+            normalizeBooleanFlag(process.env.LIVE_PREVIEW_AUTHORIZATION, false)
+        ),
         allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
         allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
         allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, undefined),
@@ -239,12 +264,12 @@ function validatePreviewInput(input = {}) {
     if (!value.matchId) {
         errors.push('missing match-id');
     } else if (value.matchId !== TARGET.matchId) {
-        errors.push(`match-id must be ${TARGET.matchId} in Phase 5.11L2`);
+        errors.push(`match-id must be ${TARGET.matchId} in Phase 5.12L2B`);
     }
     if (!value.externalId) {
         errors.push('missing external-id');
     } else if (value.externalId !== TARGET.externalId) {
-        errors.push(`external-id must be ${TARGET.externalId} in Phase 5.11L2`);
+        errors.push(`external-id must be ${TARGET.externalId} in Phase 5.12L2B`);
     }
     if (!value.homeTeam) {
         errors.push('missing home-team');
@@ -256,8 +281,10 @@ function validatePreviewInput(input = {}) {
     } else if (!includesText(value.awayTeam, TARGET.awayTeam)) {
         errors.push(`away-team must contain ${TARGET.awayTeam}`);
     }
+    if (![ROUTES.AUTO, ROUTES.HTML_HYDRATION, ROUTES.API_MATCH_DETAILS].includes(value.route)) {
+        errors.push(`unsupported route: use ${ROUTES.AUTO}, ${ROUTES.HTML_HYDRATION}, or ${ROUTES.API_MATCH_DETAILS}`);
+    }
 
-    pushRequiredBooleanError(errors, value.networkAuthorization, 'network-authorization', true);
     pushRequiredBooleanError(errors, value.allowDbWrite, 'allow-db-write', false);
     pushRequiredBooleanError(errors, value.allowRawMatchDataWrite, 'allow-raw-match-data-write', false);
     pushRequiredBooleanError(errors, value.allowBrowserRuntime, 'allow-browser-runtime', false);
@@ -272,13 +299,36 @@ function validatePreviewInput(input = {}) {
         errors.push(value.retry > 0 ? 'retry > 0 is blocked' : 'retry must be 0');
     }
     if (value.bulk === true) {
-        errors.push('bulk=yes is blocked in Phase 5.11L2');
+        errors.push('bulk=yes is blocked in Phase 5.12L2B');
     }
 
     return {
         ok: errors.length === 0,
         errors,
         value,
+    };
+}
+
+function buildFotMobPageRequest(input = {}) {
+    const validation = validatePreviewInput(input);
+    if (!validation.ok) {
+        throw new Error(`INVALID_PREVIEW_INPUT:${validation.errors.join('; ')}`);
+    }
+
+    const url = new URL(`/match/${validation.value.externalId}`, FOTMOB_BASE_URL);
+
+    return {
+        route: ROUTES.HTML_HYDRATION,
+        method: 'GET',
+        url: url.href,
+        headers: {
+            accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'accept-language': 'en-US,en;q=0.9',
+            'accept-encoding': 'identity',
+            referer: FOTMOB_BASE_URL,
+            'user-agent':
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+        },
     };
 }
 
@@ -292,6 +342,7 @@ function buildFotMobDetailRequest(input = {}) {
     url.searchParams.set('matchId', validation.value.externalId);
 
     return {
+        route: ROUTES.API_MATCH_DETAILS,
         method: 'GET',
         url: url.href,
         headers: {
@@ -304,6 +355,71 @@ function buildFotMobDetailRequest(input = {}) {
             'x-requested-with': 'XMLHttpRequest',
         },
     };
+}
+
+function buildAlternateRoutePlan(input = {}) {
+    const validation = validatePreviewInput(input);
+    if (!validation.ok) {
+        throw new Error(`INVALID_PREVIEW_INPUT:${validation.errors.join('; ')}`);
+    }
+
+    const url = new URL(FOTMOB_ALTERNATE_DETAIL_URL);
+    url.searchParams.set('matchId', validation.value.externalId);
+
+    return {
+        route: ROUTES.ALTERNATE_ROUTE,
+        method: 'GET',
+        url: url.href,
+        headers: {
+            accept: 'application/json, text/plain, */*',
+            'accept-language': 'en-US,en;q=0.9',
+            'accept-encoding': 'identity',
+            referer: buildFotMobPageRequest(input).url,
+            'user-agent':
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+            'x-requested-with': 'XMLHttpRequest',
+        },
+        plan_only: true,
+    };
+}
+
+function resolveRouteOrder(route = ROUTES.AUTO) {
+    if (route === ROUTES.HTML_HYDRATION) {
+        return [ROUTES.HTML_HYDRATION];
+    }
+    if (route === ROUTES.API_MATCH_DETAILS) {
+        return [ROUTES.API_MATCH_DETAILS];
+    }
+    return [ROUTES.HTML_HYDRATION, ROUTES.API_MATCH_DETAILS];
+}
+
+function buildRequestForRoute(route, input = {}) {
+    if (route === ROUTES.HTML_HYDRATION) {
+        return buildFotMobPageRequest(input);
+    }
+    if (route === ROUTES.API_MATCH_DETAILS) {
+        return buildFotMobDetailRequest(input);
+    }
+    if (route === ROUTES.ALTERNATE_ROUTE) {
+        return buildAlternateRoutePlan(input);
+    }
+    throw new Error(`UNSUPPORTED_ROUTE:${route}`);
+}
+
+function buildFotMobDetailRoutePlan(input = {}) {
+    const validation = validatePreviewInput(input);
+    if (!validation.ok) {
+        throw new Error(`INVALID_PREVIEW_INPUT:${validation.errors.join('; ')}`);
+    }
+
+    const executableRouteOrder = resolveRouteOrder(validation.value.route);
+    const plannedRoutes = [...executableRouteOrder, ROUTES.ALTERNATE_ROUTE];
+    return plannedRoutes.map(route => ({
+        route,
+        request: buildRequestForRoute(route, input),
+        executable: EXECUTABLE_ROUTES.has(route),
+        plan_only: route === ROUTES.ALTERNATE_ROUTE,
+    }));
 }
 
 function getObjectKeys(value) {
@@ -344,23 +460,6 @@ function parseJsonPayload(bodyText) {
     }
 }
 
-function extractNextDataPayload(bodyText) {
-    const match = String(bodyText || '').match(/<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i);
-    if (!match) {
-        return {
-            ok: false,
-            value: null,
-            error: 'NEXT_DATA_NOT_FOUND',
-        };
-    }
-
-    const parsed = parseJsonPayload(match[1].trim());
-    return {
-        ...parsed,
-        error: parsed.ok ? null : parsed.error,
-    };
-}
-
 function detectBlockSignals(bodyText, httpStatus = null) {
     const signals = [];
     if ([403, 429].includes(Number(httpStatus))) {
@@ -382,6 +481,8 @@ function extractJsonOrHydrationPreview(body, contentType = '', context = {}) {
     const likelyJson = contentTypeText.includes('json') || /^[\s\n\r]*[{[]/.test(bodyText);
     let jsonParseOk = false;
     let hydrationParseOk = false;
+    let hydrationTransformOk = false;
+    let parseError = null;
     let parsedRoot = null;
 
     if (likelyJson) {
@@ -391,16 +492,30 @@ function extractJsonOrHydrationPreview(body, contentType = '', context = {}) {
             parsedRoot = parsed.value;
             markers.push('json');
             collectCandidatePaths(parsed.value, '', candidatePaths);
+        } else {
+            parseError = parsed.error;
         }
     }
 
     if (bodyText.includes('__NEXT_DATA__')) {
         markers.push('__NEXT_DATA__');
-        const nextData = extractNextDataPayload(bodyText);
-        hydrationParseOk = nextData.ok;
-        if (nextData.ok) {
-            parsedRoot = nextData.value;
-            collectCandidatePaths(nextData.value, '__NEXT_DATA__', candidatePaths);
+        const nextData = extractFromHtml(bodyText);
+        hydrationParseOk = nextData.success === true;
+        if (hydrationParseOk) {
+            const transformedData = transformToApiFormat(
+                nextData.data,
+                String(context.externalId || TARGET.externalId)
+            );
+            hydrationTransformOk = Boolean(transformedData);
+            parsedRoot = transformedData || nextData.data;
+            markers.push('next_data_parser');
+            if (transformedData) {
+                markers.push('transformed_api_format');
+                collectCandidatePaths(transformedData, '', candidatePaths);
+            }
+            collectCandidatePaths(nextData.data, '__NEXT_DATA__', candidatePaths);
+        } else {
+            parseError = nextData.error || 'NEXT_DATA_PARSE_FAILED';
         }
     }
 
@@ -419,10 +534,12 @@ function extractJsonOrHydrationPreview(body, contentType = '', context = {}) {
         contains_away_team: containsAwayTeam,
         json_parse_ok: jsonParseOk,
         hydration_parse_ok: hydrationParseOk,
+        hydration_transform_ok: hydrationTransformOk,
         hydration_or_json_markers: [...new Set(markers)].sort(),
         top_level_keys: topLevelKeys,
         candidate_raw_data_paths: [...candidatePaths].sort().slice(0, 30),
         block_signals: blockSignals,
+        parse_error: parseError,
         looks_like_valid_match_detail:
             blockSignals.length === 0 && containsMatchId && (jsonParseOk || hydrationParseOk) && hasExpectedStructure,
     };
@@ -492,9 +609,15 @@ function buildRawDetailPreviewSummary({ input, request, response = {}, body = ''
         looks_like_valid_match_detail: preview.looks_like_valid_match_detail,
         json_parse_ok: preview.json_parse_ok,
         hydration_parse_ok: preview.hydration_parse_ok,
+        hydration_transform_ok: preview.hydration_transform_ok,
         hydration_or_json_markers: preview.hydration_or_json_markers,
         top_level_keys: preview.top_level_keys,
         candidate_raw_data_paths: preview.candidate_raw_data_paths,
+        route_selector_enabled: false,
+        selected_route: request?.route || ROUTES.API_MATCH_DETAILS,
+        attempted_routes: [],
+        fallback_routes_planned: [],
+        existing_client_integration: buildExistingClientIntegrationSummary(),
         raw_match_data_write_allowed: false,
         db_write_allowed: false,
         would_write_raw_match_data: false,
@@ -542,6 +665,22 @@ async function fetchPreviewBody(request, dependencies = {}) {
     }
 }
 
+const routeSelector = createFotMobDetailRouteSelector({
+    TARGET,
+    ROUTES,
+    validatePreviewInput,
+    normalizePreviewInput,
+    buildFotMobDetailRoutePlan,
+    fetchPreviewBody,
+    extractJsonOrHydrationPreview,
+    getHeaderValue,
+    sha256,
+    PHASE,
+    NEXT_REQUIRED_PHASE,
+});
+const { buildExistingClientIntegrationSummary, runFotMobDetailRouteSelector, buildRouteSelectorPreviewSummary } =
+    routeSelector;
+
 function buildValidationFailureSummary(args, errors) {
     return {
         phase: PHASE,
@@ -551,6 +690,11 @@ function buildValidationFailureSummary(args, errors) {
         source: args.source || null,
         match_id: args.matchId || null,
         external_id: args.externalId || null,
+        route_selector_enabled: true,
+        selected_route: 'none',
+        attempted_routes: [],
+        fallback_routes_planned: [],
+        existing_client_integration: buildExistingClientIntegrationSummary(),
         raw_match_data_write_allowed: false,
         db_write_allowed: false,
         would_write_raw_match_data: false,
@@ -568,10 +712,12 @@ function buildValidationFailureSummary(args, errors) {
 function usage() {
     return [
         'Usage:',
-        '  node scripts/ops/l2_raw_detail_preview.js --source=fotmob --match-id=53_20252026_4830746 --external-id=4830746 --home-team=Angers --away-team=Strasbourg --network-authorization=yes --allow-db-write=no --allow-raw-match-data-write=no --allow-browser-runtime=no --allow-proxy-runtime=no --concurrency=1 --retry=0 --print-body=no --save-body=no',
+        '  node scripts/ops/l2_raw_detail_preview.js --source=fotmob --match-id=53_20252026_4830746 --external-id=4830746 --home-team=Angers --away-team=Strasbourg --route=auto --network-authorization=no --live-preview-authorization=no --allow-db-write=no --allow-raw-match-data-write=no --allow-browser-runtime=no --allow-proxy-runtime=no --concurrency=1 --retry=0 --print-body=no --save-body=no',
         '',
         'Safety:',
-        '  Phase 5.11L2 is preview-only: no DB write, no raw_match_data write, no browser/proxy, no full body print/save.',
+        '  Phase 5.12L2B is route-selector preview planning by default: no DB write, no raw_match_data write, no browser/proxy, no full body print/save.',
+        '  Default route order is html_hydration before api_match_details; alternate_route is plan-only.',
+        '  Live external execution remains blocked unless a future phase provides explicit authorization.',
     ].join('\n');
 }
 
@@ -590,40 +736,51 @@ async function runCli(argv = process.argv.slice(2), streams = {}, dependencies =
         return 1;
     }
 
-    const request = buildFotMobDetailRequest(args);
     try {
-        const { response, body } = await fetchPreviewBody(request, dependencies);
-        const contentType = getHeaderValue(response.headers, 'content-type');
-        const extraction = extractJsonOrHydrationPreview(body, contentType, {
-            externalId: validation.value.externalId,
-            homeTeam: validation.value.homeTeam,
-            awayTeam: validation.value.awayTeam,
-            httpStatus: response.status,
-        });
-        const summary = buildRawDetailPreviewSummary({
-            input: args,
-            request,
-            response,
-            body,
-            extraction,
-        });
+        const selectorResult = await runFotMobDetailRouteSelector(validation.value, dependencies);
+        const summary = buildRouteSelectorPreviewSummary(validation.value, selectorResult);
         stdout(`${JSON.stringify(summary, null, 2)}\n`);
         return summary.ok ? 0 : 1;
     } catch (error) {
-        const summary = buildRawDetailPreviewSummary({
-            input: args,
-            request,
-            response: {
-                status: null,
-                url: request.url,
-                headers: {},
-            },
-            body: '',
-            error,
-        });
+        const selectorResult = {
+            ok: false,
+            plan_only: true,
+            selected_route: 'none',
+            attempted_routes: [],
+            fallback_routes_planned: [],
+            controlled_error: String(error.message || error),
+            live_network_used: false,
+            existing_client_integration: buildExistingClientIntegrationSummary(),
+        };
+        const summary = buildRouteSelectorPreviewSummary(validation.value, selectorResult);
         stdout(`${JSON.stringify(summary, null, 2)}\n`);
         return 1;
     }
+}
+
+function buildFatalErrorSummary(error) {
+    return {
+        phase: PHASE,
+        preview_only: true,
+        ok: false,
+        error: error.message,
+        route_selector_enabled: true,
+        selected_route: 'none',
+        attempted_routes: [],
+        fallback_routes_planned: [],
+        existing_client_integration: buildExistingClientIntegrationSummary(),
+        raw_match_data_write_allowed: false,
+        db_write_allowed: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_train: false,
+        would_predict: false,
+        browser_used: false,
+        proxy_used: false,
+        body_printed: false,
+        body_saved: false,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
 }
 
 if (require.main === module) {
@@ -632,29 +789,7 @@ if (require.main === module) {
             process.exitCode = status;
         })
         .catch(error => {
-            console.error(
-                JSON.stringify(
-                    {
-                        phase: PHASE,
-                        preview_only: true,
-                        ok: false,
-                        error: error.message,
-                        raw_match_data_write_allowed: false,
-                        db_write_allowed: false,
-                        would_write_raw_match_data: false,
-                        would_write_db: false,
-                        would_train: false,
-                        would_predict: false,
-                        browser_used: false,
-                        proxy_used: false,
-                        body_printed: false,
-                        body_saved: false,
-                        next_required_phase: NEXT_REQUIRED_PHASE,
-                    },
-                    null,
-                    2
-                )
-            );
+            console.error(JSON.stringify(buildFatalErrorSummary(error), null, 2));
             process.exitCode = 1;
         });
 }
@@ -663,8 +798,13 @@ module.exports = {
     parseArgs,
     normalizeBooleanFlag,
     validatePreviewInput,
+    buildFotMobPageRequest,
     buildFotMobDetailRequest,
+    buildAlternateRoutePlan,
+    buildFotMobDetailRoutePlan,
     extractJsonOrHydrationPreview,
     buildRawDetailPreviewSummary,
+    runFotMobDetailRouteSelector,
+    buildRouteSelectorPreviewSummary,
     runCli,
 };

--- a/src/infrastructure/services/FotMobDetailRouteSelector.js
+++ b/src/infrastructure/services/FotMobDetailRouteSelector.js
@@ -1,0 +1,346 @@
+'use strict';
+
+function createFotMobDetailRouteSelector(dependencies = {}) {
+    const {
+        TARGET,
+        ROUTES,
+        validatePreviewInput,
+        normalizePreviewInput,
+        buildFotMobDetailRoutePlan,
+        fetchPreviewBody,
+        extractJsonOrHydrationPreview,
+        getHeaderValue,
+        sha256,
+        PHASE,
+        NEXT_REQUIRED_PHASE,
+    } = dependencies;
+
+    function listOrEmpty(value) {
+        return Array.isArray(value) ? value : [];
+    }
+
+    function valueOrFallback(value, fallback) {
+        return value === null || value === undefined ? fallback : value;
+    }
+
+    function buildPlannedRouteAttempt(routePlanItem) {
+        return {
+            route: routePlanItem.route,
+            request_url: routePlanItem.request.url,
+            executed: false,
+            status: null,
+            http_status: null,
+            content_type: '',
+            parse_ok: false,
+            json_parse_ok: false,
+            hydration_parse_ok: false,
+            hydration_transform_ok: false,
+            contains_match_id: false,
+            contains_home_team: false,
+            contains_away_team: false,
+            looks_like_valid_match_detail: false,
+            hydration_or_json_markers: [],
+            candidate_raw_data_paths: [],
+            top_level_keys: [],
+            block_signals: [],
+            controlled_error: routePlanItem.plan_only ? 'PLAN_ONLY_ROUTE_NOT_EXECUTED' : null,
+            body_byte_length: 0,
+            body_sha256: sha256(''),
+        };
+    }
+
+    function buildExecutedRouteAttempt({ route, request, response = {}, body = '', extraction = null, error = null }) {
+        const bodyText = String(body || '');
+        const httpStatus = Number(response.status || response.statusCode || 0) || null;
+        const contentType = getHeaderValue(response.headers, 'content-type');
+        const preview =
+            extraction ||
+            extractJsonOrHydrationPreview(bodyText, contentType, {
+                externalId: TARGET.externalId,
+                homeTeam: TARGET.homeTeam,
+                awayTeam: TARGET.awayTeam,
+                httpStatus,
+            });
+        const controlledError = error
+            ? String(error.message || error)
+            : preview.block_signals.length > 0
+              ? `CONTROLLED_BLOCK_SIGNAL:${preview.block_signals.join(',')}`
+              : null;
+
+        return {
+            route,
+            request_url: request?.url || '',
+            final_url: response.url || request?.url || '',
+            executed: true,
+            status: httpStatus,
+            http_status: httpStatus,
+            content_type: contentType,
+            parse_ok: preview.json_parse_ok || preview.hydration_parse_ok,
+            json_parse_ok: preview.json_parse_ok,
+            hydration_parse_ok: preview.hydration_parse_ok,
+            hydration_transform_ok: preview.hydration_transform_ok,
+            contains_match_id: preview.contains_match_id,
+            contains_home_team: preview.contains_home_team,
+            contains_away_team: preview.contains_away_team,
+            looks_like_valid_match_detail: preview.looks_like_valid_match_detail,
+            hydration_or_json_markers: preview.hydration_or_json_markers,
+            candidate_raw_data_paths: preview.candidate_raw_data_paths,
+            top_level_keys: preview.top_level_keys,
+            block_signals: preview.block_signals,
+            parse_error: preview.parse_error,
+            controlled_error: controlledError,
+            body_byte_length: Buffer.byteLength(bodyText, 'utf8'),
+            body_sha256: sha256(bodyText),
+        };
+    }
+
+    function shouldStopRouteSelector(attempt) {
+        if (!attempt || !attempt.executed) {
+            return false;
+        }
+        if (attempt.looks_like_valid_match_detail) {
+            return true;
+        }
+        return attempt.block_signals.some(signal => /^HTTP_(403|429)$/.test(signal));
+    }
+
+    function buildFallbackRoutesPlanned(routePlan, attemptedRoutes) {
+        const attemptedRouteNames = new Set(attemptedRoutes.filter(route => route.executed).map(route => route.route));
+        return routePlan
+            .filter(route => !attemptedRouteNames.has(route.route) || route.plan_only)
+            .map(route => ({
+                route: route.route,
+                request_url: route.request.url,
+                executed: false,
+                plan_only: true,
+                reason: route.plan_only ? 'alternate route is planning-only' : 'not reached by selector',
+            }));
+    }
+
+    function buildExistingClientIntegrationSummary() {
+        return {
+            fotmob_api_client_considered: true,
+            fotmob_api_client_route_aligned: true,
+            fotmob_api_client_imported: false,
+            fotmob_strategy_hydration_considered: true,
+            next_data_parser_reused: true,
+            production_harvester_used: false,
+            legacy_backfill_used: false,
+            browser_runtime_used: false,
+            proxy_runtime_used: false,
+        };
+    }
+
+    function buildInvalidSelectorResult(validation) {
+        return {
+            ok: false,
+            plan_only: true,
+            selected_route: 'none',
+            attempted_routes: [],
+            fallback_routes_planned: [],
+            controlled_error: `INVALID_PREVIEW_INPUT:${validation.errors.join('; ')}`,
+            live_network_used: false,
+            existing_client_integration: buildExistingClientIntegrationSummary(),
+        };
+    }
+
+    function canExecuteRoutes(validation, selectorDependencies) {
+        return (
+            selectorDependencies.allowRouteExecution === true ||
+            (validation.value.networkAuthorization === true && validation.value.livePreviewAuthorization === true)
+        );
+    }
+
+    function buildPlanOnlySelectorResult(routePlan, validation) {
+        const attemptedRoutes = routePlan.map(buildPlannedRouteAttempt);
+        const controlledError =
+            validation.value.networkAuthorization === true
+                ? 'LIVE_PREVIEW_BLOCKED:LIVE_PREVIEW_AUTHORIZATION=yes is required for external execution'
+                : 'PLAN_ONLY:network authorization is not enabled';
+
+        return {
+            ok: false,
+            plan_only: true,
+            selected_route: 'none',
+            attempted_routes: attemptedRoutes,
+            fallback_routes_planned: buildFallbackRoutesPlanned(routePlan, []),
+            controlled_error: controlledError,
+            live_network_used: false,
+            existing_client_integration: buildExistingClientIntegrationSummary(),
+        };
+    }
+
+    function routePlanItemCanExecute(routePlanItem) {
+        return routePlanItem.executable === true && routePlanItem.plan_only !== true;
+    }
+
+    async function executeRoutePlanItem(routePlanItem, selectorDependencies) {
+        try {
+            const { response, body } = await fetchPreviewBody(routePlanItem.request, selectorDependencies);
+            return buildExecutedRouteAttempt({
+                route: routePlanItem.route,
+                request: routePlanItem.request,
+                response,
+                body,
+            });
+        } catch (error) {
+            return buildExecutedRouteAttempt({
+                route: routePlanItem.route,
+                request: routePlanItem.request,
+                response: {
+                    status: null,
+                    url: routePlanItem.request.url,
+                    headers: {},
+                },
+                body: '',
+                error,
+            });
+        }
+    }
+
+    function appendAlternatePlan(routePlan, attemptedRoutes) {
+        const plannedAlternate = routePlan.find(route => route.route === ROUTES.ALTERNATE_ROUTE);
+        if (plannedAlternate) {
+            attemptedRoutes.push(buildPlannedRouteAttempt(plannedAlternate));
+        }
+    }
+
+    async function executeRoutePlan(routePlan, selectorDependencies) {
+        const attemptedRoutes = [];
+        let selectedRoute = 'none';
+
+        for (const routePlanItem of routePlan) {
+            if (!routePlanItemCanExecute(routePlanItem)) {
+                continue;
+            }
+
+            const attempt = await executeRoutePlanItem(routePlanItem, selectorDependencies);
+            attemptedRoutes.push(attempt);
+
+            if (attempt.looks_like_valid_match_detail) {
+                selectedRoute = routePlanItem.route;
+                break;
+            }
+            if (attempt.controlled_error || shouldStopRouteSelector(attempt)) {
+                break;
+            }
+        }
+
+        appendAlternatePlan(routePlan, attemptedRoutes);
+        return { attemptedRoutes, selectedRoute };
+    }
+
+    function buildExecutedSelectorResult(routePlan, execution, selectorDependencies, validation) {
+        const selectedAttempt = execution.attemptedRoutes.find(route => route.route === execution.selectedRoute);
+        const lastExecutedAttempt = [...execution.attemptedRoutes].reverse().find(route => route.executed);
+        const noPayloadError = execution.selectedRoute === 'none' ? 'NO_VALID_ROUTE_PAYLOAD' : null;
+
+        return {
+            ok: Boolean(selectedAttempt?.looks_like_valid_match_detail),
+            plan_only: false,
+            selected_route: execution.selectedRoute,
+            attempted_routes: execution.attemptedRoutes,
+            fallback_routes_planned: buildFallbackRoutesPlanned(routePlan, execution.attemptedRoutes),
+            controlled_error:
+                selectedAttempt?.controlled_error || lastExecutedAttempt?.controlled_error || noPayloadError,
+            live_network_used:
+                selectorDependencies.allowRouteExecution === true ? false : validation.value.networkAuthorization,
+            existing_client_integration: buildExistingClientIntegrationSummary(),
+        };
+    }
+
+    async function runFotMobDetailRouteSelector(input = {}, selectorDependencies = {}) {
+        const validation = validatePreviewInput(input);
+        if (!validation.ok) {
+            return buildInvalidSelectorResult(validation);
+        }
+
+        const routePlan = buildFotMobDetailRoutePlan(validation.value);
+        if (!canExecuteRoutes(validation, selectorDependencies)) {
+            return buildPlanOnlySelectorResult(routePlan, validation);
+        }
+
+        const execution = await executeRoutePlan(routePlan, selectorDependencies);
+        return buildExecutedSelectorResult(routePlan, execution, selectorDependencies, validation);
+    }
+
+    function findSelectedAttempt(selectorResult = {}) {
+        const attemptedRoutes = listOrEmpty(selectorResult.attempted_routes);
+        const selectedAttempt =
+            attemptedRoutes.find(route => route.route === selectorResult.selected_route) ||
+            attemptedRoutes.find(route => route.executed);
+        return valueOrFallback(selectedAttempt, valueOrFallback(attemptedRoutes[0], {}));
+    }
+
+    function buildRouteSelectorPreviewSummary(input = {}, selectorResult = {}) {
+        const normalized = normalizePreviewInput(input);
+        const selectedAttempt = findSelectedAttempt(selectorResult);
+        const httpStatus = valueOrFallback(selectedAttempt.http_status, valueOrFallback(selectedAttempt.status, null));
+
+        return {
+            phase: PHASE,
+            preview_only: true,
+            plan_only: selectorResult.plan_only === true,
+            source: TARGET.source,
+            match_id: TARGET.matchId,
+            external_id: TARGET.externalId,
+            home_team: TARGET.homeTeam,
+            away_team: TARGET.awayTeam,
+            requested_route: normalized.route,
+            route_selector_enabled: true,
+            selected_route: valueOrFallback(selectorResult.selected_route, 'none'),
+            attempted_routes: listOrEmpty(selectorResult.attempted_routes),
+            fallback_routes_planned: listOrEmpty(selectorResult.fallback_routes_planned),
+            existing_client_integration: valueOrFallback(
+                selectorResult.existing_client_integration,
+                buildExistingClientIntegrationSummary()
+            ),
+            network_authorization_used: normalized.networkAuthorization === true,
+            live_preview_authorization_used: normalized.livePreviewAuthorization === true,
+            external_network_used: selectorResult.live_network_used === true,
+            live_network_used: selectorResult.live_network_used === true,
+            request_url: valueOrFallback(selectedAttempt.request_url, ''),
+            final_url: valueOrFallback(selectedAttempt.final_url, valueOrFallback(selectedAttempt.request_url, '')),
+            http_status: httpStatus,
+            ok: selectorResult.ok === true,
+            controlled_error: valueOrFallback(
+                selectorResult.controlled_error,
+                valueOrFallback(selectedAttempt.controlled_error, null)
+            ),
+            content_type: valueOrFallback(selectedAttempt.content_type, ''),
+            body_byte_length: valueOrFallback(selectedAttempt.body_byte_length, 0),
+            body_sha256: valueOrFallback(selectedAttempt.body_sha256, sha256('')),
+            contains_match_id: selectedAttempt.contains_match_id === true,
+            contains_home_team: selectedAttempt.contains_home_team === true,
+            contains_away_team: selectedAttempt.contains_away_team === true,
+            looks_like_valid_match_detail: selectedAttempt.looks_like_valid_match_detail === true,
+            json_parse_ok: selectedAttempt.json_parse_ok === true,
+            hydration_parse_ok: selectedAttempt.hydration_parse_ok === true,
+            hydration_transform_ok: selectedAttempt.hydration_transform_ok === true,
+            hydration_or_json_markers: listOrEmpty(selectedAttempt.hydration_or_json_markers),
+            top_level_keys: listOrEmpty(selectedAttempt.top_level_keys),
+            candidate_raw_data_paths: listOrEmpty(selectedAttempt.candidate_raw_data_paths),
+            raw_match_data_write_allowed: false,
+            db_write_allowed: false,
+            would_write_raw_match_data: false,
+            would_write_db: false,
+            would_train: false,
+            would_predict: false,
+            browser_used: false,
+            proxy_used: false,
+            body_printed: false,
+            body_saved: false,
+            next_required_phase: NEXT_REQUIRED_PHASE,
+        };
+    }
+
+    return {
+        buildExistingClientIntegrationSummary,
+        runFotMobDetailRouteSelector,
+        buildRouteSelectorPreviewSummary,
+    };
+}
+
+module.exports = {
+    createFotMobDetailRouteSelector,
+};

--- a/tests/unit/l2_raw_detail_preview.test.js
+++ b/tests/unit/l2_raw_detail_preview.test.js
@@ -5,6 +5,8 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const childProcess = require('node:child_process');
+const http = require('node:http');
+const https = require('node:https');
 const Module = require('node:module');
 const { pathToFileURL } = require('node:url');
 
@@ -23,7 +25,9 @@ function validArgs(overrides = {}) {
         externalId: '4830746',
         homeTeam: 'Angers',
         awayTeam: 'Strasbourg',
+        route: 'auto',
         networkAuthorization: true,
+        livePreviewAuthorization: false,
         allowDbWrite: false,
         allowRawMatchDataWrite: false,
         allowBrowserRuntime: false,
@@ -45,7 +49,9 @@ function cliArgs(overrides = {}) {
         `--external-id=${args.externalId}`,
         `--home-team=${args.homeTeam}`,
         `--away-team=${args.awayTeam}`,
+        `--route=${args.route}`,
         `--network-authorization=${args.networkAuthorization ? 'yes' : 'no'}`,
+        `--live-preview-authorization=${args.livePreviewAuthorization ? 'yes' : 'no'}`,
         `--allow-db-write=${args.allowDbWrite ? 'yes' : 'no'}`,
         `--allow-raw-match-data-write=${args.allowRawMatchDataWrite ? 'yes' : 'no'}`,
         `--allow-browser-runtime=${args.allowBrowserRuntime ? 'yes' : 'no'}`,
@@ -100,6 +106,16 @@ function fakeHtmlBody() {
                         id: 4830746,
                         fixture: 'Angers vs Strasbourg',
                     },
+                    stats: {
+                        periods: [],
+                    },
+                    lineup: {
+                        homeTeam: 'Angers',
+                        awayTeam: 'Strasbourg',
+                    },
+                },
+                header: {
+                    teams: [{ name: 'Angers' }, { name: 'Strasbourg' }],
                 },
             },
         },
@@ -135,7 +151,7 @@ async function runCli(gate, argv, dependencies = {}) {
                 stdout += text;
             },
         },
-        dependencies
+        dependencies.fetchImpl ? { allowRouteExecution: true, ...dependencies } : dependencies
     );
     return {
         status,
@@ -153,6 +169,8 @@ function installExecutionGuards(t) {
     const originalSpawn = childProcess.spawn;
     const originalExec = childProcess.exec;
     const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
     const originalLoad = Module._load;
 
     const fail = name => () => {
@@ -167,6 +185,8 @@ function installExecutionGuards(t) {
     childProcess.spawn = fail('child_process.spawn');
     childProcess.exec = fail('child_process.exec');
     childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
 
     Module._load = function patchedLoad(request, parent, isMain) {
         const blockedImports = new Set([
@@ -200,6 +220,8 @@ function installExecutionGuards(t) {
         childProcess.spawn = originalSpawn;
         childProcess.exec = originalExec;
         childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
         Module._load = originalLoad;
     });
 }
@@ -218,7 +240,9 @@ test('parseArgs maps dashed CLI flags', () => {
     assert.equal(parsed.externalId, '4830746');
     assert.equal(parsed.homeTeam, 'Angers');
     assert.equal(parsed.awayTeam, 'Strasbourg');
+    assert.equal(parsed.route, 'auto');
     assert.equal(parsed.networkAuthorization, true);
+    assert.equal(parsed.livePreviewAuthorization, false);
     assert.equal(parsed.allowDbWrite, false);
     assert.equal(parsed.allowRawMatchDataWrite, false);
 });
@@ -263,7 +287,7 @@ const invalidInputCases = [
     ['home-team mismatch fails', { homeTeam: 'Nice' }, /home-team must contain/],
     ['missing away-team fails', { awayTeam: null }, /missing away-team/],
     ['away-team mismatch fails', { awayTeam: 'Lyon' }, /away-team must contain/],
-    ['network-authorization=no fails for actual preview', { networkAuthorization: false }, /network-authorization=no/],
+    ['unsupported route fails', { route: 'alternate_route' }, /unsupported route/],
     ['allow-db-write=yes blocked', { allowDbWrite: true }, /allow-db-write=yes/],
     ['allow-raw-match-data-write=yes blocked', { allowRawMatchDataWrite: true }, /allow-raw-match-data-write=yes/],
     ['allow-browser-runtime=yes blocked', { allowBrowserRuntime: true }, /allow-browser-runtime=yes/],
@@ -291,8 +315,31 @@ test('build request URL contains 4830746', () => {
     const gate = loadModuleFresh();
     const request = gate.buildFotMobDetailRequest(validArgs());
     assert.equal(request.method, 'GET');
+    assert.equal(request.route, 'api_match_details');
     assert.match(request.url, /matchDetails/);
     assert.match(request.url, /matchId=4830746/);
+});
+
+test('build route plan defaults to html hydration, api fallback, and alternate plan-only', () => {
+    const gate = loadModuleFresh();
+    const plan = gate.buildFotMobDetailRoutePlan(validArgs());
+    assert.deepEqual(
+        plan.map(route => route.route),
+        ['html_hydration', 'api_match_details', 'alternate_route']
+    );
+    assert.match(plan[0].request.url, /\/match\/4830746$/);
+    assert.match(plan[1].request.url, /\/api\/data\/matchDetails\?matchId=4830746$/);
+    assert.match(plan[2].request.url, /\/api\/matchDetails\?matchId=4830746$/);
+    assert.equal(plan[2].plan_only, true);
+});
+
+test('route=api_match_details builds only API route plus alternate plan', () => {
+    const gate = loadModuleFresh();
+    const plan = gate.buildFotMobDetailRoutePlan(validArgs({ route: 'api_match_details' }));
+    assert.deepEqual(
+        plan.map(route => route.route),
+        ['api_match_details', 'alternate_route']
+    );
 });
 
 test('build request rejects invalid input', () => {
@@ -300,20 +347,23 @@ test('build request rejects invalid input', () => {
     assert.throws(() => gate.buildFotMobDetailRequest(validArgs({ externalId: '4830747' })), /INVALID_PREVIEW_INPUT/);
 });
 
-test('fake JSON response preview succeeds', async t => {
+test('route=api_match_details fake JSON response preview succeeds', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
     let fetchCount = 0;
-    const result = await runCli(gate, cliArgs(), {
+    const result = await runCli(gate, cliArgs({ route: 'api_match_details' }), {
         fetchImpl: async url => {
             fetchCount += 1;
             assert.match(url, /4830746/);
+            assert.match(url, /api\/data\/matchDetails/);
             return createResponse(fakeJsonBody());
         },
     });
 
     assert.equal(result.status, 0);
     assert.equal(fetchCount, 1);
+    assert.equal(result.payload.route_selector_enabled, true);
+    assert.equal(result.payload.selected_route, 'api_match_details');
     assert.equal(result.payload.http_status, 200);
     assert.equal(result.payload.contains_match_id, true);
     assert.equal(result.payload.contains_home_team, true);
@@ -327,23 +377,73 @@ test('fake JSON response preview succeeds', async t => {
 test('fake HTML __NEXT_DATA__ response preview succeeds', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
+    const requestedUrls = [];
     const result = await runCli(gate, cliArgs(), {
-        fetchImpl: async () => createResponse(fakeHtmlBody(), { contentType: 'text/html; charset=utf-8' }),
+        fetchImpl: async url => {
+            requestedUrls.push(url);
+            return createResponse(fakeHtmlBody(), {
+                url,
+                contentType: 'text/html; charset=utf-8',
+            });
+        },
     });
 
     assert.equal(result.status, 0);
+    assert.deepEqual(requestedUrls, ['https://www.fotmob.com/match/4830746']);
+    assert.equal(result.payload.selected_route, 'html_hydration');
+    assert.equal(result.payload.attempted_routes[0].route, 'html_hydration');
+    assert.equal(result.payload.attempted_routes[0].executed, true);
+    assert.equal(result.payload.attempted_routes.at(-1).route, 'alternate_route');
+    assert.equal(result.payload.attempted_routes.at(-1).executed, false);
     assert.equal(result.payload.hydration_parse_ok, true);
+    assert.equal(result.payload.hydration_transform_ok, true);
     assert.equal(result.payload.hydration_or_json_markers.includes('__NEXT_DATA__'), true);
+    assert.equal(result.payload.hydration_or_json_markers.includes('next_data_parser'), true);
     assert.equal(result.payload.contains_match_id, true);
     assert.equal(result.payload.contains_home_team, true);
     assert.equal(result.payload.contains_away_team, true);
     assert.equal(result.payload.looks_like_valid_match_detail, true);
+    assert.equal(result.payload.body_printed, false);
+    assert.equal(result.payload.body_saved, false);
+});
+
+test('route=auto falls back from missing hydration to fake API JSON', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const requestedUrls = [];
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async url => {
+            requestedUrls.push(url);
+            if (url.includes('/match/4830746')) {
+                return createResponse('<html>Angers vs Strasbourg 4830746</html>', {
+                    url,
+                    contentType: 'text/html',
+                });
+            }
+            return createResponse(fakeJsonBody(), {
+                url,
+                contentType: 'application/json',
+            });
+        },
+    });
+
+    assert.equal(result.status, 0);
+    assert.deepEqual(requestedUrls, [
+        'https://www.fotmob.com/match/4830746',
+        'https://www.fotmob.com/api/data/matchDetails?matchId=4830746',
+    ]);
+    assert.equal(result.payload.selected_route, 'api_match_details');
+    assert.equal(result.payload.attempted_routes.length, 3);
+    assert.equal(result.payload.attempted_routes[0].looks_like_valid_match_detail, false);
+    assert.equal(result.payload.attempted_routes[1].looks_like_valid_match_detail, true);
+    assert.equal(result.payload.attempted_routes[2].route, 'alternate_route');
+    assert.equal(result.payload.attempted_routes[2].executed, false);
 });
 
 test('invalid JSON response returns parse failure without printing body', async t => {
     installExecutionGuards(t);
     const gate = loadModuleFresh();
-    const result = await runCli(gate, cliArgs(), {
+    const result = await runCli(gate, cliArgs({ route: 'api_match_details' }), {
         fetchImpl: async () =>
             createResponse('{not-json Angers Strasbourg 4830746', {
                 contentType: 'application/json',
@@ -424,6 +524,30 @@ test('runCli --help prints usage and does not fetch', async () => {
     assert.match(result.stdout, /Usage:/);
 });
 
+test('runCli defaults to plan-only and does not use global fetch', async () => {
+    const gate = loadModuleFresh();
+    const originalFetch = global.fetch;
+    let fetchCalled = false;
+    global.fetch = async () => {
+        fetchCalled = true;
+        throw new Error('global fetch should not be called in plan-only mode');
+    };
+
+    try {
+        const result = await runCli(gate, cliArgs());
+        assert.equal(result.status, 1);
+        assert.equal(fetchCalled, false);
+        assert.equal(result.payload.plan_only, true);
+        assert.equal(result.payload.route_selector_enabled, true);
+        assert.equal(result.payload.selected_route, 'none');
+        assert.equal(result.payload.attempted_routes[0].route, 'html_hydration');
+        assert.equal(result.payload.attempted_routes[0].executed, false);
+        assert.match(result.payload.controlled_error, /LIVE_PREVIEW_BLOCKED|PLAN_ONLY/);
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
 test('runCli validation failure returns controlled summary', async () => {
     const gate = loadModuleFresh();
     const result = await runCli(gate, cliArgs({ source: 'bad' }), {
@@ -447,7 +571,7 @@ test('fetch unavailable returns controlled error summary', async t => {
         global.fetch = originalFetch;
     });
 
-    const result = await runCli(gate, cliArgs());
+    const result = await runCli(gate, cliArgs(), { allowRouteExecution: true });
     assert.equal(result.status, 1);
     assert.match(result.payload.controlled_error, /FETCH_UNAVAILABLE/);
     assert.equal(result.payload.body_saved, false);
@@ -507,6 +631,26 @@ test('output safety flags remain false', async t => {
     assert.equal(result.payload.proxy_used, false);
     assert.equal(result.payload.raw_match_data_write_allowed, false);
     assert.equal(result.payload.db_write_allowed, false);
+});
+
+test('route selector summary exposes existing client integration flags', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: async url =>
+            createResponse(fakeHtmlBody(), {
+                url,
+                contentType: 'text/html; charset=utf-8',
+            }),
+    });
+
+    assert.equal(result.payload.existing_client_integration.fotmob_api_client_considered, true);
+    assert.equal(result.payload.existing_client_integration.fotmob_api_client_route_aligned, true);
+    assert.equal(result.payload.existing_client_integration.fotmob_api_client_imported, false);
+    assert.equal(result.payload.existing_client_integration.fotmob_strategy_hydration_considered, true);
+    assert.equal(result.payload.existing_client_integration.next_data_parser_reused, true);
+    assert.equal(result.payload.existing_client_integration.production_harvester_used, false);
+    assert.equal(result.payload.existing_client_integration.legacy_backfill_used, false);
 });
 
 test('output body_printed=false', async t => {
@@ -579,10 +723,41 @@ test('controlled 403 error does not retry', async t => {
 
     assert.equal(result.status, 1);
     assert.equal(fetchCount, 1);
+    assert.equal(result.payload.selected_route, 'none');
+    assert.deepEqual(
+        result.payload.attempted_routes.filter(route => route.executed).map(route => route.route),
+        ['html_hydration']
+    );
     assert.equal(result.payload.http_status, 403);
     assert.match(result.payload.controlled_error, /CONTROLLED_BLOCK_SIGNAL/);
     assert.equal(result.payload.browser_used, false);
     assert.equal(result.payload.proxy_used, false);
+});
+
+test('route=api_match_details fake 403 produces controlled error', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    let fetchCount = 0;
+    const result = await runCli(gate, cliArgs({ route: 'api_match_details' }), {
+        fetchImpl: async url => {
+            fetchCount += 1;
+            assert.match(url, /api\/data\/matchDetails/);
+            return createResponse(JSON.stringify({ code: 403, error: 'Forbidden' }), {
+                url,
+                status: 403,
+                contentType: 'application/json',
+            });
+        },
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(fetchCount, 1);
+    assert.equal(result.payload.selected_route, 'none');
+    assert.equal(result.payload.http_status, 403);
+    assert.equal(result.payload.json_parse_ok, true);
+    assert.match(result.payload.controlled_error, /CONTROLLED_BLOCK_SIGNAL:HTTP_403/);
+    assert.equal(result.payload.body_printed, false);
+    assert.equal(result.payload.body_saved, false);
 });
 
 test('no fs.writeFile / mkdir or child_process operations during preview', async t => {
@@ -605,6 +780,12 @@ test('source audit: no DB client write', () => {
 test('source audit: no child_process spawn', () => {
     const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
     assert.ok(!/require\s*\(\s*['"](?:node:)?child_process['"]/.test(source));
+});
+
+test('source audit: no native http or https request client', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.ok(!/require\s*\(\s*['"](?:node:)?https?['"]/.test(source));
+    assert.ok(!/\bhttps?\.request\b/.test(source));
 });
 
 test('source audit: no ProductionHarvester', () => {


### PR DESCRIPTION
## Summary

Adds Phase 5.12L2B safe FotMob detail route selector / existing client integration.

Scope:
- Adds route selector support to L2 raw detail preview
- Supports html_hydration before direct API route
- Adds fake-fetch / fixture-backed unit tests
- Keeps live external requests blocked by default
- Keeps raw_match_data/DB writes blocked
- Keeps browser/proxy disabled
- Updates AGENTS.md, Makefile help, and report

Safety:
- No external FotMob access
- No live match detail request
- No retry
- No browser/proxy
- No DB writes
- No raw_match_data writes
- No harvest / ingest
- No training / prediction
- No full body save/print
- No file deletion

Validation:
- l2 raw detail preview tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed