### PR TITLE
docs(data): add raw_match_data ingest plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@
 - Phase 5.11L2 raw detail preview 仅允许 preview-only：除非未来用户扩大授权，只能目标 `53_20252026_4830746` / `external_id=4830746`；不得写 `raw_match_data` 或任何 DB，不得打印或保存完整 body，不得启 browser/proxy，不得调用 `ProductionHarvester` 或 legacy raw backfill；`raw_match_data` 写入必须等待后续 planning / authorization / preflight。
 - Phase 5.11L2 direct `matchDetails` endpoint 已返回 403。AI / Codex 不得擅自 retry、增加 headers、改走 browser/proxy 或尝试 alternate route；继续请求 raw detail 前必须先完成现有 L2 fetch path reconciliation 并取得明确授权，`raw_match_data` 写入仍未授权。
 - Phase 5.12L2B 新增 safe FotMob detail route selector，默认顺序为 `html_hydration` -> `api_match_details`，`alternate_route` 仅 plan-only；live external raw detail preview 仍默认 blocked，未经未来单独授权不得 retry Phase 5.11L2 direct API 403、不得加 headers/browser/proxy 绕过，`raw_match_data` 写入仍未授权。
+- Phase 5.13L2 raw_match_data ingest planning 仅允许 planning-only；`raw_match_data` 写入仍未授权。raw_data 应存 canonical transformed detail payload 而不是完整 HTML body；data_hash 应为 canonical raw_data JSON 的 SHA-256，而不是 HTML body hash；raw_match_data ingest 不得更新 `matches`、features、training 或 predictions，未来写入必须另行 authorization + preflight。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 

--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,9 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  Do not write raw_match_data until a separate controlled authorization/preflight phase."
 	@echo "  make data-l2-raw-detail-route-preview-plan  # Phase 5.12L2B route selector plan only, no network"
 	@echo "  make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg ROUTE=auto NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=no ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # route selector preview; live remains blocked without future authorization"
+	@echo "  make data-l2-raw-match-data-ingest-plan SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg PREVIEW_BODY_SHA256=<sha256> PREVIEW_BODY_BYTE_LENGTH=<bytes> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.13L2 planning-only, no network/DB/raw write"
 	@echo "  L2 raw detail preview is preview-only: no raw_match_data write, no DB write, no browser/proxy, no full body print/save."
+	@echo "  L2 raw_match_data ingest is planning-only in Phase 5.13L2: future write requires explicit authorization + preflight, and raw_match_data write remains blocked."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
 	@echo "  Phase 5.12L2B route selector supports html_hydration before api_match_details; alternate_route remains plan-only."
 	@echo "  Live raw detail requests require future explicit authorization; use audited route selector / safe adapter, not legacy harvest/backfill."
@@ -654,9 +656,34 @@ data-l2-raw-detail-preview: ## L2 raw detail preview. Phase 5.12L2B. Route selec
 		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
 		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
 		--concurrency="$(or $(CONCURRENCY),1)" \
-		--retry="$(or $(RETRY),0)" \
-		--print-body="$(or $(PRINT_BODY),no)" \
-		--save-body="$(or $(SAVE_BODY),no)"
+			--retry="$(or $(RETRY),0)" \
+			--print-body="$(or $(PRINT_BODY),no)" \
+			--save-body="$(or $(SAVE_BODY),no)"
+
+data-l2-raw-match-data-ingest-plan: ## L2 raw_match_data ingest planning. Phase 5.13L2. No network/DB/raw write.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(ROUTE)" ] || [ -z "$(MATCH_ID)" ] || [ -z "$(EXTERNAL_ID)" ] || [ -z "$(HOME_TEAM)" ] || [ -z "$(AWAY_TEAM)" ] || [ -z "$(PREVIEW_BODY_SHA256)" ] || [ -z "$(PREVIEW_BODY_BYTE_LENGTH)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg PREVIEW_BODY_SHA256=<sha256> PREVIEW_BODY_BYTE_LENGTH=<bytes>"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l2_raw_match_data_ingest_plan.js \
+		--source="$(SOURCE)" \
+		--route="$(ROUTE)" \
+		--match-id="$(MATCH_ID)" \
+		--external-id="$(EXTERNAL_ID)" \
+		--home-team="$(HOME_TEAM)" \
+		--away-team="$(AWAY_TEAM)" \
+		--preview-body-sha256="$(PREVIEW_BODY_SHA256)" \
+		--preview-body-byte-length="$(PREVIEW_BODY_BYTE_LENGTH)" \
+		--hydration-parse-ok="$(or $(HYDRATION_PARSE_OK),yes)" \
+		--looks-like-valid-match-detail="$(or $(LOOKS_LIKE_VALID_MATCH_DETAIL),yes)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-matches-write="$(or $(ALLOW_MATCHES_WRITE),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--commit="$(or $(COMMIT),no)" \
+		--execute="$(or $(EXECUTE),no)" \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)"
 
 data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.
 	@if [ -n "$(SAMPLE_HTML)" ]; then \

--- a/docs/_reports/RAW_MATCH_DATA_INGEST_PLANNING_PHASE5_13L2.md
+++ b/docs/_reports/RAW_MATCH_DATA_INGEST_PLANNING_PHASE5_13L2.md
@@ -1,0 +1,240 @@
+# Raw Match Data Ingest Planning - Phase 5.13L2
+
+## 1. Executive summary
+
+Phase 5.12L2C successfully obtained a valid FotMob match detail payload through
+the audited `html_hydration` route selector for target
+`53_20252026_4830746` / external id `4830746`.
+
+Phase 5.13L2 plans the future `raw_match_data` ingest boundary. This phase does
+not access FotMob, does not run another live match detail request, does not write
+DB, does not write `raw_match_data`, does not save a full body, and does not run
+parser, feature, training, or prediction pipelines.
+
+The goal is to define the storage shape, hash, version, collected timestamp,
+upsert, protected-table, authorization, and preflight policies before any future
+write phase.
+
+## 2. Baseline
+
+Pre-planning baseline:
+
+| Table                     | Rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+Target match:
+
+| Field         | Value                    |
+| ------------- | ------------------------ |
+| `match_id`    | `53_20252026_4830746`    |
+| `external_id` | `4830746`                |
+| `home_team`   | `Angers`                 |
+| `away_team`   | `Strasbourg`             |
+| `match_date`  | `2026-05-10 19:00:00+00` |
+| `status`      | `finished`               |
+
+Target `raw_match_data` status:
+
+- no existing row for `match_id=53_20252026_4830746`
+- no existing row for `external_id=4830746`
+
+`raw_match_data` schema summary:
+
+- `match_id varchar(50) NOT NULL`
+- `external_id varchar(100)`
+- `raw_data jsonb NOT NULL`
+- `collected_at timestamptz`, default `CURRENT_TIMESTAMP`
+- `data_version varchar(20)`, default `V26.1`
+- `data_hash varchar(64)`
+- unique constraint: `raw_match_data_match_id_key`
+- FK: `match_id -> matches(match_id) ON DELETE CASCADE`
+- check: `raw_data` must contain `matchId`, `general`, or `header`
+
+## 3. Preview result used as input
+
+Phase 5.12L2C controlled preview:
+
+| Field                           | Value                                                              |
+| ------------------------------- | ------------------------------------------------------------------ |
+| `selected_route`                | `html_hydration`                                                   |
+| `request_url`                   | `https://www.fotmob.com/match/4830746`                             |
+| `final_url`                     | `https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och`       |
+| `http_status`                   | `200`                                                              |
+| `content_type`                  | `text/html; charset=utf-8`                                         |
+| `body_byte_length`              | `1037598`                                                          |
+| `body_sha256`                   | `8710a3524807d4682ab3c66386f9cd6b4d374fb6eee4f98a29d7f4a6683a162c` |
+| `hydration_parse_ok`            | `true`                                                             |
+| `json_parse_ok`                 | `false`                                                            |
+| `looks_like_valid_match_detail` | `true`                                                             |
+| `body_printed`                  | `false`                                                            |
+| `body_saved`                    | `false`                                                            |
+| `browser_used`                  | `false`                                                            |
+| `proxy_used`                    | `false`                                                            |
+
+Top-level transformed payload keys:
+
+- `_meta`
+- `content`
+- `general`
+- `header`
+- `matchId`
+
+Candidate raw data paths:
+
+- `__NEXT_DATA__.props.pageProps.content`
+- `content.lineup`
+- `content.matchFacts`
+- `content.liveticker.teams`
+- `content.playerStats.*.shotmap`
+- `content.playerStats.*.stats`
+
+## 4. raw_data storage policy
+
+Future ingest should store the canonical transformed detail payload produced by
+the audited route selector, not the full page HTML.
+
+Recommended `raw_data` shape:
+
+- source object: `FotMobDetailRouteSelector` `html_hydration`
+  `transformed_api_format`
+- top-level keys: `_meta`, `content`, `general`, `header`, `matchId`
+- `raw_data._meta` should include source, route, request URL, final URL, fetch
+  body SHA-256, fetch body byte length, hydration parse status, parser name, and
+  collection timestamp metadata
+- parser-needed paths should be preserved:
+    - `content.matchFacts`
+    - `content.lineup`
+    - `content.liveticker.teams`
+    - `content.playerStats.*.shotmap`
+    - `content.playerStats.*.stats`
+    - `general`
+    - `header`
+    - `matchId`
+
+Explicit exclusions:
+
+- do not store the complete HTML body
+- do not store the complete HTTP response string
+- do not store screenshots
+- do not store local file paths as the raw payload
+- do not treat the page body hash as the DB `data_hash`
+
+## 5. data_hash policy
+
+`data_hash` should be:
+
+```text
+SHA-256(canonical_json(raw_data))
+```
+
+Policy:
+
+- canonical JSON must use stable key ordering
+- hash input is the exact `raw_data` object that will be written
+- the Phase 5.12L2C HTML body SHA-256 is fetch metadata only
+- body SHA-256 can be stored at `raw_data._meta.fetch_body_sha256`
+- future write phase must recompute `data_hash` from exact `raw_data` before DB
+  write
+- do not use legacy `md5($3::text)` for this controlled path
+
+## 6. data_version / collected_at policy
+
+Recommended semantic label:
+
+- `fotmob_html_hydration_v1`
+
+Current DB column is `raw_match_data.data_version varchar(20)`, so the planned
+DB-safe value is:
+
+- `fotmob_html_hyd_v1`
+
+`collected_at` policy:
+
+- generated by the future controlled write script
+- UTC timestamp
+- should represent the actual raw payload capture/write time
+- preview time can be recorded separately as `raw_data._meta.preview_at`
+
+## 7. Upsert policy
+
+Conflict key:
+
+- `match_id`
+
+Rules:
+
+- if no row exists: `would_insert`
+- if a row exists and `data_hash` is identical: `would_skip`
+- if a row exists and `data_hash` differs: `would_update` only after explicit
+  user authorization
+- no delete
+- no truncate
+- no overwrite without preflight
+- first write must be limited to rows `<= 1`
+- later controlled batch writes must be limited to rows `<= 8`
+- transaction required
+
+## 8. Protected tables
+
+Future raw ingest authorization may only allow `raw_match_data`.
+
+Protected table policy:
+
+- `matches`: read-only
+- `bookmaker_odds_history`: unchanged
+- `l3_features`: unchanged
+- `match_features_training`: unchanged
+- `predictions`: unchanged
+
+No parser, feature, training, prediction, harvest, backfill, or recon pipeline
+may be triggered by raw ingest.
+
+## 9. Recommended next phase
+
+Recommended next phase:
+
+`Phase 5.14L2: raw_match_data ingest authorization`
+
+Requirements:
+
+- user authorizes only `raw_match_data` write
+- target only `53_20252026_4830746` / `external_id=4830746`
+- no `matches` write
+- no `bookmaker_odds_history` write
+- no `l3_features` write
+- no `match_features_training` write
+- no `predictions` write
+- no training
+- no prediction
+- no DB write until a later preflight/execution phase defines the exact row and
+  transaction plan
+
+## 10. Explicit non-execution
+
+This phase does not execute:
+
+- external FotMob access
+- live match detail request
+- retry
+- browser/proxy runtime
+- DB writes
+- `raw_match_data` writes
+- `matches` writes
+- `bookmaker_odds_history` writes
+- `l3_features` writes
+- `match_features_training` writes
+- `predictions` writes
+- harvest / ingest
+- batch backfill
+- bulk harvest
+- parser / feature pipeline
+- training / prediction
+- full body save
+- full body print
+- file deletion

--- a/scripts/ops/l2_raw_match_data_ingest_plan.js
+++ b/scripts/ops/l2_raw_match_data_ingest_plan.js
@@ -1,0 +1,540 @@
+#!/usr/bin/env node
+/* eslint-disable complexity */
+'use strict';
+
+const PHASE = 'PHASE5_13L2_RAW_MATCH_DATA_INGEST_PLANNING';
+const NEXT_REQUIRED_PHASE = 'Phase 5.14L2 raw_match_data ingest authorization';
+const TARGET = Object.freeze({
+    source: 'fotmob',
+    route: 'html_hydration',
+    matchId: '53_20252026_4830746',
+    externalId: '4830746',
+    homeTeam: 'Angers',
+    awayTeam: 'Strasbourg',
+});
+
+function normalizeText(value) {
+    return String(value || '').trim();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parsePositiveInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    return Number.parseInt(normalized, 10);
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return {
+            value: nextArg,
+            consumedNext: true,
+        };
+    }
+
+    return {
+        value: true,
+        consumedNext: false,
+    };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        route: null,
+        matchId: null,
+        externalId: null,
+        homeTeam: null,
+        awayTeam: null,
+        previewBodySha256: null,
+        previewBodyByteLength: null,
+        hydrationParseOk: null,
+        looksLikeValidMatchDetail: null,
+        allowDbWrite: null,
+        allowRawMatchDataWrite: null,
+        allowMatchesWrite: null,
+        allowTraining: null,
+        allowPrediction: null,
+        commit: false,
+        execute: false,
+        networkAuthorization: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        route: 'route',
+        'match-id': 'matchId',
+        match_id: 'matchId',
+        'external-id': 'externalId',
+        external_id: 'externalId',
+        'home-team': 'homeTeam',
+        home_team: 'homeTeam',
+        'away-team': 'awayTeam',
+        away_team: 'awayTeam',
+        'preview-body-sha256': 'previewBodySha256',
+        preview_body_sha256: 'previewBodySha256',
+        'preview-body-byte-length': 'previewBodyByteLength',
+        preview_body_byte_length: 'previewBodyByteLength',
+        'hydration-parse-ok': 'hydrationParseOk',
+        hydration_parse_ok: 'hydrationParseOk',
+        'looks-like-valid-match-detail': 'looksLikeValidMatchDetail',
+        looks_like_valid_match_detail: 'looksLikeValidMatchDetail',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        commit: 'commit',
+        execute: 'execute',
+        'network-authorization': 'networkAuthorization',
+        network_authorization: 'networkAuthorization',
+        help: 'help',
+        h: 'help',
+    };
+    const booleanKeys = new Set([
+        'hydrationParseOk',
+        'looksLikeValidMatchDetail',
+        'allowDbWrite',
+        'allowRawMatchDataWrite',
+        'allowMatchesWrite',
+        'allowTraining',
+        'allowPrediction',
+        'commit',
+        'execute',
+        'networkAuthorization',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+
+        if (booleanKeys.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function includesText(value, expected) {
+    return normalizeText(value).toLowerCase().includes(normalizeText(expected).toLowerCase());
+}
+
+function pushRequiredFalseError(errors, value, flagName) {
+    if (value === false) {
+        return;
+    }
+    if (value === true) {
+        errors.push(`${flagName}=yes is blocked in Phase 5.13L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=no`);
+}
+
+function normalizePlanningInput(input = {}) {
+    return {
+        source: normalizeText(input.source).toLowerCase(),
+        route: normalizeText(input.route).toLowerCase(),
+        matchId: normalizeText(input.matchId),
+        externalId: normalizeText(input.externalId),
+        homeTeam: normalizeText(input.homeTeam),
+        awayTeam: normalizeText(input.awayTeam),
+        previewBodySha256: normalizeText(input.previewBodySha256).toLowerCase(),
+        previewBodyByteLength: parsePositiveInteger(input.previewBodyByteLength, null),
+        hydrationParseOk: normalizeBooleanFlag(input.hydrationParseOk, undefined),
+        looksLikeValidMatchDetail: normalizeBooleanFlag(input.looksLikeValidMatchDetail, undefined),
+        allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
+        allowMatchesWrite: normalizeBooleanFlag(input.allowMatchesWrite, undefined),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, undefined),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, undefined),
+        commit: normalizeBooleanFlag(input.commit, false),
+        execute: normalizeBooleanFlag(input.execute, false),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, false),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function validatePlanningInput(input = {}) {
+    const value = normalizePlanningInput(input);
+    const errors = [];
+
+    if (value.unknown.length > 0) {
+        errors.push(`unknown arguments: ${value.unknown.join(', ')}`);
+    }
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== TARGET.source) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+    if (!value.route) {
+        errors.push('missing route: provide --route=html_hydration');
+    } else if (value.route !== TARGET.route) {
+        errors.push('unsupported route: Phase 5.13L2 only plans html_hydration raw_data ingest');
+    }
+    if (!value.matchId) {
+        errors.push('missing match-id');
+    } else if (value.matchId !== TARGET.matchId) {
+        errors.push(`match-id must be ${TARGET.matchId} in Phase 5.13L2`);
+    }
+    if (!value.externalId) {
+        errors.push('missing external-id');
+    } else if (value.externalId !== TARGET.externalId) {
+        errors.push(`external-id must be ${TARGET.externalId} in Phase 5.13L2`);
+    }
+    if (!value.homeTeam) {
+        errors.push('missing home-team');
+    } else if (!includesText(value.homeTeam, TARGET.homeTeam)) {
+        errors.push(`home-team must contain ${TARGET.homeTeam}`);
+    }
+    if (!value.awayTeam) {
+        errors.push('missing away-team');
+    } else if (!includesText(value.awayTeam, TARGET.awayTeam)) {
+        errors.push(`away-team must contain ${TARGET.awayTeam}`);
+    }
+    if (!value.previewBodySha256) {
+        errors.push('missing preview-body-sha256');
+    } else if (!/^[a-f0-9]{64}$/.test(value.previewBodySha256)) {
+        errors.push('preview-body-sha256 must be a 64-character SHA-256 hex digest');
+    }
+    if (!Number.isFinite(value.previewBodyByteLength) || value.previewBodyByteLength <= 0) {
+        errors.push('preview-body-byte-length must be > 0');
+    }
+    if (value.hydrationParseOk !== true) {
+        errors.push('hydration-parse-ok=yes is required');
+    }
+    if (value.looksLikeValidMatchDetail !== true) {
+        errors.push('looks-like-valid-match-detail=yes is required');
+    }
+
+    pushRequiredFalseError(errors, value.allowDbWrite, 'allow-db-write');
+    pushRequiredFalseError(errors, value.allowRawMatchDataWrite, 'allow-raw-match-data-write');
+    pushRequiredFalseError(errors, value.allowMatchesWrite, 'allow-matches-write');
+    pushRequiredFalseError(errors, value.allowTraining, 'allow-training');
+    pushRequiredFalseError(errors, value.allowPrediction, 'allow-prediction');
+
+    if (value.commit === true) {
+        errors.push('commit=yes is blocked in Phase 5.13L2');
+    }
+    if (value.execute === true) {
+        errors.push('execute=yes is blocked in Phase 5.13L2');
+    }
+    if (value.networkAuthorization === true) {
+        errors.push('network-authorization=yes is blocked: this phase is planning-only and no-network');
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function buildRawDataPolicy(input = {}) {
+    return {
+        storage_shape: 'canonical_transformed_detail_payload',
+        recommended_source: 'FotMobDetailRouteSelector html_hydration transformed_api_format object',
+        required_top_level_keys: ['_meta', 'content', 'general', 'header', 'matchId'],
+        include_meta: true,
+        exclude_full_html_body: true,
+        exclude_full_http_response_string: true,
+        exclude_screenshot_or_file_path: true,
+        raw_data_must_not_be_page_html: true,
+        raw_data_meta_fields: {
+            source: TARGET.source,
+            route: TARGET.route,
+            request_url: 'https://www.fotmob.com/match/4830746',
+            final_url: 'https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och',
+            fetch_body_sha256: input.previewBodySha256 || null,
+            fetch_body_byte_length: input.previewBodyByteLength || null,
+            hydration_parse_ok: true,
+            parser: 'NextDataParser / FotMobDetailRouteSelector',
+            collected_at: 'write_phase_utc_timestamp',
+        },
+        preserve_paths: [
+            'content.matchFacts',
+            'content.lineup',
+            'content.liveticker.teams',
+            'content.playerStats.*.shotmap',
+            'content.playerStats.*.stats',
+            'general',
+            'header',
+            'matchId',
+        ],
+    };
+}
+
+function buildHashPolicy() {
+    return {
+        data_hash_algorithm: 'sha256',
+        data_hash_input: 'canonical_json(raw_data)',
+        canonical_json_requires_stable_key_ordering: true,
+        html_body_hash_is_data_hash: false,
+        body_sha256_metadata_field: 'raw_data._meta.fetch_body_sha256',
+        future_write_phase_must_recompute_hash_from_exact_raw_data: true,
+    };
+}
+
+function buildDataVersionPolicy() {
+    return {
+        data_version: 'fotmob_html_hyd_v1',
+        semantic_label: 'fotmob_html_hydration_v1',
+        rationale: 'raw_data comes from FotMob page HTML hydration transformed into API-compatible payload shape',
+        schema_column_limit_note:
+            'raw_match_data.data_version is varchar(20), so the DB value uses the shortened fotmob_html_hyd_v1 form while preserving the full semantic label in planning metadata',
+    };
+}
+
+function buildCollectedAtPolicy() {
+    return {
+        collected_at_source: 'write_phase_utc_timestamp',
+        collected_at_generated_by: 'future controlled write script',
+        timezone: 'UTC',
+        preview_time_handling:
+            'preview time may be recorded as raw_data._meta.preview_at, but DB collected_at must represent actual raw payload capture/write time',
+    };
+}
+
+function buildUpsertPolicy() {
+    return {
+        conflict_key: 'match_id',
+        unique_constraint: 'raw_match_data_match_id_key',
+        foreign_key: 'match_id -> matches(match_id) ON DELETE CASCADE',
+        no_existing_row: 'would_insert',
+        existing_same_data_hash: 'would_skip',
+        existing_different_data_hash: 'would_update_only_after_explicit_authorization',
+        delete_allowed: false,
+        truncate_allowed: false,
+        overwrite_without_preflight_allowed: false,
+        first_write_max_rows: 1,
+        later_batch_max_rows: 8,
+        transaction_required: true,
+    };
+}
+
+function buildProtectedTablesPolicy() {
+    return {
+        future_write_allowed_table: 'raw_match_data',
+        raw_match_data_write_allowed_this_phase: false,
+        protected_tables: {
+            matches: 'read_only',
+            bookmaker_odds_history: 'unchanged',
+            l3_features: 'unchanged',
+            match_features_training: 'unchanged',
+            predictions: 'unchanged',
+        },
+        parser_features_training_prediction_allowed_in_raw_ingest_phase: false,
+    };
+}
+
+function buildPreflightRequirements() {
+    return [
+        'SELECT target match and verify FK row exists',
+        'SELECT existing raw_match_data by match_id/external_id',
+        'Build exact raw_data object from already authorized route selector result without full HTML body',
+        'Compute SHA-256 over canonical JSON raw_data',
+        'Compare computed hash with existing row if present',
+        'Preview insert/skip/update decision with rows <= 1',
+        'Confirm transaction plan touches only raw_match_data',
+        'Confirm matches/features/training/predictions row counts remain unchanged',
+    ];
+}
+
+function buildAuthorizationRequirements() {
+    return [
+        'Phase 5.14L2 user authorization for raw_match_data write only',
+        'Target locked to 53_20252026_4830746 / external_id 4830746',
+        'No matches write',
+        'No bookmaker_odds_history write',
+        'No l3_features write',
+        'No match_features_training write',
+        'No predictions write',
+        'No parser/features/training/prediction execution',
+        'No external FotMob request unless separately authorized in a future acquisition phase',
+    ];
+}
+
+function buildRawMatchDataIngestPlan(input = {}) {
+    const validation = validatePlanningInput(input);
+    const normalized = validation.value;
+    const base = {
+        phase: PHASE,
+        planning_only: true,
+        ok: validation.ok,
+        source: TARGET.source,
+        route: TARGET.route,
+        match_id: TARGET.matchId,
+        external_id: TARGET.externalId,
+        home_team: TARGET.homeTeam,
+        away_team: TARGET.awayTeam,
+        target_table: 'raw_match_data',
+        raw_match_data_write_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_write_matches: false,
+        would_train: false,
+        would_predict: false,
+        external_network_used: false,
+        live_match_detail_request_used: false,
+        browser_used: false,
+        proxy_used: false,
+        full_body_saved: false,
+        full_body_printed: false,
+        commit_requested: normalized.commit === true,
+        execute_requested: normalized.execute === true,
+        network_authorization_requested: normalized.networkAuthorization === true,
+        preview_input: {
+            preview_body_sha256: normalized.previewBodySha256 || null,
+            preview_body_byte_length: normalized.previewBodyByteLength,
+            hydration_parse_ok: normalized.hydrationParseOk === true,
+            looks_like_valid_match_detail: normalized.looksLikeValidMatchDetail === true,
+        },
+        raw_data_policy: buildRawDataPolicy(normalized),
+        hash_policy: buildHashPolicy(),
+        data_version_policy: buildDataVersionPolicy(),
+        collected_at_policy: buildCollectedAtPolicy(),
+        upsert_policy: buildUpsertPolicy(),
+        protected_tables_policy: buildProtectedTablesPolicy(),
+        preflight_requirements: buildPreflightRequirements(),
+        authorization_requirements: buildAuthorizationRequirements(),
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+
+    if (!validation.ok) {
+        return {
+            ...base,
+            controlled_error: `INVALID_INGEST_PLAN_INPUT:${validation.errors.join('; ')}`,
+            errors: validation.errors,
+        };
+    }
+
+    return {
+        ...base,
+        controlled_error: null,
+        errors: [],
+    };
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l2_raw_match_data_ingest_plan.js --source=fotmob --route=html_hydration --match-id=53_20252026_4830746 --external-id=4830746 --home-team=Angers --away-team=Strasbourg --preview-body-sha256=<sha256> --preview-body-byte-length=<bytes> --hydration-parse-ok=yes --looks-like-valid-match-detail=yes --allow-db-write=no --allow-raw-match-data-write=no --allow-matches-write=no --allow-training=no --allow-prediction=no',
+        '',
+        'Safety:',
+        '  Phase 5.13L2 is planning-only: no network, no DB write, no raw_match_data write.',
+    ].join('\n');
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}) {
+    const stdout = io.stdout || process.stdout.write.bind(process.stdout);
+    const args = parseArgs(argv);
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    const plan = buildRawMatchDataIngestPlan(args);
+    stdout(`${JSON.stringify(plan, null, 2)}\n`);
+    return plan.ok ? 0 : 1;
+}
+
+if (require.main === module) {
+    runCli()
+        .then(status => {
+            process.exitCode = status;
+        })
+        .catch(error => {
+            process.stdout.write(
+                `${JSON.stringify(
+                    {
+                        phase: PHASE,
+                        planning_only: true,
+                        ok: false,
+                        controlled_error: String(error.message || error),
+                        raw_match_data_write_allowed_this_phase: false,
+                        db_write_allowed_this_phase: false,
+                        would_write_raw_match_data: false,
+                        would_write_db: false,
+                    },
+                    null,
+                    2
+                )}\n`
+            );
+            process.exitCode = 1;
+        });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validatePlanningInput,
+    buildRawDataPolicy,
+    buildHashPolicy,
+    buildDataVersionPolicy,
+    buildCollectedAtPolicy,
+    buildUpsertPolicy,
+    buildProtectedTablesPolicy,
+    buildPreflightRequirements,
+    buildAuthorizationRequirements,
+    buildRawMatchDataIngestPlan,
+    runCli,
+};

--- a/tests/unit/l2_raw_match_data_ingest_plan.test.js
+++ b/tests/unit/l2_raw_match_data_ingest_plan.test.js
@@ -1,0 +1,337 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l2_raw_match_data_ingest_plan.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+const PREVIEW_BODY_SHA256 = '8710a3524807d4682ab3c66386f9cd6b4d374fb6eee4f98a29d7f4a6683a162c';
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function validArgs(overrides = {}) {
+    return {
+        source: 'fotmob',
+        route: 'html_hydration',
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        homeTeam: 'Angers',
+        awayTeam: 'Strasbourg',
+        previewBodySha256: PREVIEW_BODY_SHA256,
+        previewBodyByteLength: '1037598',
+        hydrationParseOk: true,
+        looksLikeValidMatchDetail: true,
+        allowDbWrite: false,
+        allowRawMatchDataWrite: false,
+        allowMatchesWrite: false,
+        allowTraining: false,
+        allowPrediction: false,
+        commit: false,
+        execute: false,
+        networkAuthorization: false,
+        ...overrides,
+    };
+}
+
+function cliArgs(overrides = {}) {
+    const args = validArgs(overrides);
+    return [
+        `--source=${args.source}`,
+        `--route=${args.route}`,
+        `--match-id=${args.matchId}`,
+        `--external-id=${args.externalId}`,
+        `--home-team=${args.homeTeam}`,
+        `--away-team=${args.awayTeam}`,
+        `--preview-body-sha256=${args.previewBodySha256}`,
+        `--preview-body-byte-length=${args.previewBodyByteLength}`,
+        `--hydration-parse-ok=${args.hydrationParseOk ? 'yes' : 'no'}`,
+        `--looks-like-valid-match-detail=${args.looksLikeValidMatchDetail ? 'yes' : 'no'}`,
+        `--allow-db-write=${args.allowDbWrite ? 'yes' : 'no'}`,
+        `--allow-raw-match-data-write=${args.allowRawMatchDataWrite ? 'yes' : 'no'}`,
+        `--allow-matches-write=${args.allowMatchesWrite ? 'yes' : 'no'}`,
+        `--allow-training=${args.allowTraining ? 'yes' : 'no'}`,
+        `--allow-prediction=${args.allowPrediction ? 'yes' : 'no'}`,
+        `--commit=${args.commit ? 'yes' : 'no'}`,
+        `--execute=${args.execute ? 'yes' : 'no'}`,
+        `--network-authorization=${args.networkAuthorization ? 'yes' : 'no'}`,
+    ];
+}
+
+async function runCli(gate, argv) {
+    let stdout = '';
+    const status = await gate.runCli(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+    });
+    return {
+        status,
+        stdout,
+        payload: stdout.trim().startsWith('{') ? JSON.parse(stdout) : null,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalFetch = global.fetch;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l2_raw_match_data_ingest_plan`);
+    };
+
+    global.fetch = fail('global.fetch');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+            'child_process',
+            'node:child_process',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        Module._load = originalLoad;
+    });
+}
+
+function assertInvalid(overrides, expectedPattern) {
+    const gate = loadModuleFresh();
+    const plan = gate.buildRawMatchDataIngestPlan(validArgs(overrides));
+    assert.equal(plan.ok, false);
+    assert.match(plan.controlled_error, expectedPattern);
+    assert.equal(plan.would_write_raw_match_data, false);
+    assert.equal(plan.would_write_db, false);
+}
+
+test('valid planning input succeeds', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validatePlanningInput(validArgs());
+    assert.equal(validation.ok, true);
+    assert.deepEqual(validation.errors, []);
+});
+
+test('source missing fails', () => assertInvalid({ source: '' }, /missing source/));
+test('source non-fotmob fails', () => assertInvalid({ source: 'other' }, /unsupported source/));
+test('route missing fails', () => assertInvalid({ route: '' }, /missing route/));
+test('route non-html_hydration fails for this phase', () =>
+    assertInvalid({ route: 'api_match_details' }, /unsupported route/));
+test('match-id missing fails', () => assertInvalid({ matchId: '' }, /missing match-id/));
+test('match-id not 53_20252026_4830746 fails', () => assertInvalid({ matchId: 'x' }, /match-id must be/));
+test('external-id missing fails', () => assertInvalid({ externalId: '' }, /missing external-id/));
+test('external-id not 4830746 fails', () => assertInvalid({ externalId: '1' }, /external-id must be/));
+test('home-team missing Angers fails', () => assertInvalid({ homeTeam: 'Paris' }, /home-team must contain Angers/));
+test('away-team missing Strasbourg fails', () =>
+    assertInvalid({ awayTeam: 'Lens' }, /away-team must contain Strasbourg/));
+test('preview-body-sha256 missing fails', () =>
+    assertInvalid({ previewBodySha256: '' }, /missing preview-body-sha256/));
+test('preview-body-byte-length <= 0 fails', () =>
+    assertInvalid({ previewBodyByteLength: '0' }, /byte-length must be > 0/));
+test('hydration-parse-ok=no fails', () =>
+    assertInvalid({ hydrationParseOk: false }, /hydration-parse-ok=yes is required/));
+test('looks-like-valid-match-detail=no fails', () =>
+    assertInvalid({ looksLikeValidMatchDetail: false }, /looks-like-valid-match-detail=yes is required/));
+test('allow-db-write=yes blocked', () => assertInvalid({ allowDbWrite: true }, /allow-db-write=yes is blocked/));
+test('allow-raw-match-data-write=yes blocked', () =>
+    assertInvalid({ allowRawMatchDataWrite: true }, /allow-raw-match-data-write=yes is blocked/));
+test('allow-matches-write=yes blocked', () =>
+    assertInvalid({ allowMatchesWrite: true }, /allow-matches-write=yes is blocked/));
+test('allow-training=yes blocked', () => assertInvalid({ allowTraining: true }, /allow-training=yes is blocked/));
+test('allow-prediction=yes blocked', () => assertInvalid({ allowPrediction: true }, /allow-prediction=yes is blocked/));
+test('commit=yes blocked', () => assertInvalid({ commit: true }, /commit=yes is blocked/));
+test('execute=yes blocked', () => assertInvalid({ execute: true }, /execute=yes is blocked/));
+test('network-authorization=yes blocked', () =>
+    assertInvalid({ networkAuthorization: true }, /network-authorization=yes is blocked/));
+
+test('output planning_only=true and target_table=raw_match_data', () => {
+    const gate = loadModuleFresh();
+    const plan = gate.buildRawMatchDataIngestPlan(validArgs());
+    assert.equal(plan.ok, true);
+    assert.equal(plan.planning_only, true);
+    assert.equal(plan.target_table, 'raw_match_data');
+});
+
+test('output would_write_raw_match_data=false', () => {
+    const gate = loadModuleFresh();
+    const plan = gate.buildRawMatchDataIngestPlan(validArgs());
+    assert.equal(plan.raw_match_data_write_allowed_this_phase, false);
+    assert.equal(plan.db_write_allowed_this_phase, false);
+    assert.equal(plan.would_write_raw_match_data, false);
+    assert.equal(plan.would_write_db, false);
+});
+
+test('raw_data_policy forbids full HTML body', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildRawDataPolicy(validArgs());
+    assert.equal(policy.exclude_full_html_body, true);
+    assert.equal(policy.raw_data_must_not_be_page_html, true);
+});
+
+test('raw_data_policy includes transformed_api_format', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildRawDataPolicy(validArgs());
+    assert.match(policy.recommended_source, /transformed_api_format/);
+    assert.ok(policy.required_top_level_keys.includes('content'));
+    assert.ok(policy.preserve_paths.includes('content.matchFacts'));
+});
+
+test('hash_policy uses SHA-256 canonical JSON', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildHashPolicy();
+    assert.equal(policy.data_hash_algorithm, 'sha256');
+    assert.equal(policy.data_hash_input, 'canonical_json(raw_data)');
+    assert.equal(policy.canonical_json_requires_stable_key_ordering, true);
+});
+
+test('hash_policy separates body_sha256 from data_hash', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildHashPolicy();
+    assert.equal(policy.html_body_hash_is_data_hash, false);
+    assert.equal(policy.body_sha256_metadata_field, 'raw_data._meta.fetch_body_sha256');
+});
+
+test('data_version_policy contains fotmob_html_hydration_v1', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildDataVersionPolicy();
+    assert.equal(policy.semantic_label, 'fotmob_html_hydration_v1');
+    assert.equal(policy.data_version, 'fotmob_html_hyd_v1');
+});
+
+test('collected_at_policy uses write-time UTC', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildCollectedAtPolicy();
+    assert.equal(policy.collected_at_source, 'write_phase_utc_timestamp');
+    assert.equal(policy.timezone, 'UTC');
+});
+
+test('upsert_policy uses match_id unique', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildUpsertPolicy();
+    assert.equal(policy.conflict_key, 'match_id');
+    assert.equal(policy.unique_constraint, 'raw_match_data_match_id_key');
+});
+
+test('upsert_policy requires transaction', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildUpsertPolicy();
+    assert.equal(policy.transaction_required, true);
+    assert.equal(policy.first_write_max_rows, 1);
+});
+
+test('protected_tables_policy protects matches/features/predictions', () => {
+    const gate = loadModuleFresh();
+    const policy = gate.buildProtectedTablesPolicy();
+    assert.equal(policy.future_write_allowed_table, 'raw_match_data');
+    assert.equal(policy.protected_tables.matches, 'read_only');
+    assert.equal(policy.protected_tables.l3_features, 'unchanged');
+    assert.equal(policy.protected_tables.predictions, 'unchanged');
+});
+
+test('Makefile plan target is present and maps to planning script', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l2-raw-match-data-ingest-plan:/m);
+    assert.match(makefile, /scripts\/ops\/l2_raw_match_data_ingest_plan\.js/);
+});
+
+test('runCli succeeds with valid input and does not access network or DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs());
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.ok, true);
+    assert.equal(result.payload.external_network_used, false);
+    assert.equal(result.payload.would_write_db, false);
+});
+
+test('runCli returns non-zero for blocked DB write', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs({ allowDbWrite: true }));
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.ok, false);
+    assert.match(result.payload.controlled_error, /allow-db-write=yes is blocked/);
+});
+
+test('source audit: no network clients', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\(['"]node:http['"]\)|require\(['"]http['"]\)/);
+    assert.doesNotMatch(source, /require\(['"]node:https['"]\)|require\(['"]https['"]\)/);
+    assert.doesNotMatch(source, /\bfetch\s*\(/);
+});
+
+test('source audit: no DB write or pg client', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\(['"]pg['"]\)/);
+    assert.doesNotMatch(source, /\.query\s*\(/);
+    assert.doesNotMatch(source, /\bINSERT\s+INTO\b|\bUPDATE\s+\w+\s+SET\b|\bDELETE\s+FROM\b/i);
+    assert.doesNotMatch(source, /\b(TRUNCATE|ALTER\s+TABLE|DROP\s+TABLE|MERGE\s+INTO)\b/i);
+});
+
+test('source audit: no fs write / mkdir', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /writeFile|writeFileSync|mkdir|createWriteStream/);
+});
+
+test('source audit: no child_process spawn', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /child_process|spawn|execFile/);
+});
+
+test('source audit: no ProductionHarvester / raw ingest commit', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.13L2 raw_match_data ingest planning.

Scope:
- Adds planning-only script for raw_match_data ingest policy
- Defines raw_data storage policy for FotMob HTML hydration transformed payload
- Defines SHA-256 canonical JSON data_hash policy
- Defines data_version and collected_at policy
- Defines upsert and protected-table policies
- Adds Makefile planning target, tests, AGENTS.md updates, and report

Safety:
- No external FotMob access
- No live match detail request
- No DB writes
- No raw_match_data writes
- No matches writes
- No harvest / ingest
- No training / prediction
- No file deletion

Validation:
- raw_match_data ingest planning tests passed
- Makefile planning target passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed