### PR TITLE
feat(data): add controlled raw_match_data write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@
 - Phase 5.13L2 raw_match_data ingest planning 仅允许 planning-only；`raw_match_data` 写入仍未授权。raw_data 应存 canonical transformed detail payload 而不是完整 HTML body；data_hash 应为 canonical raw_data JSON 的 SHA-256，而不是 HTML body hash；raw_match_data ingest 不得更新 `matches`、features、training 或 predictions，未来写入必须另行 authorization + preflight。
 - Phase 5.14L2 raw_match_data ingest authorization 仅允许 authorization-only：它只记录未来 `raw_match_data` 写入授权范围，本阶段不得写 DB、不得写 `raw_match_data`、不得 live preview / network request；后续写入仍必须先完成 Phase 5.15L2 preflight，并在最终执行阶段再次确认。raw_match_data ingest 必须保持 raw-only，不得更新 `matches`、features、training 或 predictions。
 - Phase 5.15L2 raw_match_data ingest preflight 允许通过 safe route selector 重新 recapture exact raw payload；它必须保持 SELECT-only，不得写 DB，不得写 `raw_match_data`，不得写 `matches`、features、training 或 predictions；它必须输出 `would_insert` / `would_update` / `would_skip`，`data_hash` 必须来自 canonical raw_data JSON，不得存完整 HTML body；真正 controlled write 仅能留到 Phase 5.16L2 且必须有最终 DB-write confirmation。
+- Phase 5.16L2 controlled raw_match_data write 是目标 `4830746` 唯一允许的 raw 写入路径；它必须要求最终 DB-write confirmation，在写入前把 recapture 得到的 `raw_data_hash` 与 Phase 5.15L2 baseline 比对，一致时才允许事务写入；它只能写 `raw_match_data`，不得更新 `matches`、features、training 或 predictions，不得训练/预测，不得保存或打印完整 body。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
-        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan data-l2-raw-match-data-ingest-plan data-l2-raw-match-data-ingest-authorization data-l2-raw-match-data-ingest-preflight \
+        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan data-l2-raw-match-data-ingest-plan data-l2-raw-match-data-ingest-authorization data-l2-raw-match-data-ingest-preflight data-l2-raw-match-data-write \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -336,9 +336,11 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l2-raw-match-data-ingest-plan SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg PREVIEW_BODY_SHA256=<sha256> PREVIEW_BODY_BYTE_LENGTH=<bytes> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.13L2 planning-only, no network/DB/raw write"
 	@echo "  make data-l2-raw-match-data-ingest-authorization SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 PREVIEW_BODY_SHA256=<sha256> HYDRATION_PARSE_OK=yes LOOKS_LIKE_VALID_MATCH_DETAIL=yes USER_AUTHORIZED_RAW_MATCH_DATA_INGEST=yes ALLOW_RAW_MATCH_DATA_WRITE_NEXT_PHASE=yes ALLOW_DB_WRITE_NOW=no ALLOW_RAW_MATCH_DATA_WRITE_NOW=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes  # Phase 5.14L2 authorization-only, no network/DB/raw write"
 	@echo "  make data-l2-raw-match-data-ingest-preflight SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # Phase 5.15L2 preflight-only: recapture exact payload/hash and output would_insert/update/skip, no DB/raw write"
+	@echo "  make data-l2-raw-match-data-write SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 BASELINE_RAW_DATA_HASH=d40f757adccf5be96d107188196efa905b6b573b62d7b4428014d7ce4f39a1f6 NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=yes FINAL_DB_WRITE_CONFIRMATION=yes ALLOW_DB_WRITE=yes ALLOW_RAW_MATCH_DATA_WRITE=yes ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # Phase 5.16L2 controlled single-target raw_match_data write"
 	@echo "  L2 raw detail preview is preview-only: no raw_match_data write, no DB write, no browser/proxy, no full body print/save."
 	@echo "  L2 raw_match_data ingest authorization is authorization-only in Phase 5.14L2: future write requires preflight + final DB-write confirmation, and raw_match_data write remains blocked this phase."
 	@echo "  L2 raw_match_data ingest preflight recomputes exact payload/hash and outputs would_insert/update/skip; it does not write raw_match_data. Future write requires final DB-write confirmation."
+	@echo "  L2 raw_match_data write is controlled single-target execution: it requires final DB-write confirmation, writes only raw_match_data, and keeps protected tables untouched."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
 	@echo "  Phase 5.12L2B route selector supports html_hydration before api_match_details; alternate_route remains plan-only."
 	@echo "  Live raw detail requests require future explicit authorization; use audited route selector / safe adapter, not legacy harvest/backfill."
@@ -743,6 +745,38 @@ data-l2-raw-match-data-ingest-preflight: ## L2 raw_match_data ingest preflight. 
 		--retry="$(or $(RETRY),0)" \
 		--print-body="$(or $(PRINT_BODY),no)" \
 		--save-body="$(or $(SAVE_BODY),no)" \
+		--commit="$(or $(COMMIT),no)" \
+		--execute="$(or $(EXECUTE),no)"
+
+data-l2-raw-match-data-write: ## L2 controlled raw_match_data write. Phase 5.16L2. Single-target transaction, raw_match_data only.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(ROUTE)" ] || [ -z "$(MATCH_ID)" ] || [ -z "$(EXTERNAL_ID)" ] || [ -z "$(HOME_TEAM)" ] || [ -z "$(AWAY_TEAM)" ] || [ -z "$(DATA_VERSION)" ] || [ -z "$(BASELINE_RAW_DATA_HASH)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830746 EXTERNAL_ID=4830746 HOME_TEAM=Angers AWAY_TEAM=Strasbourg DATA_VERSION=fotmob_html_hyd_v1 BASELINE_RAW_DATA_HASH=d40f757adccf5be96d107188196efa905b6b573b62d7b4428014d7ce4f39a1f6"; \
+		exit 1; \
+	fi
+	@$(COMPOSE_DEV) exec -T dev node scripts/ops/l2_raw_match_data_write.js \
+		--source="$(SOURCE)" \
+		--route="$(ROUTE)" \
+		--match-id="$(MATCH_ID)" \
+		--external-id="$(EXTERNAL_ID)" \
+		--home-team="$(HOME_TEAM)" \
+		--away-team="$(AWAY_TEAM)" \
+		--data-version="$(DATA_VERSION)" \
+		--baseline-raw-data-hash="$(BASELINE_RAW_DATA_HASH)" \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--live-preview-authorization="$(or $(LIVE_PREVIEW_AUTHORIZATION),no)" \
+		--final-db-write-confirmation="$(or $(FINAL_DB_WRITE_CONFIRMATION),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-matches-write="$(or $(ALLOW_MATCHES_WRITE),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--concurrency="$(or $(CONCURRENCY),1)" \
+		--retry="$(or $(RETRY),0)" \
+		--print-body="$(or $(PRINT_BODY),no)" \
+		--save-body="$(or $(SAVE_BODY),no)" \
+		--bulk="$(or $(BULK),no)" \
 		--commit="$(or $(COMMIT),no)" \
 		--execute="$(or $(EXECUTE),no)"
 

--- a/docs/_reports/CONTROLLED_RAW_MATCH_DATA_WRITE_PHASE5_16L2.md
+++ b/docs/_reports/CONTROLLED_RAW_MATCH_DATA_WRITE_PHASE5_16L2.md
@@ -1,0 +1,114 @@
+# Controlled Raw Match Data Write - Phase 5.16L2
+
+## 1. Executive summary
+
+Phase 5.16L2 defines the only approved controlled `raw_match_data` write path for
+target match `53_20252026_4830746` / `external_id=4830746`.
+
+This phase:
+
+- recaptures the exact FotMob detail payload via the safe route selector
+- rebuilds canonical transformed `raw_data`
+- compares `raw_data_hash` against the Phase 5.15L2 baseline
+- writes only `raw_match_data` inside a transaction when the hash gate matches
+
+This phase does not write `matches`, `bookmaker_odds_history`, `l3_features`,
+`match_features_training`, or `predictions`.
+
+## 2. Baseline before write
+
+Expected baseline before real execution:
+
+- `matches=10`
+- `raw_match_data=2`
+- `bookmaker_odds_history=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+- target `matches` row exists for `53_20252026_4830746`
+- target `raw_match_data` row does not yet exist
+
+## 3. Pre-write recapture and hash gate
+
+The controlled writer must perform one live recapture via the safe route selector:
+
+- `selected_route=html_hydration`
+- `request_url=https://www.fotmob.com/match/4830746`
+- `final_url=https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och`
+- `http_status=200`
+- `hydration_parse_ok=true`
+- `looks_like_valid_match_detail=true`
+
+Hash gate:
+
+- baseline `raw_data_hash`:
+  `d40f757adccf5be96d107188196efa905b6b573b62d7b4428014d7ce4f39a1f6`
+- computed `raw_data_hash` must exactly match the baseline before any DB write
+- if the recaptured hash drifts, the script must stop and write nothing
+
+## 4. Transaction execution
+
+The controlled write transaction is intentionally narrow:
+
+1. `BEGIN`
+2. `SELECT` target `matches` row
+3. `SELECT` target `raw_match_data` row
+4. verify protected-table baseline
+5. `INSERT INTO raw_match_data (...)` when no row exists
+6. `SELECT` inserted-row metadata and protected-table counts
+7. `COMMIT`
+
+On any failure the script must `ROLLBACK` and exit non-zero.
+
+## 5. Post-write verification
+
+Expected post-write state after successful real execution:
+
+- `raw_match_data=3`
+- `matches=10`
+- `bookmaker_odds_history=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+Expected inserted-row metadata preview:
+
+- `match_id=53_20252026_4830746`
+- `external_id=4830746`
+- `data_version=fotmob_html_hyd_v1`
+- `data_hash=d40f757adccf5be96d107188196efa905b6b573b62d7b4428014d7ce4f39a1f6`
+- `collected_at=<UTC timestamp generated during write>`
+
+The script verifies raw-data shape by keys only and must not print the full
+`raw_data` payload.
+
+## 6. Next phase
+
+Recommended next phase:
+
+`Phase 5.17L2: raw_match_data local parser planning`
+
+Scope for the next phase:
+
+- read local `raw_match_data` only
+- no additional live network access
+- no features write yet
+- no training
+- no prediction
+- plan how to extract `matchFacts`, `lineup`, `stats`, `shotmap`, and related detail sections
+
+## 7. Explicit non-execution
+
+Confirmed out of scope for this phase:
+
+- no `matches` writes
+- no `bookmaker_odds_history` writes
+- no `l3_features` writes
+- no `match_features_training` writes
+- no `predictions` writes
+- no harvest or backfill
+- no training or prediction
+- no browser or proxy runtime
+- no full HTML body save
+- no full HTML body print
+- no file deletion

--- a/scripts/ops/l2_raw_match_data_write.js
+++ b/scripts/ops/l2_raw_match_data_write.js
@@ -1,0 +1,1263 @@
+#!/usr/bin/env node
+/* eslint-disable complexity, max-lines */
+'use strict';
+
+const crypto = require('node:crypto');
+const { extractFromHtml, transformToApiFormat } = require('../../src/parsers/fotmob/NextDataParser');
+const { runFotMobDetailRouteSelector, buildRouteSelectorPreviewSummary } = require('./l2_raw_detail_preview');
+
+const PHASE = 'PHASE5_16L2_CONTROLLED_RAW_MATCH_DATA_WRITE';
+const NEXT_REQUIRED_PHASE = 'Phase 5.17L2 raw_match_data local parser planning';
+const TARGET = Object.freeze({
+    source: 'fotmob',
+    route: 'html_hydration',
+    matchId: '53_20252026_4830746',
+    externalId: '4830746',
+    homeTeam: 'Angers',
+    awayTeam: 'Strasbourg',
+    dataVersion: 'fotmob_html_hyd_v1',
+    baselineRawDataHash: 'd40f757adccf5be96d107188196efa905b6b573b62d7b4428014d7ce4f39a1f6',
+});
+const EXPECTED_PRE_WRITE_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 2,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+const EXPECTED_POST_WRITE_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 3,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+const FORBIDDEN_SELECT_SQL_VERBS = Object.freeze([
+    'INSERT',
+    'UPDATE',
+    'DELETE',
+    'CREATE',
+    'ALTER',
+    'DROP',
+    'TRUNCATE',
+    'UPSERT',
+    'MERGE',
+    'GRANT',
+    'REVOKE',
+    'LOCK',
+    'COPY',
+]);
+
+function normalizeText(value) {
+    return String(value || '').trim();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+    return Number.parseInt(normalized, 10);
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return {
+            value: nextArg,
+            consumedNext: true,
+        };
+    }
+
+    return {
+        value: true,
+        consumedNext: false,
+    };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        route: null,
+        matchId: null,
+        externalId: null,
+        homeTeam: null,
+        awayTeam: null,
+        dataVersion: null,
+        baselineRawDataHash: null,
+        networkAuthorization: null,
+        livePreviewAuthorization: null,
+        finalDbWriteConfirmation: null,
+        allowDbWrite: null,
+        allowRawMatchDataWrite: null,
+        allowMatchesWrite: null,
+        allowTraining: null,
+        allowPrediction: null,
+        allowBrowserRuntime: null,
+        allowProxyRuntime: null,
+        concurrency: null,
+        retry: null,
+        printBody: null,
+        saveBody: null,
+        bulk: false,
+        commit: false,
+        execute: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        route: 'route',
+        'match-id': 'matchId',
+        match_id: 'matchId',
+        'external-id': 'externalId',
+        external_id: 'externalId',
+        'home-team': 'homeTeam',
+        home_team: 'homeTeam',
+        'away-team': 'awayTeam',
+        away_team: 'awayTeam',
+        'data-version': 'dataVersion',
+        data_version: 'dataVersion',
+        'baseline-raw-data-hash': 'baselineRawDataHash',
+        baseline_raw_data_hash: 'baselineRawDataHash',
+        'network-authorization': 'networkAuthorization',
+        network_authorization: 'networkAuthorization',
+        'live-preview-authorization': 'livePreviewAuthorization',
+        live_preview_authorization: 'livePreviewAuthorization',
+        'final-db-write-confirmation': 'finalDbWriteConfirmation',
+        final_db_write_confirmation: 'finalDbWriteConfirmation',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        'allow-browser-runtime': 'allowBrowserRuntime',
+        allow_browser_runtime: 'allowBrowserRuntime',
+        'allow-proxy-runtime': 'allowProxyRuntime',
+        allow_proxy_runtime: 'allowProxyRuntime',
+        concurrency: 'concurrency',
+        retry: 'retry',
+        'print-body': 'printBody',
+        print_body: 'printBody',
+        'save-body': 'saveBody',
+        save_body: 'saveBody',
+        bulk: 'bulk',
+        commit: 'commit',
+        execute: 'execute',
+        help: 'help',
+        h: 'help',
+    };
+    const booleanKeys = new Set([
+        'networkAuthorization',
+        'livePreviewAuthorization',
+        'finalDbWriteConfirmation',
+        'allowDbWrite',
+        'allowRawMatchDataWrite',
+        'allowMatchesWrite',
+        'allowTraining',
+        'allowPrediction',
+        'allowBrowserRuntime',
+        'allowProxyRuntime',
+        'printBody',
+        'saveBody',
+        'bulk',
+        'commit',
+        'execute',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+
+        if (booleanKeys.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function includesText(value, expected) {
+    return normalizeText(value).toLowerCase().includes(normalizeText(expected).toLowerCase());
+}
+
+function pushRequiredTrueError(errors, value, flagName) {
+    if (value === true) {
+        return;
+    }
+    if (value === false) {
+        errors.push(`${flagName}=yes is required in Phase 5.16L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=yes`);
+}
+
+function pushRequiredFalseError(errors, value, flagName) {
+    if (value === false) {
+        return;
+    }
+    if (value === true) {
+        errors.push(`${flagName}=yes is blocked in Phase 5.16L2`);
+        return;
+    }
+    errors.push(`missing ${flagName}=no`);
+}
+
+function normalizeWriteInput(input = {}) {
+    return {
+        source: normalizeText(input.source).toLowerCase(),
+        route: normalizeText(input.route).toLowerCase(),
+        matchId: normalizeText(input.matchId),
+        externalId: normalizeText(input.externalId),
+        homeTeam: normalizeText(input.homeTeam),
+        awayTeam: normalizeText(input.awayTeam),
+        dataVersion: normalizeText(input.dataVersion).toLowerCase(),
+        baselineRawDataHash: normalizeText(input.baselineRawDataHash).toLowerCase(),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, undefined),
+        livePreviewAuthorization: normalizeBooleanFlag(input.livePreviewAuthorization, undefined),
+        finalDbWriteConfirmation: normalizeBooleanFlag(input.finalDbWriteConfirmation, undefined),
+        allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
+        allowMatchesWrite: normalizeBooleanFlag(input.allowMatchesWrite, undefined),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, undefined),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, undefined),
+        allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, false),
+        allowProxyRuntime: normalizeBooleanFlag(input.allowProxyRuntime, false),
+        concurrency: parseInteger(input.concurrency, null),
+        retry: parseInteger(input.retry, null),
+        printBody: normalizeBooleanFlag(input.printBody, undefined),
+        saveBody: normalizeBooleanFlag(input.saveBody, undefined),
+        bulk: normalizeBooleanFlag(input.bulk, false),
+        commit: normalizeBooleanFlag(input.commit, false),
+        execute: normalizeBooleanFlag(input.execute, false),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function validateWriteInput(input = {}) {
+    const value = normalizeWriteInput(input);
+    const errors = [];
+
+    if (value.unknown.length > 0) {
+        errors.push(`unknown arguments: ${value.unknown.join(', ')}`);
+    }
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== TARGET.source) {
+        errors.push('unsupported source: only fotmob is allowed');
+    }
+    if (!value.route) {
+        errors.push('missing route: provide --route=html_hydration');
+    } else if (value.route !== TARGET.route) {
+        errors.push('unsupported route: Phase 5.16L2 only allows html_hydration');
+    }
+    if (!value.matchId) {
+        errors.push('missing match-id');
+    } else if (value.matchId !== TARGET.matchId) {
+        errors.push(`match-id must be ${TARGET.matchId} in Phase 5.16L2`);
+    }
+    if (!value.externalId) {
+        errors.push('missing external-id');
+    } else if (value.externalId !== TARGET.externalId) {
+        errors.push(`external-id must be ${TARGET.externalId} in Phase 5.16L2`);
+    }
+    if (!value.homeTeam) {
+        errors.push('missing home-team');
+    } else if (!includesText(value.homeTeam, TARGET.homeTeam)) {
+        errors.push(`home-team must contain ${TARGET.homeTeam}`);
+    }
+    if (!value.awayTeam) {
+        errors.push('missing away-team');
+    } else if (!includesText(value.awayTeam, TARGET.awayTeam)) {
+        errors.push(`away-team must contain ${TARGET.awayTeam}`);
+    }
+    if (!value.dataVersion) {
+        errors.push('missing data-version');
+    } else if (value.dataVersion !== TARGET.dataVersion) {
+        errors.push(`data-version must be ${TARGET.dataVersion} in Phase 5.16L2`);
+    }
+    if (!value.baselineRawDataHash) {
+        errors.push('missing baseline-raw-data-hash');
+    } else if (value.baselineRawDataHash !== TARGET.baselineRawDataHash) {
+        errors.push(`baseline-raw-data-hash must be ${TARGET.baselineRawDataHash}`);
+    }
+
+    pushRequiredTrueError(errors, value.networkAuthorization, 'network-authorization');
+    pushRequiredTrueError(errors, value.livePreviewAuthorization, 'live-preview-authorization');
+    pushRequiredTrueError(errors, value.finalDbWriteConfirmation, 'final-db-write-confirmation');
+    pushRequiredTrueError(errors, value.allowDbWrite, 'allow-db-write');
+    pushRequiredTrueError(errors, value.allowRawMatchDataWrite, 'allow-raw-match-data-write');
+    pushRequiredFalseError(errors, value.allowMatchesWrite, 'allow-matches-write');
+    pushRequiredFalseError(errors, value.allowTraining, 'allow-training');
+    pushRequiredFalseError(errors, value.allowPrediction, 'allow-prediction');
+    pushRequiredFalseError(errors, value.printBody, 'print-body');
+    pushRequiredFalseError(errors, value.saveBody, 'save-body');
+
+    if (value.allowBrowserRuntime === true) {
+        errors.push('allow-browser-runtime=yes is blocked in Phase 5.16L2');
+    }
+    if (value.allowProxyRuntime === true) {
+        errors.push('allow-proxy-runtime=yes is blocked in Phase 5.16L2');
+    }
+    if (value.concurrency !== 1) {
+        errors.push(value.concurrency > 1 ? 'concurrency > 1 is blocked' : 'concurrency must be 1');
+    }
+    if (value.retry !== 0) {
+        errors.push(value.retry > 0 ? 'retry > 0 is blocked' : 'retry must be 0');
+    }
+    if (value.bulk === true) {
+        errors.push('bulk=yes is blocked in Phase 5.16L2');
+    }
+    if (value.commit === true) {
+        errors.push('commit=yes is blocked in Phase 5.16L2');
+    }
+    if (value.execute === true) {
+        errors.push('execute=yes is blocked in Phase 5.16L2');
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function canonicalizeValue(value, inArray = false) {
+    if (value === undefined || typeof value === 'function' || typeof value === 'symbol') {
+        return inArray ? null : undefined;
+    }
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+    if (Array.isArray(value)) {
+        return value.map(item => {
+            const normalized = canonicalizeValue(item, true);
+            return normalized === undefined ? null : normalized;
+        });
+    }
+    if (value && typeof value === 'object') {
+        const normalized = {};
+        for (const key of Object.keys(value).sort()) {
+            const child = canonicalizeValue(value[key], false);
+            if (child !== undefined) {
+                normalized[key] = child;
+            }
+        }
+        return normalized;
+    }
+    return null;
+}
+
+function canonicalizeJson(value) {
+    return JSON.stringify(canonicalizeValue(value));
+}
+
+function sha256Text(text) {
+    return crypto
+        .createHash('sha256')
+        .update(String(text || ''), 'utf8')
+        .digest('hex');
+}
+
+function sha256CanonicalJson(value) {
+    return sha256Text(canonicalizeJson(value));
+}
+
+function jsonClone(value, fallback = {}) {
+    if (value === undefined || value === null) {
+        return fallback;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function buildRawDataFromPreviewPayload(payload = {}, previewSummary = {}, input = {}) {
+    const value = normalizeWriteInput(input);
+    const safePayload = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {};
+    const payloadMeta = safePayload._meta && typeof safePayload._meta === 'object' ? safePayload._meta : {};
+
+    return {
+        _meta: {
+            source: TARGET.source,
+            route: previewSummary.selected_route || TARGET.route,
+            requested_route: value.route || TARGET.route,
+            request_url: previewSummary.request_url || null,
+            final_url: previewSummary.final_url || null,
+            fetch_body_sha256: previewSummary.body_sha256 || null,
+            fetch_body_byte_length: Number(previewSummary.body_byte_length || 0),
+            hydration_parse_ok: previewSummary.hydration_parse_ok === true,
+            looks_like_valid_match_detail: previewSummary.looks_like_valid_match_detail === true,
+            parser: 'NextDataParser.transformToApiFormat',
+            data_version: TARGET.dataVersion,
+            collected_at_policy: 'generated_by_phase_5_16_db_write_timestamp',
+            full_html_body_stored: false,
+            http_response_string_stored: false,
+            has_stats: payloadMeta.hasStats === true || Boolean(safePayload.content?.stats),
+            has_lineup: payloadMeta.hasLineup === true || Boolean(safePayload.content?.lineup),
+            has_shotmap: payloadMeta.hasShotmap === true || Boolean(safePayload.content?.shotmap),
+        },
+        content: jsonClone(safePayload.content || {}),
+        general: jsonClone(safePayload.general || {}),
+        header: jsonClone(safePayload.header || {}),
+        matchId: String(safePayload.matchId || value.externalId || TARGET.externalId),
+    };
+}
+
+function validateRawDataShape(rawData = {}) {
+    const errors = [];
+    for (const key of ['_meta', 'content', 'general', 'header', 'matchId']) {
+        if (!Object.prototype.hasOwnProperty.call(rawData, key)) {
+            errors.push(`raw_data missing ${key}`);
+        }
+    }
+    if (rawData._meta?.full_html_body_stored !== false) {
+        errors.push('raw_data._meta.full_html_body_stored must be false');
+    }
+    if (rawData._meta?.http_response_string_stored !== false) {
+        errors.push('raw_data._meta.http_response_string_stored must be false');
+    }
+    return errors;
+}
+
+function buildProtectedTableBaseline(source = {}) {
+    const rows = Array.isArray(source) ? source : null;
+    const objectSource = rows
+        ? Object.fromEntries(rows.map(row => [row.table_name, Number(row.rows)]))
+        : source && typeof source === 'object'
+          ? source
+          : {};
+
+    return {
+        matches: Number(objectSource.matches ?? 0),
+        raw_match_data: Number(objectSource.raw_match_data ?? 0),
+        bookmaker_odds_history: Number(objectSource.bookmaker_odds_history ?? 0),
+        l3_features: Number(objectSource.l3_features ?? 0),
+        match_features_training: Number(objectSource.match_features_training ?? 0),
+        predictions: Number(objectSource.predictions ?? 0),
+    };
+}
+
+function buildExpectedBaselineForExistingRows(existingRows = []) {
+    return {
+        ...EXPECTED_PRE_WRITE_BASELINE,
+        raw_match_data: Array.isArray(existingRows) && existingRows.length > 0 ? 3 : 2,
+    };
+}
+
+function validateBaselineExact(actual = {}, expected = {}) {
+    return Object.entries(expected)
+        .filter(([key, expectedValue]) => Number(actual[key]) !== expectedValue)
+        .map(([key, expectedValue]) => `${key} baseline expected ${expectedValue}, got ${actual[key]}`);
+}
+
+function assertSafeSelect(sql) {
+    const text = String(sql || '').trim();
+    const withoutTrailingSemicolon = text.replace(/;+\s*$/, '');
+    if (!/^\s*SELECT\b/i.test(withoutTrailingSemicolon)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (withoutTrailingSemicolon.includes(';')) {
+        throw new Error('Unsafe SQL blocked: multiple statements are not allowed');
+    }
+    if (/\bFOR\s+UPDATE\b/i.test(withoutTrailingSemicolon)) {
+        throw new Error('Unsafe SQL blocked: SELECT FOR UPDATE is not allowed');
+    }
+    for (const verb of FORBIDDEN_SELECT_SQL_VERBS) {
+        if (new RegExp(`\\b${verb}\\b`, 'i').test(withoutTrailingSemicolon)) {
+            throw new Error(`Unsafe SQL blocked: ${verb} is not allowed`);
+        }
+    }
+}
+
+async function safeSelect(client, sql, values = []) {
+    assertSafeSelect(sql);
+    return client.query(sql, values);
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD || 'football_pass',
+        application_name: 'l2_raw_match_data_write',
+        max: 2,
+        idleTimeoutMillis: 5000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+function createPgPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+function createCapturingFetchImpl(fetchImpl, captures) {
+    return async function capturingFetch(url, options) {
+        const response = await fetchImpl(url, options);
+        return {
+            status: response.status,
+            statusCode: response.statusCode,
+            ok: response.ok,
+            url: response.url || String(url),
+            headers: response.headers || {},
+            text: async () => {
+                const body = typeof response.text === 'function' ? await response.text() : '';
+                captures.push({
+                    request_url: String(url),
+                    final_url: response.url || String(url),
+                    body,
+                });
+                return body;
+            },
+        };
+    };
+}
+
+function extractPayloadFromBody(body, input = {}) {
+    const bodyText = String(body || '');
+    const nextData = extractFromHtml(bodyText);
+    if (!nextData.success) {
+        throw new Error(nextData.error || 'NEXT_DATA_PARSE_FAILED');
+    }
+
+    const transformed = transformToApiFormat(nextData.data, input.externalId || TARGET.externalId);
+    if (!transformed) {
+        throw new Error('NEXT_DATA_TRANSFORM_FAILED');
+    }
+    return transformed;
+}
+
+function buildRouteSelectorInput(value = {}) {
+    return {
+        source: value.source || TARGET.source,
+        matchId: value.matchId || TARGET.matchId,
+        externalId: value.externalId || TARGET.externalId,
+        homeTeam: value.homeTeam || TARGET.homeTeam,
+        awayTeam: value.awayTeam || TARGET.awayTeam,
+        route: TARGET.route,
+        networkAuthorization: true,
+        livePreviewAuthorization: true,
+        allowDbWrite: false,
+        allowRawMatchDataWrite: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        concurrency: 1,
+        retry: 0,
+        printBody: false,
+        saveBody: false,
+    };
+}
+
+async function recapturePreviewPayload(value, dependencies = {}) {
+    const fetchImpl = dependencies.fetchImpl || global.fetch;
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('FETCH_UNAVAILABLE: native fetch is not available');
+    }
+
+    const captures = [];
+    const selectorInput = buildRouteSelectorInput(value);
+    const selectorDependencies = {
+        ...dependencies,
+        fetchImpl: createCapturingFetchImpl(fetchImpl, captures),
+    };
+    const selectorResult = await runFotMobDetailRouteSelector(selectorInput, selectorDependencies);
+    const summary = buildRouteSelectorPreviewSummary(selectorInput, selectorResult);
+    const capture =
+        captures.find(item => item.final_url === summary.final_url || item.request_url === summary.request_url) ||
+        captures[captures.length - 1];
+
+    if (!capture) {
+        throw new Error('NO_CAPTURED_PREVIEW_BODY');
+    }
+
+    return {
+        summary,
+        payload: extractPayloadFromBody(capture.body, value),
+    };
+}
+
+async function resolvePreviewPayload(value, dependencies = {}) {
+    if (dependencies.previewPayloadResult) {
+        return dependencies.previewPayloadResult;
+    }
+    if (typeof dependencies.resolvePreviewPayload === 'function') {
+        return dependencies.resolvePreviewPayload({ input: value });
+    }
+    return recapturePreviewPayload(value, dependencies);
+}
+
+function validatePreviewSummary(summary = {}) {
+    const errors = [];
+    if (summary.ok !== true) {
+        errors.push(summary.controlled_error || 'route selector did not return a valid match detail payload');
+    }
+    if (summary.selected_route !== TARGET.route) {
+        errors.push(`selected_route must be ${TARGET.route}, got ${summary.selected_route || 'none'}`);
+    }
+    if (Number(summary.http_status) < 200 || Number(summary.http_status) >= 300) {
+        errors.push(`http_status must be 2xx, got ${summary.http_status}`);
+    }
+    if (summary.hydration_parse_ok !== true) {
+        errors.push('hydration_parse_ok must be true');
+    }
+    if (summary.looks_like_valid_match_detail !== true) {
+        errors.push('looks_like_valid_match_detail must be true');
+    }
+    if (summary.body_printed === true) {
+        errors.push('body_printed=true is blocked');
+    }
+    if (summary.body_saved === true) {
+        errors.push('body_saved=true is blocked');
+    }
+    if (summary.browser_used === true) {
+        errors.push('browser_used=true is blocked');
+    }
+    if (summary.proxy_used === true) {
+        errors.push('proxy_used=true is blocked');
+    }
+    return errors;
+}
+
+function validateTargetMatchRows(rows = []) {
+    const errors = [];
+    if (!Array.isArray(rows) || rows.length !== 1) {
+        return [`target match SELECT expected exactly 1 row, got ${Array.isArray(rows) ? rows.length : 0}`];
+    }
+    const row = rows[0];
+    if (normalizeText(row.match_id) !== TARGET.matchId) {
+        errors.push(`target match_id mismatch: ${row.match_id}`);
+    }
+    if (normalizeText(row.external_id) !== TARGET.externalId) {
+        errors.push(`target external_id mismatch: ${row.external_id}`);
+    }
+    if (!includesText(row.home_team, TARGET.homeTeam)) {
+        errors.push(`target home_team must contain ${TARGET.homeTeam}`);
+    }
+    if (!includesText(row.away_team, TARGET.awayTeam)) {
+        errors.push(`target away_team must contain ${TARGET.awayTeam}`);
+    }
+    return errors;
+}
+
+function validateExistingRawRows(rows = []) {
+    if (!Array.isArray(rows)) {
+        return ['existing raw_match_data SELECT did not return an array'];
+    }
+    if (rows.length > 1) {
+        return [`existing raw_match_data SELECT expected <= 1 row, got ${rows.length}`];
+    }
+    return [];
+}
+
+function createFailureResult(input = {}, overrides = {}) {
+    return buildControlledWriteResult({
+        input: normalizeWriteInput(input),
+        executionCompleted: false,
+        insertedCount: 0,
+        updatedCount: 0,
+        skippedCount: 0,
+        rawMatchDataWriteExecuted: false,
+        dbWriteExecuted: false,
+        matchesWriteExecuted: false,
+        trainingExecuted: false,
+        predictionExecuted: false,
+        transaction: {
+            began: false,
+            committed: false,
+            rolled_back: false,
+        },
+        hashMatchesPreflightBaseline:
+            overrides.hashMatchesPreflightBaseline === undefined ? null : overrides.hashMatchesPreflightBaseline,
+        bodyPrinted: false,
+        bodySaved: false,
+        browserUsed: false,
+        proxyUsed: false,
+        ...overrides,
+    });
+}
+
+function buildInsertRawMatchDataSql({ matchId, externalId, rawData, collectedAt, dataVersion, dataHash }) {
+    return {
+        text: `
+            INSERT INTO raw_match_data (
+                match_id,
+                external_id,
+                raw_data,
+                collected_at,
+                data_version,
+                data_hash
+            )
+            VALUES ($1, $2, $3::jsonb, $4::timestamptz, $5, $6)
+            RETURNING id, match_id, external_id, collected_at, data_version, data_hash
+        `,
+        values: [matchId, externalId, JSON.stringify(rawData), collectedAt, dataVersion, dataHash],
+    };
+}
+
+function buildPostWriteVerification(baselineSource = {}, verificationRow = null) {
+    const baseline = buildProtectedTableBaseline(baselineSource);
+    return {
+        raw_match_data_row_found: Boolean(verificationRow),
+        matches: baseline.matches,
+        raw_match_data: baseline.raw_match_data,
+        bookmaker_odds_history: baseline.bookmaker_odds_history,
+        l3_features: baseline.l3_features,
+        match_features_training: baseline.match_features_training,
+        predictions: baseline.predictions,
+    };
+}
+
+function buildControlledWriteResult({
+    input = {},
+    previewSummary = {},
+    rawDataHash = null,
+    executionCompleted = false,
+    existingRawMatchDataFound = false,
+    insertedCount = 0,
+    updatedCount = 0,
+    skippedCount = 0,
+    rawMatchDataWriteExecuted = false,
+    dbWriteExecuted = false,
+    matchesWriteExecuted = false,
+    trainingExecuted = false,
+    predictionExecuted = false,
+    transaction = {},
+    postWriteVerification = null,
+    insertedRow = null,
+    controlledError = null,
+    reason = null,
+    hashMatchesPreflightBaseline = null,
+    bodyPrinted = false,
+    bodySaved = false,
+    browserUsed = false,
+    proxyUsed = false,
+}) {
+    const value = normalizeWriteInput(input);
+    const result = {
+        phase: PHASE,
+        execution_completed: executionCompleted,
+        source: TARGET.source,
+        route: TARGET.route,
+        match_id: TARGET.matchId,
+        external_id: TARGET.externalId,
+        home_team: TARGET.homeTeam,
+        away_team: TARGET.awayTeam,
+        data_version: TARGET.dataVersion,
+        baseline_raw_data_hash: value.baselineRawDataHash || null,
+        raw_data_hash: rawDataHash,
+        hash_matches_preflight_baseline: hashMatchesPreflightBaseline,
+        selected_route: previewSummary.selected_route || null,
+        request_url: previewSummary.request_url || null,
+        final_url: previewSummary.final_url || null,
+        http_status: previewSummary.http_status ?? null,
+        content_type: previewSummary.content_type || null,
+        body_byte_length: previewSummary.body_byte_length ?? null,
+        body_sha256: previewSummary.body_sha256 || null,
+        hydration_parse_ok: previewSummary.hydration_parse_ok === true,
+        looks_like_valid_match_detail: previewSummary.looks_like_valid_match_detail === true,
+        existing_raw_match_data_found: existingRawMatchDataFound,
+        inserted_count: insertedCount,
+        updated_count: updatedCount,
+        skipped_count: skippedCount,
+        raw_match_data_write_executed: rawMatchDataWriteExecuted,
+        db_write_executed: dbWriteExecuted,
+        matches_write_executed: matchesWriteExecuted,
+        training_executed: trainingExecuted,
+        prediction_executed: predictionExecuted,
+        transaction: {
+            began: transaction.began === true,
+            committed: transaction.committed === true,
+            rolled_back: transaction.rolled_back === true,
+        },
+        post_write_verification: postWriteVerification || {
+            raw_match_data_row_found: false,
+            matches: null,
+            raw_match_data: null,
+            bookmaker_odds_history: null,
+            l3_features: null,
+            match_features_training: null,
+            predictions: null,
+        },
+        inserted_row_metadata: insertedRow
+            ? {
+                  id: insertedRow.id ?? null,
+                  match_id: insertedRow.match_id ?? null,
+                  external_id: insertedRow.external_id ?? null,
+                  collected_at: insertedRow.collected_at ?? null,
+                  data_version: insertedRow.data_version ?? null,
+                  data_hash: insertedRow.data_hash ?? null,
+              }
+            : null,
+        body_printed: bodyPrinted,
+        body_saved: bodySaved,
+        browser_used: browserUsed,
+        proxy_used: proxyUsed,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+
+    if (reason) {
+        result.reason = reason;
+    }
+    if (controlledError) {
+        result.controlled_error = controlledError;
+    }
+
+    return result;
+}
+
+async function acquireDbConnection(dependencies = {}) {
+    if (dependencies.client) {
+        return {
+            client: dependencies.client,
+            release: async () => {},
+            cleanupPool: async () => {},
+        };
+    }
+
+    const pool = dependencies.pool || (dependencies.createPool || createPgPool)();
+    if (pool && typeof pool.connect === 'function') {
+        const client = await pool.connect();
+        return {
+            client,
+            release: async () => {
+                if (typeof client.release === 'function') {
+                    client.release();
+                }
+            },
+            cleanupPool: async () => {
+                if (!dependencies.pool && typeof pool.end === 'function') {
+                    await pool.end();
+                }
+            },
+        };
+    }
+
+    return {
+        client: pool,
+        release: async () => {},
+        cleanupPool: async () => {
+            if (!dependencies.pool && pool && typeof pool.end === 'function') {
+                await pool.end();
+            }
+        },
+    };
+}
+
+async function selectTargetMatch(client, value) {
+    const query = `
+        SELECT match_id, external_id, home_team, away_team, match_date, status
+        FROM matches
+        WHERE match_id = $1
+           OR external_id = $2
+        ORDER BY match_id
+    `;
+    const result = await safeSelect(client, query, [value.matchId, value.externalId]);
+    return result.rows || [];
+}
+
+async function selectExistingRawMatchData(client, value) {
+    const query = `
+        SELECT id, match_id, external_id, collected_at, data_version, data_hash
+        FROM raw_match_data
+        WHERE match_id = $1
+           OR external_id = $2
+        ORDER BY collected_at DESC NULLS LAST, id DESC
+    `;
+    const result = await safeSelect(client, query, [value.matchId, value.externalId]);
+    return result.rows || [];
+}
+
+async function selectProtectedTableBaseline(client) {
+    const query = `
+        SELECT 'matches' AS table_name, COUNT(*)::int AS rows FROM matches
+        UNION ALL
+        SELECT 'bookmaker_odds_history', COUNT(*)::int FROM bookmaker_odds_history
+        UNION ALL
+        SELECT 'raw_match_data', COUNT(*)::int FROM raw_match_data
+        UNION ALL
+        SELECT 'l3_features', COUNT(*)::int FROM l3_features
+        UNION ALL
+        SELECT 'match_features_training', COUNT(*)::int FROM match_features_training
+        UNION ALL
+        SELECT 'predictions', COUNT(*)::int FROM predictions
+    `;
+    const result = await safeSelect(client, query, []);
+    return buildProtectedTableBaseline(result.rows || []);
+}
+
+async function selectVerificationRow(client, value) {
+    const query = `
+        SELECT id, match_id, external_id, collected_at, data_version, data_hash
+        FROM raw_match_data
+        WHERE match_id = $1
+           OR external_id = $2
+        ORDER BY collected_at DESC NULLS LAST, id DESC
+    `;
+    const result = await safeSelect(client, query, [value.matchId, value.externalId]);
+    return Array.isArray(result.rows) && result.rows.length > 0 ? result.rows[0] : null;
+}
+
+function nowUtcIso(dependencies = {}) {
+    if (typeof dependencies.now === 'function') {
+        return dependencies.now();
+    }
+    if (dependencies.now) {
+        return dependencies.now;
+    }
+    return new Date().toISOString();
+}
+
+async function executeRawMatchDataWrite(input = {}, dependencies = {}) {
+    const validation = dependencies.skipValidation
+        ? {
+              ok: true,
+              errors: [],
+              value: normalizeWriteInput(input),
+          }
+        : validateWriteInput(input);
+    if (!validation.ok) {
+        return createFailureResult(input, {
+            controlledError: `INVALID_CONTROLLED_WRITE_INPUT:${validation.errors.join('; ')}`,
+            hashMatchesPreflightBaseline: false,
+        });
+    }
+
+    const value = validation.value;
+    const preview = await resolvePreviewPayload(value, dependencies);
+    const previewSummary = preview.summary || {};
+    const previewErrors = validatePreviewSummary(previewSummary);
+    if (previewErrors.length > 0) {
+        return createFailureResult(value, {
+            previewSummary,
+            controlledError: `INVALID_PREVIEW_RESULT:${previewErrors.join('; ')}`,
+            hashMatchesPreflightBaseline: false,
+        });
+    }
+
+    const rawData = buildRawDataFromPreviewPayload(preview.payload, previewSummary, value);
+    const rawDataErrors = validateRawDataShape(rawData);
+    if (rawDataErrors.length > 0) {
+        return createFailureResult(value, {
+            previewSummary,
+            controlledError: `INVALID_RAW_DATA:${rawDataErrors.join('; ')}`,
+            hashMatchesPreflightBaseline: false,
+        });
+    }
+
+    const rawDataHash = dependencies.rawDataHashOverride || sha256CanonicalJson(rawData);
+    if (rawDataHash !== value.baselineRawDataHash) {
+        return createFailureResult(value, {
+            previewSummary,
+            rawDataHash,
+            hashMatchesPreflightBaseline: false,
+            controlledError: `RAW_DATA_HASH_DRIFT: computed raw_data_hash ${rawDataHash} differs from baseline ${value.baselineRawDataHash}`,
+            reason: 'hash_drift',
+        });
+    }
+
+    let connection = null;
+    const transaction = {
+        began: false,
+        committed: false,
+        rolled_back: false,
+    };
+    try {
+        connection = await acquireDbConnection(dependencies);
+        await connection.client.query('BEGIN');
+        transaction.began = true;
+
+        const targetMatchRows = await selectTargetMatch(connection.client, value);
+        const targetErrors = validateTargetMatchRows(targetMatchRows);
+        if (targetErrors.length > 0) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return createFailureResult(value, {
+                previewSummary,
+                rawDataHash,
+                hashMatchesPreflightBaseline: true,
+                transaction,
+                controlledError: `TARGET_MATCH_VALIDATION_FAILED:${targetErrors.join('; ')}`,
+            });
+        }
+
+        const existingRawMatchDataRows =
+            dependencies.existingRawMatchDataRowsOverride ||
+            (await selectExistingRawMatchData(connection.client, value));
+        const existingRawErrors = validateExistingRawRows(existingRawMatchDataRows);
+        if (existingRawErrors.length > 0) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return createFailureResult(value, {
+                previewSummary,
+                rawDataHash,
+                hashMatchesPreflightBaseline: true,
+                transaction,
+                controlledError: `EXISTING_RAW_MATCH_DATA_VALIDATION_FAILED:${existingRawErrors.join('; ')}`,
+            });
+        }
+
+        const preWriteBaseline =
+            dependencies.preWriteBaselineOverride || (await selectProtectedTableBaseline(connection.client));
+        const preWriteBaselineErrors = validateBaselineExact(
+            preWriteBaseline,
+            buildExpectedBaselineForExistingRows(existingRawMatchDataRows)
+        );
+        if (preWriteBaselineErrors.length > 0) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return createFailureResult(value, {
+                previewSummary,
+                rawDataHash,
+                hashMatchesPreflightBaseline: true,
+                transaction,
+                controlledError: `PRE_WRITE_BASELINE_MISMATCH:${preWriteBaselineErrors.join('; ')}`,
+            });
+        }
+
+        if (existingRawMatchDataRows.length === 1) {
+            const existingRow = existingRawMatchDataRows[0];
+            if (normalizeText(existingRow.data_hash) === rawDataHash) {
+                const verificationRow = dependencies.verificationRowOverride || existingRow;
+                const postWriteVerification = buildPostWriteVerification(preWriteBaseline, verificationRow);
+                await connection.client.query('COMMIT');
+                transaction.committed = true;
+                return buildControlledWriteResult({
+                    input: value,
+                    previewSummary,
+                    rawDataHash,
+                    executionCompleted: true,
+                    existingRawMatchDataFound: true,
+                    insertedCount: 0,
+                    updatedCount: 0,
+                    skippedCount: 1,
+                    rawMatchDataWriteExecuted: false,
+                    dbWriteExecuted: false,
+                    matchesWriteExecuted: false,
+                    trainingExecuted: false,
+                    predictionExecuted: false,
+                    transaction,
+                    postWriteVerification,
+                    insertedRow: verificationRow,
+                    reason: 'same_hash_existing_row',
+                    hashMatchesPreflightBaseline: true,
+                    bodyPrinted: false,
+                    bodySaved: false,
+                    browserUsed: false,
+                    proxyUsed: false,
+                });
+            }
+
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return createFailureResult(value, {
+                previewSummary,
+                rawDataHash,
+                hashMatchesPreflightBaseline: true,
+                transaction,
+                controlledError: `EXISTING_ROW_HASH_MISMATCH_REQUIRES_UPDATE_AUTHORIZATION: existing ${normalizeText(
+                    existingRow.data_hash
+                )} differs from computed ${rawDataHash}`,
+                reason: 'existing_row_hash_mismatch',
+            });
+        }
+
+        const collectedAt = nowUtcIso(dependencies);
+        const insertSql = buildInsertRawMatchDataSql({
+            matchId: value.matchId,
+            externalId: value.externalId,
+            rawData,
+            collectedAt,
+            dataVersion: value.dataVersion,
+            dataHash: rawDataHash,
+        });
+        const insertResult = await connection.client.query(insertSql.text, insertSql.values);
+        const insertedRow =
+            dependencies.insertedRowOverride ||
+            (Array.isArray(insertResult.rows) && insertResult.rows.length > 0 ? insertResult.rows[0] : null);
+        const verificationRow =
+            dependencies.verificationRowOverride || (await selectVerificationRow(connection.client, value));
+        const postWriteCounts =
+            dependencies.postWriteBaselineOverride || (await selectProtectedTableBaseline(connection.client));
+        const postWriteBaselineErrors = validateBaselineExact(postWriteCounts, EXPECTED_POST_WRITE_BASELINE);
+        if (!verificationRow) {
+            postWriteBaselineErrors.push('post-write verification row not found');
+        }
+        if (postWriteBaselineErrors.length > 0) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return createFailureResult(value, {
+                previewSummary,
+                rawDataHash,
+                hashMatchesPreflightBaseline: true,
+                transaction,
+                controlledError: `POST_WRITE_VERIFICATION_FAILED:${postWriteBaselineErrors.join('; ')}`,
+            });
+        }
+
+        await connection.client.query('COMMIT');
+        transaction.committed = true;
+
+        return buildControlledWriteResult({
+            input: value,
+            previewSummary,
+            rawDataHash,
+            executionCompleted: true,
+            existingRawMatchDataFound: false,
+            insertedCount: 1,
+            updatedCount: 0,
+            skippedCount: 0,
+            rawMatchDataWriteExecuted: true,
+            dbWriteExecuted: true,
+            matchesWriteExecuted: false,
+            trainingExecuted: false,
+            predictionExecuted: false,
+            transaction,
+            postWriteVerification: buildPostWriteVerification(postWriteCounts, verificationRow),
+            insertedRow: insertedRow || verificationRow,
+            hashMatchesPreflightBaseline: true,
+            bodyPrinted: false,
+            bodySaved: false,
+            browserUsed: false,
+            proxyUsed: false,
+        });
+    } catch (error) {
+        if (transaction.began && transaction.committed !== true && transaction.rolled_back !== true) {
+            try {
+                await connection.client.query('ROLLBACK');
+                transaction.rolled_back = true;
+            } catch (rollbackError) {
+                error.rollback_error = rollbackError.message;
+            }
+        }
+        return createFailureResult(value, {
+            previewSummary,
+            rawDataHash,
+            hashMatchesPreflightBaseline:
+                rawDataHash && value.baselineRawDataHash ? rawDataHash === value.baselineRawDataHash : null,
+            transaction,
+            controlledError: String(error.message || error),
+        });
+    } finally {
+        if (connection) {
+            await connection.release();
+            await connection.cleanupPool();
+        }
+    }
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l2_raw_match_data_write.js --source=fotmob --route=html_hydration --match-id=53_20252026_4830746 --external-id=4830746 --home-team=Angers --away-team=Strasbourg --data-version=fotmob_html_hyd_v1 --baseline-raw-data-hash=d40f757adccf5be96d107188196efa905b6b573b62d7b4428014d7ce4f39a1f6 --network-authorization=yes --live-preview-authorization=yes --final-db-write-confirmation=yes --allow-db-write=yes --allow-raw-match-data-write=yes --allow-matches-write=no --allow-training=no --allow-prediction=no --concurrency=1 --retry=0 --print-body=no --save-body=no',
+        '',
+        'Safety:',
+        '  Phase 5.16L2 performs one controlled live recapture, enforces the Phase 5.15 baseline raw_data_hash, and writes only raw_match_data inside a transaction.',
+    ].join('\n');
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const stdout = io.stdout || process.stdout.write.bind(process.stdout);
+    const args = parseArgs(argv);
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    const result = await executeRawMatchDataWrite(args, dependencies);
+    stdout(`${JSON.stringify(result, null, 2)}\n`);
+    return result.execution_completed ? 0 : 1;
+}
+
+if (require.main === module) {
+    runCli()
+        .then(status => {
+            process.exitCode = status;
+        })
+        .catch(error => {
+            process.stdout.write(
+                `${JSON.stringify(
+                    createFailureResult(
+                        {},
+                        {
+                            controlledError: String(error.message || error),
+                        }
+                    ),
+                    null,
+                    2
+                )}\n`
+            );
+            process.exitCode = 1;
+        });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    validateWriteInput,
+    canonicalizeJson,
+    sha256CanonicalJson,
+    buildRawDataFromPreviewPayload,
+    buildInsertRawMatchDataSql,
+    buildPostWriteVerification,
+    executeRawMatchDataWrite,
+    buildControlledWriteResult,
+    runCli,
+};

--- a/tests/unit/l2_raw_match_data_write.test.js
+++ b/tests/unit/l2_raw_match_data_write.test.js
@@ -1,0 +1,1097 @@
+/* eslint-disable max-lines */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l2_raw_match_data_write.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+const BASELINE_RAW_DATA_HASH = 'd40f757adccf5be96d107188196efa905b6b573b62d7b4428014d7ce4f39a1f6';
+const PREVIEW_BODY_SHA256 = '394e4d4546ba52859b93b07167cd9000cd89758770d7cc16b3688626acee7980';
+const PRE_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 2,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+const POST_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 3,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function validArgs(overrides = {}) {
+    return {
+        source: 'fotmob',
+        route: 'html_hydration',
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        homeTeam: 'Angers',
+        awayTeam: 'Strasbourg',
+        dataVersion: 'fotmob_html_hyd_v1',
+        baselineRawDataHash: BASELINE_RAW_DATA_HASH,
+        networkAuthorization: true,
+        livePreviewAuthorization: true,
+        finalDbWriteConfirmation: true,
+        allowDbWrite: true,
+        allowRawMatchDataWrite: true,
+        allowMatchesWrite: false,
+        allowTraining: false,
+        allowPrediction: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        concurrency: 1,
+        retry: 0,
+        printBody: false,
+        saveBody: false,
+        bulk: false,
+        commit: false,
+        execute: false,
+        ...overrides,
+    };
+}
+
+function toYesNo(value) {
+    return value ? 'yes' : 'no';
+}
+
+function cliArgs(overrides = {}) {
+    const args = validArgs(overrides);
+    const pairs = [
+        ['source', args.source],
+        ['route', args.route],
+        ['match-id', args.matchId],
+        ['external-id', args.externalId],
+        ['home-team', args.homeTeam],
+        ['away-team', args.awayTeam],
+        ['data-version', args.dataVersion],
+        ['baseline-raw-data-hash', args.baselineRawDataHash],
+        ['network-authorization', toYesNo(args.networkAuthorization)],
+        ['live-preview-authorization', toYesNo(args.livePreviewAuthorization)],
+        ['final-db-write-confirmation', toYesNo(args.finalDbWriteConfirmation)],
+        ['allow-db-write', toYesNo(args.allowDbWrite)],
+        ['allow-raw-match-data-write', toYesNo(args.allowRawMatchDataWrite)],
+        ['allow-matches-write', toYesNo(args.allowMatchesWrite)],
+        ['allow-training', toYesNo(args.allowTraining)],
+        ['allow-prediction', toYesNo(args.allowPrediction)],
+        ['allow-browser-runtime', toYesNo(args.allowBrowserRuntime)],
+        ['allow-proxy-runtime', toYesNo(args.allowProxyRuntime)],
+        ['concurrency', args.concurrency],
+        ['retry', args.retry],
+        ['print-body', toYesNo(args.printBody)],
+        ['save-body', toYesNo(args.saveBody)],
+        ['bulk', toYesNo(args.bulk)],
+        ['commit', toYesNo(args.commit)],
+        ['execute', toYesNo(args.execute)],
+    ];
+    return pairs.map(([key, value]) => `--${key}=${value}`);
+}
+
+function fakePayload() {
+    return {
+        matchId: '4830746',
+        content: {
+            stats: [{ title: 'Top stats', stats: [] }],
+            lineup: { homeTeam: 'Angers', awayTeam: 'Strasbourg' },
+            shotmap: [],
+        },
+        general: {
+            matchId: '4830746',
+            homeTeam: { name: 'Angers' },
+            awayTeam: { name: 'Strasbourg' },
+        },
+        header: {
+            teams: [
+                { name: 'Angers', id: 982 },
+                { name: 'Strasbourg', id: 984 },
+            ],
+        },
+        _meta: {
+            hasStats: true,
+            hasLineup: true,
+            hasShotmap: true,
+        },
+        fullHtmlBody: '<html>must not be copied</html>',
+        httpResponseString: 'must not be copied',
+    };
+}
+
+function fakePreviewResult(overrides = {}) {
+    return {
+        summary: {
+            ok: true,
+            selected_route: 'html_hydration',
+            request_url: 'https://www.fotmob.com/match/4830746',
+            final_url: 'https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och',
+            http_status: 200,
+            content_type: 'text/html; charset=utf-8',
+            body_byte_length: 1037598,
+            body_sha256: PREVIEW_BODY_SHA256,
+            hydration_parse_ok: true,
+            looks_like_valid_match_detail: true,
+            body_printed: false,
+            body_saved: false,
+            browser_used: false,
+            proxy_used: false,
+            ...overrides.summary,
+        },
+        payload: overrides.payload || fakePayload(),
+    };
+}
+
+function fakeHtml() {
+    const nextData = {
+        props: {
+            pageProps: {
+                content: {
+                    stats: [{ title: 'Top stats', stats: [] }],
+                    lineup: { homeTeam: 'Angers', awayTeam: 'Strasbourg' },
+                    shotmap: [],
+                },
+                general: {
+                    matchId: '4830746',
+                    homeTeam: { name: 'Angers' },
+                    awayTeam: { name: 'Strasbourg' },
+                },
+                header: {
+                    teams: [
+                        { name: 'Angers', id: 982 },
+                        { name: 'Strasbourg', id: 984 },
+                    ],
+                },
+            },
+        },
+    };
+    return `<html><body>Angers Strasbourg 4830746<script id="__NEXT_DATA__" type="application/json">${JSON.stringify(
+        nextData
+    )}</script></body></html>`;
+}
+
+function fakeFetchImpl() {
+    return async url => ({
+        status: 200,
+        statusCode: 200,
+        ok: true,
+        url: 'https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och',
+        headers: {
+            get: name => (String(name).toLowerCase() === 'content-type' ? 'text/html; charset=utf-8' : ''),
+        },
+        text: async () => {
+            assert.equal(String(url), 'https://www.fotmob.com/match/4830746');
+            return fakeHtml();
+        },
+    });
+}
+
+function targetMatchRows() {
+    return [
+        {
+            match_id: '53_20252026_4830746',
+            external_id: '4830746',
+            home_team: 'Angers',
+            away_team: 'Strasbourg',
+            match_date: '2026-05-10T19:00:00.000Z',
+            status: 'finished',
+        },
+    ];
+}
+
+function insertedRow(overrides = {}) {
+    return {
+        id: 99,
+        match_id: '53_20252026_4830746',
+        external_id: '4830746',
+        collected_at: '2026-05-14T10:11:12.000Z',
+        data_version: 'fotmob_html_hyd_v1',
+        data_hash: BASELINE_RAW_DATA_HASH,
+        ...overrides,
+    };
+}
+
+function fakeDeps(overrides = {}) {
+    return {
+        previewPayloadResult: fakePreviewResult(overrides.preview || {}),
+        now: '2026-05-14T10:11:12.000Z',
+        rawDataHashOverride: BASELINE_RAW_DATA_HASH,
+        ...overrides,
+    };
+}
+
+function isSelectUnionQuery(text) {
+    return /^SELECT/i.test(text) && text.includes('UNION ALL');
+}
+
+function isSelectMatchesQuery(text) {
+    return /^SELECT/i.test(text) && text.includes('FROM matches');
+}
+
+function isSelectRawMatchDataQuery(text) {
+    return /^SELECT/i.test(text) && text.includes('FROM raw_match_data');
+}
+
+function isInsertRawMatchDataQuery(text) {
+    return /^INSERT\s+INTO\s+raw_match_data/i.test(text);
+}
+
+function buildBaselineRows(baselineRows) {
+    return Object.entries(baselineRows).map(([table_name, rows]) => ({ table_name, rows }));
+}
+
+function resolveBaselineRows(queries, existingRows, preBaseline, postBaseline) {
+    return queries.some(item => isInsertRawMatchDataQuery(item.text)) || existingRows.length > 0
+        ? postBaseline
+        : preBaseline;
+}
+
+function resolveRawMatchRows(queries, existingRows, verificationRow) {
+    const selectCount = queries.filter(item => isSelectRawMatchDataQuery(item.text)).length;
+    if (existingRows.length > 0) {
+        return existingRows;
+    }
+    if (selectCount === 1) {
+        return [];
+    }
+    return verificationRow ? [verificationRow] : [];
+}
+
+function buildQueryResponse(text, queries, options) {
+    const { existingRows, preBaseline, postBaseline, insertFailure, verificationRow } = options;
+
+    if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') {
+        return { rows: [] };
+    }
+    if (isSelectUnionQuery(text)) {
+        return {
+            rows: buildBaselineRows(resolveBaselineRows(queries, existingRows, preBaseline, postBaseline)),
+        };
+    }
+    if (isSelectMatchesQuery(text)) {
+        return { rows: targetMatchRows() };
+    }
+    if (isSelectRawMatchDataQuery(text)) {
+        return {
+            rows: resolveRawMatchRows(queries, existingRows, verificationRow),
+        };
+    }
+    if (isInsertRawMatchDataQuery(text)) {
+        if (insertFailure) {
+            throw insertFailure;
+        }
+        return {
+            rows: verificationRow ? [verificationRow] : [],
+        };
+    }
+    throw new Error(`unexpected query: ${text}`);
+}
+
+function buildReadWriteClient({
+    existingRows = [],
+    preBaseline = PRE_BASELINE,
+    postBaseline = POST_BASELINE,
+    insertFailure = null,
+    verificationRow = insertedRow(),
+} = {}) {
+    const queries = [];
+    const options = {
+        existingRows,
+        preBaseline,
+        postBaseline,
+        insertFailure,
+        verificationRow,
+    };
+    return {
+        queries,
+        async query(sql, values = []) {
+            const text = String(sql || '').trim();
+            queries.push({ text, values });
+            return buildQueryResponse(text, queries, options);
+        },
+    };
+}
+
+function buildConnectablePool(client) {
+    let released = false;
+    let ended = false;
+    return {
+        pool: {
+            async connect() {
+                return {
+                    query: client.query.bind(client),
+                    release() {
+                        released = true;
+                    },
+                };
+            },
+            async end() {
+                ended = true;
+            },
+        },
+        get released() {
+            return released;
+        },
+        get ended() {
+            return ended;
+        },
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalFetch = global.fetch;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l2_raw_match_data_write`);
+    };
+
+    global.fetch = fail('global.fetch');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'playwright',
+            'playwright-core',
+            'puppeteer',
+            'child_process',
+            'node:child_process',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        Module._load = originalLoad;
+    });
+}
+
+async function runCli(gate, argv, dependencies = fakeDeps()) {
+    let stdout = '';
+    const status = await gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return {
+        status,
+        stdout,
+        payload: stdout.trim().startsWith('{') ? JSON.parse(stdout) : null,
+    };
+}
+
+function assertInvalid(overrides, pattern) {
+    const gate = loadModuleFresh();
+    const validation = gate.validateWriteInput(validArgs(overrides));
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), pattern);
+}
+
+test('valid input succeeds', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validateWriteInput(validArgs());
+    assert.equal(validation.ok, true);
+    assert.deepEqual(validation.errors, []);
+});
+
+test('source missing fails', () => assertInvalid({ source: '' }, /missing source/));
+test('source non-fotmob fails', () => assertInvalid({ source: 'other' }, /unsupported source/));
+test('route missing fails', () => assertInvalid({ route: '' }, /missing route/));
+test('route unsupported fails', () => assertInvalid({ route: 'auto' }, /unsupported route/));
+test('match-id missing fails', () => assertInvalid({ matchId: '' }, /missing match-id/));
+test('match-id not 53_20252026_4830746 fails', () => assertInvalid({ matchId: 'x' }, /match-id must be/));
+test('external-id missing fails', () => assertInvalid({ externalId: '' }, /missing external-id/));
+test('external-id not 4830746 fails', () => assertInvalid({ externalId: '1' }, /external-id must be/));
+test('home-team missing Angers fails', () => assertInvalid({ homeTeam: 'Paris' }, /home-team must contain Angers/));
+test('away-team missing Strasbourg fails', () =>
+    assertInvalid({ awayTeam: 'Lens' }, /away-team must contain Strasbourg/));
+test('data-version missing fails', () => assertInvalid({ dataVersion: '' }, /missing data-version/));
+test('data-version not fotmob_html_hyd_v1 fails', () =>
+    assertInvalid({ dataVersion: 'other_v1' }, /data-version must be/));
+test('baseline hash missing fails', () => assertInvalid({ baselineRawDataHash: '' }, /missing baseline-raw-data-hash/));
+test('baseline hash wrong fails', () =>
+    assertInvalid({ baselineRawDataHash: 'abc' }, /baseline-raw-data-hash must be/));
+test('network-authorization=no fails', () =>
+    assertInvalid({ networkAuthorization: false }, /network-authorization=yes is required/));
+test('live-preview-authorization=no fails', () =>
+    assertInvalid({ livePreviewAuthorization: false }, /live-preview-authorization=yes is required/));
+test('final-db-write-confirmation=no fails', () =>
+    assertInvalid({ finalDbWriteConfirmation: false }, /final-db-write-confirmation=yes is required/));
+test('allow-db-write=no fails', () => assertInvalid({ allowDbWrite: false }, /allow-db-write=yes is required/));
+test('allow-raw-match-data-write=no fails', () =>
+    assertInvalid({ allowRawMatchDataWrite: false }, /allow-raw-match-data-write=yes is required/));
+test('allow-matches-write=yes blocked', () =>
+    assertInvalid({ allowMatchesWrite: true }, /allow-matches-write=yes is blocked/));
+test('allow-training=yes blocked', () => assertInvalid({ allowTraining: true }, /allow-training=yes is blocked/));
+test('allow-prediction=yes blocked', () => assertInvalid({ allowPrediction: true }, /allow-prediction=yes is blocked/));
+test('retry > 0 blocked', () => assertInvalid({ retry: 1 }, /retry > 0 is blocked/));
+test('concurrency > 1 blocked', () => assertInvalid({ concurrency: 2 }, /concurrency > 1 is blocked/));
+test('print-body=yes blocked', () => assertInvalid({ printBody: true }, /print-body=yes is blocked/));
+test('save-body=yes blocked', () => assertInvalid({ saveBody: true }, /save-body=yes is blocked/));
+test('browser/proxy allowed blocked', () => {
+    assertInvalid({ allowBrowserRuntime: true }, /allow-browser-runtime=yes is blocked/);
+    assertInvalid({ allowProxyRuntime: true }, /allow-proxy-runtime=yes is blocked/);
+});
+test('bulk=yes blocked', () => assertInvalid({ bulk: true }, /bulk=yes is blocked/));
+
+test('normalizeBooleanFlag handles fallback and parseArgs handles unknown arguments', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.normalizeBooleanFlag('YES'), true);
+    assert.equal(gate.normalizeBooleanFlag('off'), false);
+    assert.equal(gate.normalizeBooleanFlag('maybe', false), false);
+    assert.equal(gate.normalizeBooleanFlag('', true), true);
+
+    const args = gate.parseArgs(['orphan', '--source', 'fotmob', '--route', 'html_hydration', '--mystery', '--help']);
+    assert.equal(args.source, 'fotmob');
+    assert.equal(args.route, 'html_hydration');
+    assert.equal(args.help, true);
+    assert.deepEqual(args.unknown, ['orphan', 'mystery']);
+});
+
+test('validateWriteInput reports missing required flags and invalid numeric knobs', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validateWriteInput(
+        validArgs({
+            networkAuthorization: undefined,
+            livePreviewAuthorization: undefined,
+            finalDbWriteConfirmation: undefined,
+            allowDbWrite: undefined,
+            allowRawMatchDataWrite: undefined,
+            allowMatchesWrite: undefined,
+            allowTraining: undefined,
+            allowPrediction: undefined,
+            printBody: undefined,
+            saveBody: undefined,
+            homeTeam: '',
+            awayTeam: '',
+            concurrency: 'many',
+            retry: 'later',
+        })
+    );
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), /missing network-authorization=yes/);
+    assert.match(validation.errors.join('\n'), /missing live-preview-authorization=yes/);
+    assert.match(validation.errors.join('\n'), /missing final-db-write-confirmation=yes/);
+    assert.match(validation.errors.join('\n'), /missing allow-db-write=yes/);
+    assert.match(validation.errors.join('\n'), /missing allow-raw-match-data-write=yes/);
+    assert.match(validation.errors.join('\n'), /missing allow-matches-write=no/);
+    assert.match(validation.errors.join('\n'), /missing allow-training=no/);
+    assert.match(validation.errors.join('\n'), /missing allow-prediction=no/);
+    assert.match(validation.errors.join('\n'), /missing print-body=no/);
+    assert.match(validation.errors.join('\n'), /missing save-body=no/);
+    assert.match(validation.errors.join('\n'), /missing home-team/);
+    assert.match(validation.errors.join('\n'), /missing away-team/);
+    assert.match(validation.errors.join('\n'), /concurrency must be 1/);
+    assert.match(validation.errors.join('\n'), /retry must be 0/);
+});
+
+test('canonicalizeJson stable', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.canonicalizeJson({ z: 1, a: { c: 3, b: 2 } }), '{"a":{"b":2,"c":3},"z":1}');
+});
+
+test('sha256CanonicalJson stable', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.sha256CanonicalJson({ b: 2, a: 1 }), gate.sha256CanonicalJson({ a: 1, b: 2 }));
+});
+
+test('buildRawData excludes full HTML body', () => {
+    const gate = loadModuleFresh();
+    const preview = fakePreviewResult();
+    const rawData = gate.buildRawDataFromPreviewPayload(preview.payload, preview.summary, validArgs());
+    assert.equal(rawData.fullHtmlBody, undefined);
+    assert.equal(rawData.httpResponseString, undefined);
+    assert.equal(JSON.stringify(rawData).includes('<html>must not be copied</html>'), false);
+});
+
+test('buildRawData includes _meta/content/general/header/matchId', () => {
+    const gate = loadModuleFresh();
+    const preview = fakePreviewResult();
+    const rawData = gate.buildRawDataFromPreviewPayload(preview.payload, preview.summary, validArgs());
+    assert.deepEqual(Object.keys(rawData).sort(), ['_meta', 'content', 'general', 'header', 'matchId'].sort());
+    assert.equal(rawData.matchId, '4830746');
+});
+
+test('buildRawData handles non-object payload without HTML body fields', () => {
+    const gate = loadModuleFresh();
+    const rawData = gate.buildRawDataFromPreviewPayload(null, fakePreviewResult().summary, validArgs());
+    assert.deepEqual(rawData.content, {});
+    assert.deepEqual(rawData.general, {});
+    assert.deepEqual(rawData.header, {});
+    assert.equal(rawData.matchId, '4830746');
+    assert.equal(rawData._meta.has_stats, false);
+    assert.equal(rawData._meta.full_html_body_stored, false);
+    assert.equal(rawData._meta.http_response_string_stored, false);
+});
+
+test('invalid preview summary returns controlled error', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps({
+            preview: {
+                summary: {
+                    ok: false,
+                    controlled_error: 'NO_VALID_ROUTE_PAYLOAD',
+                    selected_route: 'none',
+                    http_status: 403,
+                    hydration_parse_ok: false,
+                    looks_like_valid_match_detail: false,
+                    body_printed: true,
+                    body_saved: true,
+                    browser_used: true,
+                    proxy_used: true,
+                },
+            },
+        }),
+    });
+    assert.equal(result.execution_completed, false);
+    assert.match(result.controlled_error, /NO_VALID_ROUTE_PAYLOAD/);
+    assert.match(result.controlled_error, /body_printed=true is blocked/);
+    assert.match(result.controlled_error, /body_saved=true is blocked/);
+    assert.match(result.controlled_error, /browser_used=true is blocked/);
+    assert.match(result.controlled_error, /proxy_used=true is blocked/);
+});
+
+test('target match validation failures return controlled error', async () => {
+    const gate = loadModuleFresh();
+    const missingTargetClient = buildReadWriteClient();
+    missingTargetClient.query = async (sql, values = []) => {
+        const text = String(sql || '').trim();
+        missingTargetClient.queries.push({ text, values });
+        if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') {
+            return { rows: [] };
+        }
+        if (isSelectMatchesQuery(text)) {
+            return { rows: [] };
+        }
+        return buildQueryResponse(text, missingTargetClient.queries, {
+            existingRows: [],
+            preBaseline: PRE_BASELINE,
+            postBaseline: POST_BASELINE,
+            insertFailure: null,
+            verificationRow: insertedRow(),
+        });
+    };
+    const missingResult = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client: missingTargetClient,
+    });
+    assert.equal(missingResult.execution_completed, false);
+    assert.match(missingResult.controlled_error, /TARGET_MATCH_VALIDATION_FAILED/);
+
+    const mismatchClient = buildReadWriteClient();
+    mismatchClient.query = async (sql, values = []) => {
+        const text = String(sql || '').trim();
+        mismatchClient.queries.push({ text, values });
+        if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') {
+            return { rows: [] };
+        }
+        if (isSelectMatchesQuery(text)) {
+            return {
+                rows: [
+                    {
+                        match_id: '53_20252026_4830746',
+                        external_id: '999',
+                        home_team: 'Paris',
+                        away_team: 'Lens',
+                    },
+                ],
+            };
+        }
+        return buildQueryResponse(text, mismatchClient.queries, {
+            existingRows: [],
+            preBaseline: PRE_BASELINE,
+            postBaseline: POST_BASELINE,
+            insertFailure: null,
+            verificationRow: insertedRow(),
+        });
+    };
+    const mismatchResult = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client: mismatchClient,
+    });
+    assert.equal(mismatchResult.execution_completed, false);
+    assert.match(mismatchResult.controlled_error, /target external_id mismatch/);
+    assert.match(mismatchResult.controlled_error, /target home_team must contain Angers/);
+    assert.match(mismatchResult.controlled_error, /target away_team must contain Strasbourg/);
+});
+
+test('multiple existing raw rows return controlled error', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient({
+        existingRows: [insertedRow({ id: 1 }), insertedRow({ id: 2 })],
+        preBaseline: POST_BASELINE,
+        postBaseline: POST_BASELINE,
+    });
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, false);
+    assert.match(result.controlled_error, /EXISTING_RAW_MATCH_DATA_VALIDATION_FAILED/);
+});
+
+test('pre-write baseline mismatch returns controlled error', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient({
+        preBaseline: {
+            ...PRE_BASELINE,
+            raw_match_data: 9,
+        },
+    });
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, false);
+    assert.match(result.controlled_error, /PRE_WRITE_BASELINE_MISMATCH/);
+});
+
+test('post-write verification failure rolls back', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient({
+        verificationRow: null,
+        postBaseline: {
+            ...POST_BASELINE,
+            raw_match_data: 2,
+        },
+    });
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.transaction.rolled_back, true);
+    assert.match(result.controlled_error, /POST_WRITE_VERIFICATION_FAILED/);
+});
+
+test('hash drift stops before DB write', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+        rawDataHashOverride: 'hash-drift',
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.hash_matches_preflight_baseline, false);
+    assert.equal(result.db_write_executed, false);
+    assert.equal(result.raw_match_data_write_executed, false);
+    assert.equal(client.queries.length, 0);
+});
+
+test('executeRawMatchDataWrite supports connectable pool cleanup and now() function', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient();
+    const pooled = buildConnectablePool(client);
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps({
+            now: () => '2026-05-14T10:11:12.000Z',
+        }),
+        createPool: () => pooled.pool,
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(pooled.released, true);
+    assert.equal(pooled.ended, true);
+});
+
+test('skipValidation path can execute with provided dependencies', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        skipValidation: true,
+        client: buildReadWriteClient(),
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.inserted_count, 1);
+});
+
+test('existing same hash skips without write', async () => {
+    const gate = loadModuleFresh();
+    const existing = insertedRow();
+    const client = buildReadWriteClient({
+        existingRows: [existing],
+        preBaseline: POST_BASELINE,
+        postBaseline: POST_BASELINE,
+        verificationRow: existing,
+    });
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.raw_match_data_write_executed, false);
+    assert.equal(result.db_write_executed, false);
+    assert.equal(result.reason, 'same_hash_existing_row');
+    assert.equal(
+        client.queries.some(item => /^INSERT/i.test(item.text)),
+        false
+    );
+});
+
+test('existing different hash stops without update', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient({
+        existingRows: [insertedRow({ data_hash: 'old-hash' })],
+        preBaseline: POST_BASELINE,
+        postBaseline: POST_BASELINE,
+    });
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.raw_match_data_write_executed, false);
+    assert.equal(result.db_write_executed, false);
+    assert.equal(result.transaction.rolled_back, true);
+    assert.match(result.controlled_error, /EXISTING_ROW_HASH_MISMATCH_REQUIRES_UPDATE_AUTHORIZATION/);
+});
+
+test('no existing row inserts exactly one row in fake DB transaction', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.inserted_count, 1);
+    assert.equal(result.updated_count, 0);
+    assert.equal(result.skipped_count, 0);
+    assert.equal(client.queries.filter(item => /^INSERT/i.test(item.text)).length, 1);
+});
+
+test('transaction commits on success', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.transaction.began, true);
+    assert.equal(result.transaction.committed, true);
+    assert.equal(result.transaction.rolled_back, false);
+});
+
+test('transaction rolls back on insert failure', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient({
+        insertFailure: new Error('insert failed'),
+    });
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.transaction.began, true);
+    assert.equal(result.transaction.committed, false);
+    assert.equal(result.transaction.rolled_back, true);
+    assert.match(result.controlled_error, /insert failed/);
+});
+
+test('SQL plan only targets raw_match_data', () => {
+    const gate = loadModuleFresh();
+    const rawData = gate.buildRawDataFromPreviewPayload(fakePayload(), fakePreviewResult().summary, validArgs());
+    const sql = gate.buildInsertRawMatchDataSql({
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        rawData,
+        collectedAt: '2026-05-14T10:11:12.000Z',
+        dataVersion: 'fotmob_html_hyd_v1',
+        dataHash: BASELINE_RAW_DATA_HASH,
+    });
+    assert.match(sql.text, /INSERT INTO raw_match_data/i);
+});
+
+test('SQL plan does not mention matches update', () => {
+    const gate = loadModuleFresh();
+    const rawData = gate.buildRawDataFromPreviewPayload(fakePayload(), fakePreviewResult().summary, validArgs());
+    const sql = gate.buildInsertRawMatchDataSql({
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        rawData,
+        collectedAt: '2026-05-14T10:11:12.000Z',
+        dataVersion: 'fotmob_html_hyd_v1',
+        dataHash: BASELINE_RAW_DATA_HASH,
+    });
+    assert.doesNotMatch(sql.text, /\bUPDATE\s+matches\b/i);
+});
+
+test('SQL plan does not mention features/predictions', () => {
+    const gate = loadModuleFresh();
+    const rawData = gate.buildRawDataFromPreviewPayload(fakePayload(), fakePreviewResult().summary, validArgs());
+    const sql = gate.buildInsertRawMatchDataSql({
+        matchId: '53_20252026_4830746',
+        externalId: '4830746',
+        rawData,
+        collectedAt: '2026-05-14T10:11:12.000Z',
+        dataVersion: 'fotmob_html_hyd_v1',
+        dataHash: BASELINE_RAW_DATA_HASH,
+    });
+    assert.doesNotMatch(sql.text, /\b(l3_features|match_features_training|predictions)\b/i);
+});
+
+test('output inserted_count=1 on fake success', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client: buildReadWriteClient(),
+    });
+    assert.equal(result.inserted_count, 1);
+});
+
+test('output raw_match_data_write_executed=true on fake success', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client: buildReadWriteClient(),
+    });
+    assert.equal(result.raw_match_data_write_executed, true);
+});
+
+test('output matches_write_executed=false', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client: buildReadWriteClient(),
+    });
+    assert.equal(result.matches_write_executed, false);
+});
+
+test('post_write_verification includes protected tables', () => {
+    const gate = loadModuleFresh();
+    const verification = gate.buildPostWriteVerification(POST_BASELINE, insertedRow());
+    assert.deepEqual(verification, {
+        raw_match_data_row_found: true,
+        matches: 10,
+        raw_match_data: 3,
+        bookmaker_odds_history: 2,
+        l3_features: 2,
+        match_features_training: 2,
+        predictions: 2,
+    });
+});
+
+test('no full body print/save', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client: buildReadWriteClient(),
+    });
+    assert.equal(result.body_printed, false);
+    assert.equal(result.body_saved, false);
+});
+
+test('runCli uses fake payload and fake write DB without fs writes or spawn', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient();
+    const result = await runCli(gate, cliArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.execution_completed, true);
+    assert.equal(result.payload.inserted_count, 1);
+});
+
+test('runCli returns non-zero for blocked allow-matches-write', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs({ allowMatchesWrite: true }));
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.execution_completed, false);
+    assert.match(result.payload.controlled_error, /allow-matches-write=yes is blocked/);
+});
+
+test('runCli help returns usage without executing write', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, ['--help'], fakeDeps());
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Phase 5\.16L2 performs one controlled live recapture/);
+    assert.equal(result.payload, null);
+});
+
+test('recapture path uses fake fetch and does not save or print body', async () => {
+    const gate = loadModuleFresh();
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        fetchImpl: fakeFetchImpl(),
+        rawDataHashOverride: BASELINE_RAW_DATA_HASH,
+        client: buildReadWriteClient(),
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.selected_route, 'html_hydration');
+    assert.equal(result.body_printed, false);
+    assert.equal(result.body_saved, false);
+});
+
+test('recapture path fails closed when fetch is unavailable', async t => {
+    const originalFetch = global.fetch;
+    global.fetch = undefined;
+    t.after(() => {
+        global.fetch = originalFetch;
+    });
+
+    const gate = loadModuleFresh();
+    await assert.rejects(
+        () => gate.executeRawMatchDataWrite(validArgs(), { client: buildReadWriteClient() }),
+        /FETCH_UNAVAILABLE/
+    );
+});
+
+test('recapture path fails closed when hydration payload cannot be parsed', async () => {
+    const gate = loadModuleFresh();
+    await assert.rejects(
+        () =>
+            gate.executeRawMatchDataWrite(validArgs(), {
+                fetchImpl: async () => ({
+                    status: 200,
+                    statusCode: 200,
+                    ok: true,
+                    url: 'https://www.fotmob.com/matches/angers-vs-strasbourg/2o4och',
+                    headers: {
+                        get: () => 'text/html; charset=utf-8',
+                    },
+                    text: async () => '<html><body>Angers Strasbourg 4830746</body></html>',
+                }),
+                client: buildReadWriteClient(),
+            }),
+        /NEXT_DATA_PARSE_FAILED|NO_NEXT_DATA|__NEXT_DATA__/
+    );
+});
+
+test('catch path records rollback failure without throwing', async () => {
+    const gate = loadModuleFresh();
+    const queries = [];
+    const client = {
+        async query(sql) {
+            const text = String(sql || '').trim();
+            queries.push(text);
+            if (text === 'BEGIN') {
+                return { rows: [] };
+            }
+            if (text === 'ROLLBACK') {
+                throw new Error('rollback failed');
+            }
+            if (isSelectMatchesQuery(text)) {
+                throw new Error('select exploded');
+            }
+            return { rows: [] };
+        },
+    };
+    const result = await gate.executeRawMatchDataWrite(validArgs(), {
+        ...fakeDeps(),
+        client,
+    });
+    assert.equal(result.execution_completed, false);
+    assert.match(result.controlled_error, /select exploded/);
+    assert.equal(queries.includes('ROLLBACK'), true);
+});
+
+test('buildControlledWriteResult renders success shape', () => {
+    const gate = loadModuleFresh();
+    const result = gate.buildControlledWriteResult({
+        input: validArgs(),
+        previewSummary: fakePreviewResult().summary,
+        rawDataHash: BASELINE_RAW_DATA_HASH,
+        executionCompleted: true,
+        existingRawMatchDataFound: false,
+        insertedCount: 1,
+        rawMatchDataWriteExecuted: true,
+        dbWriteExecuted: true,
+        transaction: {
+            began: true,
+            committed: true,
+            rolled_back: false,
+        },
+        postWriteVerification: gate.buildPostWriteVerification(POST_BASELINE, insertedRow()),
+        insertedRow: insertedRow(),
+        hashMatchesPreflightBaseline: true,
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.inserted_row_metadata.match_id, '53_20252026_4830746');
+});
+
+test('Makefile write target exists and no legacy commit target added', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l2-raw-match-data-write:/m);
+    assert.match(makefile, /scripts\/ops\/l2_raw_match_data_write\.js/);
+    assert.doesNotMatch(makefile, /^data-l2-raw-match-data-ingest-commit:/m);
+});
+
+test('no child_process spawn source usage', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /child_process|spawn|execFile/);
+});
+
+test('no fs write or mkdir source usage', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /writeFile|writeFileSync|mkdir|createWriteStream/);
+});
+
+test('no ProductionHarvester/raw ingest commit import', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/);
+});
+
+test('no browser/proxy import', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\(['"].*(playwright|puppeteer|chromium|BrowserProvider|socks-proxy-agent)/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.16L2 controlled raw_match_data write.

Scope:
- Adds single-target controlled raw_match_data writer for 53_20252026_4830746 / external_id 4830746
- Recaptures exact FotMob HTML hydration payload via safe route selector
- Compares raw_data_hash with Phase 5.15L2 preflight baseline before writing
- Writes only raw_match_data in a transaction
- Keeps matches/features/predictions protected
- Adds Makefile target, tests, AGENTS.md updates, and report

Safety:
- No DB writes before post-merge execution
- No matches writes
- No features/predictions writes
- No harvest / ingest / backfill
- No training / prediction
- No browser/proxy
- No full body save/print
- No file deletion

Validation:
- raw_match_data write tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged before execution
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed