### PR TITLE
feat(data): add controlled remaining raw_match_data write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@
 - Phase 5.17L2 起，L2 当前策略改为 raw-first / parse-later / train-driven parsing：在训练目标与数据泄漏策略明确前，agents 不得把 `raw_match_data` 解析成 features，不得进入 parser implementation；剩余 seeded matches 的 raw acquisition 只能继续走 authorization / preflight / controlled write，且这些 phase 不得做 parser/features/training/prediction。
 - Phase 5.18L2 授权剩余 7 场 seeded matches（4830747-4830754）进入 future controlled raw_match_data acquisition；本阶段是 authorization-only，不触网、不写 DB、不写 raw_match_data；parser/features/training/prediction 仍 deferred；剩余 raw acquisition 必须先完成 preflight 才能进入 controlled write。
 - Phase 5.19L2 允许对剩余 7 场执行 controlled live preflight，通过 safe html_hydration route recapture exact payload；必须输出 would_insert/would_update/would_skip per target；不得写 DB 或 raw_match_data；parser/features/training/prediction 仍 deferred；controlled write 必须留到 Phase 5.20L2。
+- Phase 5.20L2C 是剩余 7 场 seeded matches（4830747-4830754）唯一允许的 `raw_match_data` 写入路径；它必须使用 `FotMobRawDetailFetcher` 逐场 recapture，并在写入前把每个 `raw_data_hash` 与 Phase 5.20L2B baseline 对比，任何 hash drift 都必须停止且不得写 DB；它只能单事务写入 `raw_match_data` 7 行，不得写 `matches`、features、training 或 predictions，不得保存或打印完整 body/raw_data。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
-        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan data-l2-raw-match-data-ingest-plan data-l2-raw-match-data-ingest-authorization data-l2-raw-match-data-ingest-preflight data-l2-raw-match-data-write data-l2-remaining-raw-match-data-acquisition-plan data-l2-remaining-raw-match-data-acquisition-authorization data-l2-remaining-raw-match-data-acquisition-preflight \
+        data-l2-raw-detail-preview data-l2-raw-detail-route-preview-plan data-l2-raw-match-data-ingest-plan data-l2-raw-match-data-ingest-authorization data-l2-raw-match-data-ingest-preflight data-l2-raw-match-data-write data-l2-remaining-raw-match-data-acquisition-plan data-l2-remaining-raw-match-data-acquisition-authorization data-l2-remaining-raw-match-data-acquisition-preflight data-l2-remaining-raw-match-data-write \
         data-fotmob-single-target-adapter-preflight data-fotmob-single-target-adapter-commit \
         data-fotmob-stdout-network-dry-run-authorization-packet-preview data-fotmob-stdout-network-dry-run-authorization-packet-commit \
         data-fotmob-stdout-network-dry-run-execution-plan-preview data-fotmob-stdout-network-dry-run-execution-plan-commit \
@@ -340,11 +340,13 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-l2-remaining-raw-match-data-acquisition-plan SOURCE=fotmob LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 EXPECTED_SEEDED_COUNT=8 EXPECTED_EXISTING_RAW_COUNT=1 EXPECTED_MISSING_RAW_COUNT=7 ALLOW_NETWORK=no ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.17L2 planning-only: remaining seeded raw acquisition scope"
 	@echo "  make data-l2-remaining-raw-match-data-acquisition-authorization SOURCE=fotmob LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 ROUTE=html_hydration EXPECTED_SEEDED_COUNT=8 EXPECTED_EXISTING_RAW_COUNT=1 EXPECTED_MISSING_RAW_COUNT=7 REMAINING_EXTERNAL_IDS=4830747,4830748,4830750,4830751,4830752,4830753,4830754 USER_AUTHORIZED_REMAINING_RAW_ACQUISITION=yes ALLOW_NETWORK_NEXT_PHASE=yes ALLOW_RAW_MATCH_DATA_WRITE_FUTURE_PHASE=yes ALLOW_NETWORK_THIS_PHASE=no ALLOW_DB_WRITE_THIS_PHASE=no ALLOW_RAW_MATCH_DATA_WRITE_THIS_PHASE=no ALLOW_MATCHES_WRITE=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no FINAL_HUMAN_CONFIRMATION=yes  # Phase 5.18L2 authorization-only: remaining 7 targets authorized for future preflight"
 	@echo "  make data-l2-remaining-raw-match-data-acquisition-preflight SOURCE=fotmob LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 ROUTE=html_hydration REMAINING_EXTERNAL_IDS=4830747,4830748,4830750,4830751,4830752,4830753,4830754 EXPECTED_TARGET_COUNT=7 NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # Phase 5.19L2 preflight-only: recaptures 7 payloads, computes hashes, outputs would_insert/update/skip, no DB write"
+	@echo "  make data-l2-remaining-raw-match-data-write SOURCE=fotmob LEAGUE_ID=53 SEASON=2025/2026 DATE=2026-05-10 ROUTE=html_hydration REMAINING_EXTERNAL_IDS=4830747,4830748,4830750,4830751,4830752,4830753,4830754 EXPECTED_TARGET_COUNT=7 BASELINE_RAW_DATA_HASHES=4830747:435296093b7d73ec822262c00a22903fa1d28d260a5a2b982b0bf8006e191728,4830748:e98b0adb557d54ba0ada53ff836a5f6eea2629a0ed06389b78f23d83fbe617e5,4830750:5c02a11384459581821026aa2c85677e05877f219e158e5f733aef2ddb484880,4830751:b391b896c3260446b7185d81b31949ac47ad50cf956f733c87920f36579aed0f,4830752:dfe719cae63e09710b04aba411bf74b9662c554aff284a1f414fa255ee5cd93f,4830753:6b4438453fa7d0ceb99c80fb736d3cb7dcc51d5593b4ca48bb1ba682fe78fe4f,4830754:c843897451773c8317111a4c010da59223f1bb98cb7ce12253eafa4f57f550f7 DATA_VERSION=fotmob_html_hyd_v1 NETWORK_AUTHORIZATION=yes LIVE_PREVIEW_AUTHORIZATION=yes FINAL_DB_WRITE_CONFIRMATION=yes ALLOW_DB_WRITE=yes ALLOW_RAW_MATCH_DATA_WRITE=yes ALLOW_MATCHES_WRITE=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no  # Phase 5.20L2C controlled remaining raw_match_data write"
 	@echo "  L2 raw detail preview is preview-only: no raw_match_data write, no DB write, no browser/proxy, no full body print/save."
 	@echo "  L2 raw_match_data ingest authorization is authorization-only in Phase 5.14L2: future write requires preflight + final DB-write confirmation, and raw_match_data write remains blocked this phase."
 	@echo "  L2 raw_match_data ingest preflight recomputes exact payload/hash and outputs would_insert/update/skip; it does not write raw_match_data. Future write requires final DB-write confirmation."
 	@echo "  L2 raw_match_data write is controlled single-target execution: it requires final DB-write confirmation, writes only raw_match_data, and keeps protected tables untouched."
 	@echo "  L2 remaining raw_match_data acquisition planning is raw-first / parse-later. Parser is deferred until training data design."
+	@echo "  Phase 5.20L2C remaining write requires final DB-write confirmation, uses FotMobRawDetailFetcher, compares every Phase 5.20L2B baseline hash, writes only raw_match_data rows=7, and does not run parser/features/training/prediction."
 	@echo "  Remaining seeded matches require separate authorization, preflight, and controlled write phases."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
 	@echo "  Phase 5.12L2B route selector supports html_hydration before api_match_details; alternate_route remains plan-only."
@@ -865,6 +867,40 @@ data-l2-remaining-raw-match-data-acquisition-preflight: ## L2 remaining raw_matc
 		--retry="$(or $(RETRY),0)" \
 		--print-body="$(or $(PRINT_BODY),no)" \
 		--save-body="$(or $(SAVE_BODY),no)"
+
+data-l2-remaining-raw-match-data-write: ## L2 controlled remaining raw_match_data write. Phase 5.20L2C. Single transaction, raw_match_data only, rows=7.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(ROUTE)" ] || [ -z "$(BASELINE_RAW_DATA_HASHES)" ] || [ -z "$(DATA_VERSION)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob LEAGUE_ID=53 ROUTE=html_hydration BASELINE_RAW_DATA_HASHES=<7 hashes> DATA_VERSION=fotmob_html_hyd_v1"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/l2_remaining_raw_match_data_write.js \
+		--source="$(SOURCE)" \
+		--league-id="$(LEAGUE_ID)" \
+		--season="$(or $(SEASON),2025/2026)" \
+		--date="$(or $(DATE),2026-05-10)" \
+		--route="$(ROUTE)" \
+		--remaining-external-ids="$(or $(REMAINING_EXTERNAL_IDS),4830747,4830748,4830750,4830751,4830752,4830753,4830754)" \
+		--expected-target-count="$(or $(EXPECTED_TARGET_COUNT),7)" \
+		--baseline-raw-data-hashes="$(BASELINE_RAW_DATA_HASHES)" \
+		--data-version="$(DATA_VERSION)" \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--live-preview-authorization="$(or $(LIVE_PREVIEW_AUTHORIZATION),no)" \
+		--final-db-write-confirmation="$(or $(FINAL_DB_WRITE_CONFIRMATION),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-matches-write="$(or $(ALLOW_MATCHES_WRITE),no)" \
+		--allow-parser-features="$(or $(ALLOW_PARSER_FEATURES),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--concurrency="$(or $(CONCURRENCY),1)" \
+		--retry="$(or $(RETRY),0)" \
+		--print-body="$(or $(PRINT_BODY),no)" \
+		--save-body="$(or $(SAVE_BODY),no)" \
+		--bulk="$(or $(BULK),no)" \
+		--commit="$(or $(COMMIT),no)" \
+		--execute="$(or $(EXECUTE),no)"
 
 data-local-dry-run: ## Run a safe local-only dry-run. Requires SAMPLE_HTML or SAMPLE_CSV.
 	@if [ -n "$(SAMPLE_HTML)" ]; then \

--- a/docs/_reports/CONTROLLED_REMAINING_RAW_MATCH_DATA_WRITE_PHASE5_20L2C.md
+++ b/docs/_reports/CONTROLLED_REMAINING_RAW_MATCH_DATA_WRITE_PHASE5_20L2C.md
@@ -1,0 +1,141 @@
+# Controlled Remaining Raw Match Data Write - Phase 5.20L2C
+
+## 1. Executive summary
+
+本阶段执行 controlled remaining `raw_match_data` write，目标范围固定为剩余 7 场
+seeded Ligue 1 matches：
+
+- `4830747`
+- `4830748`
+- `4830750`
+- `4830751`
+- `4830752`
+- `4830753`
+- `4830754`
+
+本阶段实现并执行的链路要求：
+
+- 使用 consolidated `FotMobRawDetailFetcher`
+- 使用 Phase 5.20L2B `raw_data_hash` baseline
+- 写入前逐场 recapture exact payload
+- 逐场比较 `raw_data_hash`
+- 只写 `raw_match_data`
+- 不写其他表
+
+## 2. Baseline before write
+
+执行前 baseline 约束：
+
+- `matches=10`
+- `raw_match_data=3`
+- `bookmaker_odds_history=2`
+- `l3_features=2`
+- `match_features_training=2`
+- `predictions=2`
+
+seeded raw coverage 约束：
+
+- existing raw target: `53_20252026_4830746 / 4830746 / Angers vs Strasbourg`
+- remaining 7 raw rows absent before execution
+
+## 3. Baseline hashes
+
+Phase 5.20L2B baseline `raw_data_hash`:
+
+- `4830747` → `435296093b7d73ec822262c00a22903fa1d28d260a5a2b982b0bf8006e191728`
+- `4830748` → `e98b0adb557d54ba0ada53ff836a5f6eea2629a0ed06389b78f23d83fbe617e5`
+- `4830750` → `5c02a11384459581821026aa2c85677e05877f219e158e5f733aef2ddb484880`
+- `4830751` → `b391b896c3260446b7185d81b31949ac47ad50cf956f733c87920f36579aed0f`
+- `4830752` → `dfe719cae63e09710b04aba411bf74b9662c554aff284a1f414fa255ee5cd93f`
+- `4830753` → `6b4438453fa7d0ceb99c80fb736d3cb7dcc51d5593b4ca48bb1ba682fe78fe4f`
+- `4830754` → `c843897451773c8317111a4c010da59223f1bb98cb7ce12253eafa4f57f550f7`
+
+## 4. Pre-write recapture and hash gate
+
+post-merge `main` healthy 且 `main` push CI success 后，真实执行时填写：
+
+- selected route per target
+- request URL / final URL per target
+- body SHA-256 per target
+- `raw_data_hash` per target
+- baseline hash per target
+- hash matched / drifted
+
+本阶段 gate：
+
+- route=`html_hydration`
+- concurrency=`1`
+- retry=`0`
+- no browser/proxy
+- no full body print/save
+- any hash drift => stop, no DB write
+
+## 5. Transaction execution
+
+真实执行后记录：
+
+- transaction began
+- inserted_count
+- updated_count
+- skipped_count
+- committed / rolled_back
+
+本阶段只允许：
+
+- one transaction
+- `INSERT INTO raw_match_data`
+- rows=`7`
+
+## 6. Post-write verification
+
+真实执行后记录：
+
+- `raw_match_data=10`
+- `matches=10`
+- protected tables unchanged
+- inserted row metadata:
+    - `id`
+    - `match_id`
+    - `external_id`
+    - `collected_at`
+    - `data_version`
+    - `data_hash`
+- raw_data key checks:
+    - `_meta`
+    - `content`
+    - `general`
+    - `header`
+    - `matchId`
+
+不打印完整 `raw_data`。
+
+## 7. Next phase
+
+推荐进入：
+
+`Phase 5.21L2 raw_match_data inventory and parser-deferred training design`
+
+要求：
+
+- 只读盘点 `raw_match_data=10`
+- 不触网
+- 不写 features
+- 不训练/预测
+- 先设计训练目标、标签、时间切分、数据泄漏策略
+- parser 继续 deferred，直到训练数据设计明确
+
+## 8. Explicit non-execution
+
+本阶段明确不执行：
+
+- no matches writes
+- no bookmaker_odds_history writes
+- no l3_features writes
+- no match_features_training writes
+- no predictions writes
+- no parser/features
+- no harvest/backfill
+- no training/prediction
+- no browser/proxy
+- no full body save/print
+- no file deletion

--- a/scripts/ops/l2_remaining_raw_match_data_write.js
+++ b/scripts/ops/l2_remaining_raw_match_data_write.js
@@ -1,0 +1,1373 @@
+#!/usr/bin/env node
+/* eslint-disable complexity, max-lines */
+'use strict';
+
+const { extractFromHtml, transformToApiFormat } = require('../../src/parsers/fotmob/NextDataParser');
+const {
+    fetchFotMobRawDetail,
+    sha256CanonicalJson,
+} = require('../../src/infrastructure/services/FotMobRawDetailFetcher');
+
+const PHASE = 'PHASE5_20L2C_CONTROLLED_REMAINING_RAW_MATCH_DATA_WRITE';
+const NEXT_REQUIRED_PHASE = 'Phase 5.21L2 raw_match_data inventory and parser-deferred training design';
+
+const REMAINING_TARGET_REGISTRY = Object.freeze([
+    Object.freeze({ match_id: '53_20252026_4830747', external_id: '4830747', home_team: 'Auxerre', away_team: 'Nice' }),
+    Object.freeze({
+        match_id: '53_20252026_4830748',
+        external_id: '4830748',
+        home_team: 'Le Havre',
+        away_team: 'Marseille',
+    }),
+    Object.freeze({ match_id: '53_20252026_4830750', external_id: '4830750', home_team: 'Metz', away_team: 'Lorient' }),
+    Object.freeze({ match_id: '53_20252026_4830751', external_id: '4830751', home_team: 'Monaco', away_team: 'Lille' }),
+    Object.freeze({
+        match_id: '53_20252026_4830752',
+        external_id: '4830752',
+        home_team: 'Paris Saint-Germain',
+        away_team: 'Brest',
+    }),
+    Object.freeze({
+        match_id: '53_20252026_4830753',
+        external_id: '4830753',
+        home_team: 'Rennes',
+        away_team: 'Paris FC',
+    }),
+    Object.freeze({
+        match_id: '53_20252026_4830754',
+        external_id: '4830754',
+        home_team: 'Toulouse',
+        away_team: 'Lyon',
+    }),
+]);
+
+const BASELINE_RAW_DATA_HASHES = Object.freeze({
+    4830747: '435296093b7d73ec822262c00a22903fa1d28d260a5a2b982b0bf8006e191728',
+    4830748: 'e98b0adb557d54ba0ada53ff836a5f6eea2629a0ed06389b78f23d83fbe617e5',
+    4830750: '5c02a11384459581821026aa2c85677e05877f219e158e5f733aef2ddb484880',
+    4830751: 'b391b896c3260446b7185d81b31949ac47ad50cf956f733c87920f36579aed0f',
+    4830752: 'dfe719cae63e09710b04aba411bf74b9662c554aff284a1f414fa255ee5cd93f',
+    4830753: '6b4438453fa7d0ceb99c80fb736d3cb7dcc51d5593b4ca48bb1ba682fe78fe4f',
+    4830754: 'c843897451773c8317111a4c010da59223f1bb98cb7ce12253eafa4f57f550f7',
+});
+
+const EXPECTED_EXTERNAL_IDS = Object.freeze(REMAINING_TARGET_REGISTRY.map(target => target.external_id));
+
+const EXPECTED_SCOPE = Object.freeze({
+    source: 'fotmob',
+    leagueId: '53',
+    season: '2025/2026',
+    date: '2026-05-10',
+    route: 'html_hydration',
+    dataVersion: 'fotmob_html_hyd_v1',
+    targetCount: 7,
+});
+
+const EXPECTED_PRE_WRITE_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 3,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+
+const EXPECTED_POST_WRITE_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 10,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+
+const FORBIDDEN_SELECT_SQL_VERBS = Object.freeze([
+    'INSERT',
+    'UPDATE',
+    'DELETE',
+    'CREATE',
+    'ALTER',
+    'DROP',
+    'TRUNCATE',
+    'UPSERT',
+    'MERGE',
+    'GRANT',
+    'REVOKE',
+    'LOCK',
+    'COPY',
+]);
+
+function normalizeText(value) {
+    return String(value || '').trim();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') return value;
+    if (value === null || value === undefined || value === '') return fallback;
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') return fallback;
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) return Number.NaN;
+    return Number.parseInt(normalized, 10);
+}
+
+function parseRemainingExternalIds(value) {
+    if (Array.isArray(value)) {
+        return value.map(id => normalizeText(id)).filter(Boolean);
+    }
+    if (value === null || value === undefined || value === '') return [];
+    return String(value)
+        .split(',')
+        .map(id => normalizeText(id))
+        .filter(Boolean);
+}
+
+function parseBaselineRawDataHashes(value) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+        return Object.fromEntries(
+            Object.entries(value)
+                .map(([externalId, hash]) => [normalizeText(externalId), normalizeText(hash).toLowerCase()])
+                .filter(([externalId]) => Boolean(externalId))
+        );
+    }
+    if (value === null || value === undefined || value === '') return {};
+
+    const parsed = {};
+    const segments = String(value)
+        .split(',')
+        .map(segment => segment.trim())
+        .filter(Boolean);
+
+    for (const segment of segments) {
+        const separatorIndex = segment.indexOf(':');
+        if (separatorIndex === -1) {
+            parsed[`__invalid__${Object.keys(parsed).length}`] = normalizeText(segment).toLowerCase();
+            continue;
+        }
+        const externalId = normalizeText(segment.slice(0, separatorIndex));
+        const hash = normalizeText(segment.slice(separatorIndex + 1)).toLowerCase();
+        if (externalId) parsed[externalId] = hash;
+    }
+
+    return parsed;
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return { value: arg.slice(arg.indexOf('=') + 1), consumedNext: false };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        leagueId: null,
+        season: null,
+        date: null,
+        route: null,
+        remainingExternalIds: null,
+        expectedTargetCount: null,
+        baselineRawDataHashes: null,
+        dataVersion: null,
+        networkAuthorization: null,
+        livePreviewAuthorization: null,
+        finalDbWriteConfirmation: null,
+        allowDbWrite: null,
+        allowRawMatchDataWrite: null,
+        allowMatchesWrite: null,
+        allowParserFeatures: null,
+        allowTraining: null,
+        allowPrediction: null,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        concurrency: null,
+        retry: null,
+        printBody: null,
+        saveBody: null,
+        bulk: false,
+        commit: false,
+        execute: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        'league-id': 'leagueId',
+        league_id: 'leagueId',
+        season: 'season',
+        date: 'date',
+        route: 'route',
+        'remaining-external-ids': 'remainingExternalIds',
+        remaining_external_ids: 'remainingExternalIds',
+        'expected-target-count': 'expectedTargetCount',
+        expected_target_count: 'expectedTargetCount',
+        'baseline-raw-data-hashes': 'baselineRawDataHashes',
+        baseline_raw_data_hashes: 'baselineRawDataHashes',
+        'data-version': 'dataVersion',
+        data_version: 'dataVersion',
+        'network-authorization': 'networkAuthorization',
+        network_authorization: 'networkAuthorization',
+        'live-preview-authorization': 'livePreviewAuthorization',
+        live_preview_authorization: 'livePreviewAuthorization',
+        'final-db-write-confirmation': 'finalDbWriteConfirmation',
+        final_db_write_confirmation: 'finalDbWriteConfirmation',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        'allow-parser-features': 'allowParserFeatures',
+        allow_parser_features: 'allowParserFeatures',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        'allow-browser-runtime': 'allowBrowserRuntime',
+        allow_browser_runtime: 'allowBrowserRuntime',
+        'allow-proxy-runtime': 'allowProxyRuntime',
+        allow_proxy_runtime: 'allowProxyRuntime',
+        concurrency: 'concurrency',
+        retry: 'retry',
+        'print-body': 'printBody',
+        print_body: 'printBody',
+        'save-body': 'saveBody',
+        save_body: 'saveBody',
+        bulk: 'bulk',
+        commit: 'commit',
+        execute: 'execute',
+        help: 'help',
+        h: 'help',
+    };
+    const booleanKeys = new Set([
+        'networkAuthorization',
+        'livePreviewAuthorization',
+        'finalDbWriteConfirmation',
+        'allowDbWrite',
+        'allowRawMatchDataWrite',
+        'allowMatchesWrite',
+        'allowParserFeatures',
+        'allowTraining',
+        'allowPrediction',
+        'allowBrowserRuntime',
+        'allowProxyRuntime',
+        'printBody',
+        'saveBody',
+        'bulk',
+        'commit',
+        'execute',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) index += 1;
+
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+
+        if (booleanKeys.has(optionKey)) {
+            options[optionKey] = normalizeBooleanFlag(value, true);
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : value;
+    }
+
+    return options;
+}
+
+function pushRequiredYesError(errors, value, flagName) {
+    if (value === true) return;
+    if (value === false) {
+        errors.push(`${flagName}=yes is required in Phase 5.20L2C`);
+        return;
+    }
+    errors.push(`missing ${flagName}=yes`);
+}
+
+function pushRequiredNoError(errors, value, flagName) {
+    if (value === false) return;
+    if (value === true) {
+        errors.push(`${flagName}=yes is blocked in Phase 5.20L2C`);
+        return;
+    }
+    errors.push(`missing ${flagName}=no`);
+}
+
+function pushRequiredIntegerError(errors, value, expected, flagName) {
+    if (!Number.isFinite(value) || value !== expected) {
+        errors.push(`${flagName} must be ${expected} in Phase 5.20L2C`);
+    }
+}
+
+function normalizeWriteInput(input = {}) {
+    return {
+        source: normalizeText(input.source).toLowerCase(),
+        leagueId: normalizeText(input.leagueId),
+        season: normalizeText(input.season),
+        date: normalizeText(input.date),
+        route: normalizeText(input.route).toLowerCase(),
+        remainingExternalIds: parseRemainingExternalIds(input.remainingExternalIds),
+        expectedTargetCount: parseInteger(input.expectedTargetCount, null),
+        baselineRawDataHashes: parseBaselineRawDataHashes(input.baselineRawDataHashes),
+        dataVersion: normalizeText(input.dataVersion).toLowerCase(),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, undefined),
+        livePreviewAuthorization: normalizeBooleanFlag(input.livePreviewAuthorization, undefined),
+        finalDbWriteConfirmation: normalizeBooleanFlag(input.finalDbWriteConfirmation, undefined),
+        allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
+        allowMatchesWrite: normalizeBooleanFlag(input.allowMatchesWrite, undefined),
+        allowParserFeatures: normalizeBooleanFlag(input.allowParserFeatures, undefined),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, undefined),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, undefined),
+        allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, false),
+        allowProxyRuntime: normalizeBooleanFlag(input.allowProxyRuntime, false),
+        concurrency: parseInteger(input.concurrency, null),
+        retry: parseInteger(input.retry, null),
+        printBody: normalizeBooleanFlag(input.printBody, undefined),
+        saveBody: normalizeBooleanFlag(input.saveBody, undefined),
+        bulk: normalizeBooleanFlag(input.bulk, false),
+        commit: normalizeBooleanFlag(input.commit, false),
+        execute: normalizeBooleanFlag(input.execute, false),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function validateWriteInput(input = {}) {
+    const value = normalizeWriteInput(input);
+    const errors = [];
+
+    if (value.unknown.length > 0) {
+        errors.push(`unknown arguments: ${value.unknown.join(', ')}`);
+    }
+    if (!value.source) {
+        errors.push('missing source: provide --source=fotmob');
+    } else if (value.source !== EXPECTED_SCOPE.source) {
+        errors.push('source must be fotmob');
+    }
+    if (!value.leagueId) {
+        errors.push('missing league-id');
+    } else if (value.leagueId !== EXPECTED_SCOPE.leagueId) {
+        errors.push('league-id must be 53');
+    }
+    if (!value.season) {
+        errors.push('missing season');
+    } else if (value.season !== EXPECTED_SCOPE.season) {
+        errors.push('season must be 2025/2026');
+    }
+    if (!value.date) {
+        errors.push('missing date');
+    } else if (value.date !== EXPECTED_SCOPE.date) {
+        errors.push('date must be 2026-05-10');
+    }
+    if (!value.route) {
+        errors.push('missing route');
+    } else if (value.route !== EXPECTED_SCOPE.route) {
+        errors.push('route must be html_hydration');
+    }
+
+    const ids = value.remainingExternalIds;
+    if (ids.length === 0) {
+        errors.push('remaining-external-ids is required');
+    } else if (ids.length !== EXPECTED_EXTERNAL_IDS.length) {
+        errors.push(`remaining-external-ids must have ${EXPECTED_EXTERNAL_IDS.length} ids`);
+    } else {
+        const expectedIds = new Set(EXPECTED_EXTERNAL_IDS);
+        for (const externalId of ids) {
+            if (externalId === '4830746') {
+                errors.push('4830746 is already ingested');
+            }
+            if (!expectedIds.has(externalId)) {
+                errors.push(`unexpected remaining external_id: ${externalId}`);
+            }
+        }
+        for (const expectedExternalId of EXPECTED_EXTERNAL_IDS) {
+            if (!ids.includes(expectedExternalId)) {
+                errors.push(`missing expected remaining external_id: ${expectedExternalId}`);
+            }
+        }
+    }
+
+    pushRequiredIntegerError(errors, value.expectedTargetCount, EXPECTED_SCOPE.targetCount, 'expected-target-count');
+
+    const baselineHashKeys = Object.keys(value.baselineRawDataHashes);
+    if (baselineHashKeys.length === 0) {
+        errors.push('baseline-raw-data-hashes is required');
+    } else if (baselineHashKeys.length !== EXPECTED_EXTERNAL_IDS.length) {
+        errors.push(`baseline-raw-data-hashes must contain ${EXPECTED_EXTERNAL_IDS.length} hashes`);
+    }
+    for (const externalId of baselineHashKeys) {
+        if (!EXPECTED_EXTERNAL_IDS.includes(externalId)) {
+            errors.push(`unexpected baseline external_id: ${externalId}`);
+        }
+    }
+    for (const externalId of EXPECTED_EXTERNAL_IDS) {
+        const hash = value.baselineRawDataHashes[externalId];
+        if (!hash) {
+            errors.push(`missing baseline raw_data_hash for external_id ${externalId}`);
+            continue;
+        }
+        if (!/^[a-f0-9]{64}$/.test(hash)) {
+            errors.push(`invalid baseline raw_data_hash format for external_id ${externalId}`);
+            continue;
+        }
+        if (hash !== BASELINE_RAW_DATA_HASHES[externalId]) {
+            errors.push(`baseline raw_data_hash mismatch for external_id ${externalId}`);
+        }
+    }
+
+    if (!value.dataVersion) {
+        errors.push('missing data-version');
+    } else if (value.dataVersion !== EXPECTED_SCOPE.dataVersion) {
+        errors.push(`data-version must be ${EXPECTED_SCOPE.dataVersion}`);
+    }
+
+    pushRequiredYesError(errors, value.networkAuthorization, 'network-authorization');
+    pushRequiredYesError(errors, value.livePreviewAuthorization, 'live-preview-authorization');
+    pushRequiredYesError(errors, value.finalDbWriteConfirmation, 'final-db-write-confirmation');
+    pushRequiredYesError(errors, value.allowDbWrite, 'allow-db-write');
+    pushRequiredYesError(errors, value.allowRawMatchDataWrite, 'allow-raw-match-data-write');
+    pushRequiredNoError(errors, value.allowMatchesWrite, 'allow-matches-write');
+    pushRequiredNoError(errors, value.allowParserFeatures, 'allow-parser-features');
+    pushRequiredNoError(errors, value.allowTraining, 'allow-training');
+    pushRequiredNoError(errors, value.allowPrediction, 'allow-prediction');
+    pushRequiredNoError(errors, value.printBody, 'print-body');
+    pushRequiredNoError(errors, value.saveBody, 'save-body');
+    pushRequiredIntegerError(errors, value.concurrency, 1, 'concurrency');
+    pushRequiredIntegerError(errors, value.retry, 0, 'retry');
+
+    if (value.allowBrowserRuntime === true) {
+        errors.push('allow-browser-runtime=yes is blocked in Phase 5.20L2C');
+    }
+    if (value.allowProxyRuntime === true) {
+        errors.push('allow-proxy-runtime=yes is blocked in Phase 5.20L2C');
+    }
+    if (value.bulk === true) {
+        errors.push('bulk=yes is blocked in Phase 5.20L2C');
+    }
+    if (value.commit === true) {
+        errors.push('commit=yes is blocked in Phase 5.20L2C');
+    }
+    if (value.execute === true) {
+        errors.push('execute=yes is blocked in Phase 5.20L2C');
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value,
+    };
+}
+
+function getRemainingTargetRegistry(baselineRawDataHashes = BASELINE_RAW_DATA_HASHES) {
+    return REMAINING_TARGET_REGISTRY.map(target => ({
+        ...target,
+        baseline_raw_data_hash: baselineRawDataHashes[target.external_id] || null,
+    }));
+}
+
+async function recaptureTarget(target, fetcherDeps = {}) {
+    const fetchFn = fetcherDeps.fetchFn || global.fetch;
+    if (typeof fetchFn !== 'function') {
+        throw new Error('FETCH_DEPENDENCY_MISSING: fetchFn is required');
+    }
+
+    return fetchFotMobRawDetail(
+        {
+            externalId: target.external_id,
+            matchId: target.match_id,
+            homeTeam: target.home_team,
+            awayTeam: target.away_team,
+            route: EXPECTED_SCOPE.route,
+            dataVersion: EXPECTED_SCOPE.dataVersion,
+            printBody: false,
+            saveBody: false,
+            retry: 0,
+            allowBrowserRuntime: false,
+            allowProxyRuntime: false,
+        },
+        {
+            fetchFn,
+            now: fetcherDeps.now,
+            parser: fetcherDeps.parser || { extractFromHtml, transformToApiFormat },
+        }
+    );
+}
+
+function validateRawDataShape(rawData = {}) {
+    const errors = [];
+    if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
+        return ['raw_data must be a plain object'];
+    }
+    for (const key of ['_meta', 'content', 'general', 'header', 'matchId']) {
+        if (!Object.prototype.hasOwnProperty.call(rawData, key)) {
+            errors.push(`raw_data missing ${key}`);
+        }
+    }
+    return errors;
+}
+
+function buildPerTargetRecapture(target, recaptureResult = {}) {
+    const rawData =
+        recaptureResult.raw_data &&
+        typeof recaptureResult.raw_data === 'object' &&
+        !Array.isArray(recaptureResult.raw_data)
+            ? JSON.parse(JSON.stringify(recaptureResult.raw_data))
+            : null;
+    const rawDataHash = rawData
+        ? sha256CanonicalJson(rawData)
+        : normalizeText(recaptureResult.raw_data_hash).toLowerCase() || null;
+    const rawDataErrors = rawData ? validateRawDataShape(rawData) : ['raw_data missing from recapture result'];
+    const validPayload =
+        recaptureResult.ok === true &&
+        recaptureResult.hydration_parse_ok === true &&
+        recaptureResult.looks_like_valid_match_detail === true &&
+        rawDataErrors.length === 0;
+    const hashMatchesBaseline = validPayload && rawDataHash === target.baseline_raw_data_hash;
+
+    return {
+        match_id: target.match_id,
+        external_id: target.external_id,
+        home_team: target.home_team,
+        away_team: target.away_team,
+        selected_route: recaptureResult.route || EXPECTED_SCOPE.route,
+        request_url: recaptureResult.request_url || null,
+        final_url: recaptureResult.final_url || null,
+        http_status: recaptureResult.http_status ?? 0,
+        content_type: recaptureResult.content_type || null,
+        body_byte_length: recaptureResult.body_byte_length ?? 0,
+        body_sha256: recaptureResult.body_sha256 || null,
+        hydration_parse_ok: recaptureResult.hydration_parse_ok === true,
+        looks_like_valid_match_detail: recaptureResult.looks_like_valid_match_detail === true,
+        baseline_raw_data_hash: target.baseline_raw_data_hash,
+        raw_data_hash: rawDataHash,
+        hash_matches_baseline: hashMatchesBaseline,
+        existing_raw_match_data_found: false,
+        decision: !validPayload ? 'invalid_payload' : hashMatchesBaseline ? 'would_insert' : 'hash_drift',
+        body_printed: false,
+        body_saved: false,
+        browser_used: false,
+        proxy_used: false,
+        valid_payload: validPayload,
+        raw_data_errors: rawDataErrors,
+        raw_data: rawData,
+        controlled_error: recaptureResult.controlled_error || null,
+    };
+}
+
+function buildHashGateResult(perTargetRecapture = [], targetCount = EXPECTED_SCOPE.targetCount) {
+    const attemptedTargetCount = perTargetRecapture.length;
+    const validPayloadCount = perTargetRecapture.filter(entry => entry.valid_payload === true).length;
+    const hashMatchCount = perTargetRecapture.filter(entry => entry.hash_matches_baseline === true).length;
+    const hashDriftCount = perTargetRecapture.filter(
+        entry => entry.valid_payload === true && entry.hash_matches_baseline === false
+    ).length;
+    const invalidPayloadCount = perTargetRecapture.filter(entry => entry.valid_payload !== true).length;
+
+    return {
+        ok:
+            attemptedTargetCount === targetCount &&
+            validPayloadCount === targetCount &&
+            hashMatchCount === targetCount &&
+            hashDriftCount === 0 &&
+            invalidPayloadCount === 0,
+        targetCount,
+        attemptedTargetCount,
+        validPayloadCount,
+        hashMatchCount,
+        hashDriftCount,
+        invalidPayloadCount,
+    };
+}
+
+function buildInsertRawMatchDataRows(perTargetRecapture = [], collectedAt, dataVersion = EXPECTED_SCOPE.dataVersion) {
+    return perTargetRecapture.map(entry => ({
+        matchId: entry.match_id,
+        externalId: entry.external_id,
+        rawData: JSON.parse(JSON.stringify(entry.raw_data)),
+        collectedAt,
+        dataVersion,
+        dataHash: entry.raw_data_hash,
+    }));
+}
+
+function buildProtectedTableBaseline(source = {}) {
+    const rows = Array.isArray(source) ? source : null;
+    const objectSource = rows
+        ? Object.fromEntries(rows.map(row => [row.table_name, Number(row.rows)]))
+        : source && typeof source === 'object'
+          ? source
+          : {};
+
+    return {
+        matches: Number(objectSource.matches ?? 0),
+        raw_match_data: Number(objectSource.raw_match_data ?? 0),
+        bookmaker_odds_history: Number(objectSource.bookmaker_odds_history ?? 0),
+        l3_features: Number(objectSource.l3_features ?? 0),
+        match_features_training: Number(objectSource.match_features_training ?? 0),
+        predictions: Number(objectSource.predictions ?? 0),
+    };
+}
+
+function buildPostWriteVerification(baselineSource = {}) {
+    const baseline = buildProtectedTableBaseline(baselineSource);
+    return {
+        matches: baseline.matches,
+        raw_match_data: baseline.raw_match_data,
+        bookmaker_odds_history: baseline.bookmaker_odds_history,
+        l3_features: baseline.l3_features,
+        match_features_training: baseline.match_features_training,
+        predictions: baseline.predictions,
+    };
+}
+
+function createEmptyPostWriteVerification() {
+    return {
+        matches: null,
+        raw_match_data: null,
+        bookmaker_odds_history: null,
+        l3_features: null,
+        match_features_training: null,
+        predictions: null,
+    };
+}
+
+function includesText(value, expected) {
+    return normalizeText(value).toLowerCase().includes(normalizeText(expected).toLowerCase());
+}
+
+function validateBaselineExact(actual = {}, expected = {}) {
+    return Object.entries(expected)
+        .filter(([key, expectedValue]) => Number(actual[key]) !== expectedValue)
+        .map(([key, expectedValue]) => `${key} baseline expected ${expectedValue}, got ${actual[key]}`);
+}
+
+function validateTargetMatchRows(rows = [], targetRegistry = []) {
+    if (!Array.isArray(rows)) return ['target match SELECT did not return an array'];
+    if (rows.length !== targetRegistry.length) {
+        return [`target match SELECT expected ${targetRegistry.length} rows, got ${rows.length}`];
+    }
+
+    const rowByMatchId = new Map(rows.map(row => [normalizeText(row.match_id), row]));
+    const errors = [];
+    for (const target of targetRegistry) {
+        const row = rowByMatchId.get(target.match_id);
+        if (!row) {
+            errors.push(`missing target match row for ${target.match_id}`);
+            continue;
+        }
+        if (normalizeText(row.external_id) !== target.external_id) {
+            errors.push(`target external_id mismatch for ${target.match_id}: ${row.external_id}`);
+        }
+        if (!includesText(row.home_team, target.home_team)) {
+            errors.push(`target home_team mismatch for ${target.match_id}: ${row.home_team}`);
+        }
+        if (!includesText(row.away_team, target.away_team)) {
+            errors.push(`target away_team mismatch for ${target.match_id}: ${row.away_team}`);
+        }
+    }
+    return errors;
+}
+
+function validateInsertedRows(rows = [], targetRegistry = [], dataVersion = EXPECTED_SCOPE.dataVersion) {
+    if (!Array.isArray(rows)) return ['inserted row metadata SELECT did not return an array'];
+    if (rows.length !== targetRegistry.length) {
+        return [`inserted row metadata expected ${targetRegistry.length} rows, got ${rows.length}`];
+    }
+
+    const rowByExternalId = new Map(rows.map(row => [normalizeText(row.external_id), row]));
+    const errors = [];
+    for (const target of targetRegistry) {
+        const row = rowByExternalId.get(target.external_id);
+        if (!row) {
+            errors.push(`missing inserted row metadata for external_id ${target.external_id}`);
+            continue;
+        }
+        if (normalizeText(row.match_id) !== target.match_id) {
+            errors.push(`inserted row match_id mismatch for external_id ${target.external_id}`);
+        }
+        if (normalizeText(row.data_version).toLowerCase() !== dataVersion) {
+            errors.push(`inserted row data_version mismatch for external_id ${target.external_id}`);
+        }
+        if (normalizeText(row.data_hash).toLowerCase() !== normalizeText(target.baseline_raw_data_hash).toLowerCase()) {
+            errors.push(`inserted row data_hash mismatch for external_id ${target.external_id}`);
+        }
+    }
+    return errors;
+}
+
+function assertSafeSelect(sql) {
+    const text = String(sql || '').trim();
+    const withoutTrailingSemicolon = text.replace(/;+\s*$/, '');
+    if (!/^\s*SELECT\b/i.test(withoutTrailingSemicolon)) {
+        throw new Error('Unsafe SQL blocked: query must start with SELECT');
+    }
+    if (withoutTrailingSemicolon.includes(';')) {
+        throw new Error('Unsafe SQL blocked: multiple statements are not allowed');
+    }
+    if (/\bFOR\s+UPDATE\b/i.test(withoutTrailingSemicolon)) {
+        throw new Error('Unsafe SQL blocked: SELECT FOR UPDATE is not allowed');
+    }
+    for (const verb of FORBIDDEN_SELECT_SQL_VERBS) {
+        if (new RegExp(`\\b${verb}\\b`, 'i').test(withoutTrailingSemicolon)) {
+            throw new Error(`Unsafe SQL blocked: ${verb} is not allowed`);
+        }
+    }
+}
+
+async function safeSelect(client, sql, values = []) {
+    assertSafeSelect(sql);
+    return client.query(sql, values);
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD || 'football_pass',
+        application_name: 'l2_remaining_raw_match_data_write',
+        max: 2,
+        idleTimeoutMillis: 5000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+function createPgPool() {
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+async function acquireDbConnection(dependencies = {}) {
+    if (dependencies.client) {
+        return {
+            client: dependencies.client,
+            release: async () => {},
+            cleanupPool: async () => {},
+        };
+    }
+
+    const pool = dependencies.pool || (dependencies.createPool || createPgPool)();
+    if (pool && typeof pool.connect === 'function') {
+        const client = await pool.connect();
+        return {
+            client,
+            release: async () => {
+                if (typeof client.release === 'function') client.release();
+            },
+            cleanupPool: async () => {
+                if (!dependencies.pool && typeof pool.end === 'function') await pool.end();
+            },
+        };
+    }
+
+    return {
+        client: pool,
+        release: async () => {},
+        cleanupPool: async () => {
+            if (!dependencies.pool && pool && typeof pool.end === 'function') await pool.end();
+        },
+    };
+}
+
+async function selectTargetMatches(client, targetRegistry = []) {
+    const query = `
+        SELECT match_id, external_id, home_team, away_team, match_date, status
+        FROM matches
+        WHERE match_id = ANY($1::text[])
+        ORDER BY match_id
+    `;
+    const result = await safeSelect(client, query, [targetRegistry.map(target => target.match_id)]);
+    return result.rows || [];
+}
+
+async function selectExistingRawMatchData(client, targetRegistry = []) {
+    const query = `
+        SELECT id, match_id, external_id, collected_at, data_version, data_hash
+        FROM raw_match_data
+        WHERE match_id = ANY($1::text[])
+           OR external_id = ANY($2::text[])
+        ORDER BY external_id, collected_at DESC NULLS LAST, id DESC
+    `;
+    const result = await safeSelect(client, query, [
+        targetRegistry.map(target => target.match_id),
+        targetRegistry.map(target => target.external_id),
+    ]);
+    return result.rows || [];
+}
+
+async function selectProtectedTableBaseline(client) {
+    const query = `
+        SELECT 'matches' AS table_name, COUNT(*)::int AS rows FROM matches
+        UNION ALL
+        SELECT 'bookmaker_odds_history', COUNT(*)::int FROM bookmaker_odds_history
+        UNION ALL
+        SELECT 'raw_match_data', COUNT(*)::int FROM raw_match_data
+        UNION ALL
+        SELECT 'l3_features', COUNT(*)::int FROM l3_features
+        UNION ALL
+        SELECT 'match_features_training', COUNT(*)::int FROM match_features_training
+        UNION ALL
+        SELECT 'predictions', COUNT(*)::int FROM predictions
+    `;
+    const result = await safeSelect(client, query, []);
+    return buildProtectedTableBaseline(result.rows || []);
+}
+
+async function selectInsertedRowsMetadata(client, targetRegistry = []) {
+    const query = `
+        SELECT id, match_id, external_id, collected_at, data_version, data_hash
+        FROM raw_match_data
+        WHERE external_id = ANY($1::text[])
+        ORDER BY external_id, id
+    `;
+    const result = await safeSelect(client, query, [targetRegistry.map(target => target.external_id)]);
+    return result.rows || [];
+}
+
+function buildInsertRawMatchDataSql({ matchId, externalId, rawData, collectedAt, dataVersion, dataHash }) {
+    return {
+        text: `
+            INSERT INTO raw_match_data (
+                match_id,
+                external_id,
+                raw_data,
+                collected_at,
+                data_version,
+                data_hash
+            )
+            VALUES ($1, $2, $3::jsonb, $4::timestamptz, $5, $6)
+            RETURNING id, match_id, external_id, collected_at, data_version, data_hash
+        `,
+        values: [matchId, externalId, JSON.stringify(rawData), collectedAt, dataVersion, dataHash],
+    };
+}
+
+function nowUtcIso(dependencies = {}) {
+    if (typeof dependencies.now === 'function') return dependencies.now();
+    if (dependencies.now) return dependencies.now;
+    return new Date().toISOString();
+}
+
+function sanitizePerTargetWrite(perTargetWrite = []) {
+    return perTargetWrite.map(entry => ({
+        match_id: entry.match_id,
+        external_id: entry.external_id,
+        home_team: entry.home_team,
+        away_team: entry.away_team,
+        selected_route: entry.selected_route,
+        request_url: entry.request_url,
+        final_url: entry.final_url,
+        http_status: entry.http_status,
+        content_type: entry.content_type,
+        body_byte_length: entry.body_byte_length,
+        body_sha256: entry.body_sha256,
+        hydration_parse_ok: entry.hydration_parse_ok === true,
+        looks_like_valid_match_detail: entry.looks_like_valid_match_detail === true,
+        baseline_raw_data_hash: entry.baseline_raw_data_hash,
+        raw_data_hash: entry.raw_data_hash,
+        hash_matches_baseline: entry.hash_matches_baseline === true,
+        existing_raw_match_data_found: entry.existing_raw_match_data_found === true,
+        decision: entry.decision,
+        body_printed: false,
+        body_saved: false,
+        browser_used: false,
+        proxy_used: false,
+    }));
+}
+
+function buildControlledRemainingWriteResult({
+    input = {},
+    executionCompleted = false,
+    targetCount = EXPECTED_SCOPE.targetCount,
+    attemptedTargetCount = 0,
+    validPayloadCount = 0,
+    hashMatchCount = 0,
+    hashDriftCount = 0,
+    invalidPayloadCount = 0,
+    existingRawMatchDataCount = 0,
+    insertedCount = 0,
+    updatedCount = 0,
+    skippedCount = 0,
+    rawMatchDataWriteExecuted = false,
+    dbWriteExecuted = false,
+    matchesWriteExecuted = false,
+    parserFeaturesExecuted = false,
+    trainingExecuted = false,
+    predictionExecuted = false,
+    perTargetWrite = [],
+    transaction = {},
+    postWriteVerification = null,
+    insertedRowsMetadata = [],
+    controlledError = null,
+    reason = null,
+}) {
+    const value = normalizeWriteInput(input);
+    const result = {
+        phase: PHASE,
+        execution_completed: executionCompleted,
+        source: value.source || EXPECTED_SCOPE.source,
+        league_id: value.leagueId || EXPECTED_SCOPE.leagueId,
+        season: value.season || EXPECTED_SCOPE.season,
+        date: value.date || EXPECTED_SCOPE.date,
+        route: value.route || EXPECTED_SCOPE.route,
+        data_version: value.dataVersion || EXPECTED_SCOPE.dataVersion,
+        target_count: targetCount,
+        attempted_target_count: attemptedTargetCount,
+        valid_payload_count: validPayloadCount,
+        hash_match_count: hashMatchCount,
+        hash_drift_count: hashDriftCount,
+        invalid_payload_count: invalidPayloadCount,
+        existing_raw_match_data_count: existingRawMatchDataCount,
+        inserted_count: insertedCount,
+        updated_count: updatedCount,
+        skipped_count: skippedCount,
+        raw_match_data_write_executed: rawMatchDataWriteExecuted,
+        db_write_executed: dbWriteExecuted,
+        matches_write_executed: matchesWriteExecuted,
+        parser_features_executed: parserFeaturesExecuted,
+        training_executed: trainingExecuted,
+        prediction_executed: predictionExecuted,
+        consolidated_fetcher_used: true,
+        per_target_write: sanitizePerTargetWrite(perTargetWrite),
+        transaction: {
+            began: transaction.began === true,
+            committed: transaction.committed === true,
+            rolled_back: transaction.rolled_back === true,
+        },
+        post_write_verification: postWriteVerification || createEmptyPostWriteVerification(),
+        inserted_row_metadata: Array.isArray(insertedRowsMetadata)
+            ? insertedRowsMetadata.map(row => ({
+                  id: row.id ?? null,
+                  match_id: row.match_id ?? null,
+                  external_id: row.external_id ?? null,
+                  collected_at: row.collected_at ?? null,
+                  data_version: row.data_version ?? null,
+                  data_hash: row.data_hash ?? null,
+              }))
+            : [],
+        body_printed: false,
+        body_saved: false,
+        browser_used: false,
+        proxy_used: false,
+        next_required_phase: NEXT_REQUIRED_PHASE,
+    };
+
+    if (reason) result.reason = reason;
+    if (controlledError) result.controlled_error = controlledError;
+    return result;
+}
+
+function buildRecaptureFailure(target, error) {
+    return {
+        route: EXPECTED_SCOPE.route,
+        request_url: null,
+        final_url: null,
+        http_status: 0,
+        content_type: null,
+        body_byte_length: 0,
+        body_sha256: null,
+        ok: false,
+        hydration_parse_ok: false,
+        looks_like_valid_match_detail: false,
+        raw_data: null,
+        raw_data_hash: null,
+        controlled_error: `RECAPTURE_ERROR:${target.external_id}:${String(error.message || error)}`,
+    };
+}
+
+async function executeRemainingRawMatchDataWrite(input = {}, dependencies = {}) {
+    const validation = dependencies.skipValidation
+        ? { ok: true, errors: [], value: normalizeWriteInput(input) }
+        : validateWriteInput(input);
+
+    if (!validation.ok) {
+        return buildControlledRemainingWriteResult({
+            input,
+            executionCompleted: false,
+            controlledError: `INVALID_CONTROLLED_REMAINING_WRITE_INPUT:${validation.errors.join('; ')}`,
+        });
+    }
+
+    const value = validation.value;
+    const targetRegistry = getRemainingTargetRegistry(value.baselineRawDataHashes);
+    const recaptureFn = dependencies.recaptureFn || recaptureTarget;
+    const recaptureDeps = dependencies.recaptureDeps || {
+        fetchFn: dependencies.fetchFn || global.fetch,
+        now: dependencies.fetchNow || dependencies.now,
+    };
+
+    const perTargetRecapture = [];
+    for (const target of targetRegistry) {
+        let recaptureResult;
+        try {
+            recaptureResult = await recaptureFn(target, recaptureDeps);
+        } catch (error) {
+            recaptureResult = buildRecaptureFailure(target, error);
+        }
+
+        const entry = buildPerTargetRecapture(target, recaptureResult);
+        perTargetRecapture.push(entry);
+
+        if (entry.valid_payload !== true) {
+            const hashGate = buildHashGateResult(perTargetRecapture, targetRegistry.length);
+            return buildControlledRemainingWriteResult({
+                input: value,
+                executionCompleted: false,
+                targetCount: targetRegistry.length,
+                attemptedTargetCount: hashGate.attemptedTargetCount,
+                validPayloadCount: hashGate.validPayloadCount,
+                hashMatchCount: hashGate.hashMatchCount,
+                hashDriftCount: hashGate.hashDriftCount,
+                invalidPayloadCount: hashGate.invalidPayloadCount,
+                perTargetWrite: perTargetRecapture,
+                reason: 'invalid_payload',
+                controlledError:
+                    entry.controlled_error ||
+                    `INVALID_PAYLOAD_FOR_EXTERNAL_ID:${entry.external_id}:${entry.raw_data_errors.join('; ')}`,
+            });
+        }
+
+        if (entry.hash_matches_baseline !== true) {
+            const hashGate = buildHashGateResult(perTargetRecapture, targetRegistry.length);
+            return buildControlledRemainingWriteResult({
+                input: value,
+                executionCompleted: false,
+                targetCount: targetRegistry.length,
+                attemptedTargetCount: hashGate.attemptedTargetCount,
+                validPayloadCount: hashGate.validPayloadCount,
+                hashMatchCount: hashGate.hashMatchCount,
+                hashDriftCount: hashGate.hashDriftCount,
+                invalidPayloadCount: hashGate.invalidPayloadCount,
+                perTargetWrite: perTargetRecapture,
+                reason: 'hash_drift',
+                controlledError: `RAW_DATA_HASH_DRIFT:${entry.external_id}: computed ${entry.raw_data_hash} differs from baseline ${entry.baseline_raw_data_hash}`,
+            });
+        }
+    }
+
+    const hashGate = buildHashGateResult(perTargetRecapture, targetRegistry.length);
+    if (!hashGate.ok) {
+        return buildControlledRemainingWriteResult({
+            input: value,
+            executionCompleted: false,
+            targetCount: targetRegistry.length,
+            attemptedTargetCount: hashGate.attemptedTargetCount,
+            validPayloadCount: hashGate.validPayloadCount,
+            hashMatchCount: hashGate.hashMatchCount,
+            hashDriftCount: hashGate.hashDriftCount,
+            invalidPayloadCount: hashGate.invalidPayloadCount,
+            perTargetWrite: perTargetRecapture,
+            reason: 'hash_gate_failed',
+            controlledError: 'HASH_GATE_FAILED',
+        });
+    }
+
+    const rowsToInsert = buildInsertRawMatchDataRows(perTargetRecapture, nowUtcIso(dependencies), value.dataVersion);
+    let connection = null;
+    const transaction = {
+        began: false,
+        committed: false,
+        rolled_back: false,
+    };
+
+    try {
+        connection = await acquireDbConnection(dependencies);
+        await connection.client.query('BEGIN');
+        transaction.began = true;
+
+        const targetMatchRows =
+            dependencies.targetMatchRowsOverride || (await selectTargetMatches(connection.client, targetRegistry));
+        const targetErrors = validateTargetMatchRows(targetMatchRows, targetRegistry);
+        if (targetErrors.length > 0) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return buildControlledRemainingWriteResult({
+                input: value,
+                executionCompleted: false,
+                targetCount: targetRegistry.length,
+                attemptedTargetCount: hashGate.attemptedTargetCount,
+                validPayloadCount: hashGate.validPayloadCount,
+                hashMatchCount: hashGate.hashMatchCount,
+                hashDriftCount: hashGate.hashDriftCount,
+                invalidPayloadCount: hashGate.invalidPayloadCount,
+                perTargetWrite: perTargetRecapture,
+                transaction,
+                reason: 'target_match_validation_failed',
+                controlledError: `TARGET_MATCH_VALIDATION_FAILED:${targetErrors.join('; ')}`,
+            });
+        }
+
+        const existingRawRows =
+            dependencies.existingRawRowsOverride ||
+            (await selectExistingRawMatchData(connection.client, targetRegistry));
+        if (!Array.isArray(existingRawRows)) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return buildControlledRemainingWriteResult({
+                input: value,
+                executionCompleted: false,
+                targetCount: targetRegistry.length,
+                attemptedTargetCount: hashGate.attemptedTargetCount,
+                validPayloadCount: hashGate.validPayloadCount,
+                hashMatchCount: hashGate.hashMatchCount,
+                hashDriftCount: hashGate.hashDriftCount,
+                invalidPayloadCount: hashGate.invalidPayloadCount,
+                perTargetWrite: perTargetRecapture,
+                transaction,
+                reason: 'existing_raw_query_invalid',
+                controlledError: 'EXISTING_RAW_MATCH_DATA_QUERY_INVALID',
+            });
+        }
+
+        if (existingRawRows.length > 0) {
+            const existingByExternalId = new Map(existingRawRows.map(row => [normalizeText(row.external_id), row]));
+            const blockedPerTarget = perTargetRecapture.map(entry => {
+                const existing = existingByExternalId.get(entry.external_id);
+                if (!existing) return entry;
+                return {
+                    ...entry,
+                    existing_raw_match_data_found: true,
+                    decision:
+                        normalizeText(existing.data_hash).toLowerCase() ===
+                        normalizeText(entry.raw_data_hash).toLowerCase()
+                            ? 'existing_row_conflict_same_hash'
+                            : 'existing_row_conflict_different_hash',
+                };
+            });
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return buildControlledRemainingWriteResult({
+                input: value,
+                executionCompleted: false,
+                targetCount: targetRegistry.length,
+                attemptedTargetCount: hashGate.attemptedTargetCount,
+                validPayloadCount: hashGate.validPayloadCount,
+                hashMatchCount: hashGate.hashMatchCount,
+                hashDriftCount: hashGate.hashDriftCount,
+                invalidPayloadCount: hashGate.invalidPayloadCount,
+                existingRawMatchDataCount: existingRawRows.length,
+                perTargetWrite: blockedPerTarget,
+                transaction,
+                reason: 'existing_raw_match_data_found',
+                controlledError: `EXISTING_RAW_MATCH_DATA_FOUND:${existingRawRows
+                    .map(row => `${row.external_id}:${row.data_hash}`)
+                    .join(', ')}`,
+            });
+        }
+
+        const preWriteBaseline =
+            dependencies.preWriteBaselineOverride || (await selectProtectedTableBaseline(connection.client));
+        const preWriteBaselineErrors = validateBaselineExact(preWriteBaseline, EXPECTED_PRE_WRITE_BASELINE);
+        if (preWriteBaselineErrors.length > 0) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return buildControlledRemainingWriteResult({
+                input: value,
+                executionCompleted: false,
+                targetCount: targetRegistry.length,
+                attemptedTargetCount: hashGate.attemptedTargetCount,
+                validPayloadCount: hashGate.validPayloadCount,
+                hashMatchCount: hashGate.hashMatchCount,
+                hashDriftCount: hashGate.hashDriftCount,
+                invalidPayloadCount: hashGate.invalidPayloadCount,
+                perTargetWrite: perTargetRecapture,
+                transaction,
+                reason: 'pre_write_baseline_mismatch',
+                controlledError: `PRE_WRITE_BASELINE_MISMATCH:${preWriteBaselineErrors.join('; ')}`,
+            });
+        }
+
+        for (const row of rowsToInsert) {
+            const insertSql = buildInsertRawMatchDataSql(row);
+            await connection.client.query(insertSql.text, insertSql.values);
+        }
+
+        const insertedRowsMetadata =
+            dependencies.insertedRowsMetadataOverride ||
+            (await selectInsertedRowsMetadata(connection.client, targetRegistry));
+        const insertedRowErrors = validateInsertedRows(insertedRowsMetadata, targetRegistry, value.dataVersion);
+        const postWriteBaseline =
+            dependencies.postWriteBaselineOverride || (await selectProtectedTableBaseline(connection.client));
+        const postWriteBaselineErrors = validateBaselineExact(postWriteBaseline, EXPECTED_POST_WRITE_BASELINE);
+        const verificationErrors = [...insertedRowErrors, ...postWriteBaselineErrors];
+
+        if (verificationErrors.length > 0) {
+            await connection.client.query('ROLLBACK');
+            transaction.rolled_back = true;
+            return buildControlledRemainingWriteResult({
+                input: value,
+                executionCompleted: false,
+                targetCount: targetRegistry.length,
+                attemptedTargetCount: hashGate.attemptedTargetCount,
+                validPayloadCount: hashGate.validPayloadCount,
+                hashMatchCount: hashGate.hashMatchCount,
+                hashDriftCount: hashGate.hashDriftCount,
+                invalidPayloadCount: hashGate.invalidPayloadCount,
+                perTargetWrite: perTargetRecapture,
+                transaction,
+                reason: 'post_write_verification_failed',
+                controlledError: `POST_WRITE_VERIFICATION_FAILED:${verificationErrors.join('; ')}`,
+            });
+        }
+
+        await connection.client.query('COMMIT');
+        transaction.committed = true;
+
+        const successPerTarget = perTargetRecapture.map(entry => ({
+            ...entry,
+            existing_raw_match_data_found: false,
+            decision: 'inserted',
+        }));
+
+        return buildControlledRemainingWriteResult({
+            input: value,
+            executionCompleted: true,
+            targetCount: targetRegistry.length,
+            attemptedTargetCount: hashGate.attemptedTargetCount,
+            validPayloadCount: hashGate.validPayloadCount,
+            hashMatchCount: hashGate.hashMatchCount,
+            hashDriftCount: hashGate.hashDriftCount,
+            invalidPayloadCount: hashGate.invalidPayloadCount,
+            existingRawMatchDataCount: 0,
+            insertedCount: targetRegistry.length,
+            updatedCount: 0,
+            skippedCount: 0,
+            rawMatchDataWriteExecuted: true,
+            dbWriteExecuted: true,
+            matchesWriteExecuted: false,
+            parserFeaturesExecuted: false,
+            trainingExecuted: false,
+            predictionExecuted: false,
+            perTargetWrite: successPerTarget,
+            transaction,
+            postWriteVerification: buildPostWriteVerification(postWriteBaseline),
+            insertedRowsMetadata,
+        });
+    } catch (error) {
+        if (transaction.began && transaction.committed !== true && transaction.rolled_back !== true) {
+            try {
+                await connection.client.query('ROLLBACK');
+                transaction.rolled_back = true;
+            } catch (rollbackError) {
+                error.rollback_error = rollbackError.message;
+            }
+        }
+        return buildControlledRemainingWriteResult({
+            input: value,
+            executionCompleted: false,
+            targetCount: targetRegistry.length,
+            attemptedTargetCount: hashGate.attemptedTargetCount,
+            validPayloadCount: hashGate.validPayloadCount,
+            hashMatchCount: hashGate.hashMatchCount,
+            hashDriftCount: hashGate.hashDriftCount,
+            invalidPayloadCount: hashGate.invalidPayloadCount,
+            perTargetWrite: perTargetRecapture,
+            transaction,
+            reason: 'controlled_write_error',
+            controlledError: String(error.message || error),
+        });
+    } finally {
+        if (connection) {
+            await connection.release();
+            await connection.cleanupPool();
+        }
+    }
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/l2_remaining_raw_match_data_write.js \\',
+        '    --source=fotmob --league-id=53 --season=2025/2026 --date=2026-05-10 \\',
+        '    --route=html_hydration \\',
+        '    --remaining-external-ids=4830747,4830748,4830750,4830751,4830752,4830753,4830754 \\',
+        '    --expected-target-count=7 \\',
+        '    --baseline-raw-data-hashes=4830747:435296093b7d73ec822262c00a22903fa1d28d260a5a2b982b0bf8006e191728,4830748:e98b0adb557d54ba0ada53ff836a5f6eea2629a0ed06389b78f23d83fbe617e5,4830750:5c02a11384459581821026aa2c85677e05877f219e158e5f733aef2ddb484880,4830751:b391b896c3260446b7185d81b31949ac47ad50cf956f733c87920f36579aed0f,4830752:dfe719cae63e09710b04aba411bf74b9662c554aff284a1f414fa255ee5cd93f,4830753:6b4438453fa7d0ceb99c80fb736d3cb7dcc51d5593b4ca48bb1ba682fe78fe4f,4830754:c843897451773c8317111a4c010da59223f1bb98cb7ce12253eafa4f57f550f7 \\',
+        '    --data-version=fotmob_html_hyd_v1 \\',
+        '    --network-authorization=yes --live-preview-authorization=yes --final-db-write-confirmation=yes \\',
+        '    --allow-db-write=yes --allow-raw-match-data-write=yes --allow-matches-write=no \\',
+        '    --allow-parser-features=no --allow-training=no --allow-prediction=no \\',
+        '    --concurrency=1 --retry=0 --print-body=no --save-body=no',
+        '',
+        'Safety:',
+        '  Phase 5.20L2C performs one controlled recapture pass for the remaining 7 targets,',
+        '  compares every raw_data_hash with the Phase 5.20L2B baselines,',
+        '  and writes only raw_match_data inside one transaction.',
+    ].join('\n');
+}
+
+async function runCli(argv = process.argv.slice(2), io = {}, dependencies = {}) {
+    const stdout = io.stdout || process.stdout.write.bind(process.stdout);
+    const args = parseArgs(argv);
+    if (args.help) {
+        stdout(`${usage()}\n`);
+        return 0;
+    }
+
+    const result = await executeRemainingRawMatchDataWrite(args, dependencies);
+    stdout(`${JSON.stringify(result, null, 2)}\n`);
+    return result.execution_completed ? 0 : 1;
+}
+
+if (require.main === module) {
+    runCli()
+        .then(status => {
+            process.exitCode = status;
+        })
+        .catch(error => {
+            process.stdout.write(
+                `${JSON.stringify(
+                    buildControlledRemainingWriteResult({
+                        input: {},
+                        executionCompleted: false,
+                        controlledError: String(error.message || error),
+                    }),
+                    null,
+                    2
+                )}\n`
+            );
+            process.exitCode = 1;
+        });
+}
+
+module.exports = {
+    parseArgs,
+    normalizeBooleanFlag,
+    parseRemainingExternalIds,
+    parseBaselineRawDataHashes,
+    validateWriteInput,
+    getRemainingTargetRegistry,
+    buildPerTargetRecapture,
+    buildHashGateResult,
+    buildInsertRawMatchDataRows,
+    buildPostWriteVerification,
+    executeRemainingRawMatchDataWrite,
+    buildControlledRemainingWriteResult,
+    runCli,
+};

--- a/tests/unit/l2_remaining_raw_match_data_write.test.js
+++ b/tests/unit/l2_remaining_raw_match_data_write.test.js
@@ -1,0 +1,1051 @@
+/* eslint-disable max-lines */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts/ops/l2_remaining_raw_match_data_write.js');
+const MAKEFILE_PATH = path.join(PROJECT_ROOT, 'Makefile');
+
+const EXPECTED_IDS = Object.freeze(['4830747', '4830748', '4830750', '4830751', '4830752', '4830753', '4830754']);
+const EXPECTED_MATCH_IDS = Object.freeze([
+    '53_20252026_4830747',
+    '53_20252026_4830748',
+    '53_20252026_4830750',
+    '53_20252026_4830751',
+    '53_20252026_4830752',
+    '53_20252026_4830753',
+    '53_20252026_4830754',
+]);
+
+const BASELINE_MAP = Object.freeze({
+    4830747: '435296093b7d73ec822262c00a22903fa1d28d260a5a2b982b0bf8006e191728',
+    4830748: 'e98b0adb557d54ba0ada53ff836a5f6eea2629a0ed06389b78f23d83fbe617e5',
+    4830750: '5c02a11384459581821026aa2c85677e05877f219e158e5f733aef2ddb484880',
+    4830751: 'b391b896c3260446b7185d81b31949ac47ad50cf956f733c87920f36579aed0f',
+    4830752: 'dfe719cae63e09710b04aba411bf74b9662c554aff284a1f414fa255ee5cd93f',
+    4830753: '6b4438453fa7d0ceb99c80fb736d3cb7dcc51d5593b4ca48bb1ba682fe78fe4f',
+    4830754: 'c843897451773c8317111a4c010da59223f1bb98cb7ce12253eafa4f57f550f7',
+});
+
+const PRE_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 3,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+
+const POST_BASELINE = Object.freeze({
+    matches: 10,
+    raw_match_data: 10,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+
+const TARGETS = Object.freeze([
+    { match_id: '53_20252026_4830747', external_id: '4830747', home_team: 'Auxerre', away_team: 'Nice' },
+    { match_id: '53_20252026_4830748', external_id: '4830748', home_team: 'Le Havre', away_team: 'Marseille' },
+    { match_id: '53_20252026_4830750', external_id: '4830750', home_team: 'Metz', away_team: 'Lorient' },
+    { match_id: '53_20252026_4830751', external_id: '4830751', home_team: 'Monaco', away_team: 'Lille' },
+    {
+        match_id: '53_20252026_4830752',
+        external_id: '4830752',
+        home_team: 'Paris Saint-Germain',
+        away_team: 'Brest',
+    },
+    { match_id: '53_20252026_4830753', external_id: '4830753', home_team: 'Rennes', away_team: 'Paris FC' },
+    { match_id: '53_20252026_4830754', external_id: '4830754', home_team: 'Toulouse', away_team: 'Lyon' },
+]);
+
+function loadModuleFresh() {
+    delete require.cache[SCRIPT_PATH];
+    return require(SCRIPT_PATH);
+}
+
+function baselineHashString(map = BASELINE_MAP) {
+    return EXPECTED_IDS.map(externalId => `${externalId}:${map[externalId]}`).join(',');
+}
+
+function validArgs(overrides = {}) {
+    return {
+        source: 'fotmob',
+        leagueId: '53',
+        season: '2025/2026',
+        date: '2026-05-10',
+        route: 'html_hydration',
+        remainingExternalIds: EXPECTED_IDS.join(','),
+        expectedTargetCount: 7,
+        baselineRawDataHashes: baselineHashString(),
+        dataVersion: 'fotmob_html_hyd_v1',
+        networkAuthorization: true,
+        livePreviewAuthorization: true,
+        finalDbWriteConfirmation: true,
+        allowDbWrite: true,
+        allowRawMatchDataWrite: true,
+        allowMatchesWrite: false,
+        allowParserFeatures: false,
+        allowTraining: false,
+        allowPrediction: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        concurrency: 1,
+        retry: 0,
+        printBody: false,
+        saveBody: false,
+        bulk: false,
+        commit: false,
+        execute: false,
+        ...overrides,
+    };
+}
+
+function toYesNo(value) {
+    return value ? 'yes' : 'no';
+}
+
+function cliArgs(overrides = {}) {
+    const args = validArgs(overrides);
+    return [
+        `--source=${args.source}`,
+        `--league-id=${args.leagueId}`,
+        `--season=${args.season}`,
+        `--date=${args.date}`,
+        `--route=${args.route}`,
+        `--remaining-external-ids=${args.remainingExternalIds}`,
+        `--expected-target-count=${args.expectedTargetCount}`,
+        `--baseline-raw-data-hashes=${args.baselineRawDataHashes}`,
+        `--data-version=${args.dataVersion}`,
+        `--network-authorization=${toYesNo(args.networkAuthorization)}`,
+        `--live-preview-authorization=${toYesNo(args.livePreviewAuthorization)}`,
+        `--final-db-write-confirmation=${toYesNo(args.finalDbWriteConfirmation)}`,
+        `--allow-db-write=${toYesNo(args.allowDbWrite)}`,
+        `--allow-raw-match-data-write=${toYesNo(args.allowRawMatchDataWrite)}`,
+        `--allow-matches-write=${toYesNo(args.allowMatchesWrite)}`,
+        `--allow-parser-features=${toYesNo(args.allowParserFeatures)}`,
+        `--allow-training=${toYesNo(args.allowTraining)}`,
+        `--allow-prediction=${toYesNo(args.allowPrediction)}`,
+        `--allow-browser-runtime=${toYesNo(args.allowBrowserRuntime)}`,
+        `--allow-proxy-runtime=${toYesNo(args.allowProxyRuntime)}`,
+        `--concurrency=${args.concurrency}`,
+        `--retry=${args.retry}`,
+        `--print-body=${toYesNo(args.printBody)}`,
+        `--save-body=${toYesNo(args.saveBody)}`,
+        `--bulk=${toYesNo(args.bulk)}`,
+        `--commit=${toYesNo(args.commit)}`,
+        `--execute=${toYesNo(args.execute)}`,
+    ];
+}
+
+function fakeRawData(target) {
+    return {
+        _meta: {
+            source: 'fotmob',
+            route: 'html_hydration',
+            request_url: `https://www.fotmob.com/match/${target.external_id}`,
+            final_url: `https://www.fotmob.com/match/${target.external_id}`,
+            http_status: 200,
+            content_type: 'text/html; charset=utf-8',
+            body_byte_length: 100000 + Number(target.external_id),
+            fetch_body_sha256: `body-${target.external_id}`,
+            parser: 'NextDataParser',
+            data_version: 'fotmob_html_hyd_v1',
+            fetched_at: '2026-05-15T00:00:00.000Z',
+        },
+        content: {
+            stats: [{ title: 'Top stats', stats: [] }],
+            lineup: { homeTeam: target.home_team, awayTeam: target.away_team },
+        },
+        general: {
+            matchId: target.external_id,
+            homeTeam: { name: target.home_team },
+            awayTeam: { name: target.away_team },
+        },
+        header: {
+            teams: [{ name: target.home_team }, { name: target.away_team }],
+        },
+        matchId: target.external_id,
+    };
+}
+
+function fakeRecapture(target, gate, overrides = {}) {
+    const rawData = overrides.rawData || fakeRawData(target);
+    const rawDataHash =
+        overrides.rawDataHash ||
+        gate.buildPerTargetRecapture(
+            { ...target, baseline_raw_data_hash: BASELINE_MAP[target.external_id] },
+            {
+                route: 'html_hydration',
+                request_url: `https://www.fotmob.com/match/${target.external_id}`,
+                final_url: `https://www.fotmob.com/match/${target.external_id}`,
+                http_status: 200,
+                content_type: 'text/html; charset=utf-8',
+                body_byte_length: 100000 + Number(target.external_id),
+                body_sha256: `body-sha-${target.external_id}`,
+                ok: true,
+                hydration_parse_ok: true,
+                looks_like_valid_match_detail: true,
+                raw_data: rawData,
+                raw_data_hash: null,
+            }
+        ).raw_data_hash;
+    return {
+        route: 'html_hydration',
+        request_url: `https://www.fotmob.com/match/${target.external_id}`,
+        final_url: `https://www.fotmob.com/match/${target.external_id}`,
+        http_status: 200,
+        content_type: 'text/html; charset=utf-8',
+        body_byte_length: 100000 + Number(target.external_id),
+        body_sha256: `body-sha-${target.external_id}`,
+        ok: true,
+        hydration_parse_ok: true,
+        looks_like_valid_match_detail: true,
+        raw_data: rawData,
+        raw_data_hash: rawDataHash,
+        controlled_error: null,
+        ...overrides,
+    };
+}
+
+function computedBaselineMap(gate) {
+    return Object.fromEntries(
+        TARGETS.map(target => {
+            const entry = gate.buildPerTargetRecapture(
+                { ...target, baseline_raw_data_hash: 'placeholder' },
+                fakeRecapture(target, gate)
+            );
+            return [target.external_id, entry.raw_data_hash];
+        })
+    );
+}
+
+function computedBaselineString(gate) {
+    const map = computedBaselineMap(gate);
+    return EXPECTED_IDS.map(externalId => `${externalId}:${map[externalId]}`).join(',');
+}
+
+function executionArgs(gate, overrides = {}) {
+    return validArgs({
+        baselineRawDataHashes: computedBaselineString(gate),
+        ...overrides,
+    });
+}
+
+function executionCliArgs(gate, overrides = {}) {
+    return cliArgs({
+        baselineRawDataHashes: computedBaselineString(gate),
+        ...overrides,
+    });
+}
+
+function targetMatchRows() {
+    return TARGETS.map(target => ({
+        match_id: target.match_id,
+        external_id: target.external_id,
+        home_team: target.home_team,
+        away_team: target.away_team,
+        match_date: '2026-05-10T19:00:00.000Z',
+        status: 'finished',
+    }));
+}
+
+function insertedRowsMetadata(hashMap = BASELINE_MAP) {
+    return TARGETS.map((target, index) => ({
+        id: 100 + index,
+        match_id: target.match_id,
+        external_id: target.external_id,
+        collected_at: '2026-05-15T01:02:03.000Z',
+        data_version: 'fotmob_html_hyd_v1',
+        data_hash: hashMap[target.external_id],
+    }));
+}
+
+function buildBaselineRows(baselineRows) {
+    return Object.entries(baselineRows).map(([table_name, rows]) => ({ table_name, rows }));
+}
+
+function isSelectUnionQuery(text) {
+    return /^SELECT/i.test(text) && text.includes('UNION ALL');
+}
+
+function isSelectMatchesQuery(text) {
+    return /^SELECT/i.test(text) && text.includes('FROM matches');
+}
+
+function isSelectRawMatchDataQuery(text) {
+    return /^SELECT/i.test(text) && text.includes('FROM raw_match_data');
+}
+
+function isInsertRawMatchDataQuery(text) {
+    return /^INSERT\s+INTO\s+raw_match_data/i.test(text);
+}
+
+function buildQueryResponse(text, queries, options) {
+    const { existingRows, preBaseline, postBaseline, insertFailure, insertedMetadata } = options;
+
+    if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') {
+        return { rows: [] };
+    }
+    if (isSelectUnionQuery(text)) {
+        const hasInsert = queries.some(item => isInsertRawMatchDataQuery(item.text));
+        return { rows: buildBaselineRows(hasInsert ? postBaseline : preBaseline) };
+    }
+    if (isSelectMatchesQuery(text)) {
+        return { rows: targetMatchRows() };
+    }
+    if (isSelectRawMatchDataQuery(text)) {
+        const values = queries[queries.length - 1].values || [];
+        if (values.length === 1) {
+            return { rows: insertedMetadata };
+        }
+        return { rows: existingRows };
+    }
+    if (isInsertRawMatchDataQuery(text)) {
+        if (insertFailure) throw insertFailure;
+        return { rows: [] };
+    }
+    throw new Error(`unexpected query: ${text}`);
+}
+
+function buildReadWriteClient({
+    existingRows = [],
+    preBaseline = PRE_BASELINE,
+    postBaseline = POST_BASELINE,
+    insertFailure = null,
+    hashMap = BASELINE_MAP,
+    insertedMetadata = insertedRowsMetadata(hashMap),
+} = {}) {
+    const queries = [];
+    const options = {
+        existingRows,
+        preBaseline,
+        postBaseline,
+        insertFailure,
+        insertedMetadata,
+    };
+    return {
+        queries,
+        async query(sql, values = []) {
+            const text = String(sql || '').trim();
+            queries.push({ text, values });
+            return buildQueryResponse(text, queries, options);
+        },
+    };
+}
+
+function buildConnectablePool(client) {
+    let released = false;
+    let ended = false;
+    return {
+        pool: {
+            async connect() {
+                return {
+                    query: client.query.bind(client),
+                    release() {
+                        released = true;
+                    },
+                };
+            },
+            async end() {
+                ended = true;
+            },
+        },
+        get released() {
+            return released;
+        },
+        get ended() {
+            return ended;
+        },
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalFetch = global.fetch;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by l2_remaining_raw_match_data_write`);
+    };
+
+    global.fetch = fail('global.fetch');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'pg',
+            'playwright',
+            'playwright-core',
+            'puppeteer',
+            'child_process',
+            'node:child_process',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (/ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/i.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        Module._load = originalLoad;
+    });
+}
+
+async function runCli(gate, argv, dependencies = {}) {
+    let stdout = '';
+    const status = await gate.runCli(
+        argv,
+        {
+            stdout: text => {
+                stdout += text;
+            },
+        },
+        dependencies
+    );
+    return {
+        status,
+        stdout,
+        payload: stdout.trim().startsWith('{') ? JSON.parse(stdout) : null,
+    };
+}
+
+function assertInvalid(overrides, pattern) {
+    const gate = loadModuleFresh();
+    const validation = gate.validateWriteInput(validArgs(overrides));
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), pattern);
+}
+
+test('valid input succeeds', () => {
+    const gate = loadModuleFresh();
+    const validation = gate.validateWriteInput(validArgs());
+    assert.equal(validation.ok, true);
+    assert.deepEqual(validation.errors, []);
+});
+
+test('source missing fails', () => assertInvalid({ source: '' }, /missing source/));
+test('source non-fotmob fails', () => assertInvalid({ source: 'other' }, /source must be fotmob/));
+test('league-id missing fails', () => assertInvalid({ leagueId: '' }, /missing league-id/));
+test('league-id not 53 fails', () => assertInvalid({ leagueId: '1' }, /league-id must be 53/));
+test('season missing fails', () => assertInvalid({ season: '' }, /missing season/));
+test('season not 2025\\/2026 fails', () => assertInvalid({ season: '2024/2025' }, /season must be 2025\/2026/));
+test('date missing fails', () => assertInvalid({ date: '' }, /missing date/));
+test('date not 2026-05-10 fails', () => assertInvalid({ date: '2026-05-11' }, /date must be 2026-05-10/));
+test('route missing fails', () => assertInvalid({ route: '' }, /missing route/));
+test('route not html_hydration fails', () => assertInvalid({ route: 'api' }, /route must be html_hydration/));
+test('remaining-external-ids missing fails', () =>
+    assertInvalid({ remainingExternalIds: '' }, /remaining-external-ids is required/));
+test('remaining-external-ids wrong count fails', () =>
+    assertInvalid({ remainingExternalIds: '4830747' }, /must have 7 ids/));
+test('remaining-external-ids includes 4830746 fails', () =>
+    assertInvalid(
+        { remainingExternalIds: '4830746,4830747,4830748,4830750,4830751,4830752,4830753' },
+        /already ingested/
+    ));
+test('remaining-external-ids missing 4830754 fails', () =>
+    assertInvalid(
+        { remainingExternalIds: '4830747,4830748,4830750,4830751,4830752,4830753,9999999' },
+        /missing expected remaining external_id: 4830754/
+    ));
+test('expected-target-count not 7 fails', () => assertInvalid({ expectedTargetCount: 6 }, /must be 7/));
+test('baseline hashes missing fails', () =>
+    assertInvalid({ baselineRawDataHashes: '' }, /baseline-raw-data-hashes is required/));
+test('baseline hashes wrong count fails', () =>
+    assertInvalid(
+        { baselineRawDataHashes: '4830747:435296093b7d73ec822262c00a22903fa1d28d260a5a2b982b0bf8006e191728' },
+        /must contain 7 hashes/
+    ));
+test('baseline hashes missing 4830754 fails', () => {
+    const partial = EXPECTED_IDS.slice(0, 6)
+        .map(externalId => `${externalId}:${BASELINE_MAP[externalId]}`)
+        .join(',');
+    assertInvalid({ baselineRawDataHashes: partial }, /missing baseline raw_data_hash for external_id 4830754/);
+});
+test('baseline hash invalid format fails', () =>
+    assertInvalid(
+        {
+            baselineRawDataHashes:
+                '4830747:bad,4830748:e98b0adb557d54ba0ada53ff836a5f6eea2629a0ed06389b78f23d83fbe617e5,4830750:5c02a11384459581821026aa2c85677e05877f219e158e5f733aef2ddb484880,4830751:b391b896c3260446b7185d81b31949ac47ad50cf956f733c87920f36579aed0f,4830752:dfe719cae63e09710b04aba411bf74b9662c554aff284a1f414fa255ee5cd93f,4830753:6b4438453fa7d0ceb99c80fb736d3cb7dcc51d5593b4ca48bb1ba682fe78fe4f,4830754:c843897451773c8317111a4c010da59223f1bb98cb7ce12253eafa4f57f550f7',
+        },
+        /invalid baseline raw_data_hash format/
+    ));
+test('data-version missing fails', () => assertInvalid({ dataVersion: '' }, /missing data-version/));
+test('data-version not fotmob_html_hyd_v1 fails', () =>
+    assertInvalid({ dataVersion: 'other_v1' }, /data-version must be fotmob_html_hyd_v1/));
+test('network-authorization=no fails', () =>
+    assertInvalid({ networkAuthorization: false }, /network-authorization=yes is required/));
+test('live-preview-authorization=no fails', () =>
+    assertInvalid({ livePreviewAuthorization: false }, /live-preview-authorization=yes is required/));
+test('final-db-write-confirmation=no fails', () =>
+    assertInvalid({ finalDbWriteConfirmation: false }, /final-db-write-confirmation=yes is required/));
+test('allow-db-write=no fails', () => assertInvalid({ allowDbWrite: false }, /allow-db-write=yes is required/));
+test('allow-raw-match-data-write=no fails', () =>
+    assertInvalid({ allowRawMatchDataWrite: false }, /allow-raw-match-data-write=yes is required/));
+test('allow-matches-write=yes blocked', () =>
+    assertInvalid({ allowMatchesWrite: true }, /allow-matches-write=yes is blocked/));
+test('allow-parser-features=yes blocked', () =>
+    assertInvalid({ allowParserFeatures: true }, /allow-parser-features=yes is blocked/));
+test('allow-training=yes blocked', () => assertInvalid({ allowTraining: true }, /allow-training=yes is blocked/));
+test('allow-prediction=yes blocked', () => assertInvalid({ allowPrediction: true }, /allow-prediction=yes is blocked/));
+test('retry > 0 blocked', () => assertInvalid({ retry: 1 }, /retry must be 0/));
+test('concurrency > 1 blocked', () => assertInvalid({ concurrency: 2 }, /concurrency must be 1/));
+test('print-body=yes blocked', () => assertInvalid({ printBody: true }, /print-body=yes is blocked/));
+test('save-body=yes blocked', () => assertInvalid({ saveBody: true }, /save-body=yes is blocked/));
+test('browser\\/proxy allowed blocked', () => {
+    assertInvalid({ allowBrowserRuntime: true }, /allow-browser-runtime=yes is blocked/);
+    assertInvalid({ allowProxyRuntime: true }, /allow-proxy-runtime=yes is blocked/);
+});
+test('bulk=yes blocked', () => assertInvalid({ bulk: true }, /bulk=yes is blocked/));
+
+test('normalizeBooleanFlag handles fallback and parseArgs handles unknown arguments', () => {
+    const gate = loadModuleFresh();
+    assert.equal(gate.normalizeBooleanFlag('YES'), true);
+    assert.equal(gate.normalizeBooleanFlag('off'), false);
+    assert.equal(gate.normalizeBooleanFlag('maybe', false), false);
+    assert.equal(gate.normalizeBooleanFlag('', true), true);
+
+    const args = gate.parseArgs(['orphan', '--source', 'fotmob', '--league-id', '53', '--mystery', '--help']);
+    assert.equal(args.source, 'fotmob');
+    assert.equal(args.leagueId, '53');
+    assert.equal(args.help, true);
+    assert.deepEqual(args.unknown, ['orphan', 'mystery']);
+});
+
+test('parseRemainingExternalIds and parseBaselineRawDataHashes parse exact scope', () => {
+    const gate = loadModuleFresh();
+    assert.deepEqual(gate.parseRemainingExternalIds(EXPECTED_IDS.join(',')), EXPECTED_IDS);
+    assert.deepEqual(gate.parseBaselineRawDataHashes(baselineHashString()), BASELINE_MAP);
+});
+
+test('getRemainingTargetRegistry returns exact ordered targets with baseline hashes', () => {
+    const gate = loadModuleFresh();
+    const registry = gate.getRemainingTargetRegistry(BASELINE_MAP);
+    assert.equal(registry.length, 7);
+    assert.equal(registry[0].external_id, '4830747');
+    assert.equal(registry[6].external_id, '4830754');
+    assert.equal(registry[0].baseline_raw_data_hash, BASELINE_MAP['4830747']);
+});
+
+test('buildPerTargetRecapture builds canonical per-target shape', () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const target = gate.getRemainingTargetRegistry(baselineMap)[0];
+    const recapture = fakeRecapture(target, gate, {
+        rawDataHash: baselineMap[target.external_id],
+    });
+    const entry = gate.buildPerTargetRecapture(target, recapture);
+    assert.equal(entry.hash_matches_baseline, true);
+    assert.equal(entry.body_printed, false);
+    assert.equal(entry.body_saved, false);
+    assert.equal(entry.browser_used, false);
+    assert.equal(entry.proxy_used, false);
+});
+
+test('buildHashGateResult counts matching entries', () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const registry = gate.getRemainingTargetRegistry(baselineMap);
+    const entries = registry.map(target =>
+        gate.buildPerTargetRecapture(
+            target,
+            fakeRecapture(target, gate, {
+                rawDataHash: baselineMap[target.external_id],
+            })
+        )
+    );
+    const result = gate.buildHashGateResult(entries, 7);
+    assert.equal(result.ok, true);
+    assert.equal(result.hashMatchCount, 7);
+    assert.equal(result.hashDriftCount, 0);
+});
+
+test('buildInsertRawMatchDataRows returns 7 parameter rows', () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const registry = gate.getRemainingTargetRegistry(baselineMap);
+    const entries = registry.map(target =>
+        gate.buildPerTargetRecapture(
+            target,
+            fakeRecapture(target, gate, {
+                rawDataHash: baselineMap[target.external_id],
+            })
+        )
+    );
+    const rows = gate.buildInsertRawMatchDataRows(entries, '2026-05-15T01:02:03.000Z');
+    assert.equal(rows.length, 7);
+    assert.deepEqual(
+        rows.map(row => row.externalId),
+        EXPECTED_IDS
+    );
+});
+
+test('buildPostWriteVerification includes protected tables', () => {
+    const gate = loadModuleFresh();
+    assert.deepEqual(gate.buildPostWriteVerification(POST_BASELINE), POST_BASELINE);
+});
+
+test('fake fetcher returns 7 matching hashes -> inserts 7 rows in fake transaction', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const registry = gate.getRemainingTargetRegistry(baselineMap);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target =>
+            fakeRecapture(target, gate, {
+                rawDataHash: baselineMap[target.external_id],
+            }),
+        recaptureDeps: {},
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.attempted_target_count, registry.length);
+    assert.equal(result.valid_payload_count, 7);
+    assert.equal(result.hash_match_count, 7);
+    assert.equal(result.hash_drift_count, 0);
+    assert.equal(result.inserted_count, 7);
+    assert.equal(result.updated_count, 0);
+    assert.equal(result.skipped_count, 0);
+    assert.equal(result.raw_match_data_write_executed, true);
+    assert.equal(result.db_write_executed, true);
+});
+
+test('hash drift on first target -> no transaction / no write', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient();
+    let callIndex = 0;
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => {
+            callIndex += 1;
+            const driftedRawData =
+                callIndex === 1
+                    ? {
+                          ...fakeRawData(target),
+                          _meta: {
+                              ...fakeRawData(target)._meta,
+                              drift_marker: 'first',
+                          },
+                      }
+                    : undefined;
+            return fakeRecapture(target, gate, {
+                rawData: driftedRawData,
+            });
+        },
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.hash_drift_count, 1);
+    assert.equal(result.db_write_executed, false);
+    assert.equal(result.raw_match_data_write_executed, false);
+    assert.equal(client.queries.length, 0);
+});
+
+test('hash drift on middle target -> no write', async () => {
+    const gate = loadModuleFresh();
+    const client = buildReadWriteClient();
+    let callIndex = 0;
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => {
+            callIndex += 1;
+            const driftedRawData =
+                callIndex === 4
+                    ? {
+                          ...fakeRawData(target),
+                          _meta: {
+                              ...fakeRawData(target)._meta,
+                              drift_marker: 'middle',
+                          },
+                      }
+                    : undefined;
+            return fakeRecapture(target, gate, {
+                rawData: driftedRawData,
+            });
+        },
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.hash_drift_count, 1);
+    assert.equal(result.db_write_executed, false);
+    assert.equal(result.raw_match_data_write_executed, false);
+    assert.equal(client.queries.length, 0);
+});
+
+test('existing raw row found -> no write', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const existingRows = [
+        {
+            id: 1,
+            match_id: '53_20252026_4830747',
+            external_id: '4830747',
+            collected_at: '2026-05-14T00:00:00.000Z',
+            data_version: 'fotmob_html_hyd_v1',
+            data_hash: 'old-hash',
+        },
+    ];
+    const client = buildReadWriteClient({ existingRows });
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.raw_match_data_write_executed, false);
+    assert.equal(result.db_write_executed, false);
+    assert.equal(result.existing_raw_match_data_count, 1);
+    assert.equal(result.transaction.rolled_back, true);
+});
+
+test('existing same hash row found -> no write in this phase, report conflict', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const existingRows = [
+        {
+            id: 1,
+            match_id: '53_20252026_4830747',
+            external_id: '4830747',
+            collected_at: '2026-05-14T00:00:00.000Z',
+            data_version: 'fotmob_html_hyd_v1',
+            data_hash: baselineMap['4830747'],
+        },
+    ];
+    const client = buildReadWriteClient({ existingRows });
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.raw_match_data_write_executed, false);
+    assert.match(result.controlled_error, /EXISTING_RAW_MATCH_DATA_FOUND/);
+    assert.equal(
+        result.per_target_write.find(entry => entry.external_id === '4830747').decision,
+        'existing_row_conflict_same_hash'
+    );
+});
+
+test('fake insert failure -> transaction rollback', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const client = buildReadWriteClient({ insertFailure: new Error('insert failed'), hashMap: baselineMap });
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.execution_completed, false);
+    assert.equal(result.transaction.began, true);
+    assert.equal(result.transaction.committed, false);
+    assert.equal(result.transaction.rolled_back, true);
+    assert.match(result.controlled_error, /insert failed/);
+});
+
+test('transaction commits on success', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const client = buildReadWriteClient({ hashMap: baselineMap });
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.transaction.began, true);
+    assert.equal(result.transaction.committed, true);
+    assert.equal(result.transaction.rolled_back, false);
+});
+
+test('SQL targets only raw_match_data', () => {
+    const gate = loadModuleFresh();
+    const sql = gate.buildInsertRawMatchDataRows(
+        TARGETS.map(target => ({
+            match_id: target.match_id,
+            external_id: target.external_id,
+            raw_data: fakeRawData(target),
+            raw_data_hash: BASELINE_MAP[target.external_id],
+        })),
+        '2026-05-15T01:02:03.000Z'
+    );
+    assert.equal(sql.length, 7);
+});
+
+test('no SQL writes to matches/features/predictions', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const client = buildReadWriteClient({ hashMap: baselineMap });
+    await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    const sqlText = client.queries.map(item => item.text).join('\n');
+    assert.doesNotMatch(sqlText, /\bINSERT\s+INTO\s+matches\b/i);
+    assert.doesNotMatch(sqlText, /\bUPDATE\s+matches\b/i);
+    assert.doesNotMatch(sqlText, /\bINSERT\s+INTO\s+l3_features\b/i);
+    assert.doesNotMatch(sqlText, /\bINSERT\s+INTO\s+match_features_training\b/i);
+    assert.doesNotMatch(sqlText, /\bINSERT\s+INTO\s+predictions\b/i);
+    assert.doesNotMatch(sqlText, /\bUPDATE\s+l3_features\b/i);
+    assert.doesNotMatch(sqlText, /\bUPDATE\s+match_features_training\b/i);
+    assert.doesNotMatch(sqlText, /\bUPDATE\s+predictions\b/i);
+});
+
+test('output inserted_count=7 on fake success', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.inserted_count, 7);
+});
+
+test('output raw_match_data_write_executed=true on fake success', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.raw_match_data_write_executed, true);
+});
+
+test('output matches_write_executed=false', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.matches_write_executed, false);
+});
+
+test('output parser_features_executed=false', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.parser_features_executed, false);
+});
+
+test('post_write_verification includes protected tables', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.deepEqual(result.post_write_verification, POST_BASELINE);
+});
+
+test('no full body print/save', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.body_printed, false);
+    assert.equal(result.body_saved, false);
+});
+
+test('runCli uses fake payload and fake write DB without fs writes or spawn', async t => {
+    installExecutionGuards(t);
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const client = buildReadWriteClient({ hashMap: baselineMap });
+    const result = await runCli(gate, executionCliArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.status, 0);
+    assert.equal(result.payload.execution_completed, true);
+    assert.equal(result.payload.inserted_count, 7);
+});
+
+test('runCli returns non-zero for blocked allow-matches-write', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, cliArgs({ allowMatchesWrite: true }));
+    assert.equal(result.status, 1);
+    assert.equal(result.payload.execution_completed, false);
+    assert.match(result.payload.controlled_error, /allow-matches-write=yes is blocked/);
+});
+
+test('runCli help returns usage without executing write', async () => {
+    const gate = loadModuleFresh();
+    const result = await runCli(gate, ['--help']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Phase 5\.20L2C performs one controlled recapture pass/);
+    assert.equal(result.payload, null);
+});
+
+test('executeRemainingRawMatchDataWrite supports connectable pool cleanup and now() function', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const client = buildReadWriteClient({ hashMap: baselineMap });
+    const pooled = buildConnectablePool(client);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        createPool: () => pooled.pool,
+        now: () => '2026-05-15T01:02:03.000Z',
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(pooled.released, true);
+    assert.equal(pooled.ended, true);
+});
+
+test('skipValidation path can execute with provided dependencies', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client: buildReadWriteClient({ hashMap: baselineMap }),
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.inserted_count, 7);
+});
+
+test('catch path records rollback failure without throwing', async () => {
+    const gate = loadModuleFresh();
+    const baselineMap = computedBaselineMap(gate);
+    const queries = [];
+    const client = {
+        async query(sql) {
+            const text = String(sql || '').trim();
+            queries.push(text);
+            if (text === 'BEGIN') return { rows: [] };
+            if (text === 'ROLLBACK') throw new Error('rollback failed');
+            if (isSelectMatchesQuery(text)) throw new Error('select exploded');
+            return { rows: [] };
+        },
+    };
+    const result = await gate.executeRemainingRawMatchDataWrite(executionArgs(gate), {
+        skipValidation: true,
+        client,
+        recaptureFn: async target => fakeRecapture(target, gate, { rawDataHash: baselineMap[target.external_id] }),
+    });
+    assert.equal(result.execution_completed, false);
+    assert.match(result.controlled_error, /select exploded/);
+    assert.equal(queries.includes('ROLLBACK'), true);
+});
+
+test('buildControlledRemainingWriteResult renders success shape', () => {
+    const gate = loadModuleFresh();
+    const result = gate.buildControlledRemainingWriteResult({
+        input: validArgs(),
+        executionCompleted: true,
+        targetCount: 7,
+        attemptedTargetCount: 7,
+        validPayloadCount: 7,
+        hashMatchCount: 7,
+        hashDriftCount: 0,
+        invalidPayloadCount: 0,
+        insertedCount: 7,
+        rawMatchDataWriteExecuted: true,
+        dbWriteExecuted: true,
+        perTargetWrite: TARGETS.map(target => ({
+            ...target,
+            selected_route: 'html_hydration',
+            request_url: `https://www.fotmob.com/match/${target.external_id}`,
+            final_url: `https://www.fotmob.com/match/${target.external_id}`,
+            http_status: 200,
+            content_type: 'text/html',
+            body_byte_length: 1,
+            body_sha256: `body-${target.external_id}`,
+            hydration_parse_ok: true,
+            looks_like_valid_match_detail: true,
+            baseline_raw_data_hash: BASELINE_MAP[target.external_id],
+            raw_data_hash: BASELINE_MAP[target.external_id],
+            hash_matches_baseline: true,
+            existing_raw_match_data_found: false,
+            decision: 'inserted',
+        })),
+        transaction: { began: true, committed: true, rolled_back: false },
+        postWriteVerification: POST_BASELINE,
+        insertedRowsMetadata: insertedRowsMetadata(),
+    });
+    assert.equal(result.execution_completed, true);
+    assert.equal(result.inserted_row_metadata.length, 7);
+    assert.equal(result.per_target_write[0].match_id, EXPECTED_MATCH_IDS[0]);
+});
+
+test('Makefile write target exists and points to remaining writer script', () => {
+    const makefile = fs.readFileSync(MAKEFILE_PATH, 'utf8');
+    assert.match(makefile, /^data-l2-remaining-raw-match-data-write:/m);
+    assert.match(makefile, /scripts\/ops\/l2_remaining_raw_match_data_write\.js/);
+});
+
+test('no child_process spawn source usage', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /child_process|spawn|execFile/);
+});
+
+test('no fs write or mkdir source usage', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /writeFile|writeFileSync|mkdir|createWriteStream/);
+});
+
+test('no ProductionHarvester\\/raw ingest commit import', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/);
+});
+
+test('no browser\\/proxy import', () => {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\(['"].*(playwright|puppeteer|chromium|BrowserProvider|socks-proxy-agent)/);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.20L2C controlled remaining raw_match_data write.

Scope:
- Adds controlled writer for the remaining 7 seeded Ligue 1 raw_match_data rows
- Uses consolidated FotMobRawDetailFetcher for pre-write recapture
- Compares each raw_data_hash against Phase 5.20L2B baselines before writing
- Writes only raw_match_data in a single transaction
- Keeps matches/features/predictions protected
- Adds Makefile target, tests, AGENTS.md update, and report

Safety:
- No DB writes before post-merge execution
- No matches writes
- No features/predictions writes
- No parser/features work
- No harvest / ingest / backfill
- No training / prediction
- No browser/proxy
- No full body save/print
- No file deletion

Validation:
- remaining raw_match_data write tests passed
- FotMobRawDetailFetcher tests passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged before execution
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed