### PR TITLE
docs(data): add raw_match_data ingest authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 - Phase 5.11L2 direct `matchDetails` endpoint 已返回 403。AI / Codex 不得擅自 retry、增加 headers、改走 browser/proxy 或尝试 alternate route；继续请求 raw detail 前必须先完成现有 L2 fetch path reconciliation 并取得明确授权，`raw_match_data` 写入仍未授权。
 - Phase 5.12L2B 新增 safe FotMob detail route selector，默认顺序为 `html_hydration` -> `api_match_details`，`alternate_route` 仅 plan-only；live external raw detail preview 仍默认 blocked，未经未来单独授权不得 retry Phase 5.11L2 direct API 403、不得加 headers/browser/proxy 绕过，`raw_match_data` 写入仍未授权。
 - Phase 5.13L2 raw_match_data ingest planning 仅允许 planning-only；`raw_match_data` 写入仍未授权。raw_data 应存 canonical transformed detail payload 而不是完整 HTML body；data_hash 应为 canonical raw_data JSON 的 SHA-256，而不是 HTML body hash；raw_match_data ingest 不得更新 `matches`、features、training 或 predictions，未来写入必须另行 authorization + preflight。
+- Phase 5.14L2 raw_match_data ingest authorization 仅允许 authorization-only：它只记录未来 `raw_match_data` 写入授权范围，本阶段不得写 DB、不得写 `raw_match_data`、不得 live preview / network request；后续写入仍必须先完成 Phase 5.15L2 preflight，并在最终执行阶段再次确认。raw_match_data ingest 必须保持 raw-only，不得更新 `matches`、features、training 或 predictions。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 
@@ -229,6 +230,7 @@ AI / Codex 默认只能执行：
 - legacy L1/data entrypoints 对 agents 视为 deprecated：admin / 人工兼容可以继续保留，但默认不得直接运行；L1 discovery 和 matches seed 默认必须走 `data-l1-*` safe workflow。
 - L2 raw JSON acquisition 仍处于 planning 阶段，默认不得触网、不得抓取 FotMob match detail、不得写 `raw_match_data`；后续必须走 controlled preview / authorization / preflight。
 - Phase 5.11L2 仅允许用户明确授权的 `make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg NETWORK_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no`；只输出 stdout metadata/hash/markers，不写 DB，不写 `raw_match_data`，不保存或打印完整 body。
+- Phase 5.14L2 仅允许用户明确授权的 `make data-l2-raw-match-data-ingest-authorization SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 PREVIEW_BODY_SHA256=<sha256> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes USER_AUTHORIZED_RAW_MATCH_DATA_INGEST=yes ALLOW_RAW_MATCH_DATA_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE_NOW=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes`；只输出 stdout authorization JSON，不触网、不写 DB、不写 `raw_match_data`。
 - `make data-help`
 - `make data-check`
 - `make data-l1-discovery-preview SOURCE=fotmob SCOPE=<config_only_preview|league_season_date|league_season_window_preview> ...`

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
-        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan \
+        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan data-l2-raw-match-data-ingest-plan data-l2-raw-match-data-ingest-authorization \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -334,8 +334,9 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l2-raw-detail-route-preview-plan  # Phase 5.12L2B route selector plan only, no network"
 	@echo "  make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg ROUTE=auto NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=no ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # route selector preview; live remains blocked without future authorization"
 	@echo "  make data-l2-raw-match-data-ingest-plan SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg PREVIEW_BODY_SHA256=<sha256> PREVIEW_BODY_BYTE_LENGTH=<bytes> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.13L2 planning-only, no network/DB/raw write"
+	@echo "  make data-l2-raw-match-data-ingest-authorization SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 PREVIEW_BODY_SHA256=<sha256> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes USER_AUTHORIZED_RAW_MATCH_DATA_INGEST=yes ALLOW_RAW_MATCH_DATA_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE_NOW=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes  # Phase 5.14L2 authorization-only, no network/DB/raw write"
 	@echo "  L2 raw detail preview is preview-only: no raw_match_data write, no DB write, no browser/proxy, no full body print/save."
-	@echo "  L2 raw_match_data ingest is planning-only in Phase 5.13L2: future write requires explicit authorization + preflight, and raw_match_data write remains blocked."
+	@echo "  L2 raw_match_data ingest authorization is authorization-only in Phase 5.14L2: future write requires preflight + final DB-write confirmation, and raw_match_data write remains blocked this phase."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
 	@echo "  Phase 5.12L2B route selector supports html_hydration before api_match_details; alternate_route remains plan-only."
 	@echo "  Live raw detail requests require future explicit authorization; use audited route selector / safe adapter, not legacy harvest/backfill."
@@ -684,6 +685,35 @@ data-l2-raw-match-data-ingest-plan: ## L2 raw_match_data ingest planning. Phase 
 		--commit="$(or $(COMMIT),no)" \
 		--execute="$(or $(EXECUTE),no)" \
 		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)"
+
+data-l2-raw-match-data-ingest-authorization: ## L2 raw_match_data ingest authorization. Phase 5.14L2. Authorization-only, no network/DB/raw write.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(ROUTE)" ] || [ -z "$(MATCH_ID)" ] || [ -z "$(EXTERNAL_ID)" ] || [ -z "$(HOME_TEAM)" ] || [ -z "$(AWAY_TEAM)" ] || [ -z "$(DATA_VERSION)" ] || [ -z "$(PREVIEW_BODY_SHA256)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 PREVIEW_BODY_SHA256=<sha256>"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l2_raw_match_data_ingest_authorization.js \
+		--source="$(SOURCE)" \
+		--route="$(ROUTE)" \
+		--match-id="$(MATCH_ID)" \
+		--external-id="$(EXTERNAL_ID)" \
+		--home-team="$(HOME_TEAM)" \
+		--away-team="$(AWAY_TEAM)" \
+		--data-version="$(DATA_VERSION)" \
+		--preview-body-sha256="$(PREVIEW_BODY_SHA256)" \
+		--hydration-parse-ok="$(or $(HYDRATION_PARSE_OK),yes)" \
+		--looks-like-valid-match-detail="$(or $(LOOKS_LIKE_VALID_MATCH_DETAIL),yes)" \
+		--user-authorized-raw-match-data-ingest="$(or $(USER_AUTHORIZED_RAW_MATCH_DATA_INGEST),no)" \
+		--allow-raw-match-data-write-next-phase="$(or $(ALLOW_RAW_MATCH_DATA_WRITE_NEXT_PHASE),no)" \
+		--allow-db-write-now="$(or $(ALLOW_DB_WRITE_NOW),no)" \
+		--allow-raw-match-data-write-now="$(or $(ALLOW_RAW_MATCH_DATA_WRITE_NOW),no)" \
+		--allow-matches-write="$(or $(ALLOW_MATCHES_WRITE),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--final-human-confirmation="$(or $(FINAL_HUMAN_CONFIRMATION),no)" \
+		--commit="$(or $(COMMIT),no)" \
+		--execute="$(or $(EXECUTE),no)" \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--live-preview-authorization="$(or $(LIVE_PREVIEW_AUTHORIZATION),no)"
 
 data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.
 	@if [ -n "$(SAMPLE_HTML)" ]; then \

--- a/docs/_reports/RAW_MATCH_DATA_INGEST_AUTHORIZATION_PHASE5_14L2.md
+++ b/docs/_reports/RAW_MATCH_DATA_INGEST_AUTHORIZATION_PHASE5_14L2.md
@@ -1,0 +1,155 @@
+# Raw Match Data Ingest Authorization - Phase 5.14L2
+
+## 1. Executive summary
+
+The user authorized entry into the `raw_match_data` ingest flow for target
+`53_20252026_4830746` / external id `4830746`.
+
+Phase 5.14L2 is authorization-only. It records the allowed future ingest scope
+for one `raw_match_data` row, but it does not write DB, does not write
+`raw_match_data`, does not run a live preview, and does not execute harvest,
+ingest, training, or prediction.
+
+Future write remains blocked until Phase 5.15L2 preflight and a later controlled
+execution phase with final DB-write confirmation.
+
+## 2. Baseline
+
+Pre-authorization baseline:
+
+| Table                     | Rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+Target match exists:
+
+| Field         | Value                    |
+| ------------- | ------------------------ |
+| `match_id`    | `53_20252026_4830746`    |
+| `external_id` | `4830746`                |
+| `home_team`   | `Angers`                 |
+| `away_team`   | `Strasbourg`             |
+| `match_date`  | `2026-05-10 19:00:00+00` |
+| `status`      | `finished`               |
+
+Target `raw_match_data` existing status:
+
+- no existing row for `match_id=53_20252026_4830746`
+- no existing row for `external_id=4830746`
+
+## 3. Authorized scope
+
+Authorized future scope:
+
+- `source=fotmob`
+- `route=html_hydration`
+- target table: `raw_match_data`
+- `match_id=53_20252026_4830746`
+- `external_id=4830746`
+- `home_team=Angers`
+- `away_team=Strasbourg`
+- `rows_limit=1`
+- `data_version=fotmob_html_hyd_v1`
+- raw data policy: canonical transformed detail payload
+- data hash policy: `SHA-256(canonical_json(raw_data))`
+
+Protected tables:
+
+- `matches`
+- `bookmaker_odds_history`
+- `l3_features`
+- `match_features_training`
+- `predictions`
+
+No matches, features, training, or prediction writes are authorized by this
+phase.
+
+## 4. Authorization boundary
+
+Authorization does not equal DB write.
+
+Boundary:
+
+- `raw_match_data_write_allowed_this_phase=false`
+- `raw_match_data_write_allowed_next_phase=true`
+- `db_write_allowed_this_phase=false`
+- future preflight required
+- future final DB-write confirmation required
+- no live preview or network request is allowed in this authorization phase
+
+The authorization-only script must only output an authorization JSON summary.
+It must not access FotMob, load browser/proxy runtime, save body content, print
+body content, write files, write DB, or run any legacy harvest/backfill/ingest
+entrypoint.
+
+## 5. Next phase requirements
+
+Phase 5.15L2 must:
+
+- reload or recapture the exact raw payload under explicit preview/write flow
+- compute canonical `raw_data`
+- compute `data_hash`
+- SELECT existing `raw_match_data`
+- output `would_insert` / `would_update` / `would_skip`
+- verify protected table baselines
+- not write DB yet
+
+The later execution phase must require final DB-write confirmation and a
+transaction touching only `raw_match_data`.
+
+## 6. Validation
+
+Local validation results:
+
+| Check                                                                   | Result             |
+| ----------------------------------------------------------------------- | ------------------ |
+| `node --test tests/unit/l2_raw_match_data_ingest_authorization.test.js` | Passed, 48/48      |
+| `make data-l2-raw-match-data-ingest-authorization ...`                  | Passed             |
+| `npm test`                                                              | Passed             |
+| `npm run test:coverage`                                                 | Passed             |
+| `git diff --check`                                                      | Passed             |
+| `eslint` on authorization script and unit test                          | Passed             |
+| `prettier --check` on touched files                                     | Passed             |
+| DB row-count safety check                                               | Passed, unchanged  |
+| `tests/fixtures/l1-config-*` residue check                              | Passed, no residue |
+| `docs/_staging_preview` residue check                                   | Passed, absent     |
+
+Post-validation DB row counts remained unchanged:
+
+| Table                     | Rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+## 7. Explicit non-execution
+
+This phase does not execute:
+
+- external FotMob access
+- live match detail request
+- network dry-run
+- retry
+- browser/proxy runtime
+- DB writes
+- `raw_match_data` writes
+- `matches` writes
+- `bookmaker_odds_history` writes
+- `l3_features` writes
+- `match_features_training` writes
+- `predictions` writes
+- harvest / ingest
+- batch backfill
+- bulk harvest
+- training / prediction
+- full body save
+- full body print
+- file deletion

--- a/scripts/ops/l2_raw_match_data_ingest_authorization.js
+++ b/scripts/ops/l2_raw_match_data_ingest_authorization.js
@@ -1,0 +1,493 @@
+#!/usr/bin/env node
+/* eslint-disable complexity */
+'use strict';
+
+const PHASE = 'PHASE5_14L2_RAW_MATCH_DATA_INGEST_AUTHORIZATION';
+const NEXT_REQUIRED_PHASE = 'Phase 5.15L2 raw_match_data ingest preflight';
+const TARGET = Object.freeze({
+    source: 'fotmob',
+    route: 'html_hydration',
+    matchId: '53_20252026_4830746',
+    externalId: '4830746',
+    homeTeam: 'Angers',
+    awayTeam: 'Strasbourg',
+    dataVersion: 'fotmob_html_hyd_v1',
+});
+
+function normalizeText(value) {
+    return String(value || '').trim();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return {
+            value: nextArg,
+            consumedNext: true,
+        };
+    }
+
+    return {
+        value: true,
+        consumedNext: false,
+    };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        route: null,
+        matchId: null,
+        externalId: null,
+        homeTeam: null,
+        awayTeam: null,
+        dataVersion: null,
+        previewBodySha256: null,
+        hydrationParseOk: null,
+        looksLikeValidMatchDetail: null,
+        userAuthorizedRawMatchDataIngest: null,
+        allowRawMatchDataWriteNextPhase: null,
+        allowDbWriteNow: null,
+        allowRawMatchDataWriteNow: null,
+        allowMatchesWrite: null,
+        allowTraining: null,
+        allowPrediction: null,
+        finalHumanConfirmation: null,
+        commit: false,
+        execute: false,
+        networkAuthorization: false,
+        livePreviewAuthorization: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        route: 'route',
+        'match-id': 'matchId',
+        match_id: 'matchId',
+        'external-id': 'externalId',
+        external_id: 'externalId',
+        'home-team': 'homeTeam',
+        home_team: 'homeTeam',
+        'away-team': 'awayTeam',
+        away_team: 'awayTeam',
+        'data-version': 'dataVersion',
+        data_version: 'dataVersion',
+        'preview-body-sha256': 'previewBodySha256',
+        preview_body_sha256: 'previewBodySha256',
+        'hydration-parse-ok': 'hydrationParseOk',
+        hydration_parse_ok: 'hydrationParseOk',
+        'looks-like-valid-match-detail': 'looksLikeValidMatchDetail',
+        looks_like_valid_match_detail: 'looksLikeValidMatchDetail',
+        'user-authorized-raw-match-data-ingest': 'userAuthorizedRawMatchDataIngest',
+        user_authorized_raw_match_data_ingest: 'userAuthorizedRawMatchDataIngest',
+        'allow-raw-match-data-write-next-phase': 'allowRawMatchDataWriteNextPhase',
+        allow_raw_match_data_write_next_phase: 'allowRawMatchDataWriteNextPhase',
+        'allow-db-write-now': 'allowDbWriteNow',
+        allow_db_write_now: 'allowDbWriteNow',
+        'allow-raw-match-data-write-now': 'allowRawMatchDataWriteNow',
+        allow_raw_match_data_write_now: 'allowRawMatchDataWriteNow',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        'final-human-confirmation': 'finalHumanConfirmation',
+        final_human_confirmation: 'finalHumanConfirmation',
+        commit: 'commit',
+        execute: 'execute',
+        'network-authorization': 'networkAuthorization',
+        network_authorization: 'networkAuthorization',
+        'live-preview-authorization': 'livePreviewAuthorization',
+        live_preview_authorization: 'livePreviewAuthorization',
+        help: 'help',
+        h: 'help',
+    };
+    const booleanKeys = new Set([
+        'hydrationParseOk',
+        'looksLikeValidMatchDetail',
+        'userAuthorizedRawMatchDataIngest',
+        'allowRawMatchDataWriteNextPhase',
+        'allowDbWriteNow',
+        'allowRawMatchDataWriteNow',
+        'allowMatchesWrite',
+        'allowTraining',
+        'allowPrediction',
+        'finalHumanConfirmation',
+        'commit',
+        'execute',
+        'networkAuthorization',
+        'livePreviewAuthorization',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+
+        if (booleanKeys.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function includesText(value, expected) {
+    return normalizeText(value).toLowerCase().includes(normalizeText(expected).toLowerCase());
+}
+
+function pushRequiredTrueError(errors, value, flagName) {
+    if (value === true) {
+        return;
+    }
+    if (value === false) {
+        errors.push(`${flagName}=yes is required in Phase 5.14L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=yes`);
+}
+
+function pushRequiredFalseError(errors, value, flagName) {
+    if (value === false) {
+        return;
+    }
+    if (value === true) {
+        errors.push(`${flagName}=yes is blocked in Phase 5.14L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=no`);
+}
+
+function normalizeAuthorizationInput(input = {}) {
+    return {
+        source: normalizeText(input.source).toLowerCase(),
+        route: normalizeText(input.route).toLowerCase(),
+        matchId: normalizeText(input.matchId),
+        externalId: normalizeText(input.externalId),
+        homeTeam: normalizeText(input.homeTeam),
+        awayTeam: normalizeText(input.awayTeam),
+        dataVersion: normalizeText(input.dataVersion).toLowerCase(),
+        previewBodySha256: normalizeText(input.previewBodySha256).toLowerCase(),
+        hydrationParseOk: normalizeBooleanFlag(input.hydrationParseOk, undefined),
+        looksLikeValidMatchDetail: normalizeBooleanFlag(input.looksLikeValidMatchDetail, undefined),
+        userAuthorizedRawMatchDataIngest: normalizeBooleanFlag(input.userAuthorizedRawMatchDataIngest, undefined),
+        allowRawMatchDataWriteNextPhase: normalizeBooleanFlag(input.allowRawMatchDataWriteNextPhase, undefined),
+        allowDbWriteNow: normalizeBooleanFlag(input.allowDbWriteNow, undefined),
+        allowRawMatchDataWriteNow: normalizeBooleanFlag(input.allowRawMatchDataWriteNow, undefined),
+        allowMatchesWrite: normalizeBooleanFlag(input.allowMatchesWrite, undefined),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, undefined),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, undefined),
+        finalHumanConfirmation: normalizeBooleanFlag(input.finalHumanConfirmation, undefined),
+        commit: normalizeBooleanFlag(input.commit, false),
+        execute: normalizeBooleanFlag(input.execute, false),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, false),
+        livePreviewAuthorization: normalizeBooleanFlag(input.livePreviewAuthorization, false),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function validateAuthorizationInput(input = {}) {
+    const value = normalizeAuthorizationInput(input);
+    const errors = [];
+
+    if (value.unknown.length > 0) {
+        errors.push(`unknown arguments: ${value.unknown.join(', ')}`);
+    }
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== TARGET.source) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+    if (!value.route) {
+        errors.push('missing route: provide --route=html_hydration');
+    } else if (value.route !== TARGET.route) {
+        errors.push('unsupported route: Phase 5.14L2 only authorizes html_hydration raw_data ingest');
+    }
+    if (!value.matchId) {
+        errors.push('missing match-id');
+    } else if (value.matchId !== TARGET.matchId) {
+        errors.push(`match-id must be ${TARGET.matchId} in Phase 5.14L2`);
+    }
+    if (!value.externalId) {
+        errors.push('missing external-id');
+    } else if (value.externalId !== TARGET.externalId) {
+        errors.push(`external-id must be ${TARGET.externalId} in Phase 5.14L2`);
+    }
+    if (!value.homeTeam) {
+        errors.push('missing home-team');
+    } else if (!includesText(value.homeTeam, TARGET.homeTeam)) {
+        errors.push(`home-team must contain ${TARGET.homeTeam}`);
+    }
+    if (!value.awayTeam) {
+        errors.push('missing away-team');
+    } else if (!includesText(value.awayTeam, TARGET.awayTeam)) {
+        errors.push(`away-team must contain ${TARGET.awayTeam}`);
+    }
+    if (!value.dataVersion) {
+        errors.push('missing data-version');
+    } else if (value.dataVersion !== TARGET.dataVersion) {
+        errors.push(`data-version must be ${TARGET.dataVersion} in Phase 5.14L2`);
+    }
+    if (!value.previewBodySha256) {
+        errors.push('missing preview-body-sha256');
+    } else if (!/^[a-f0-9]{64}$/.test(value.previewBodySha256)) {
+        errors.push('preview-body-sha256 must be a 64-character SHA-256 hex digest');
+    }
+    if (value.hydrationParseOk !== true) {
+        errors.push('hydration-parse-ok=yes is required');
+    }
+    if (value.looksLikeValidMatchDetail !== true) {
+        errors.push('looks-like-valid-match-detail=yes is required');
+    }
+
+    pushRequiredTrueError(errors, value.userAuthorizedRawMatchDataIngest, 'user-authorized-raw-match-data-ingest');
+    pushRequiredTrueError(errors, value.allowRawMatchDataWriteNextPhase, 'allow-raw-match-data-write-next-phase');
+    pushRequiredTrueError(errors, value.finalHumanConfirmation, 'final-human-confirmation');
+    pushRequiredFalseError(errors, value.allowDbWriteNow, 'allow-db-write-now');
+    pushRequiredFalseError(errors, value.allowRawMatchDataWriteNow, 'allow-raw-match-data-write-now');
+    pushRequiredFalseError(errors, value.allowMatchesWrite, 'allow-matches-write');
+    pushRequiredFalseError(errors, value.allowTraining, 'allow-training');
+    pushRequiredFalseError(errors, value.allowPrediction, 'allow-prediction');
+
+    if (value.commit === true) {
+        errors.push('commit=yes is blocked in Phase 5.14L2');
+    }
+    if (value.execute === true) {
+        errors.push('execute=yes is blocked in Phase 5.14L2');
+    }
+    if (value.networkAuthorization === true) {
+        errors.push('network-authorization=yes is blocked: authorization phase is no-network');
+    }
+    if (value.livePreviewAuthorization === true) {
+        errors.push('live-preview-authorization=yes is blocked: authorization phase is not live preview');
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function buildAuthorizedScope() {
+    return {
+        source: TARGET.source,
+        route: TARGET.route,
+        match_id: TARGET.matchId,
+        external_id: TARGET.externalId,
+        home_team: TARGET.homeTeam,
+        away_team: TARGET.awayTeam,
+        target_table: 'raw_match_data',
+        rows_limit: 1,
+        data_version: TARGET.dataVersion,
+        raw_data_policy: 'canonical transformed detail payload',
+        data_hash_policy: 'SHA-256(canonical_json(raw_data))',
+        protected_tables: [
+            'matches',
+            'bookmaker_odds_history',
+            'l3_features',
+            'match_features_training',
+            'predictions',
+        ],
+    };
+}
+
+function buildAuthorizationGates() {
+    return [
+        'user_authorized_raw_match_data_ingest=true',
+        'final_human_confirmation=true',
+        'allow_raw_match_data_write_next_phase=true',
+        'allow_raw_match_data_write_now=false',
+        'allow_db_write_now=false',
+        'allow_matches_write=false',
+        'allow_training=false',
+        'allow_prediction=false',
+        'network_authorization_this_phase=false',
+    ];
+}
+
+function buildBlockedActionsThisPhase() {
+    return [
+        'write_raw_match_data',
+        'write_db',
+        'write_matches',
+        'run_live_preview',
+        'run_harvest',
+        'run_backfill',
+        'run_training',
+        'run_prediction',
+        'save_full_body',
+        'print_full_body',
+    ];
+}
+
+function buildNextPhaseRequirements() {
+    return [
+        'reload or recapture exact raw payload under explicit preview/write flow',
+        'compute canonical raw_data',
+        'compute data_hash',
+        'SELECT existing raw_match_data row',
+        'output would_insert / would_update / would_skip',
+        'show protected table baselines',
+        'require final DB-write confirmation before execution',
+        'transaction required for future write',
+    ];
+}
+
+function buildRawMatchDataIngestAuthorization(input = {}) {
+    const validation = validateAuthorizationInput(input);
+    const normalized = validation.value;
+    const base = {
+        phase: PHASE,
+        authorization_only: true,
+        ok: validation.ok,
+        source: TARGET.source,
+        route: TARGET.route,
+        match_id: TARGET.matchId,
+        external_id: TARGET.externalId,
+        home_team: TARGET.homeTeam,
+        away_team: TARGET.awayTeam,
+        data_version: TARGET.dataVersion,
+        user_authorized_raw_match_data_ingest: normalized.userAuthorizedRawMatchDataIngest === true,
+        raw_match_data_ingest_authorization_recorded: validation.ok,
+        raw_match_data_write_allowed_next_phase: validation.ok,
+        raw_match_data_write_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        final_human_confirmation: normalized.finalHumanConfirmation === true,
+        authorized_scope: buildAuthorizedScope(),
+        authorization_gates: buildAuthorizationGates(),
+        blocked_actions_this_phase: buildBlockedActionsThisPhase(),
+        next_phase_requirements: buildNextPhaseRequirements(),
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_write_matches: false,
+        would_train: false,
+        would_predict: false,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+
+    if (!validation.ok) {
+        return {
+            ...base,
+            raw_match_data_write_allowed_next_phase: false,
+            controlled_error: `INVALID_INGEST_AUTHORIZATION_INPUT:${validation.errors.join('; ')}`,
+            errors: validation.errors,
+        };
+    }
+
+    return {
+        ...base,
+        controlled_error: null,
+        errors: [],
+    };
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l2_raw_match_data_ingest_authorization.js --source=fotmob --route=html_hydration --match-id=53_20252026_4830746 --external-id=4830746 --home-team=Angers --away-team=Strasbourg --data-version=fotmob_html_hyd_v1 --preview-body-sha256=<sha256> --hydration-parse-ok=yes --looks-like-valid-match-detail=yes --user-authorized-raw-match-data-ingest=yes --allow-raw-match-data-write-next-phase=yes --allow-db-write-now=no --allow-raw-match-data-write-now=no --allow-matches-write=no --allow-training=no --allow-prediction=no --final-human-confirmation=yes',
+        '',
+        'Safety:',
+        '  Phase 5.14L2 is authorization-only: no network, no DB write, no raw_match_data write.',
+    ].join('\n');
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}) {
+    const stdout = io.stdout || process.stdout.write.bind(process.stdout);
+    const args = parseArgs(argv);
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    const authorization = buildRawMatchDataIngestAuthorization(args);
+    stdout(`${JSON.stringify(authorization, null, 2)}\n`);
+    return authorization.ok ? 0 : 1;
+}
+
+if (require.main === module) {
+    runCli()
+        .then(status => {
+            process.exitCode = status;
+        })
+        .catch(error => {
+            process.stdout.write(
+                `${JSON.stringify(
+                    {
+                        phase: PHASE,
+                        authorization_only: true,
+                        ok: false,
+                        controlled_error: String(error.message || error),
+                        raw_match_data_write_allowed_next_phase: false,
+                        raw_match_data_write_allowed_this_phase: false,
+                        db_write_allowed_this_phase: false,
+                        would_write_raw_match_data: false,
+                        would_write_db: false,
+                    },
+                    null,
+                    2
+                )}\n`
+            );
+            process.exitCode = 1;
+        });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validateAuthorizationInput,
+    buildAuthorizedScope,
+    buildAuthorizationGates,
+    buildBlockedActionsThisPhase,
+    buildNextPhaseRequirements,
+    buildRawMatchDataIngestAuthorization,
+    runCli,
+};

--- a/tests/unit/l2_raw_match_data_ingest_authorization.test.js
+++ b/tests/unit/l2_raw_match_data_ingest_authorization.test.js
@@ -1,0 +1,346 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l2_raw_match_data_ingest_authorization.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+const PREVIEW_BODY_SHA256 = '8710a3524807d4682ab3c66386f9cd6b4d374fb6eee4f98a29d7f4a6683a162c';
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function validArgs(overrides = {}) {
+    return {
+        source: 'fotmob',
+        route: 'html_hydration',
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        homeTeam: 'Angers',
+        awayTeam: 'Strasbourg',
+        dataVersion: 'fotmob_html_hyd_v1',
+        previewBodySha256: PREVIEW_BODY_SHA256,
+        hydrationParseOk: true,
+        looksLikeValidMatchDetail: true,
+        userAuthorizedRawMatchDataIngest: true,
+        allowRawMatchDataWriteNextPhase: true,
+        allowDbWriteNow: false,
+        allowRawMatchDataWriteNow: false,
+        allowMatchesWrite: false,
+        allowTraining: false,
+        allowPrediction: false,
+        finalHumanConfirmation: true,
+        commit: false,
+        execute: false,
+        networkAuthorization: false,
+        livePreviewAuthorization: false,
+        ...overrides,
+    };
+}
+
+function cliArgs(overrides = {}) {
+    const args = validArgs(overrides);
+    return [
+        `--source=${args.source}`,
+        `--route=${args.route}`,
+        `--match-id=${args.matchId}`,
+        `--external-id=${args.externalId}`,
+        `--home-team=${args.homeTeam}`,
+        `--away-team=${args.awayTeam}`,
+        `--data-version=${args.dataVersion}`,
+        `--preview-body-sha256=${args.previewBodySha256}`,
+        `--hydration-parse-ok=${args.hydrationParseOk ? 'yes' : 'no'}`,
+        `--looks-like-valid-match-detail=${args.looksLikeValidMatchDetail ? 'yes' : 'no'}`,
+        `--user-authorized-raw-match-data-ingest=${args.userAuthorizedRawMatchDataIngest ? 'yes' : 'no'}`,
+        `--allow-raw-match-data-write-next-phase=${args.allowRawMatchDataWriteNextPhase ? 'yes' : 'no'}`,
+        `--allow-db-write-now=${args.allowDbWriteNow ? 'yes' : 'no'}`,
+        `--allow-raw-match-data-write-now=${args.allowRawMatchDataWriteNow ? 'yes' : 'no'}`,
+        `--allow-matches-write=${args.allowMatchesWrite ? 'yes' : 'no'}`,
+        `--allow-training=${args.allowTraining ? 'yes' : 'no'}`,
+        `--allow-prediction=${args.allowPrediction ? 'yes' : 'no'}`,
+        `--final-human-confirmation=${args.finalHumanConfirmation ? 'yes' : 'no'}`,
+        `--commit=${args.commit ? 'yes' : 'no'}`,
+        `--execute=${args.execute ? 'yes' : 'no'}`,
+        `--network-authorization=${args.networkAuthorization ? 'yes' : 'no'}`,
+        `--live-preview-authorization=${args.livePreviewAuthorization ? 'yes' : 'no'}`,
+    ];
+}
+
+async function runCli(gate, argv) {
+    let stdout = '';
+    const status = await gate.runCli(argv, {
+        stdout: text => {
+            stdout += text;
+        },
+    });
+    return {
+        status,
+        stdout,
+        payload: stdout.trim().startsWith('{') ? JSON.parse(stdout) : null,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalFetch = global.fetch;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalLoad = Module._load;
+
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l2_raw_match_data_ingest_authorization`);
+    };
+
+    global.fetch = fail('global.fetch');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'redis',
+            'ioredis',
+            'playwright',
+            'playwright-core',
+            'child_process',
+            'node:child_process',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        Module._load = originalLoad;
+    });
+}
+
+function assertInvalid(overrides, expectedPattern) {
+    const gate = loadModuleFresh();
+    const authorization = gate.buildRawMatchDataIngestAuthorization(validArgs(overrides));
+    assert.equal(authorization.ok, false);
+    assert.match(authorization.controlled_error, expectedPattern);
+    assert.equal(authorization.would_write_raw_match_data, false);
+    assert.equal(authorization.would_write_db, false);
+}
+
+test('valid authorization input succeeds', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validateAuthorizationInput(validArgs());
+    assert.equal(validation.ok, true);
+    assert.deepEqual(validation.errors, []);
+});
+
+test('source missing fails', () => assertInvalid({ source: '' }, /missing source/));
+test('source non-fotmob fails', () => assertInvalid({ source: 'other' }, /unsupported source/));
+test('route missing fails', () => assertInvalid({ route: '' }, /missing route/));
+test('route non-html_hydration fails', () => assertInvalid({ route: 'api_match_details' }, /unsupported route/));
+test('match-id missing fails', () => assertInvalid({ matchId: '' }, /missing match-id/));
+test('match-id not 53_20252026_4830746 fails', () => assertInvalid({ matchId: 'x' }, /match-id must be/));
+test('external-id missing fails', () => assertInvalid({ externalId: '' }, /missing external-id/));
+test('external-id not 4830746 fails', () => assertInvalid({ externalId: '1' }, /external-id must be/));
+test('home-team missing Angers fails', () => assertInvalid({ homeTeam: 'Paris' }, /home-team must contain Angers/));
+test('away-team missing Strasbourg fails', () =>
+    assertInvalid({ awayTeam: 'Lens' }, /away-team must contain Strasbourg/));
+test('data-version missing fails', () => assertInvalid({ dataVersion: '' }, /missing data-version/));
+test('data-version not fotmob_html_hyd_v1 fails', () =>
+    assertInvalid({ dataVersion: 'fotmob_html_hydration_v1' }, /data-version must be/));
+test('preview-body-sha256 missing fails', () =>
+    assertInvalid({ previewBodySha256: '' }, /missing preview-body-sha256/));
+test('hydration-parse-ok=no fails', () =>
+    assertInvalid({ hydrationParseOk: false }, /hydration-parse-ok=yes is required/));
+test('looks-like-valid-match-detail=no fails', () =>
+    assertInvalid({ looksLikeValidMatchDetail: false }, /looks-like-valid-match-detail=yes is required/));
+test('user-authorized-raw-match-data-ingest=no fails', () =>
+    assertInvalid(
+        { userAuthorizedRawMatchDataIngest: false },
+        /user-authorized-raw-match-data-ingest=yes is required/
+    ));
+test('allow-raw-match-data-write-next-phase=no fails', () =>
+    assertInvalid({ allowRawMatchDataWriteNextPhase: false }, /allow-raw-match-data-write-next-phase=yes is required/));
+test('final-human-confirmation=no fails', () =>
+    assertInvalid({ finalHumanConfirmation: false }, /final-human-confirmation=yes is required/));
+test('allow-db-write-now=yes blocked', () =>
+    assertInvalid({ allowDbWriteNow: true }, /allow-db-write-now=yes is blocked/));
+test('allow-raw-match-data-write-now=yes blocked', () =>
+    assertInvalid({ allowRawMatchDataWriteNow: true }, /allow-raw-match-data-write-now=yes is blocked/));
+test('allow-matches-write=yes blocked', () =>
+    assertInvalid({ allowMatchesWrite: true }, /allow-matches-write=yes is blocked/));
+test('allow-training=yes blocked', () => assertInvalid({ allowTraining: true }, /allow-training=yes is blocked/));
+test('allow-prediction=yes blocked', () => assertInvalid({ allowPrediction: true }, /allow-prediction=yes is blocked/));
+test('commit=yes blocked', () => assertInvalid({ commit: true }, /commit=yes is blocked/));
+test('execute=yes blocked', () => assertInvalid({ execute: true }, /execute=yes is blocked/));
+test('network-authorization=yes blocked', () =>
+    assertInvalid({ networkAuthorization: true }, /network-authorization=yes is blocked/));
+test('live-preview-authorization=yes blocked', () =>
+    assertInvalid({ livePreviewAuthorization: true }, /live-preview-authorization=yes is blocked/));
+
+test('output authorization_only=true', () => {
+    const gate = loadModuleFresh();
+    const authorization = gate.buildRawMatchDataIngestAuthorization(validArgs());
+    assert.equal(authorization.ok, true);
+    assert.equal(authorization.authorization_only, true);
+});
+
+test('raw_match_data_write_allowed_next_phase=true', () => {
+    const gate = loadModuleFresh();
+    const authorization = gate.buildRawMatchDataIngestAuthorization(validArgs());
+    assert.equal(authorization.raw_match_data_write_allowed_next_phase, true);
+});
+
+test('raw_match_data_write_allowed_this_phase=false', () => {
+    const gate = loadModuleFresh();
+    const authorization = gate.buildRawMatchDataIngestAuthorization(validArgs());
+    assert.equal(authorization.raw_match_data_write_allowed_this_phase, false);
+});
+
+test('db_write_allowed_this_phase=false', () => {
+    const gate = loadModuleFresh();
+    const authorization = gate.buildRawMatchDataIngestAuthorization(validArgs());
+    assert.equal(authorization.db_write_allowed_this_phase, false);
+});
+
+test('would_write_raw_match_data=false', () => {
+    const gate = loadModuleFresh();
+    const authorization = gate.buildRawMatchDataIngestAuthorization(validArgs());
+    assert.equal(authorization.would_write_raw_match_data, false);
+});
+
+test('would_write_db=false', () => {
+    const gate = loadModuleFresh();
+    const authorization = gate.buildRawMatchDataIngestAuthorization(validArgs());
+    assert.equal(authorization.would_write_db, false);
+});
+
+test('authorized_scope target_table=raw_match_data', () => {
+    const gate = loadModuleFresh();
+    const scope = gate.buildAuthorizedScope();
+    assert.equal(scope.target_table, 'raw_match_data');
+});
+
+test('authorized_scope rows_limit=1', () => {
+    const gate = loadModuleFresh();
+    const scope = gate.buildAuthorizedScope();
+    assert.equal(scope.rows_limit, 1);
+});
+
+test('authorization_gates include network_authorization_this_phase=false', () => {
+    const gate = loadModuleFresh();
+    const gates = gate.buildAuthorizationGates();
+    assert.ok(gates.includes('network_authorization_this_phase=false'));
+});
+
+test('blocked_actions include write_raw_match_data', () => {
+    const gate = loadModuleFresh();
+    const blocked = gate.buildBlockedActionsThisPhase();
+    assert.ok(blocked.includes('write_raw_match_data'));
+});
+
+test('blocked_actions include run_live_preview', () => {
+    const gate = loadModuleFresh();
+    const blocked = gate.buildBlockedActionsThisPhase();
+    assert.ok(blocked.includes('run_live_preview'));
+});
+
+test('next_phase_requirements include would_insert/update/skip', () => {
+    const gate = loadModuleFresh();
+    const requirements = gate.buildNextPhaseRequirements().join('\n');
+    assert.match(requirements, /would_insert \/ would_update \/ would_skip/);
+});
+
+test('Makefile authorization target is present and maps to authorization script', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l2-raw-match-data-ingest-authorization:/m);
+    assert.match(makefile, /scripts\/ops\/l2_raw_match_data_ingest_authorization\.js/);
+});
+
+test('runCli succeeds with valid input and does not access network or DB', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs());
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.ok, true);
+    assert.equal(result.payload.authorization_only, true);
+    assert.equal(result.payload.db_write_allowed_this_phase, false);
+});
+
+test('runCli returns non-zero for blocked DB write', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs({ allowDbWriteNow: true }));
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.ok, false);
+    assert.match(result.payload.controlled_error, /allow-db-write-now=yes is blocked/);
+});
+
+test('source audit: no network access', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\(['"]node:http['"]\)|require\(['"]http['"]\)/);
+    assert.doesNotMatch(source, /require\(['"]node:https['"]\)|require\(['"]https['"]\)/);
+    assert.doesNotMatch(source, /\bfetch\s*\(/);
+});
+
+test('source audit: no DB write or pg client', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\(['"]pg['"]\)/);
+    assert.doesNotMatch(source, /\.query\s*\(/);
+    assert.doesNotMatch(source, /\bINSERT\s+INTO\b|\bUPDATE\s+\w+\s+SET\b|\bDELETE\s+FROM\b/i);
+    assert.doesNotMatch(source, /\b(TRUNCATE|ALTER\s+TABLE|DROP\s+TABLE|MERGE\s+INTO)\b/i);
+});
+
+test('source audit: no fs write / mkdir', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /writeFile|writeFileSync|mkdir|createWriteStream/);
+});
+
+test('source audit: no child_process spawn', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /child_process|spawn|execFile/);
+});
+
+test('source audit: no ProductionHarvester / raw ingest commit', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.14L2 raw_match_data ingest authorization.

Scope:
- Adds authorization-only script for future raw_match_data ingest
- Records user-authorized scope for target 53_20252026_4830746 / external_id 4830746
- Keeps DB/raw_match_data writes blocked this phase
- Keeps matches/features/predictions protected
- Adds Makefile authorization target, tests, AGENTS.md updates, and report

Safety:
- No external FotMob access
- No live match detail request
- No DB writes
- No raw_match_data writes
- No matches writes
- No harvest / ingest
- No training / prediction
- No file deletion

Validation:
- raw_match_data ingest authorization tests passed
- Makefile authorization target passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed