### PR TITLE
docs(data): plan pageProps v2 controlled write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@
 - Phase 5.21L2B 仅允许在明确授权后执行 single-target source fidelity live compare：必须 no-write，不得保存或打印完整 HTML body / full JSON，不得 browser/proxy，不得 parser/features/training/prediction；若确认 stored `raw_data` 是 transformed/lossy，必须先解决 raw storage strategy，再进入 parser/training。
 - Phase 5.21L2C 起，当前 FotMob v1 `raw_data` 明确视为 transformed hydration payload；未来 canonical FotMob raw 默认应优先 `fotmob_pageprops_v2`，即存 `__NEXT_DATA__.props.pageProps` 并使用 stable pageProps hash。transformed payload 只能作为 derived/helper，不得作为唯一 raw source；parser/features/training 必须按 data_version/source/provenance 分支。低级别/冷门联赛扩展前必须先做 raw completeness profile；未经明确授权不得 rewrite 现有 raw rows，也不得默认存 full `__NEXT_DATA__`。
 - Phase 5.21L2D 仅允许明确授权后的 single-target pageProps v2 no-write preview：`fotmob_pageprops_v2` candidate 必须只留在内存中；在 schema/version coexistence 完成规划前不得写 v2 rows，且需先复核当前 `raw_match_data` `unique(match_id)` 是否阻止同一 match 多版本共存；parser/features/training 继续 deferred。
+- Phase 5.21L2E 起，pageProps v2 write 在完成 `raw_match_data` version coexistence 规划前不得推进；当前 `unique(match_id)` 必须视为潜在 blocker。不得覆盖或 rewrite `fotmob_html_hyd_v1`，优先规划 versioned coexistence；parser/features/training 必须显式选择 `data_version`。schema migration 必须另行明确授权，pageProps v2 写入也必须先完成独立 preflight 并取得 DB-write authorization。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
         data-training-dry-run data-training-commit data-prediction-dry-run data-prediction-commit \
         data-training-feature-dry-run data-training-feature-commit \
         data-prediction-write-dry-run data-prediction-write-commit \
-        data-dataset-status data-raw-match-data-completeness-audit data-html-hydration-source-fidelity-live-compare data-raw-storage-strategy-revision-plan data-pageprops-v2-no-write-preview data-training-dataset-dry-run data-training-dataset-export \
+        data-dataset-status data-raw-match-data-completeness-audit data-html-hydration-source-fidelity-live-compare data-raw-storage-strategy-revision-plan data-pageprops-v2-no-write-preview data-pageprops-v2-controlled-write-plan data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
@@ -312,6 +312,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-html-hydration-source-fidelity-live-compare SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830747 EXTERNAL_ID=4830747 HOME_TEAM=Auxerre AWAY_TEAM=Nice NETWORK_AUTHORIZATION=yes LIVE_COMPARE_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no PRINT_FULL_JSON=no SAVE_FULL_JSON=no  # Phase 5.21L2B single-target live source fidelity compare, no DB/raw write, no parser/features/training/prediction"
 	@echo "  make data-raw-storage-strategy-revision-plan SOURCE=fotmob CURRENT_VERSION=fotmob_html_hyd_v1 RECOMMENDED_VERSION=fotmob_pageprops_v2 RECOMMENDED_HASH_STRATEGY=stable_pageprops_payload_v1 ALLOW_NETWORK=no ALLOW_DB_WRITE=no ALLOW_MIGRATION=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2C planning-only: recommends full pageProps raw v2, transformed payload derived/helper, no DB write/parser/features/training/prediction"
 	@echo "  make data-pageprops-v2-no-write-preview SOURCE=fotmob ROUTE=html_hydration MATCH_ID=53_20252026_4830747 EXTERNAL_ID=4830747 HOME_TEAM=Auxerre AWAY_TEAM=Nice CANDIDATE_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 NETWORK_AUTHORIZATION=yes PAGEPROPS_V2_PREVIEW_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no PRINT_FULL_JSON=no SAVE_FULL_JSON=no  # Phase 5.21L2D single-target pageProps v2 no-write preview, candidate in memory only"
+	@echo "  make data-pageprops-v2-controlled-write-plan SOURCE=fotmob CURRENT_VERSION=fotmob_html_hyd_v1 TARGET_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 TARGET_MATCH_ID=53_20252026_4830747 TARGET_EXTERNAL_ID=4830747 ALLOW_NETWORK=no ALLOW_DB_WRITE=no ALLOW_MIGRATION=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2E planning-only: reviews raw_match_data schema/version coexistence, no DB write/migration/parser/features/training/prediction"
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
@@ -355,6 +356,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  Phase 5.21L2B live source fidelity compare is single-target only: compare live __NEXT_DATA__.props.pageProps with stored raw_data path coverage, no DB/raw write, no parser/features/training/prediction."
 	@echo "  Phase 5.21L2C raw storage strategy planning is planning-only: future canonical raw should prefer fotmob_pageprops_v2, transformed payload is derived/helper, no rewrite/DB write/parser/features/training/prediction."
 	@echo "  Phase 5.21L2D pageProps v2 no-write preview is single-target only: constructs fotmob_pageprops_v2 in memory, computes stable_pageprops_payload_v1 hash, compares v2 candidate vs existing v1, no DB/raw write/parser/features/training/prediction."
+	@echo "  Phase 5.21L2E pageProps v2 controlled write planning is planning-only: review raw_match_data unique constraints, plan v1/v2 coexistence, no DB write/migration/parser/features/training/prediction."
 	@echo "  Phase 5.20L2D hash stability audit is local-only: verify stable_raw_payload_v1, keep volatile _meta out of data_hash, no network, no DB writes."
 	@echo "  Remaining seeded matches require separate authorization, preflight, and controlled write phases."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
@@ -1153,6 +1155,26 @@ data-pageprops-v2-no-write-preview: ## Run Phase 5.21L2D single-target pageProps
 		--save-body="$(or $(SAVE_BODY),no)" \
 		--print-full-json="$(or $(PRINT_FULL_JSON),no)" \
 		--save-full-json="$(or $(SAVE_FULL_JSON),no)"
+
+data-pageprops-v2-controlled-write-plan: ## Run Phase 5.21L2E pageProps v2 controlled write planning. No network, DB write, migration, raw write, parser/features, training, or prediction.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(CURRENT_VERSION)" ] || [ -z "$(TARGET_VERSION)" ] || [ -z "$(HASH_STRATEGY)" ] || [ -z "$(TARGET_MATCH_ID)" ] || [ -z "$(TARGET_EXTERNAL_ID)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob CURRENT_VERSION=fotmob_html_hyd_v1 TARGET_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 TARGET_MATCH_ID=53_20252026_4830747 TARGET_EXTERNAL_ID=4830747"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/pageprops_v2_controlled_write_plan.js \
+		--source="$(SOURCE)" \
+		--current-version="$(CURRENT_VERSION)" \
+		--target-version="$(TARGET_VERSION)" \
+		--hash-strategy="$(HASH_STRATEGY)" \
+		--target-match-id="$(TARGET_MATCH_ID)" \
+		--target-external-id="$(TARGET_EXTERNAL_ID)" \
+		--allow-network="$(or $(ALLOW_NETWORK),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-migration="$(or $(ALLOW_MIGRATION),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-parser-features="$(or $(ALLOW_PARSER_FEATURES),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)"
 
 data-training-dataset-dry-run: ## Run SELECT-only training dataset readiness audit. Does not train, export, or write DB.
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/dataset_status_audit.js

--- a/docs/_reports/PAGEPROPS_V2_CONTROLLED_WRITE_PLANNING_PHASE5_21L2E.md
+++ b/docs/_reports/PAGEPROPS_V2_CONTROLLED_WRITE_PLANNING_PHASE5_21L2E.md
@@ -1,0 +1,312 @@
+# Phase 5.21L2E: pageProps v2 controlled write planning
+
+## 1. Executive summary
+
+Phase 5.21L2D 已完成 single-target pageProps v2 no-write preview，目标
+`53_20252026_4830747` / `4830747` / Auxerre vs Nice 的
+`fotmob_pageprops_v2` candidate 有效，并确认它比现有
+`fotmob_html_hyd_v1` transformed payload 更完整：
+
+- `stable_pageprops_hash`: `f892b403fe6e420a745888ab31e825843c4fd5387a7518ce61c4b456bb980acc`
+- v1 JSON bytes: `234856`
+- v2 candidate JSON bytes: `321681`
+- size ratio: `1.369695`
+- v1 paths: `7220`
+- v2 paths: `9678`
+- v1 content paths: `6922`
+- v2 content paths: `6922`
+- v2-only paths: `2482`
+- v1-only paths: `24`
+- content diff paths: `0`
+
+本阶段只规划 future controlled write。关键阻塞是 `raw_match_data`
+当前 schema 的 identity / unique constraint 是否允许同一 `match_id`
+保存多个 `data_version`。本阶段未触网、未写库、未执行 migration、未写
+`raw_match_data`。
+
+## 2. Current DB baseline
+
+只读 baseline：
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `raw_match_data`          |   10 |
+| `bookmaker_odds_history`  |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+当前 data_version 分布：
+
+| data_version          | rows |
+| --------------------- | ---: |
+| `PHASE4.23`           |    1 |
+| `PHASE4.43_SYNTHETIC` |    1 |
+| `fotmob_html_hyd_v1`  |    8 |
+
+目标 `external_id=4830747` 当前只有 1 条 raw row：
+
+- `match_id`: `53_20252026_4830747`
+- `data_version`: `fotmob_html_hyd_v1`
+- `data_hash`: `8dfc7faaf236ee9f8090301cce9dede32a11ed5b66f2a89e1b3324064f788b25`
+
+## 3. Schema findings
+
+`raw_match_data` 当前 columns：
+
+| column         | type / default                          | notes                                          |
+| -------------- | --------------------------------------- | ---------------------------------------------- |
+| `id`           | `bigint`                                | primary key                                    |
+| `match_id`     | `varchar(50)`                           | not null, FK to `matches(match_id)`            |
+| `external_id`  | `varchar(100)`                          | nullable                                       |
+| `raw_data`     | `jsonb`                                 | not null                                       |
+| `collected_at` | `timestamptz default CURRENT_TIMESTAMP` | not null by check                              |
+| `data_version` | `varchar(20) default 'V26.1'`           | version marker                                 |
+| `data_hash`    | `varchar(64)`                           | stable payload hash for current FotMob v1 rows |
+
+Constraints：
+
+- `raw_match_data_pkey`: `PRIMARY KEY (id)`
+- `raw_match_data_match_id_key`: `UNIQUE (match_id)`
+- `raw_match_data_match_id_fkey`: `FOREIGN KEY (match_id) REFERENCES matches(match_id) ON DELETE CASCADE`
+- `collected_at_not_null`: `CHECK (collected_at IS NOT NULL)`
+- `match_id_format`: `CHECK ((match_id)::text ~ '^[0-9][0-9A-Za-z_/-]*$')`
+- `raw_data_has_match_id`: `CHECK (raw_data ? 'matchId')`
+- `raw_data_not_empty`: `CHECK (raw_data <> '{}'::jsonb)`
+
+Indexes：
+
+- `raw_match_data_pkey`: unique btree on `id`
+- `raw_match_data_match_id_key`: unique btree on `match_id`
+- `idx_raw_data_match_id`: btree on `match_id`
+- `idx_raw_data_external_id`: btree on `external_id`
+- `idx_raw_data_collected_at`: btree on `collected_at`
+- `idx_raw_data_version_collected`: btree on `(data_version, collected_at DESC)`
+- `idx_raw_data_gin`: GIN on `raw_data`
+
+Schema conclusion：
+
+- 当前存在 `UNIQUE(match_id)`。
+- 当前不允许同一 `match_id` 保存多个 `data_version`。
+- 当前没有 duplicate `match_id`。
+- 当前 `4830747` 只有 `fotmob_html_hyd_v1` row。
+- 若直接写入 `fotmob_pageprops_v2` additional row，当前 schema 会被
+  `raw_match_data_match_id_key` 阻止。
+
+## 4. Code impact findings
+
+受影响的 write / ingest 路径：
+
+- `scripts/ops/l2_raw_match_data_write.js`
+    - controlled v1 writer 使用 plain `INSERT INTO raw_match_data`。
+    - existing-row lookup 按 `match_id OR external_id` 查询，没有
+      `data_version` filter。
+- `scripts/ops/l2_remaining_raw_match_data_write.js`
+    - remaining v1 writer 使用 plain `INSERT INTO raw_match_data`。
+    - existing-row lookup 按 match/external ids 查询，没有 `data_version`
+      filter。
+- `scripts/ops/l2_raw_match_data_ingest_preflight.js`
+    - existing raw row check 按 `match_id OR external_id` 查询，没有
+      `data_version` filter。
+- legacy/admin 路径仍有 `ON CONFLICT (match_id)`：
+    - `src/infrastructure/harvesters/components/Persistence.js`
+    - `src/infrastructure/harvesters/TitanSlimHarvester.js`
+    - `src/infrastructure/services/MarathonService.js`
+    - `scripts/ops/backfill_historical_raw_match_data.js`
+    - `scripts/ops/seed_fotmob_sample.js`
+    - `scripts/ops/bulk_import_matches.js`
+
+可能假设一场比赛只有一条 raw row 的 read paths：
+
+- `src/feature_engine/smelter/components/DataFetcher.js`
+    - joins `raw_match_data r ON m.match_id = r.match_id` without
+      `data_version` filter。
+- `src/infrastructure/services/FixtureRepository.js`
+    - reads `raw_match_data` by match-id patterns for league/team catalog
+      context。
+- `src/services/inference_service.py`
+    - treats `raw_match_data` as match-level raw input source。
+- `src/ml/dataset/dataset_generator.py`
+    - reads `raw_match_data` without versioned raw selection semantics。
+- 多个 ops/report scripts 使用 no-version `LEFT JOIN raw_match_data`，future
+  reader audit 需要补 `data_version` filter 或 canonical selector。
+
+Future compatibility impact：
+
+- future v2 writer conflict target 应为 `(match_id, data_version)`。
+- future preflight must query target version explicitly。
+- parser/features/training 不得隐式读取任意 raw row，必须选择
+  `data_version`。
+- 建议新增 canonical/latest selector helper 或 view，例如默认优先
+  `fotmob_pageprops_v2`，回退 `fotmob_html_hyd_v1`，并默认排除
+  synthetic / unknown provenance。
+
+## 5. Strategy comparison
+
+### Option A: `UNIQUE(match_id, data_version)`
+
+Pros：
+
+- 最小 schema 改动。
+- `raw_match_data` 继续作为 raw warehouse 主表。
+- 同一 match 可保存 `fotmob_html_hyd_v1` 与 `fotmob_pageprops_v2`。
+- 与当前 table / index / raw audit 语义最接近。
+
+Cons：
+
+- 需要 migration，不能在本阶段执行。
+- 当前假设 `match_id` 唯一的 writers/readers 必须审计。
+- Future upsert / lookup / report joins 需要使用 `data_version` 或 canonical
+  selector。
+
+Migration requirements：
+
+- drop or replace current `raw_match_data_match_id_key` unique constraint。
+- create versioned unique identity on `(match_id, data_version)`。
+- verify existing rows have non-null / bounded `data_version`。
+- verify no duplicate `(match_id, data_version)` before migration。
+
+Rollback considerations：
+
+- migration 前需要 backup/rollback plan。
+- rollback 前必须确认没有任何 match 同时拥有多个 version，否则无法恢复
+  `UNIQUE(match_id)`。
+
+### Option B: new `raw_match_data_versions` table
+
+Pros：
+
+- 不立即改变 `raw_match_data` 当前 one-row-per-match 语义。
+- version history 更显式。
+- 可保留 `raw_match_data` 作为 current/canonical pointer。
+
+Cons：
+
+- schema 和 query routing 更复杂。
+- writer、preflight、parser、reports 要同时理解两张表。
+- future canonical/latest selector 更早成为必须。
+
+Migration requirements：
+
+- 新建版本表、FK、indexes、copy/backfill policy、write routing policy。
+- 明确 `raw_match_data` 是否继续存 v1、latest pointer 或被只读冻结。
+
+Rollback considerations：
+
+- rollback 需删除/停用新表路径并处理已经写入的 v2 rows。
+- 不适合在没有 versioned reader abstraction 前快速推进。
+
+### Option C: `raw_match_data_v2` table
+
+Pros：
+
+- v2 isolation 清晰。
+- 不修改 v1 table 的 unique constraint。
+
+Cons：
+
+- 长期复制 raw table 语义。
+- parser/readers 需要在表层做 branching。
+- 后续 v3/v4 会继续扩表，演进成本高。
+
+### Option D: overwrite v1
+
+明确不推荐：
+
+- 会丢失已验证的 `fotmob_html_hyd_v1` provenance。
+- 破坏 source-fidelity audit trail。
+- 回滚依赖 backup，不符合当前安全演进方式。
+
+## 6. Recommended strategy
+
+推荐 Option A：将 `raw_match_data` 的版本共存身份规划为
+`UNIQUE(match_id, data_version)`。
+
+Recommended policy：
+
+- 保留所有现有 `fotmob_html_hyd_v1` rows。
+- `fotmob_pageprops_v2` 作为 additional version 写入，不覆盖 v1。
+- Future v2 writer 使用 `data_version=fotmob_pageprops_v2`。
+- Future v2 writer 使用 `data_hash=stable_pageprops_payload_v1`。
+- Future upsert / conflict target 使用 `(match_id, data_version)`。
+- Readers/parser/features/training 必须显式 filter `data_version` 或使用
+  canonical selector/helper。
+- Synthetic / unknown rows 默认不参与 FotMob v2 fidelity 判断。
+
+这个方案比新版本表更适合当前阶段：它保持 raw warehouse 单表语义，schema
+surface 最小，同时满足 v1/v2 coexistence。新版本表可以作为 fallback，但当前
+没有足够证据说明需要承担额外 routing complexity。
+
+## 7. Controlled write policy for future v2
+
+Future v2 write must：
+
+- 使用 pageProps candidate，不使用 transformed payload 作为 canonical raw。
+- `data_version=fotmob_pageprops_v2`。
+- `data_hash=stable_pageprops_payload_v1`。
+- 不 rewrite / overwrite `fotmob_html_hyd_v1`。
+- 首次写入只允许 single target `4830747`。
+- write 前先做 no-write preflight，重新 recapture pageProps 并与 L2D preview
+  hash baseline 对比。
+- controlled write 必须单独授权、事务执行、写后验证 row count 和 target
+  version coexistence。
+
+## 8. Migration / rollback planning
+
+本阶段不执行 migration。
+
+下一阶段需要：
+
+- 准备 exact constraint/index migration plan。
+- 验证当前 `raw_match_data` row counts 和 `(match_id, data_version)` duplicate
+  risk。
+- 审查所有 `ON CONFLICT (match_id)` 和 no-version reader joins。
+- 明确 backup/rollback plan。
+- 规划 rollback 的 blocker：一旦写入 v2 additional rows，恢复
+  `UNIQUE(match_id)` 前必须先处理 multi-version rows。
+- 规划 compatibility helper / selector，避免 parser/training 隐式读错版本。
+
+## 9. Recommended next phases
+
+推荐下一步：
+
+1. Phase 5.21L2F: `raw_match_data` versioned schema migration
+   planning/preflight
+    - no DB write
+    - no migration execution
+    - prepare exact ALTER plan
+    - verify constraint/index/code impact
+    - prepare backup/rollback plan
+
+2. Phase 5.21L2G: controlled schema migration execution
+    - only after explicit authorization
+    - changes constraint/index only
+    - no raw data writes
+
+3. Phase 5.21L2H: pageProps v2 single-target write preflight
+    - no DB write
+    - recapture target `4830747`
+    - compare stable hash with L2D preview baseline
+
+4. Phase 5.21L2I: pageProps v2 single-target controlled write
+    - only after explicit DB-write authorization
+    - insert v2 row as additional version
+    - v1 remains preserved
+
+## 10. Explicit non-execution
+
+本阶段确认未执行：
+
+- no external FotMob access
+- no live match detail request
+- no DB writes
+- no schema migration
+- no raw_match_data writes
+- no matches writes
+- no parser/features
+- no harvest/ingest/backfill
+- no training/prediction
+- no browser/proxy
+- no full raw_data print/save
+- no file deletion

--- a/scripts/ops/pageprops_v2_controlled_write_plan.js
+++ b/scripts/ops/pageprops_v2_controlled_write_plan.js
@@ -1,0 +1,390 @@
+#!/usr/bin/env node
+'use strict';
+
+const PHASE = 'PHASE5_21L2E_PAGEPROPS_V2_CONTROLLED_WRITE_PLANNING';
+const EXPECTED = Object.freeze({
+    source: 'fotmob',
+    currentVersion: 'fotmob_html_hyd_v1',
+    targetVersion: 'fotmob_pageprops_v2',
+    hashStrategy: 'stable_pageprops_payload_v1',
+    targetMatchId: '53_20252026_4830747',
+    targetExternalId: '4830747',
+});
+const REQUIRED_NO_FLAGS = Object.freeze([
+    'allow-network',
+    'allow-db-write',
+    'allow-migration',
+    'allow-raw-match-data-write',
+    'allow-parser-features',
+    'allow-training',
+    'allow-prediction',
+]);
+const BLOCKED_YES_FLAGS = Object.freeze(['execute', 'commit', 'rewrite-existing', 'drop-v1', 'alter-table']);
+
+function normalizeText(value) {
+    return String(value ?? '').trim();
+}
+
+function toKebabKey(key) {
+    return normalizeText(key)
+        .replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)
+        .replace(/^--+/, '');
+}
+
+function parseArgs(argv = []) {
+    const args = {};
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+        if (!token.startsWith('--')) continue;
+        const raw = token.slice(2);
+        const eqIndex = raw.indexOf('=');
+        if (eqIndex >= 0) {
+            args[toKebabKey(raw.slice(0, eqIndex))] = raw.slice(eqIndex + 1);
+            continue;
+        }
+        const next = argv[index + 1];
+        if (next && !next.startsWith('--')) {
+            args[toKebabKey(raw)] = next;
+            index += 1;
+        } else {
+            args[toKebabKey(raw)] = 'yes';
+        }
+    }
+    return args;
+}
+
+function normalizeBooleanFlag(value) {
+    const normalized = normalizeText(value).toLowerCase();
+    if (['yes', 'true', '1', 'y'].includes(normalized)) return true;
+    if (['no', 'false', '0', 'n'].includes(normalized)) return false;
+    return null;
+}
+
+function requireExact(input, key, expected, errors) {
+    const actual = normalizeText(input[key]);
+    if (!actual) {
+        errors.push(`${key}=${expected} is required`);
+    } else if (actual !== expected) {
+        errors.push(`${key} must be ${expected}`);
+    }
+    return actual;
+}
+
+function requireNo(input, key, errors) {
+    const value = normalizeBooleanFlag(input[key]);
+    if (value !== false) {
+        errors.push(`${key}=no is required`);
+    }
+    return value;
+}
+
+function blockYes(input, key, errors) {
+    const value = normalizeBooleanFlag(input[key]);
+    if (value === true) {
+        errors.push(`${key}=yes is blocked in Phase 5.21L2E`);
+    }
+    return value;
+}
+
+function validatePlanInput(input = {}) {
+    const errors = [];
+    const source = normalizeText(input.source).toLowerCase();
+    if (!source) {
+        errors.push('source=fotmob is required');
+    } else if (source !== EXPECTED.source) {
+        errors.push('source must be fotmob');
+    }
+
+    const currentVersion = requireExact(input, 'current-version', EXPECTED.currentVersion, errors);
+    const targetVersion = requireExact(input, 'target-version', EXPECTED.targetVersion, errors);
+    const hashStrategy = requireExact(input, 'hash-strategy', EXPECTED.hashStrategy, errors);
+    const targetMatchId = requireExact(input, 'target-match-id', EXPECTED.targetMatchId, errors);
+    const targetExternalId = requireExact(input, 'target-external-id', EXPECTED.targetExternalId, errors);
+
+    const noFlags = {};
+    for (const flag of REQUIRED_NO_FLAGS) {
+        noFlags[flag] = requireNo(input, flag, errors);
+    }
+    for (const flag of BLOCKED_YES_FLAGS) {
+        blockYes(input, flag, errors);
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value: {
+            source: EXPECTED.source,
+            currentVersion,
+            targetVersion,
+            hashStrategy,
+            targetMatchId,
+            targetExternalId,
+            allowNetwork: noFlags['allow-network'],
+            allowDbWrite: noFlags['allow-db-write'],
+            allowMigration: noFlags['allow-migration'],
+            allowRawMatchDataWrite: noFlags['allow-raw-match-data-write'],
+            allowParserFeatures: noFlags['allow-parser-features'],
+            allowTraining: noFlags['allow-training'],
+            allowPrediction: noFlags['allow-prediction'],
+        },
+    };
+}
+
+function normalizeSchemaDefinitions(items = []) {
+    if (!Array.isArray(items)) return [];
+    return items
+        .map(item => {
+            if (typeof item === 'string') return item;
+            return [item.conname, item.indexname, item.definition, item.indexdef].filter(Boolean).join(' ');
+        })
+        .map(value => normalizeText(value).replace(/\s+/g, ' ').toLowerCase())
+        .filter(Boolean);
+}
+
+function hasUniqueMatchIdDefinition(definitions = []) {
+    return definitions.some(definition => {
+        const compact = definition.replace(/\s+/g, '');
+        return (
+            compact.includes('unique(match_id)') ||
+            (compact.includes('uniqueindex') && compact.includes('btree(match_id)')) ||
+            (compact.includes('uniqueconstraint') && compact.includes('btree(match_id)'))
+        );
+    });
+}
+
+function hasUniqueMatchIdDataVersionDefinition(definitions = []) {
+    return definitions.some(definition => {
+        const compact = definition.replace(/\s+/g, '');
+        return (
+            compact.includes('unique(match_id,data_version)') ||
+            compact.includes('unique(data_version,match_id)') ||
+            (compact.includes('uniqueindex') &&
+                (compact.includes('btree(match_id,data_version)') || compact.includes('btree(data_version,match_id)')))
+        );
+    });
+}
+
+function detectConflictPolicy(policies = []) {
+    const normalized = Array.isArray(policies)
+        ? policies.map(policy => normalizeText(policy).replace(/\s+/g, ' ').toLowerCase())
+        : [];
+    if (normalized.some(policy => policy.includes('on conflict (match_id, data_version)'))) {
+        return 'ON CONFLICT (match_id, data_version)';
+    }
+    if (normalized.some(policy => policy.includes('on conflict (match_id)'))) {
+        return 'ON CONFLICT (match_id)';
+    }
+    return normalized.length > 0 ? 'other' : 'unknown';
+}
+
+function boolToFinding(value) {
+    return value === undefined ? 'unknown' : String(Boolean(value));
+}
+
+function buildSchemaFindings(schema = {}) {
+    const definitions = normalizeSchemaDefinitions([...(schema.constraints || []), ...(schema.indexes || [])]);
+    const hasDefinitions = definitions.length > 0;
+    const hasUniqueMatchId = hasDefinitions ? hasUniqueMatchIdDefinition(definitions) : undefined;
+    const hasVersionedUnique = hasDefinitions ? hasUniqueMatchIdDataVersionDefinition(definitions) : undefined;
+    const allowsMultiVersion =
+        hasVersionedUnique === true ? true : hasUniqueMatchId === true ? false : hasDefinitions ? undefined : undefined;
+
+    return {
+        raw_match_data_has_unique_match_id: boolToFinding(hasUniqueMatchId),
+        raw_match_data_has_unique_match_id_data_version: boolToFinding(hasVersionedUnique),
+        raw_match_data_allows_multi_version_per_match: boolToFinding(allowsMultiVersion),
+        current_on_conflict_policy: detectConflictPolicy(schema.onConflictPolicies || []),
+        duplicate_match_id_count:
+            Number.isInteger(schema.duplicateMatchIdCount) && schema.duplicateMatchIdCount >= 0
+                ? schema.duplicateMatchIdCount
+                : null,
+    };
+}
+
+function compareSchemaStrategies() {
+    return [
+        {
+            strategy: 'unique_match_id_data_version',
+            rank: 1,
+            summary: 'change raw_match_data uniqueness to the versioned identity',
+            pros: [
+                'minimal table surface change',
+                'keeps raw_match_data as the raw warehouse',
+                'allows v1 and v2 rows to coexist',
+            ],
+            cons: ['requires schema migration', 'writers/readers using match_id identity need compatibility review'],
+        },
+        {
+            strategy: 'new_versions_table',
+            rank: 2,
+            summary: 'add a dedicated raw_match_data_versions table',
+            pros: ['clear version history', 'does not change current raw_match_data uniqueness immediately'],
+            cons: ['more tables and query routing', 'future parser/readers must know which table to use'],
+        },
+        {
+            strategy: 'raw_match_data_v2_table',
+            rank: 3,
+            summary: 'add a v2-only sibling table',
+            pros: ['isolates v2 writes', 'keeps v1 rows untouched'],
+            cons: ['duplicates raw table semantics', 'increases long-term reader complexity'],
+        },
+        {
+            strategy: 'overwrite_v1',
+            rank: 4,
+            summary: 'overwrite current fotmob_html_hyd_v1 rows',
+            pros: ['smallest immediate schema change'],
+            cons: ['destroys v1 provenance', 'not reversible without backups', 'not recommended'],
+            recommended: false,
+        },
+    ];
+}
+
+function buildRecommendedSchemaStrategy(schemaFindings = buildSchemaFindings()) {
+    const hasVersionedUnique = schemaFindings.raw_match_data_has_unique_match_id_data_version === 'true';
+    const hasUniqueMatchId = schemaFindings.raw_match_data_has_unique_match_id === 'true';
+    return {
+        strategy: 'unique_match_id_data_version',
+        reason: hasVersionedUnique
+            ? 'raw_match_data already appears to support versioned uniqueness; keep v1/v2 coexistence on the main raw table'
+            : hasUniqueMatchId
+              ? 'current unique(match_id) blocks v1/v2 coexistence, and changing identity to (match_id, data_version) is the smallest coherent schema evolution'
+              : 'versioned uniqueness keeps raw_match_data as the canonical raw table while preserving existing v1 rows',
+        migration_required: !hasVersionedUnique,
+        migration_execute_this_phase: false,
+        overwrite_v1_recommended: false,
+    };
+}
+
+function buildVersionedWritePolicy() {
+    return {
+        write_v2_as_new_version: true,
+        do_not_rewrite_v1: true,
+        do_not_overwrite_existing: true,
+        upsert_conflict_target: ['match_id', 'data_version'],
+        expected_rows_for_initial_sample: 1,
+        first_target: {
+            match_id: EXPECTED.targetMatchId,
+            external_id: EXPECTED.targetExternalId,
+        },
+    };
+}
+
+function buildCompatibilityPolicy() {
+    return {
+        readers_must_filter_data_version: true,
+        parser_must_branch_by_data_version: true,
+        synthetic_unknown_excluded_by_default: true,
+        canonical_selector_recommended: true,
+        recommended_canonical_selector_order: ['fotmob_pageprops_v2', 'fotmob_html_hyd_v1'],
+    };
+}
+
+function buildRollbackPolicy() {
+    return {
+        pre_migration_backup_required: true,
+        rollback_plan_required: true,
+        no_execution_this_phase: true,
+        verify_existing_row_counts_before_and_after: true,
+    };
+}
+
+function buildPagePropsV2ControlledWritePlan(input = {}, schema = {}) {
+    const source = input.source || EXPECTED.source;
+    const currentVersion = input.currentVersion || EXPECTED.currentVersion;
+    const targetVersion = input.targetVersion || EXPECTED.targetVersion;
+    const hashStrategy = input.hashStrategy || EXPECTED.hashStrategy;
+    const targetMatchId = input.targetMatchId || EXPECTED.targetMatchId;
+    const targetExternalId = input.targetExternalId || EXPECTED.targetExternalId;
+    const schemaFindings = buildSchemaFindings(schema);
+
+    return {
+        phase: PHASE,
+        planning_only: true,
+        source,
+        current_version: currentVersion,
+        target_version: targetVersion,
+        hash_strategy: hashStrategy,
+        target: {
+            match_id: targetMatchId,
+            external_id: targetExternalId,
+        },
+        schema_findings: schemaFindings,
+        strategy_comparison: compareSchemaStrategies(),
+        recommended_schema_strategy: buildRecommendedSchemaStrategy(schemaFindings),
+        write_policy: buildVersionedWritePolicy(),
+        compatibility_policy: buildCompatibilityPolicy(),
+        rollback_policy: buildRollbackPolicy(),
+        next_phases: [
+            'Phase 5.21L2F: raw_match_data versioned schema migration planning/preflight',
+            'Phase 5.21L2G: controlled schema migration execution',
+            'Phase 5.21L2H: pageProps v2 single-target write preflight',
+            'Phase 5.21L2I: pageProps v2 single-target controlled write',
+        ],
+        network_access_executed: false,
+        db_write_executed: false,
+        migration_executed: false,
+        raw_match_data_write_executed: false,
+        parser_features_executed: false,
+        training_executed: false,
+        prediction_executed: false,
+    };
+}
+
+async function runCli(argv = process.argv.slice(2), dependencies = {}) {
+    const parsedArgs = Array.isArray(argv) ? parseArgs(argv) : argv;
+    const validation = validatePlanInput(parsedArgs);
+    const output = dependencies.output || (payload => process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`));
+
+    if (!validation.ok) {
+        const payload = {
+            phase: PHASE,
+            planning_only: true,
+            ok: false,
+            blocked: true,
+            errors: validation.errors,
+            network_access_executed: false,
+            db_write_executed: false,
+            migration_executed: false,
+            raw_match_data_write_executed: false,
+            parser_features_executed: false,
+            training_executed: false,
+            prediction_executed: false,
+        };
+        output(payload);
+        return { status: 1, payload };
+    }
+
+    const payload = {
+        ok: true,
+        ...buildPagePropsV2ControlledWritePlan(validation.value, dependencies.schema || {}),
+    };
+    output(payload);
+    return { status: 0, payload };
+}
+
+module.exports = {
+    PHASE,
+    EXPECTED,
+    parseArgs,
+    normalizeBooleanFlag,
+    validatePlanInput,
+    buildSchemaFindings,
+    compareSchemaStrategies,
+    buildRecommendedSchemaStrategy,
+    buildVersionedWritePolicy,
+    buildCompatibilityPolicy,
+    buildRollbackPolicy,
+    buildPagePropsV2ControlledWritePlan,
+    runCli,
+};
+
+if (require.main === module) {
+    runCli()
+        .then(result => {
+            process.exitCode = result.status;
+        })
+        .catch(error => {
+            process.stderr.write(`${error.stack || error.message}\n`);
+            process.exitCode = 1;
+        });
+}

--- a/tests/unit/pageprops_v2_controlled_write_plan.test.js
+++ b/tests/unit/pageprops_v2_controlled_write_plan.test.js
@@ -1,0 +1,320 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const path = require('node:path');
+const test = require('node:test');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const MODULE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/pageprops_v2_controlled_write_plan.js');
+const plan = require(MODULE_PATH);
+
+function validArgs(overrides = {}) {
+    return {
+        source: 'fotmob',
+        'current-version': 'fotmob_html_hyd_v1',
+        'target-version': 'fotmob_pageprops_v2',
+        'hash-strategy': 'stable_pageprops_payload_v1',
+        'target-match-id': '53_20252026_4830747',
+        'target-external-id': '4830747',
+        'allow-network': 'no',
+        'allow-db-write': 'no',
+        'allow-migration': 'no',
+        'allow-raw-match-data-write': 'no',
+        'allow-parser-features': 'no',
+        'allow-training': 'no',
+        'allow-prediction': 'no',
+        ...overrides,
+    };
+}
+
+function assertInvalid(overrides, pattern) {
+    const result = plan.validatePlanInput(validArgs(overrides));
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), pattern);
+}
+
+function withPatched(object, property, replacement, callback) {
+    const original = object[property];
+    object[property] = replacement;
+    return Promise.resolve()
+        .then(callback)
+        .finally(() => {
+            object[property] = original;
+        });
+}
+
+test('valid input succeeds', () => {
+    const result = plan.validatePlanInput(validArgs());
+    assert.equal(result.ok, true);
+    assert.equal(result.value.source, 'fotmob');
+});
+
+test('source missing fails', () => {
+    assertInvalid({ source: '' }, /source=fotmob is required/);
+});
+
+test('source non-fotmob fails', () => {
+    assertInvalid({ source: 'other' }, /source must be fotmob/);
+});
+
+test('current-version missing fails', () => {
+    assertInvalid({ 'current-version': '' }, /current-version=fotmob_html_hyd_v1 is required/);
+});
+
+test('current-version not fotmob_html_hyd_v1 fails', () => {
+    assertInvalid({ 'current-version': 'wrong' }, /current-version must be fotmob_html_hyd_v1/);
+});
+
+test('target-version missing fails', () => {
+    assertInvalid({ 'target-version': '' }, /target-version=fotmob_pageprops_v2 is required/);
+});
+
+test('target-version not fotmob_pageprops_v2 fails', () => {
+    assertInvalid({ 'target-version': 'wrong' }, /target-version must be fotmob_pageprops_v2/);
+});
+
+test('hash-strategy missing fails', () => {
+    assertInvalid({ 'hash-strategy': '' }, /hash-strategy=stable_pageprops_payload_v1 is required/);
+});
+
+test('hash-strategy not stable_pageprops_payload_v1 fails', () => {
+    assertInvalid({ 'hash-strategy': 'wrong' }, /hash-strategy must be stable_pageprops_payload_v1/);
+});
+
+test('target-match-id wrong fails', () => {
+    assertInvalid({ 'target-match-id': 'wrong' }, /target-match-id must be 53_20252026_4830747/);
+});
+
+test('target-external-id wrong fails', () => {
+    assertInvalid({ 'target-external-id': '1' }, /target-external-id must be 4830747/);
+});
+
+test('allow-network=yes blocked', () => {
+    assertInvalid({ 'allow-network': 'yes' }, /allow-network=no is required/);
+});
+
+test('allow-db-write=yes blocked', () => {
+    assertInvalid({ 'allow-db-write': 'yes' }, /allow-db-write=no is required/);
+});
+
+test('allow-migration=yes blocked', () => {
+    assertInvalid({ 'allow-migration': 'yes' }, /allow-migration=no is required/);
+});
+
+test('allow-raw-match-data-write=yes blocked', () => {
+    assertInvalid({ 'allow-raw-match-data-write': 'yes' }, /allow-raw-match-data-write=no is required/);
+});
+
+test('allow-parser-features=yes blocked', () => {
+    assertInvalid({ 'allow-parser-features': 'yes' }, /allow-parser-features=no is required/);
+});
+
+test('allow-training=yes blocked', () => {
+    assertInvalid({ 'allow-training': 'yes' }, /allow-training=no is required/);
+});
+
+test('allow-prediction=yes blocked', () => {
+    assertInvalid({ 'allow-prediction': 'yes' }, /allow-prediction=no is required/);
+});
+
+test('execute=yes blocked', () => {
+    assertInvalid({ execute: 'yes' }, /execute=yes is blocked/);
+});
+
+test('commit=yes blocked', () => {
+    assertInvalid({ commit: 'yes' }, /commit=yes is blocked/);
+});
+
+test('rewrite-existing=yes blocked', () => {
+    assertInvalid({ 'rewrite-existing': 'yes' }, /rewrite-existing=yes is blocked/);
+});
+
+test('drop-v1=yes blocked', () => {
+    assertInvalid({ 'drop-v1': 'yes' }, /drop-v1=yes is blocked/);
+});
+
+test('alter-table=yes blocked', () => {
+    assertInvalid({ 'alter-table': 'yes' }, /alter-table=yes is blocked/);
+});
+
+test('buildSchemaFindings detects unique(match_id)', () => {
+    const findings = plan.buildSchemaFindings({
+        constraints: [{ definition: 'UNIQUE (match_id)' }],
+    });
+    assert.equal(findings.raw_match_data_has_unique_match_id, 'true');
+    assert.equal(findings.raw_match_data_allows_multi_version_per_match, 'false');
+});
+
+test('buildSchemaFindings detects unique(match_id,data_version)', () => {
+    const findings = plan.buildSchemaFindings({
+        constraints: [{ definition: 'UNIQUE (match_id, data_version)' }],
+    });
+    assert.equal(findings.raw_match_data_has_unique_match_id_data_version, 'true');
+    assert.equal(findings.raw_match_data_allows_multi_version_per_match, 'true');
+});
+
+test('compareSchemaStrategies ranks unique(match_id,data_version)', () => {
+    const strategies = plan.compareSchemaStrategies();
+    assert.equal(strategies[0].strategy, 'unique_match_id_data_version');
+    assert.equal(strategies[0].rank, 1);
+});
+
+test('compareSchemaStrategies documents new_versions_table tradeoff', () => {
+    const strategy = plan.compareSchemaStrategies().find(item => item.strategy === 'new_versions_table');
+    assert.ok(strategy);
+    assert.ok(strategy.pros.length > 0);
+    assert.ok(strategy.cons.length > 0);
+});
+
+test('recommended strategy does not overwrite v1', () => {
+    const recommended = plan.buildRecommendedSchemaStrategy(
+        plan.buildSchemaFindings({ constraints: [{ definition: 'UNIQUE (match_id)' }] })
+    );
+    assert.equal(recommended.strategy, 'unique_match_id_data_version');
+    assert.equal(recommended.overwrite_v1_recommended, false);
+});
+
+test('write policy uses conflict target match_id,data_version', () => {
+    assert.deepEqual(plan.buildVersionedWritePolicy().upsert_conflict_target, ['match_id', 'data_version']);
+});
+
+test('compatibility policy requires data_version filtering', () => {
+    assert.equal(plan.buildCompatibilityPolicy().readers_must_filter_data_version, true);
+    assert.equal(plan.buildCompatibilityPolicy().parser_must_branch_by_data_version, true);
+});
+
+test('rollback policy requires backup/preflight', () => {
+    const policy = plan.buildRollbackPolicy();
+    assert.equal(policy.pre_migration_backup_required, true);
+    assert.equal(policy.rollback_plan_required, true);
+    assert.equal(policy.no_execution_this_phase, true);
+});
+
+test('plan is planning_only=true', () => {
+    const payload = plan.buildPagePropsV2ControlledWritePlan();
+    assert.equal(payload.planning_only, true);
+    assert.equal(payload.phase, 'PHASE5_21L2E_PAGEPROPS_V2_CONTROLLED_WRITE_PLANNING');
+});
+
+test('no fs write / mkdir', async () => {
+    await withPatched(
+        fs,
+        'writeFileSync',
+        () => {
+            throw new Error('writeFileSync should not be called');
+        },
+        async () => {
+            await withPatched(
+                fs,
+                'writeFile',
+                () => {
+                    throw new Error('writeFile should not be called');
+                },
+                async () => {
+                    await withPatched(
+                        fs,
+                        'mkdir',
+                        () => {
+                            throw new Error('mkdir should not be called');
+                        },
+                        async () => {
+                            const result = await plan.runCli(validArgs(), { output() {} });
+                            assert.equal(result.status, 0);
+                        }
+                    );
+                }
+            );
+        }
+    );
+});
+
+test('no child_process spawn', async () => {
+    await withPatched(
+        childProcess,
+        'spawn',
+        () => {
+            throw new Error('spawn should not be called');
+        },
+        async () => {
+            await withPatched(
+                childProcess,
+                'exec',
+                () => {
+                    throw new Error('exec should not be called');
+                },
+                async () => {
+                    await withPatched(
+                        childProcess,
+                        'execFile',
+                        () => {
+                            throw new Error('execFile should not be called');
+                        },
+                        async () => {
+                            const result = await plan.runCli(validArgs(), { output() {} });
+                            assert.equal(result.status, 0);
+                        }
+                    );
+                }
+            );
+        }
+    );
+});
+
+test('no network access', async () => {
+    await withPatched(
+        globalThis,
+        'fetch',
+        () => {
+            throw new Error('fetch should not be called');
+        },
+        async () => {
+            await withPatched(
+                http,
+                'request',
+                () => {
+                    throw new Error('http.request should not be called');
+                },
+                async () => {
+                    await withPatched(
+                        https,
+                        'request',
+                        () => {
+                            throw new Error('https.request should not be called');
+                        },
+                        async () => {
+                            const result = await plan.runCli(validArgs(), { output() {} });
+                            assert.equal(result.status, 0);
+                            assert.equal(result.payload.network_access_executed, false);
+                        }
+                    );
+                }
+            );
+        }
+    );
+});
+
+test('no DB write', () => {
+    const payload = plan.buildPagePropsV2ControlledWritePlan();
+    assert.equal(payload.db_write_executed, false);
+    assert.equal(payload.raw_match_data_write_executed, false);
+});
+
+test('no migration execution', () => {
+    const payload = plan.buildPagePropsV2ControlledWritePlan();
+    assert.equal(payload.migration_executed, false);
+    assert.equal(payload.recommended_schema_strategy.migration_execute_this_phase, false);
+});
+
+test('no ProductionHarvester/raw ingest import', () => {
+    const source = fs.readFileSync(MODULE_PATH, 'utf8');
+    assert.doesNotMatch(source, /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/);
+});
+
+test('no parser/features/training import', () => {
+    const source = fs.readFileSync(MODULE_PATH, 'utf8');
+    assert.doesNotMatch(source, /require\([^)]*(parser|feature|train|predict)/i);
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.21L2E pageProps v2 controlled write planning.

Scope:
- Reviews raw_match_data schema constraints and version coexistence requirements
- Plans how fotmob_pageprops_v2 can coexist with existing fotmob_html_hyd_v1 rows
- Compares schema strategies: unique(match_id, data_version), versions table, v2 table, and overwrite
- Recommends controlled next phases for schema migration planning, migration execution, v2 preflight, and v2 write
- Adds planning-only script, Makefile target, tests, AGENTS.md update, and report

Safety:
- No external FotMob access
- No live match detail request
- No DB writes
- No schema migration
- No raw_match_data writes
- No matches writes
- No parser/features work
- No harvest / ingest / backfill
- No training / prediction
- No browser/proxy
- No full raw_data print/save
- No file deletion

Validation:
- pageProps v2 controlled write plan tests passed
- Makefile plan target passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed