### PR TITLE
feat(data): add raw_match_data ingest preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@
 - Phase 5.12L2B 新增 safe FotMob detail route selector，默认顺序为 `html_hydration` -> `api_match_details`，`alternate_route` 仅 plan-only；live external raw detail preview 仍默认 blocked，未经未来单独授权不得 retry Phase 5.11L2 direct API 403、不得加 headers/browser/proxy 绕过，`raw_match_data` 写入仍未授权。
 - Phase 5.13L2 raw_match_data ingest planning 仅允许 planning-only；`raw_match_data` 写入仍未授权。raw_data 应存 canonical transformed detail payload 而不是完整 HTML body；data_hash 应为 canonical raw_data JSON 的 SHA-256，而不是 HTML body hash；raw_match_data ingest 不得更新 `matches`、features、training 或 predictions，未来写入必须另行 authorization + preflight。
 - Phase 5.14L2 raw_match_data ingest authorization 仅允许 authorization-only：它只记录未来 `raw_match_data` 写入授权范围，本阶段不得写 DB、不得写 `raw_match_data`、不得 live preview / network request；后续写入仍必须先完成 Phase 5.15L2 preflight，并在最终执行阶段再次确认。raw_match_data ingest 必须保持 raw-only，不得更新 `matches`、features、training 或 predictions。
+- Phase 5.15L2 raw_match_data ingest preflight 允许通过 safe route selector 重新 recapture exact raw payload；它必须保持 SELECT-only，不得写 DB，不得写 `raw_match_data`，不得写 `matches`、features、training 或 predictions；它必须输出 `would_insert` / `would_update` / `would_skip`，`data_hash` 必须来自 canonical raw_data JSON，不得存完整 HTML body；真正 controlled write 仅能留到 Phase 5.16L2 且必须有最终 DB-write confirmation。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
-        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan data-l2-raw-match-data-ingest-plan data-l2-raw-match-data-ingest-authorization \
+        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan data-l2-raw-match-data-ingest-plan data-l2-raw-match-data-ingest-authorization data-l2-raw-match-data-ingest-preflight \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -335,8 +335,10 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l2-raw-detail-preview SOURCE=fotmob MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg ROUTE=auto NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=no ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # route selector preview; live remains blocked without future authorization"
 	@echo "  make data-l2-raw-match-data-ingest-plan SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg PREVIEW_BODY_SHA256=<sha256> PREVIEW_BODY_BYTE_LENGTH=<bytes> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.13L2 planning-only, no network/DB/raw write"
 	@echo "  make data-l2-raw-match-data-ingest-authorization SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 PREVIEW_BODY_SHA256=<sha256> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes USER_AUTHORIZED_RAW_MATCH_DATA_INGEST=yes ALLOW_RAW_MATCH_DATA_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE_NOW=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes  # Phase 5.14L2 authorization-only, no network/DB/raw write"
+	@echo "  make data-l2-raw-match-data-ingest-preflight SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # Phase 5.15L2 preflight-only: recapture exact payload/hash and output would_insert/update/skip, no DB/raw write"
 	@echo "  L2 raw detail preview is preview-only: no raw_match_data write, no DB write, no browser/proxy, no full body print/save."
 	@echo "  L2 raw_match_data ingest authorization is authorization-only in Phase 5.14L2: future write requires preflight + final DB-write confirmation, and raw_match_data write remains blocked this phase."
+	@echo "  L2 raw_match_data ingest preflight recomputes exact payload/hash and outputs would_insert/update/skip; it does not write raw_match_data. Future write requires final DB-write confirmation."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
 	@echo "  Phase 5.12L2B route selector supports html_hydration before api_match_details; alternate_route remains plan-only."
 	@echo "  Live raw detail requests require future explicit authorization; use audited route selector / safe adapter, not legacy harvest/backfill."
@@ -712,8 +714,37 @@ data-l2-raw-match-data-ingest-authorization: ## L2 raw_match_data ingest authori
 		--final-human-confirmation="$(or $(FINAL_HUMAN_CONFIRMATION),no)" \
 		--commit="$(or $(COMMIT),no)" \
 		--execute="$(or $(EXECUTE),no)" \
+			--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+			--live-preview-authorization="$(or $(LIVE_PREVIEW_AUTHORIZATION),no)"
+
+data-l2-raw-match-data-ingest-preflight: ## L2 raw_match_data ingest preflight. Phase 5.15L2. Live preview + SELECT-only, no DB/raw write.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(ROUTE)" ] || [ -z "$(MATCH_ID)" ] || [ -z "$(EXTERNAL_ID)" ] || [ -z "$(HOME_TEAM)" ] || [ -z "$(AWAY_TEAM)" ] || [ -z "$(DATA_VERSION)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l2_raw_match_data_ingest_preflight.js \
+		--source="$(SOURCE)" \
+		--route="$(ROUTE)" \
+		--match-id="$(MATCH_ID)" \
+		--external-id="$(EXTERNAL_ID)" \
+		--home-team="$(HOME_TEAM)" \
+		--away-team="$(AWAY_TEAM)" \
+		--data-version="$(DATA_VERSION)" \
 		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
-		--live-preview-authorization="$(or $(LIVE_PREVIEW_AUTHORIZATION),no)"
+		--live-preview-authorization="$(or $(LIVE_PREVIEW_AUTHORIZATION),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-matches-write="$(or $(ALLOW_MATCHES_WRITE),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--concurrency="$(or $(CONCURRENCY),1)" \
+		--retry="$(or $(RETRY),0)" \
+		--print-body="$(or $(PRINT_BODY),no)" \
+		--save-body="$(or $(SAVE_BODY),no)" \
+		--commit="$(or $(COMMIT),no)" \
+		--execute="$(or $(EXECUTE),no)"
 
 data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.
 	@if [ -n "$(SAMPLE_HTML)" ]; then \

--- a/docs/_reports/RAW_MATCH_DATA_INGEST_PREFLIGHT_PHASE5_15L2.md
+++ b/docs/_reports/RAW_MATCH_DATA_INGEST_PREFLIGHT_PHASE5_15L2.md
@@ -1,0 +1,161 @@
+# Raw Match Data Ingest Preflight - Phase 5.15L2
+
+## 1. Executive summary
+
+Phase 5.15L2 defines the `raw_match_data` ingest preflight boundary for target
+`53_20252026_4830746` / external id `4830746`.
+
+This phase is designed to recapture the exact FotMob raw payload through the
+safe route selector, canonicalize the raw payload, compute `data_hash`, SELECT
+the existing `raw_match_data` row, and preview `would_insert` /
+`would_update` / `would_skip`.
+
+It does not write DB and does not write `raw_match_data`.
+
+## 2. Baseline
+
+Current baseline confirmed before preflight execution:
+
+| Table                     | Rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+Target match exists:
+
+| Field         | Value                    |
+| ------------- | ------------------------ |
+| `match_id`    | `53_20252026_4830746`    |
+| `external_id` | `4830746`                |
+| `home_team`   | `Angers`                 |
+| `away_team`   | `Strasbourg`             |
+| `match_date`  | `2026-05-10 19:00:00+00` |
+| `status`      | `finished`               |
+
+Target `raw_match_data` status before preflight:
+
+- no existing row for `match_id=53_20252026_4830746`
+- no existing row for `external_id=4830746`
+
+## 3. Preflight input
+
+Fixed preflight scope:
+
+- `source=fotmob`
+- `route=html_hydration` or `auto` with `html_hydration` first
+- `match_id=53_20252026_4830746`
+- `external_id=4830746`
+- `home_team=Angers`
+- `away_team=Strasbourg`
+- `data_version=fotmob_html_hyd_v1`
+- `network_authorization=yes`
+- `live_preview_authorization=yes`
+- `allow_db_write=no`
+- `allow_raw_match_data_write=no`
+- `allow_matches_write=no`
+- `allow_training=no`
+- `allow_prediction=no`
+- `concurrency=1`
+- `retry=0`
+- `print_body=no`
+- `save_body=no`
+
+## 4. Exact payload recapture
+
+This section is reserved for the actual post-merge controlled preflight result.
+
+Expected capture fields:
+
+- `selected_route`
+- `request_url`
+- `final_url`
+- `http_status`
+- `content_type`
+- `body_byte_length`
+- `body_sha256`
+- `hydration_parse_ok`
+- `looks_like_valid_match_detail`
+
+## 5. Canonical raw_data / data_hash
+
+Expected canonical shape:
+
+- top-level `_meta`
+- top-level `content`
+- top-level `general`
+- top-level `header`
+- top-level `matchId`
+
+Policy:
+
+- do not store the full HTML body
+- do not store the HTTP response string
+- `data_hash = SHA-256(canonical_json(raw_data))`
+- `body_sha256` remains metadata only
+
+Actual computed `raw_data_hash` will be recorded after the controlled preflight
+run.
+
+## 6. Affected row preview
+
+Expected preview fields:
+
+- `existing_raw_match_data_found`
+- `would_insert`
+- `would_update`
+- `would_skip`
+- `affected_preview.match_id`
+- `affected_preview.external_id`
+- `affected_preview.decision`
+
+Current expectation is `would_insert=1`, because no `raw_match_data` row exists
+for the target match.
+
+## 7. Protected table baseline
+
+Protected tables remain at baseline:
+
+| Table                     | Rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `bookmaker_odds_history`  |    2 |
+| `raw_match_data`          |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+## 8. Next phase
+
+Recommended next phase:
+
+`Phase 5.16L2: controlled raw_match_data write`
+
+Requirements:
+
+- final DB-write confirmation from the user
+- use exact preflight payload/hash or recapture and compare
+- write only `raw_match_data`
+- no `matches` / features / predictions writes
+- transaction required
+- post-write verification required
+
+## 9. Explicit non-execution
+
+This phase does not execute:
+
+- DB writes
+- `raw_match_data` writes
+- `matches` writes
+- `bookmaker_odds_history` writes
+- `l3_features` writes
+- `match_features_training` writes
+- `predictions` writes
+- harvest / ingest / backfill
+- training / prediction
+- full body save
+- full body print
+- file deletion

--- a/scripts/ops/l2_raw_match_data_ingest_preflight.js
+++ b/scripts/ops/l2_raw_match_data_ingest_preflight.js
@@ -1,0 +1,1005 @@
+#!/usr/bin/env node
+/* eslint-disable complexity, max-lines */
+'use strict';
+
+const crypto = require('node:crypto');
+const { extractFromHtml, transformToApiFormat } = require('../../src/parsers/fotmob/NextDataParser');
+const { runFotMobDetailRouteSelector, buildRouteSelectorPreviewSummary } = require('./l2_raw_detail_preview');
+
+const PHASE = 'PHASE5_15L2_RAW_MATCH_DATA_INGEST_PREFLIGHT';
+const NEXT_REQUIRED_PHASE = 'Phase 5.16L2 controlled raw_match_data write';
+const TARGET = Object.freeze({
+    source: 'fotmob',
+    route: 'html_hydration',
+    autoRoute: 'auto',
+    matchId: '53_20252026_4830746',
+    externalId: '4830746',
+    homeTeam: 'Angers',
+    awayTeam: 'Strasbourg',
+    dataVersion: 'fotmob_html_hyd_v1',
+});
+const EXPECTED_PROTECTED_TABLE_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 2,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+const FORBIDDEN_SQL_VERBS = Object.freeze([
+    'INSERT',
+    'UPDATE',
+    'DELETE',
+    'CREATE',
+    'ALTER',
+    'DROP',
+    'TRUNCATE',
+    'UPSERT',
+    'MERGE',
+    'GRANT',
+    'REVOKE',
+    'BEGIN',
+    'COMMIT',
+    'ROLLBACK',
+    'LOCK',
+    'COPY',
+]);
+
+function normalizeText(value) {
+    return String(value || '').trim();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    return Number.parseInt(normalized, 10);
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return {
+            value: nextArg,
+            consumedNext: true,
+        };
+    }
+
+    return {
+        value: true,
+        consumedNext: false,
+    };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        route: null,
+        matchId: null,
+        externalId: null,
+        homeTeam: null,
+        awayTeam: null,
+        dataVersion: null,
+        networkAuthorization: null,
+        livePreviewAuthorization: null,
+        allowDbWrite: null,
+        allowRawMatchDataWrite: null,
+        allowMatchesWrite: null,
+        allowTraining: null,
+        allowPrediction: null,
+        allowBrowserRuntime: null,
+        allowProxyRuntime: null,
+        concurrency: null,
+        retry: null,
+        printBody: null,
+        saveBody: null,
+        commit: false,
+        execute: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        route: 'route',
+        'match-id': 'matchId',
+        match_id: 'matchId',
+        'external-id': 'externalId',
+        external_id: 'externalId',
+        'home-team': 'homeTeam',
+        home_team: 'homeTeam',
+        'away-team': 'awayTeam',
+        away_team: 'awayTeam',
+        'data-version': 'dataVersion',
+        data_version: 'dataVersion',
+        'network-authorization': 'networkAuthorization',
+        network_authorization: 'networkAuthorization',
+        'live-preview-authorization': 'livePreviewAuthorization',
+        live_preview_authorization: 'livePreviewAuthorization',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        'allow-browser-runtime': 'allowBrowserRuntime',
+        allow_browser_runtime: 'allowBrowserRuntime',
+        'allow-proxy-runtime': 'allowProxyRuntime',
+        allow_proxy_runtime: 'allowProxyRuntime',
+        concurrency: 'concurrency',
+        retry: 'retry',
+        'print-body': 'printBody',
+        print_body: 'printBody',
+        'save-body': 'saveBody',
+        save_body: 'saveBody',
+        commit: 'commit',
+        execute: 'execute',
+        help: 'help',
+        h: 'help',
+    };
+    const booleanKeys = new Set([
+        'networkAuthorization',
+        'livePreviewAuthorization',
+        'allowDbWrite',
+        'allowRawMatchDataWrite',
+        'allowMatchesWrite',
+        'allowTraining',
+        'allowPrediction',
+        'allowBrowserRuntime',
+        'allowProxyRuntime',
+        'printBody',
+        'saveBody',
+        'commit',
+        'execute',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+
+        if (booleanKeys.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function includesText(value, expected) {
+    return normalizeText(value).toLowerCase().includes(normalizeText(expected).toLowerCase());
+}
+
+function pushRequiredTrueError(errors, value, flagName) {
+    if (value === true) {
+        return;
+    }
+    if (value === false) {
+        errors.push(`${flagName}=yes is required in Phase 5.15L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=yes`);
+}
+
+function pushRequiredFalseError(errors, value, flagName) {
+    if (value === false) {
+        return;
+    }
+    if (value === true) {
+        errors.push(`${flagName}=yes is blocked in Phase 5.15L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=no`);
+}
+
+function normalizePreflightInput(input = {}) {
+    return {
+        source: normalizeText(input.source).toLowerCase(),
+        route: normalizeText(input.route).toLowerCase(),
+        matchId: normalizeText(input.matchId),
+        externalId: normalizeText(input.externalId),
+        homeTeam: normalizeText(input.homeTeam),
+        awayTeam: normalizeText(input.awayTeam),
+        dataVersion: normalizeText(input.dataVersion).toLowerCase(),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, undefined),
+        livePreviewAuthorization: normalizeBooleanFlag(input.livePreviewAuthorization, undefined),
+        allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
+        allowMatchesWrite: normalizeBooleanFlag(input.allowMatchesWrite, undefined),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, undefined),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, undefined),
+        allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, false),
+        allowProxyRuntime: normalizeBooleanFlag(input.allowProxyRuntime, false),
+        concurrency: parseInteger(input.concurrency, null),
+        retry: parseInteger(input.retry, null),
+        printBody: normalizeBooleanFlag(input.printBody, undefined),
+        saveBody: normalizeBooleanFlag(input.saveBody, undefined),
+        commit: normalizeBooleanFlag(input.commit, false),
+        execute: normalizeBooleanFlag(input.execute, false),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function validatePreflightInput(input = {}) {
+    const value = normalizePreflightInput(input);
+    const errors = [];
+
+    if (value.unknown.length > 0) {
+        errors.push(`unknown arguments: ${value.unknown.join(', ')}`);
+    }
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== TARGET.source) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+    if (!value.route) {
+        errors.push('missing route: provide --route=html_hydration');
+    } else if (![TARGET.route, TARGET.autoRoute].includes(value.route)) {
+        errors.push('unsupported route: Phase 5.15L2 only allows html_hydration or auto');
+    }
+    if (!value.matchId) {
+        errors.push('missing match-id');
+    } else if (value.matchId !== TARGET.matchId) {
+        errors.push(`match-id must be ${TARGET.matchId} in Phase 5.15L2`);
+    }
+    if (!value.externalId) {
+        errors.push('missing external-id');
+    } else if (value.externalId !== TARGET.externalId) {
+        errors.push(`external-id must be ${TARGET.externalId} in Phase 5.15L2`);
+    }
+    if (!value.homeTeam) {
+        errors.push('missing home-team');
+    } else if (!includesText(value.homeTeam, TARGET.homeTeam)) {
+        errors.push(`home-team must contain ${TARGET.homeTeam}`);
+    }
+    if (!value.awayTeam) {
+        errors.push('missing away-team');
+    } else if (!includesText(value.awayTeam, TARGET.awayTeam)) {
+        errors.push(`away-team must contain ${TARGET.awayTeam}`);
+    }
+    if (!value.dataVersion) {
+        errors.push('missing data-version');
+    } else if (value.dataVersion !== TARGET.dataVersion) {
+        errors.push(`data-version must be ${TARGET.dataVersion} in Phase 5.15L2`);
+    }
+
+    pushRequiredTrueError(errors, value.networkAuthorization, 'network-authorization');
+    pushRequiredTrueError(errors, value.livePreviewAuthorization, 'live-preview-authorization');
+    pushRequiredFalseError(errors, value.allowDbWrite, 'allow-db-write');
+    pushRequiredFalseError(errors, value.allowRawMatchDataWrite, 'allow-raw-match-data-write');
+    pushRequiredFalseError(errors, value.allowMatchesWrite, 'allow-matches-write');
+    pushRequiredFalseError(errors, value.allowTraining, 'allow-training');
+    pushRequiredFalseError(errors, value.allowPrediction, 'allow-prediction');
+    pushRequiredFalseError(errors, value.printBody, 'print-body');
+    pushRequiredFalseError(errors, value.saveBody, 'save-body');
+
+    if (value.allowBrowserRuntime === true) {
+        errors.push('allow-browser-runtime=yes is blocked in Phase 5.15L2');
+    }
+    if (value.allowProxyRuntime === true) {
+        errors.push('allow-proxy-runtime=yes is blocked in Phase 5.15L2');
+    }
+    if (value.concurrency !== 1) {
+        errors.push(value.concurrency > 1 ? 'concurrency > 1 is blocked' : 'concurrency must be 1');
+    }
+    if (value.retry !== 0) {
+        errors.push(value.retry > 0 ? 'retry > 0 is blocked' : 'retry must be 0');
+    }
+    if (value.commit === true) {
+        errors.push('commit=yes is blocked in Phase 5.15L2');
+    }
+    if (value.execute === true) {
+        errors.push('execute=yes is blocked in Phase 5.15L2');
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function canonicalizeValue(value, inArray = false) {
+    if (value === undefined || typeof value === 'function' || typeof value === 'symbol') {
+        return inArray ? null : undefined;
+    }
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+    if (Array.isArray(value)) {
+        return value.map(item => {
+            const normalized = canonicalizeValue(item, true);
+            return normalized === undefined ? null : normalized;
+        });
+    }
+    if (value && typeof value === 'object') {
+        const normalized = {};
+        for (const key of Object.keys(value).sort()) {
+            const child = canonicalizeValue(value[key], false);
+            if (child !== undefined) {
+                normalized[key] = child;
+            }
+        }
+        return normalized;
+    }
+    return null;
+}
+
+function canonicalizeJson(value) {
+    return JSON.stringify(canonicalizeValue(value));
+}
+
+function sha256Text(text) {
+    return crypto
+        .createHash('sha256')
+        .update(String(text || ''), 'utf8')
+        .digest('hex');
+}
+
+function sha256CanonicalJson(value) {
+    return sha256Text(canonicalizeJson(value));
+}
+
+function jsonClone(value, fallback = {}) {
+    if (value === undefined || value === null) {
+        return fallback;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function buildRawDataFromPreviewPayload(payload = {}, previewSummary = {}, input = {}) {
+    const value = normalizePreflightInput(input);
+    const safePayload = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {};
+    const payloadMeta = safePayload._meta && typeof safePayload._meta === 'object' ? safePayload._meta : {};
+
+    return {
+        _meta: {
+            source: TARGET.source,
+            route: previewSummary.selected_route || TARGET.route,
+            requested_route: value.route || TARGET.route,
+            request_url: previewSummary.request_url || null,
+            final_url: previewSummary.final_url || null,
+            fetch_body_sha256: previewSummary.body_sha256 || null,
+            fetch_body_byte_length: Number(previewSummary.body_byte_length || 0),
+            hydration_parse_ok: previewSummary.hydration_parse_ok === true,
+            looks_like_valid_match_detail: previewSummary.looks_like_valid_match_detail === true,
+            parser: 'NextDataParser.transformToApiFormat',
+            data_version: TARGET.dataVersion,
+            collected_at_policy: 'generated_by_phase_5_16_db_write_timestamp',
+            full_html_body_stored: false,
+            http_response_string_stored: false,
+            has_stats: payloadMeta.hasStats === true || Boolean(safePayload.content?.stats),
+            has_lineup: payloadMeta.hasLineup === true || Boolean(safePayload.content?.lineup),
+            has_shotmap: payloadMeta.hasShotmap === true || Boolean(safePayload.content?.shotmap),
+        },
+        content: jsonClone(safePayload.content || {}),
+        general: jsonClone(safePayload.general || {}),
+        header: jsonClone(safePayload.header || {}),
+        matchId: String(safePayload.matchId || value.externalId || TARGET.externalId),
+    };
+}
+
+function validateRawDataShape(rawData = {}) {
+    const errors = [];
+    for (const key of ['_meta', 'content', 'general', 'header', 'matchId']) {
+        if (!Object.prototype.hasOwnProperty.call(rawData, key)) {
+            errors.push(`raw_data missing ${key}`);
+        }
+    }
+    if (rawData._meta?.full_html_body_stored !== false) {
+        errors.push('raw_data._meta.full_html_body_stored must be false');
+    }
+    if (rawData._meta?.http_response_string_stored !== false) {
+        errors.push('raw_data._meta.http_response_string_stored must be false');
+    }
+    return errors;
+}
+
+function buildAffectedPreview({ matchId, externalId, existingRows = [], rawDataHash }) {
+    if (!Array.isArray(existingRows) || existingRows.length === 0) {
+        return {
+            match_id: matchId,
+            external_id: externalId,
+            decision: 'would_insert',
+            reason: 'no existing raw_match_data row for match_id',
+        };
+    }
+
+    const existingRow = existingRows[0];
+    if (normalizeText(existingRow.data_hash) === rawDataHash) {
+        return {
+            match_id: matchId,
+            external_id: externalId,
+            decision: 'would_skip',
+            reason: 'existing raw_match_data data_hash matches computed raw_data_hash',
+            existing_data_hash: normalizeText(existingRow.data_hash),
+            new_data_hash: rawDataHash,
+        };
+    }
+
+    return {
+        match_id: matchId,
+        external_id: externalId,
+        decision: 'would_update',
+        reason: 'existing raw_match_data data_hash differs from computed raw_data_hash',
+        existing_data_hash: normalizeText(existingRow.data_hash) || null,
+        new_data_hash: rawDataHash,
+    };
+}
+
+function buildProtectedTableBaseline(source = {}) {
+    const rows = Array.isArray(source) ? source : null;
+    const objectSource = rows
+        ? Object.fromEntries(rows.map(row => [row.table_name, Number(row.rows)]))
+        : source && typeof source === 'object'
+          ? source
+          : {};
+
+    return {
+        matches: Number(objectSource.matches ?? 0),
+        raw_match_data: Number(objectSource.raw_match_data ?? 0),
+        bookmaker_odds_history: Number(objectSource.bookmaker_odds_history ?? 0),
+        l3_features: Number(objectSource.l3_features ?? 0),
+        match_features_training: Number(objectSource.match_features_training ?? 0),
+        predictions: Number(objectSource.predictions ?? 0),
+    };
+}
+
+function validateProtectedTableBaseline(baseline = {}) {
+    return Object.entries(EXPECTED_PROTECTED_TABLE_BASELINE)
+        .filter(([key, expected]) => Number(baseline[key]) !== expected)
+        .map(([key, expected]) => `${key} baseline expected ${expected}, got ${baseline[key]}`);
+}
+
+function assertSafeSelect(sql) {
+    const text = String(sql || '').trim();
+    const withoutTrailingSemicolon = text.replace(/;+\s*$/, '');
+    if (!/^\s*SELECT\b/i.test(withoutTrailingSemicolon)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (withoutTrailingSemicolon.includes(';')) {
+        throw new Error('Unsafe SQL blocked: multiple statements are not allowed');
+    }
+    if (/\bFOR\s+UPDATE\b/i.test(withoutTrailingSemicolon)) {
+        throw new Error('Unsafe SQL blocked: SELECT FOR UPDATE is not allowed');
+    }
+    for (const verb of FORBIDDEN_SQL_VERBS) {
+        if (new RegExp(`\\b${verb}\\b`, 'i').test(withoutTrailingSemicolon)) {
+            throw new Error(`Unsafe SQL blocked: ${verb} is not allowed`);
+        }
+    }
+}
+
+async function safeSelect(pool, sql, values = []) {
+    assertSafeSelect(sql);
+    return pool.query(sql, values);
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD || 'football_pass',
+        application_name: 'l2_raw_match_data_ingest_preflight',
+        max: 2,
+        idleTimeoutMillis: 5000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+function createPgPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+function hasCustomDbDependencies(dependencies = {}) {
+    return (
+        dependencies.pool ||
+        dependencies.createPool ||
+        Array.isArray(dependencies.targetMatchRows) ||
+        Array.isArray(dependencies.existingRawMatchDataRows) ||
+        dependencies.protectedTableBaseline ||
+        typeof dependencies.selectTargetMatch === 'function' ||
+        typeof dependencies.selectExistingRawMatchData === 'function' ||
+        typeof dependencies.selectProtectedTableBaseline === 'function'
+    );
+}
+
+async function selectTargetMatch(pool, value, dependencies = {}) {
+    if (Array.isArray(dependencies.targetMatchRows)) {
+        return dependencies.targetMatchRows;
+    }
+    if (typeof dependencies.selectTargetMatch === 'function') {
+        return dependencies.selectTargetMatch({ input: value });
+    }
+
+    const query = `
+        SELECT match_id, external_id, home_team, away_team, match_date, status
+        FROM matches
+        WHERE match_id = $1
+           OR external_id = $2
+        ORDER BY match_id
+    `;
+    const result = await safeSelect(pool, query, [value.matchId, value.externalId]);
+    return result.rows || [];
+}
+
+async function selectExistingRawMatchData(pool, value, dependencies = {}) {
+    if (Array.isArray(dependencies.existingRawMatchDataRows)) {
+        return dependencies.existingRawMatchDataRows;
+    }
+    if (typeof dependencies.selectExistingRawMatchData === 'function') {
+        return dependencies.selectExistingRawMatchData({ input: value });
+    }
+
+    const query = `
+        SELECT id, match_id, external_id, collected_at, data_version, data_hash
+        FROM raw_match_data
+        WHERE match_id = $1
+           OR external_id = $2
+        ORDER BY collected_at DESC NULLS LAST, id DESC
+    `;
+    const result = await safeSelect(pool, query, [value.matchId, value.externalId]);
+    return result.rows || [];
+}
+
+async function selectProtectedTableBaseline(pool, dependencies = {}) {
+    if (dependencies.protectedTableBaseline) {
+        return buildProtectedTableBaseline(dependencies.protectedTableBaseline);
+    }
+    if (typeof dependencies.selectProtectedTableBaseline === 'function') {
+        return buildProtectedTableBaseline(await dependencies.selectProtectedTableBaseline());
+    }
+
+    const query = `
+        SELECT 'matches' AS table_name, COUNT(*)::int AS rows FROM matches
+        UNION ALL
+        SELECT 'bookmaker_odds_history', COUNT(*)::int FROM bookmaker_odds_history
+        UNION ALL
+        SELECT 'raw_match_data', COUNT(*)::int FROM raw_match_data
+        UNION ALL
+        SELECT 'l3_features', COUNT(*)::int FROM l3_features
+        UNION ALL
+        SELECT 'match_features_training', COUNT(*)::int FROM match_features_training
+        UNION ALL
+        SELECT 'predictions', COUNT(*)::int FROM predictions
+    `;
+    const result = await safeSelect(pool, query, []);
+    return buildProtectedTableBaseline(result.rows || []);
+}
+
+function shouldCreateDefaultPool(dependencies = {}) {
+    if (dependencies.pool) {
+        return false;
+    }
+    if (!hasCustomDbDependencies(dependencies)) {
+        return true;
+    }
+    const targetNeedsPool =
+        !Array.isArray(dependencies.targetMatchRows) && typeof dependencies.selectTargetMatch !== 'function';
+    const existingRawNeedsPool =
+        !Array.isArray(dependencies.existingRawMatchDataRows) &&
+        typeof dependencies.selectExistingRawMatchData !== 'function';
+    const baselineNeedsPool =
+        !dependencies.protectedTableBaseline && typeof dependencies.selectProtectedTableBaseline !== 'function';
+    return targetNeedsPool || existingRawNeedsPool || baselineNeedsPool;
+}
+
+async function resolveDbState(value, dependencies = {}) {
+    const usePool = shouldCreateDefaultPool(dependencies);
+    const pool = dependencies.pool || (usePool ? (dependencies.createPool || createPgPool)() : null);
+    const shouldEndPool = Boolean(pool && !dependencies.pool);
+
+    try {
+        const targetMatchRows = await selectTargetMatch(pool, value, dependencies);
+        const existingRawMatchDataRows = await selectExistingRawMatchData(pool, value, dependencies);
+        const protectedTableBaseline = await selectProtectedTableBaseline(pool, dependencies);
+        return {
+            targetMatchRows,
+            existingRawMatchDataRows,
+            protectedTableBaseline,
+        };
+    } finally {
+        if (shouldEndPool && typeof pool.end === 'function') {
+            await pool.end();
+        }
+    }
+}
+
+function validateTargetMatchRows(rows = []) {
+    const errors = [];
+    if (!Array.isArray(rows) || rows.length !== 1) {
+        return [`target match SELECT expected exactly 1 row, got ${Array.isArray(rows) ? rows.length : 0}`];
+    }
+    const row = rows[0];
+    if (normalizeText(row.match_id) !== TARGET.matchId) {
+        errors.push(`target match_id mismatch: ${row.match_id}`);
+    }
+    if (normalizeText(row.external_id) !== TARGET.externalId) {
+        errors.push(`target external_id mismatch: ${row.external_id}`);
+    }
+    if (!includesText(row.home_team, TARGET.homeTeam)) {
+        errors.push(`target home_team must contain ${TARGET.homeTeam}`);
+    }
+    if (!includesText(row.away_team, TARGET.awayTeam)) {
+        errors.push(`target away_team must contain ${TARGET.awayTeam}`);
+    }
+    return errors;
+}
+
+function validateExistingRawRows(rows = []) {
+    if (!Array.isArray(rows)) {
+        return ['existing raw_match_data SELECT did not return an array'];
+    }
+    if (rows.length > 1) {
+        return [`existing raw_match_data SELECT expected <= 1 row, got ${rows.length}`];
+    }
+    return [];
+}
+
+function createCapturingFetchImpl(fetchImpl, captures) {
+    return async function capturingFetch(url, options) {
+        const response = await fetchImpl(url, options);
+        return {
+            status: response.status,
+            statusCode: response.statusCode,
+            ok: response.ok,
+            url: response.url || String(url),
+            headers: response.headers || {},
+            text: async () => {
+                const body = typeof response.text === 'function' ? await response.text() : '';
+                captures.push({
+                    request_url: String(url),
+                    final_url: response.url || String(url),
+                    body,
+                });
+                return body;
+            },
+        };
+    };
+}
+
+function extractPayloadFromBody(body, input = {}) {
+    const bodyText = String(body || '');
+    const nextData = extractFromHtml(bodyText);
+    if (!nextData.success) {
+        throw new Error(nextData.error || 'NEXT_DATA_PARSE_FAILED');
+    }
+
+    const transformed = transformToApiFormat(nextData.data, input.externalId || TARGET.externalId);
+    if (!transformed) {
+        throw new Error('NEXT_DATA_TRANSFORM_FAILED');
+    }
+    return transformed;
+}
+
+function buildRouteSelectorInput(value = {}) {
+    return {
+        source: value.source || TARGET.source,
+        matchId: value.matchId || TARGET.matchId,
+        externalId: value.externalId || TARGET.externalId,
+        homeTeam: value.homeTeam || TARGET.homeTeam,
+        awayTeam: value.awayTeam || TARGET.awayTeam,
+        route: value.route || TARGET.route,
+        networkAuthorization: true,
+        livePreviewAuthorization: true,
+        allowDbWrite: false,
+        allowRawMatchDataWrite: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        concurrency: 1,
+        retry: 0,
+        printBody: false,
+        saveBody: false,
+    };
+}
+
+async function recapturePreviewPayload(value, dependencies = {}) {
+    const fetchImpl = dependencies.fetchImpl || global.fetch;
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('FETCH_UNAVAILABLE: native fetch is not available');
+    }
+
+    const captures = [];
+    const selectorInput = buildRouteSelectorInput(value);
+    const selectorDependencies = {
+        ...dependencies,
+        fetchImpl: createCapturingFetchImpl(fetchImpl, captures),
+    };
+    const selectorResult = await runFotMobDetailRouteSelector(selectorInput, selectorDependencies);
+    const summary = buildRouteSelectorPreviewSummary(selectorInput, selectorResult);
+    const capture =
+        captures.find(item => item.final_url === summary.final_url || item.request_url === summary.request_url) ||
+        captures[captures.length - 1];
+
+    if (!capture) {
+        throw new Error('NO_CAPTURED_PREVIEW_BODY');
+    }
+
+    return {
+        summary,
+        payload: extractPayloadFromBody(capture.body, value),
+    };
+}
+
+async function resolvePreviewPayload(value, dependencies = {}) {
+    if (dependencies.previewPayloadResult) {
+        return dependencies.previewPayloadResult;
+    }
+    if (typeof dependencies.resolvePreviewPayload === 'function') {
+        return dependencies.resolvePreviewPayload({ input: value });
+    }
+    return recapturePreviewPayload(value, dependencies);
+}
+
+function validatePreviewSummary(summary = {}) {
+    const errors = [];
+    if (summary.ok !== true) {
+        errors.push(summary.controlled_error || 'route selector did not return a valid match detail payload');
+    }
+    if (summary.selected_route !== TARGET.route) {
+        errors.push(`selected_route must be ${TARGET.route}, got ${summary.selected_route || 'none'}`);
+    }
+    if (Number(summary.http_status) < 200 || Number(summary.http_status) >= 300) {
+        errors.push(`http_status must be 2xx, got ${summary.http_status}`);
+    }
+    if (summary.hydration_parse_ok !== true) {
+        errors.push('hydration_parse_ok must be true');
+    }
+    if (summary.looks_like_valid_match_detail !== true) {
+        errors.push('looks_like_valid_match_detail must be true');
+    }
+    if (summary.body_printed === true) {
+        errors.push('body_printed=true is blocked');
+    }
+    if (summary.body_saved === true) {
+        errors.push('body_saved=true is blocked');
+    }
+    if (summary.browser_used === true) {
+        errors.push('browser_used=true is blocked');
+    }
+    if (summary.proxy_used === true) {
+        errors.push('proxy_used=true is blocked');
+    }
+    return errors;
+}
+
+function buildInvalidPreflight(input = {}, errors = []) {
+    return {
+        phase: PHASE,
+        preflight_only: true,
+        ok: false,
+        source: input.source || null,
+        route: input.route || null,
+        match_id: input.matchId || null,
+        external_id: input.externalId || null,
+        controlled_error: `INVALID_INGEST_PREFLIGHT_INPUT:${errors.join('; ')}`,
+        errors,
+        raw_match_data_write_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_write_matches: false,
+        body_printed: false,
+        body_saved: false,
+        browser_used: false,
+        proxy_used: false,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function countDecision(affectedPreview, decision) {
+    return affectedPreview.decision === decision ? 1 : 0;
+}
+
+async function buildRawMatchDataIngestPreflight(input = {}, dependencies = {}) {
+    const validation = validatePreflightInput(input);
+    if (!validation.ok) {
+        return buildInvalidPreflight(input, validation.errors);
+    }
+
+    const value = validation.value;
+    const preview = await resolvePreviewPayload(value, dependencies);
+    const previewSummary = preview.summary || {};
+    const previewErrors = validatePreviewSummary(previewSummary);
+    if (previewErrors.length > 0) {
+        return buildInvalidPreflight(value, previewErrors);
+    }
+
+    const rawData = buildRawDataFromPreviewPayload(preview.payload, previewSummary, value);
+    const rawDataErrors = validateRawDataShape(rawData);
+    if (rawDataErrors.length > 0) {
+        return buildInvalidPreflight(value, rawDataErrors);
+    }
+
+    const rawDataHash = sha256CanonicalJson(rawData);
+    const dbState = await resolveDbState(value, dependencies);
+    const targetErrors = validateTargetMatchRows(dbState.targetMatchRows);
+    const existingRawErrors = validateExistingRawRows(dbState.existingRawMatchDataRows);
+    const protectedBaseline = buildProtectedTableBaseline(dbState.protectedTableBaseline);
+    const baselineErrors = validateProtectedTableBaseline(protectedBaseline);
+    const dbErrors = [...targetErrors, ...existingRawErrors, ...baselineErrors];
+    if (dbErrors.length > 0) {
+        return buildInvalidPreflight(value, dbErrors);
+    }
+
+    const affectedPreview = buildAffectedPreview({
+        matchId: TARGET.matchId,
+        externalId: TARGET.externalId,
+        existingRows: dbState.existingRawMatchDataRows,
+        rawDataHash,
+    });
+
+    return {
+        phase: PHASE,
+        preflight_only: true,
+        ok: true,
+        source: TARGET.source,
+        route: previewSummary.selected_route,
+        requested_route: value.route,
+        match_id: TARGET.matchId,
+        external_id: TARGET.externalId,
+        home_team: TARGET.homeTeam,
+        away_team: TARGET.awayTeam,
+        data_version: TARGET.dataVersion,
+        live_preview_used: true,
+        selected_route: previewSummary.selected_route,
+        request_url: previewSummary.request_url,
+        final_url: previewSummary.final_url,
+        http_status: previewSummary.http_status,
+        content_type: previewSummary.content_type,
+        body_byte_length: previewSummary.body_byte_length,
+        body_sha256: previewSummary.body_sha256,
+        hydration_parse_ok: previewSummary.hydration_parse_ok,
+        looks_like_valid_match_detail: previewSummary.looks_like_valid_match_detail,
+        raw_data_canonicalized: true,
+        raw_data_hash: rawDataHash,
+        existing_raw_match_data_found: dbState.existingRawMatchDataRows.length > 0,
+        would_insert: affectedPreview.decision === 'would_insert',
+        would_update: affectedPreview.decision === 'would_update',
+        would_skip: affectedPreview.decision === 'would_skip',
+        would_insert_count: countDecision(affectedPreview, 'would_insert'),
+        would_update_count: countDecision(affectedPreview, 'would_update'),
+        would_skip_count: countDecision(affectedPreview, 'would_skip'),
+        affected_preview: affectedPreview,
+        protected_table_baseline: protectedBaseline,
+        raw_match_data_write_allowed_this_phase: false,
+        db_write_allowed_this_phase: false,
+        matches_write_allowed: false,
+        training_allowed: false,
+        prediction_allowed: false,
+        would_write_raw_match_data: false,
+        would_write_db: false,
+        would_write_matches: false,
+        body_printed: false,
+        body_saved: false,
+        browser_used: false,
+        proxy_used: false,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l2_raw_match_data_ingest_preflight.js --source=fotmob --route=html_hydration --match-id=53_20252026_4830746 --external-id=4830746 --home-team=Angers --away-team=Strasbourg --data-version=fotmob_html_hyd_v1 --network-authorization=yes --live-preview-authorization=yes --allow-db-write=no --allow-raw-match-data-write=no --allow-matches-write=no --allow-training=no --allow-prediction=no --concurrency=1 --retry=0 --print-body=no --save-body=no',
+        '',
+        'Safety:',
+        '  Phase 5.15L2 is preflight-only: one controlled live preview, SELECT-only DB reads, no raw_match_data write, no DB write, no full body print/save.',
+    ].join('\n');
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const stdout = io.stdout || process.stdout.write.bind(process.stdout);
+    const args = parseArgs(argv);
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    const preflight = await buildRawMatchDataIngestPreflight(args, dependencies);
+    stdout(`${JSON.stringify(preflight, null, 2)}\n`);
+    return preflight.ok ? 0 : 1;
+}
+
+if (require.main === module) {
+    runCli()
+        .then(status => {
+            process.exitCode = status;
+        })
+        .catch(error => {
+            process.stdout.write(
+                `${JSON.stringify(
+                    {
+                        phase: PHASE,
+                        preflight_only: true,
+                        ok: false,
+                        controlled_error: String(error.message || error),
+                        raw_match_data_write_allowed_this_phase: false,
+                        db_write_allowed_this_phase: false,
+                        would_write_raw_match_data: false,
+                        would_write_db: false,
+                        body_printed: false,
+                        body_saved: false,
+                        browser_used: false,
+                        proxy_used: false,
+                        next_required_phase: NEXT_REQUIRED_PHASE,
+                    },
+                    null,
+                    2
+                )}\n`
+            );
+            process.exitCode = 1;
+        });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validatePreflightInput,
+    canonicalizeJson,
+    sha256CanonicalJson,
+    buildRawDataFromPreviewPayload,
+    buildAffectedPreview,
+    buildProtectedTableBaseline,
+    buildRawMatchDataIngestPreflight,
+    runCli,
+};

--- a/tests/unit/l2_raw_match_data_ingest_preflight.test.js
+++ b/tests/unit/l2_raw_match_data_ingest_preflight.test.js
@@ -1,0 +1,935 @@
+/* eslint-disable max-lines */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l2_raw_match_data_ingest_preflight.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+const PREVIEW_BODY_SHA256 = '8710a3524807d4682ab3c66386f9cd6b4d374fb6eee4f98a29d7f4a6683a162c';
+const BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 2,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function validArgs(overrides = {}) {
+    return {
+        source: 'fotmob',
+        route: 'html_hydration',
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        homeTeam: 'Angers',
+        awayTeam: 'Strasbourg',
+        dataVersion: 'fotmob_html_hyd_v1',
+        networkAuthorization: true,
+        livePreviewAuthorization: true,
+        allowDbWrite: false,
+        allowRawMatchDataWrite: false,
+        allowMatchesWrite: false,
+        allowTraining: false,
+        allowPrediction: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        concurrency: 1,
+        retry: 0,
+        printBody: false,
+        saveBody: false,
+        commit: false,
+        execute: false,
+        ...overrides,
+    };
+}
+
+function cliArgs(overrides = {}) {
+    const args = validArgs(overrides);
+    return [
+        `--source=${args.source}`,
+        `--route=${args.route}`,
+        `--match-id=${args.matchId}`,
+        `--external-id=${args.externalId}`,
+        `--home-team=${args.homeTeam}`,
+        `--away-team=${args.awayTeam}`,
+        `--data-version=${args.dataVersion}`,
+        `--network-authorization=${args.networkAuthorization ? 'yes' : 'no'}`,
+        `--live-preview-authorization=${args.livePreviewAuthorization ? 'yes' : 'no'}`,
+        `--allow-db-write=${args.allowDbWrite ? 'yes' : 'no'}`,
+        `--allow-raw-match-data-write=${args.allowRawMatchDataWrite ? 'yes' : 'no'}`,
+        `--allow-matches-write=${args.allowMatchesWrite ? 'yes' : 'no'}`,
+        `--allow-training=${args.allowTraining ? 'yes' : 'no'}`,
+        `--allow-prediction=${args.allowPrediction ? 'yes' : 'no'}`,
+        `--allow-browser-runtime=${args.allowBrowserRuntime ? 'yes' : 'no'}`,
+        `--allow-proxy-runtime=${args.allowProxyRuntime ? 'yes' : 'no'}`,
+        `--concurrency=${args.concurrency}`,
+        `--retry=${args.retry}`,
+        `--print-body=${args.printBody ? 'yes' : 'no'}`,
+        `--save-body=${args.saveBody ? 'yes' : 'no'}`,
+        `--commit=${args.commit ? 'yes' : 'no'}`,
+        `--execute=${args.execute ? 'yes' : 'no'}`,
+    ];
+}
+
+function fakePayload() {
+    return {
+        matchId: '4830746',
+        content: {
+            stats: [{ title: 'Top stats', stats: [] }],
+            lineup: { homeTeam: 'Angers', awayTeam: 'Strasbourg' },
+            shotmap: [],
+        },
+        general: {
+            matchId: '4830746',
+            homeTeam: { name: 'Angers' },
+            awayTeam: { name: 'Strasbourg' },
+        },
+        header: {
+            teams: [
+                { name: 'Angers', id: 982 },
+                { name: 'Strasbourg', id: 984 },
+            ],
+        },
+        _meta: {
+            source: 'web_infiltration',
+            extractedAt: 'volatile',
+            hasStats: true,
+            hasLineup: true,
+            hasShotmap: true,
+        },
+        fullHtmlBody: '<html>must not be copied</html>',
+        httpResponseString: 'must not be copied',
+    };
+}
+
+function fakePreviewResult(overrides = {}) {
+    return {
+        summary: {
+            ok: true,
+            selected_route: 'html_hydration',
+            request_url: 'https://www.fotmob.com/match/4830746',
+            final_url: 'https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och',
+            http_status: 200,
+            content_type: 'text/html; charset=utf-8',
+            body_byte_length: 1037598,
+            body_sha256: PREVIEW_BODY_SHA256,
+            hydration_parse_ok: true,
+            looks_like_valid_match_detail: true,
+            body_printed: false,
+            body_saved: false,
+            browser_used: false,
+            proxy_used: false,
+            ...overrides.summary,
+        },
+        payload: overrides.payload || fakePayload(),
+    };
+}
+
+function targetMatchRows() {
+    return [
+        {
+            match_id: '53_20252026_4830746',
+            external_id: '4830746',
+            home_team: 'Angers',
+            away_team: 'Strasbourg',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+        },
+    ];
+}
+
+function fakeDeps(overrides = {}) {
+    return {
+        previewPayloadResult: fakePreviewResult(overrides.preview || {}),
+        targetMatchRows: targetMatchRows(),
+        existingRawMatchDataRows: [],
+        protectedTableBaseline: BASELINE,
+        ...overrides,
+    };
+}
+
+async function runCli(gate, argv, dependencies = fakeDeps()) {
+    let stdout = '';
+    const status = await gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return {
+        status,
+        stdout,
+        payload: stdout.trim().startsWith('{') ? JSON.parse(stdout) : null,
+    };
+}
+
+function assertInvalid(overrides, expectedPattern) {
+    const gate = loadModuleFresh();
+    const validation = gate.validatePreflightInput(validArgs(overrides));
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), expectedPattern);
+}
+
+function fakeHtml() {
+    const nextData = {
+        props: {
+            pageProps: {
+                content: {
+                    stats: [{ title: 'Top stats', stats: [] }],
+                    lineup: { homeTeam: 'Angers', awayTeam: 'Strasbourg' },
+                    shotmap: [],
+                },
+                general: {
+                    matchId: '4830746',
+                    homeTeam: { name: 'Angers' },
+                    awayTeam: { name: 'Strasbourg' },
+                },
+                header: {
+                    teams: [
+                        { name: 'Angers', id: 982 },
+                        { name: 'Strasbourg', id: 984 },
+                    ],
+                },
+            },
+        },
+    };
+    return `<html><body>Angers Strasbourg 4830746<script id="__NEXT_DATA__" type="application/json">${JSON.stringify(
+        nextData
+    )}</script></body></html>`;
+}
+
+function fakeFetchImpl() {
+    return async url => ({
+        status: 200,
+        statusCode: 200,
+        ok: true,
+        url: 'https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och',
+        headers: {
+            get: name => (String(name).toLowerCase() === 'content-type' ? 'text/html; charset=utf-8' : ''),
+        },
+        text: async () => {
+            assert.equal(String(url), 'https://www.fotmob.com/match/4830746');
+            return fakeHtml();
+        },
+    });
+}
+
+function fakeReadOnlyPool() {
+    const queries = [];
+    return {
+        queries,
+        async query(sql) {
+            const text = String(sql || '');
+            queries.push(text);
+            assert.match(text.trim(), /^SELECT/i);
+            assert.doesNotMatch(text, /\b(INSERT|UPDATE|DELETE|TRUNCATE|ALTER|DROP|BEGIN|COMMIT|ROLLBACK)\b/i);
+            if (text.includes('UNION ALL')) {
+                return {
+                    rows: Object.entries(BASELINE).map(([table_name, rows]) => ({ table_name, rows })),
+                };
+            }
+            if (text.includes('FROM raw_match_data')) {
+                return { rows: [] };
+            }
+            if (text.includes('FROM matches')) {
+                return { rows: targetMatchRows() };
+            }
+            throw new Error(`unexpected query: ${text}`);
+        },
+        async end() {},
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalFetch = global.fetch;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l2_raw_match_data_ingest_preflight`);
+    };
+
+    global.fetch = fail('global.fetch');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'playwright',
+            'playwright-core',
+            'puppeteer',
+            'child_process',
+            'node:child_process',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        Module._load = originalLoad;
+    });
+}
+
+test('valid input succeeds', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validatePreflightInput(validArgs());
+    assert.equal(validation.ok, true);
+    assert.deepEqual(validation.errors, []);
+});
+
+test('source missing fails', () => assertInvalid({ source: '' }, /missing source/));
+test('source non-fotmob fails', () => assertInvalid({ source: 'other' }, /unsupported source/));
+test('route missing fails', () => assertInvalid({ route: '' }, /missing route/));
+test('route unsupported fails', () => assertInvalid({ route: 'api_match_details' }, /unsupported route/));
+test('match-id missing fails', () => assertInvalid({ matchId: '' }, /missing match-id/));
+test('match-id not 53_20252026_4830746 fails', () => assertInvalid({ matchId: 'x' }, /match-id must be/));
+test('external-id missing fails', () => assertInvalid({ externalId: '' }, /missing external-id/));
+test('external-id not 4830746 fails', () => assertInvalid({ externalId: '1' }, /external-id must be/));
+test('home-team missing Angers fails', () => assertInvalid({ homeTeam: 'Paris' }, /home-team must contain Angers/));
+test('away-team missing Strasbourg fails', () =>
+    assertInvalid({ awayTeam: 'Lens' }, /away-team must contain Strasbourg/));
+test('data-version missing fails', () => assertInvalid({ dataVersion: '' }, /missing data-version/));
+test('data-version not fotmob_html_hyd_v1 fails', () =>
+    assertInvalid({ dataVersion: 'fotmob_html_hydration_v1' }, /data-version must be/));
+test('network-authorization=no fails', () =>
+    assertInvalid({ networkAuthorization: false }, /network-authorization=yes is required/));
+test('live-preview-authorization=no fails', () =>
+    assertInvalid({ livePreviewAuthorization: false }, /live-preview-authorization=yes is required/));
+test('allow-db-write=yes blocked', () => assertInvalid({ allowDbWrite: true }, /allow-db-write=yes is blocked/));
+test('allow-raw-match-data-write=yes blocked', () =>
+    assertInvalid({ allowRawMatchDataWrite: true }, /allow-raw-match-data-write=yes is blocked/));
+test('allow-matches-write=yes blocked', () =>
+    assertInvalid({ allowMatchesWrite: true }, /allow-matches-write=yes is blocked/));
+test('allow-training=yes blocked', () => assertInvalid({ allowTraining: true }, /allow-training=yes is blocked/));
+test('allow-prediction=yes blocked', () => assertInvalid({ allowPrediction: true }, /allow-prediction=yes is blocked/));
+test('commit=yes blocked', () => assertInvalid({ commit: true }, /commit=yes is blocked/));
+test('execute=yes blocked', () => assertInvalid({ execute: true }, /execute=yes is blocked/));
+test('retry > 0 blocked', () => assertInvalid({ retry: 1 }, /retry > 0 is blocked/));
+test('concurrency > 1 blocked', () => assertInvalid({ concurrency: 2 }, /concurrency > 1 is blocked/));
+test('print-body=yes blocked', () => assertInvalid({ printBody: true }, /print-body=yes is blocked/));
+test('save-body=yes blocked', () => assertInvalid({ saveBody: true }, /save-body=yes is blocked/));
+test('browser/proxy allowed blocked', () => {
+    assertInvalid({ allowBrowserRuntime: true }, /allow-browser-runtime=yes is blocked/);
+    assertInvalid({ allowProxyRuntime: true }, /allow-proxy-runtime=yes is blocked/);
+});
+
+test('normalizeBooleanFlag and parseArgs handle fallback and spaced values', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.normalizeBooleanFlag('YES'), true);
+    assert.equal(gate.normalizeBooleanFlag('off'), false);
+    assert.equal(gate.normalizeBooleanFlag('maybe', false), false);
+    assert.equal(gate.normalizeBooleanFlag('', true), true);
+    assert.equal(gate.normalizeBooleanFlag(undefined), undefined);
+
+    const args = gate.parseArgs(['orphan', '--source', 'fotmob', '--route', 'html_hydration', '--mystery', '--help']);
+    assert.equal(args.source, 'fotmob');
+    assert.equal(args.route, 'html_hydration');
+    assert.equal(args.help, true);
+    assert.deepEqual(args.unknown, ['orphan', 'mystery']);
+});
+
+test('validatePreflightInput reports missing required flags when omitted', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validatePreflightInput(
+        validArgs({
+            networkAuthorization: undefined,
+            livePreviewAuthorization: undefined,
+            allowDbWrite: undefined,
+            allowRawMatchDataWrite: undefined,
+            allowMatchesWrite: undefined,
+            allowTraining: undefined,
+            allowPrediction: undefined,
+            printBody: undefined,
+            saveBody: undefined,
+        })
+    );
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), /missing network-authorization=yes/);
+    assert.match(validation.errors.join('\n'), /missing live-preview-authorization=yes/);
+    assert.match(validation.errors.join('\n'), /missing allow-db-write=no/);
+    assert.match(validation.errors.join('\n'), /missing allow-raw-match-data-write=no/);
+    assert.match(validation.errors.join('\n'), /missing allow-matches-write=no/);
+    assert.match(validation.errors.join('\n'), /missing allow-training=no/);
+    assert.match(validation.errors.join('\n'), /missing allow-prediction=no/);
+    assert.match(validation.errors.join('\n'), /missing print-body=no/);
+    assert.match(validation.errors.join('\n'), /missing save-body=no/);
+});
+
+test('validatePreflightInput reports missing teams and invalid numeric safety knobs', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validatePreflightInput(
+        validArgs({
+            homeTeam: '',
+            awayTeam: '',
+            concurrency: 'many',
+            retry: 'later',
+        })
+    );
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), /missing home-team/);
+    assert.match(validation.errors.join('\n'), /missing away-team/);
+    assert.match(validation.errors.join('\n'), /concurrency must be 1/);
+    assert.match(validation.errors.join('\n'), /retry must be 0/);
+
+    const missingNumeric = gate.validatePreflightInput(validArgs({ concurrency: undefined, retry: undefined }));
+    assert.match(missingNumeric.errors.join('\n'), /concurrency must be 1/);
+    assert.match(missingNumeric.errors.join('\n'), /retry must be 0/);
+});
+
+test('canonicalizeJson sorts object keys recursively', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.canonicalizeJson({ z: 1, a: { c: 3, b: 2 } }), '{"a":{"b":2,"c":3},"z":1}');
+});
+
+test('canonicalizeJson preserves array order', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.canonicalizeJson({ items: [{ b: 1, a: 2 }, { c: 3 }] }), '{"items":[{"a":2,"b":1},{"c":3}]}');
+});
+
+test('canonicalizeJson handles undefined and non-finite values', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.canonicalizeJson(undefined), undefined);
+    assert.equal(
+        gate.canonicalizeJson({
+            z: undefined,
+            a: [1, undefined, () => {}, Symbol('x'), Number.NaN, Number.POSITIVE_INFINITY],
+            b: { y: undefined, x: 1 },
+            c: Number.NaN,
+            d: Number.POSITIVE_INFINITY,
+            e: Number.NEGATIVE_INFINITY,
+        }),
+        '{"a":[1,null,null,null,null,null],"b":{"x":1},"c":null,"d":null,"e":null}'
+    );
+});
+
+test('sha256CanonicalJson stable for equivalent objects', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.sha256CanonicalJson({ b: 2, a: 1 }), gate.sha256CanonicalJson({ a: 1, b: 2 }));
+});
+
+test('buildRawData excludes full HTML body', () => {
+    const gate = loadModuleFresh();
+    const preview = fakePreviewResult();
+    const rawData = gate.buildRawDataFromPreviewPayload(preview.payload, preview.summary, validArgs());
+    assert.equal(rawData.fullHtmlBody, undefined);
+    assert.equal(rawData.httpResponseString, undefined);
+    assert.equal(JSON.stringify(rawData).includes('<html>must not be copied</html>'), false);
+});
+
+test('buildRawData includes _meta/content/general/header/matchId', () => {
+    const gate = loadModuleFresh();
+    const preview = fakePreviewResult();
+    const rawData = gate.buildRawDataFromPreviewPayload(preview.payload, preview.summary, validArgs());
+    assert.deepEqual(Object.keys(rawData).sort(), ['_meta', 'content', 'general', 'header', 'matchId'].sort());
+    assert.equal(rawData.matchId, '4830746');
+});
+
+test('buildRawData handles non-object payload without HTML body fields', () => {
+    const gate = loadModuleFresh();
+    const preview = fakePreviewResult();
+    const rawData = gate.buildRawDataFromPreviewPayload(null, preview.summary, validArgs());
+    assert.deepEqual(rawData.content, {});
+    assert.deepEqual(rawData.general, {});
+    assert.deepEqual(rawData.header, {});
+    assert.equal(rawData.matchId, '4830746');
+    assert.equal(rawData._meta.has_stats, false);
+    assert.equal(rawData._meta.full_html_body_stored, false);
+    assert.equal(rawData._meta.http_response_string_stored, false);
+});
+
+test('no existing row -> would_insert', () => {
+    const gate = loadModuleFresh();
+    const affected = gate.buildAffectedPreview({
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        existingRows: [],
+        rawDataHash: 'abc',
+    });
+    assert.equal(affected.decision, 'would_insert');
+});
+
+test('same existing data_hash -> would_skip', () => {
+    const gate = loadModuleFresh();
+    const affected = gate.buildAffectedPreview({
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        existingRows: [{ data_hash: 'abc' }],
+        rawDataHash: 'abc',
+    });
+    assert.equal(affected.decision, 'would_skip');
+});
+
+test('different existing data_hash -> would_update', () => {
+    const gate = loadModuleFresh();
+    const affected = gate.buildAffectedPreview({
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        existingRows: [{ data_hash: 'old' }],
+        rawDataHash: 'new',
+    });
+    assert.equal(affected.decision, 'would_update');
+});
+
+test('output preflight_only=true', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), fakeDeps());
+    assert.equal(result.ok, true);
+    assert.equal(result.preflight_only, true);
+});
+
+test('output would_write_raw_match_data=false', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), fakeDeps());
+    assert.equal(result.would_write_raw_match_data, false);
+});
+
+test('output db_write_allowed_this_phase=false', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), fakeDeps());
+    assert.equal(result.db_write_allowed_this_phase, false);
+});
+
+test('output body_printed=false/body_saved=false', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), fakeDeps());
+    assert.equal(result.body_printed, false);
+    assert.equal(result.body_saved, false);
+});
+
+test('protected baseline included', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), fakeDeps());
+    assert.deepEqual(result.protected_table_baseline, BASELINE);
+});
+
+test('buildAffectedPreview treats empty existing hashes as null on update', () => {
+    const gate = loadModuleFresh();
+    const affected = gate.buildAffectedPreview({
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        existingRows: [{ data_hash: '' }],
+        rawDataHash: 'new',
+    });
+    assert.equal(affected.decision, 'would_update');
+    assert.equal(affected.existing_data_hash, null);
+});
+
+test('custom dependency functions are used without pool and array baselines', async () => {
+    const gate = loadModuleFresh();
+    const preview = fakePreviewResult();
+    const rawData = gate.buildRawDataFromPreviewPayload(preview.payload, preview.summary, validArgs());
+    const rawDataHash = gate.sha256CanonicalJson(rawData);
+
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), {
+        resolvePreviewPayload: async ({ input }) => {
+            assert.equal(input.matchId, '53_20252026_4830746');
+            return preview;
+        },
+        selectTargetMatch: async ({ input }) => {
+            assert.equal(input.externalId, '4830746');
+            return targetMatchRows();
+        },
+        selectExistingRawMatchData: async ({ input }) => {
+            assert.equal(input.matchId, '53_20252026_4830746');
+            return [{ data_hash: rawDataHash }];
+        },
+        selectProtectedTableBaseline: async () => [
+            { table_name: 'matches', rows: 10 },
+            { table_name: 'raw_match_data', rows: 2 },
+            { table_name: 'bookmaker_odds_history', rows: 2 },
+            { table_name: 'l3_features', rows: 2 },
+            { table_name: 'match_features_training', rows: 2 },
+            { table_name: 'predictions', rows: 2 },
+        ],
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.existing_raw_match_data_found, true);
+    assert.equal(result.would_skip, true);
+    assert.deepEqual(result.protected_table_baseline, BASELINE);
+});
+
+test('buildProtectedTableBaseline handles row arrays and invalid input', () => {
+    const gate = loadModuleFresh();
+    assert.deepEqual(
+        gate.buildProtectedTableBaseline([
+            { table_name: 'matches', rows: '10' },
+            { table_name: 'raw_match_data', rows: '2' },
+            { table_name: 'bookmaker_odds_history', rows: '2' },
+            { table_name: 'l3_features', rows: '2' },
+            { table_name: 'match_features_training', rows: '2' },
+            { table_name: 'predictions', rows: '2' },
+        ]),
+        BASELINE
+    );
+    assert.deepEqual(gate.buildProtectedTableBaseline(null), {
+        matches: 0,
+        raw_match_data: 0,
+        bookmaker_odds_history: 0,
+        l3_features: 0,
+        match_features_training: 0,
+        predictions: 0,
+    });
+});
+
+test('same hash output would_skip_count=1', async () => {
+    const gate = loadModuleFresh();
+    const preview = fakePreviewResult();
+    const rawData = gate.buildRawDataFromPreviewPayload(preview.payload, preview.summary, validArgs());
+    const rawHash = gate.sha256CanonicalJson(rawData);
+    const result = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({ preview, existingRawMatchDataRows: [{ data_hash: rawHash }] })
+    );
+    assert.equal(result.would_skip, true);
+    assert.equal(result.would_skip_count, 1);
+});
+
+test('different hash output would_update_count=1', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({ existingRawMatchDataRows: [{ data_hash: 'old' }] })
+    );
+    assert.equal(result.would_update, true);
+    assert.equal(result.would_update_count, 1);
+});
+
+test('Makefile preflight target can run via container target', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l2-raw-match-data-ingest-preflight:/m);
+    assert.match(makefile, /scripts\/ops\/l2_raw_match_data_ingest_preflight\.js/);
+    assert.doesNotMatch(makefile, /^data-l2-raw-match-data-ingest-commit:/m);
+});
+
+test('runCli uses fake route selector payload and fake read-only DB without fs writes or spawn', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const pool = fakeReadOnlyPool();
+    const result = await runCli(gate, cliArgs(), {
+        fetchImpl: fakeFetchImpl(),
+        pool,
+    });
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.ok, true);
+    assert.equal(result.payload.selected_route, 'html_hydration');
+    assert.equal(result.payload.would_insert_count, 1);
+    assert.equal(pool.queries.length, 3);
+});
+
+test('runCli returns non-zero for blocked DB write', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs({ allowDbWrite: true }));
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.ok, false);
+    assert.match(result.payload.controlled_error, /allow-db-write=yes is blocked/);
+});
+
+test('runCli help returns usage without executing preflight', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, ['--help'], fakeDeps());
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Phase 5\.15L2 is preflight-only/);
+    assert.equal(result.payload, null);
+});
+
+test('auto route is accepted but selected route remains html_hydration', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs({ route: 'auto' }), fakeDeps());
+    assert.equal(result.ok, true);
+    assert.equal(result.requested_route, 'auto');
+    assert.equal(result.route, 'html_hydration');
+});
+
+test('invalid preview summary returns controlled error', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({
+            preview: {
+                summary: {
+                    ok: false,
+                    controlled_error: 'NO_VALID_ROUTE_PAYLOAD',
+                    selected_route: 'none',
+                    http_status: 403,
+                    hydration_parse_ok: false,
+                    looks_like_valid_match_detail: false,
+                    body_printed: true,
+                    body_saved: true,
+                    browser_used: true,
+                    proxy_used: true,
+                },
+            },
+        })
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.controlled_error, /NO_VALID_ROUTE_PAYLOAD/);
+    assert.match(result.controlled_error, /body_printed=true is blocked/);
+    assert.match(result.controlled_error, /body_saved=true is blocked/);
+    assert.match(result.controlled_error, /browser_used=true is blocked/);
+    assert.match(result.controlled_error, /proxy_used=true is blocked/);
+});
+
+test('raw_data shape validation blocks missing payload keys', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({
+            preview: {
+                payload: {
+                    matchId: '4830746',
+                    content: null,
+                    general: null,
+                    header: null,
+                    _meta: {},
+                },
+            },
+        })
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(Object.keys(result.protected_table_baseline).sort(), Object.keys(BASELINE).sort());
+});
+
+test('target match mismatch returns controlled error', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({
+            targetMatchRows: [
+                {
+                    match_id: 'wrong',
+                    external_id: '4830746',
+                    home_team: 'Angers',
+                    away_team: 'Strasbourg',
+                },
+            ],
+        })
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.controlled_error, /target match_id mismatch/);
+});
+
+test('target match SELECT validates missing row and target identity fields', async () => {
+    const gate = loadModuleFresh();
+    const missing = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({
+            targetMatchRows: [],
+        })
+    );
+    assert.equal(missing.ok, false);
+    assert.match(missing.controlled_error, /target match SELECT expected exactly 1 row, got 0/);
+
+    const mismatchedFields = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({
+            targetMatchRows: [
+                {
+                    match_id: '53_20252026_4830746',
+                    external_id: '999',
+                    home_team: 'Paris',
+                    away_team: 'Lens',
+                },
+            ],
+        })
+    );
+    assert.equal(mismatchedFields.ok, false);
+    assert.match(mismatchedFields.controlled_error, /target external_id mismatch/);
+    assert.match(mismatchedFields.controlled_error, /target home_team must contain Angers/);
+    assert.match(mismatchedFields.controlled_error, /target away_team must contain Strasbourg/);
+});
+
+test('multiple existing raw rows return controlled error', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({
+            existingRawMatchDataRows: [{ data_hash: 'a' }, { data_hash: 'b' }],
+        })
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.controlled_error, /expected <= 1 row/);
+});
+
+test('existing raw rows must be an array', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), {
+        previewPayloadResult: fakePreviewResult(),
+        targetMatchRows: targetMatchRows(),
+        protectedTableBaseline: BASELINE,
+        selectExistingRawMatchData: async () => ({ data_hash: 'abc' }),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.controlled_error, /existing raw_match_data SELECT did not return an array/);
+});
+
+test('protected baseline mismatch returns controlled error', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(
+        validArgs(),
+        fakeDeps({
+            protectedTableBaseline: {
+                ...BASELINE,
+                raw_match_data: 3,
+            },
+        })
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.controlled_error, /raw_match_data baseline expected 2, got 3/);
+});
+
+test('default pg pool path uses SELECT-only queries', async () => {
+    const gate = loadModuleFresh();
+    const pool = fakeReadOnlyPool();
+    let ended = false;
+    pool.end = async () => {
+        ended = true;
+    };
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), {
+        previewPayloadResult: fakePreviewResult(),
+        createPool: () => pool,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(ended, true);
+    assert.equal(pool.queries.length, 3);
+});
+
+test('recapture path uses fake fetch and does not save or print body', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), {
+        fetchImpl: fakeFetchImpl(),
+        targetMatchRows: targetMatchRows(),
+        existingRawMatchDataRows: [],
+        protectedTableBaseline: BASELINE,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.body_printed, false);
+    assert.equal(result.body_saved, false);
+    assert.equal(result.selected_route, 'html_hydration');
+});
+
+test('recapture path fails closed when fetch is unavailable', async t => {
+    const originalFetch = global.fetch;
+    global.fetch = undefined;
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    const gate = loadModuleFresh();
+    await assert.rejects(
+        () =>
+            gate.buildRawMatchDataIngestPreflight(validArgs(), {
+                targetMatchRows: targetMatchRows(),
+                existingRawMatchDataRows: [],
+                protectedTableBaseline: BASELINE,
+            }),
+        /FETCH_UNAVAILABLE/
+    );
+});
+
+test('recapture path fails closed when hydration payload cannot be parsed', async () => {
+    const gate = loadModuleFresh();
+    await assert.rejects(
+        () =>
+            gate.buildRawMatchDataIngestPreflight(validArgs(), {
+                fetchImpl: async () => ({
+                    status: 200,
+                    statusCode: 200,
+                    ok: true,
+                    url: 'https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och',
+                    headers: {
+                        get: () => 'text/html; charset=utf-8',
+                    },
+                    text: async () => '<html><body>Angers Strasbourg 4830746</body></html>',
+                }),
+                targetMatchRows: targetMatchRows(),
+                existingRawMatchDataRows: [],
+                protectedTableBaseline: BASELINE,
+            }),
+        /NEXT_DATA_PARSE_FAILED|NO_NEXT_DATA|__NEXT_DATA__/
+    );
+});
+
+test('no fs write / mkdir source usage', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /writeFile|writeFileSync|mkdir|createWriteStream/);
+});
+
+test('no child_process spawn source usage', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /child_process|spawn|execFile/);
+});
+
+test('no DB write occurs with fake pool', async () => {
+    const gate = loadModuleFresh();
+    const pool = fakeReadOnlyPool();
+    const result = await gate.buildRawMatchDataIngestPreflight(validArgs(), {
+        previewPayloadResult: fakePreviewResult(),
+        pool,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(pool.queries.length, 3);
+});
+
+test('no ProductionHarvester / raw ingest commit import', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/);
+});
+
+test('no browser/proxy import', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\(['"].*(playwright|puppeteer|chromium|BrowserProvider|socks-proxy-agent)/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.15L2 raw_match_data ingest preflight.

Scope:
- Recaptures exact FotMob HTML hydration payload via safe route selector
- Computes canonical raw_data and SHA-256 data_hash
- SELECTs existing raw_match_data row
- Outputs would_insert / would_update / would_skip
- Keeps DB/raw_match_data writes blocked
- Keeps matches/features/predictions protected
- Adds Makefile preflight target, tests, AGENTS.md updates, and report

Safety:
- No DB writes
- No raw_match_data writes
- No matches writes
- No harvest / ingest / backfill
- No training / prediction
- No browser/proxy
- No full body save/print
- No file deletion

Validation:
- raw_match_data ingest preflight tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged before preflight
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed