### PR TITLE
docs(data): plan pageProps v2 parser boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@
 - Phase 5.21L2M 仅允许在明确最终 DB-write confirmation 后，为 remaining 7 个 seeded targets（4830746、4830748、4830750、4830751、4830752、4830753、4830754）插入 exactly seven `fotmob_pageprops_v2` `raw_match_data` rows；必须逐场串行 recapture 并用 Phase 5.21L2L `stable_pageprops_payload_v1` baseline 精确 hash gate，任何 hash drift / fetch failure / v2 already exists / guard failure 都阻断 whole write。不得 partial write，除非未来另行授权 reduced target set；不得 rewrite `4830747`、不得 rewrite v1、不得 parser/features/training。写后下一步是 all-seeded canonical read verification。
 - Phase 5.21L2N 是 all-seeded pageProps v2 canonical read verification：只能 SELECT-only、不触 FotMob、不写 DB；Phase 5.21L2M 后 8 个 seeded matches（4830746、4830747、4830748、4830750、4830751、4830752、4830753、4830754）都应通过 `RawMatchDataVersionSelector` canonical 选择 `fotmob_pageprops_v2`，且 selected hash 必须与授权 baseline 一致。`PHASE4.43_SYNTHETIC`、`PHASE4.23` 与 unknown 仍默认排除，不得 accidental canonical select。不得直接进入 parser/features/training；下一步应先做本地 pageProps v2 raw inventory / completeness audit。
 - Phase 5.21L2O 是 pageProps v2 raw inventory / completeness audit：只能 SELECT-only，只读本地 `raw_match_data` 中 8 条 seeded `fotmob_pageprops_v2`，不得触 FotMob/network、不得写 DB、不得保存或打印完整 `raw_data`/完整 `pageProps`。本阶段只允许做路径盘点、模块覆盖、可疑载荷和完整性 assessment；不得实现 parser/features/training。下一步应是 parser planning，不是 parser implementation。
+- Phase 5.21L2P 是 pageProps v2 parser boundary / leakage-safe planning：只能 planning-only，不得实现 parser、不得抽 features、不得写 `l3_features` / `match_features_training` / `predictions`、不得训练/预测、不得触 FotMob/network、不得写 DB。当前 8 条 seeded `fotmob_pageprops_v2` 仅是 raw pipeline / 结构 / parser design sampling，不构成训练数据集。
+- Phase 5.21L2P 起，parser implementation 必须等待 parser boundary / leakage policy review；features/training 必须等待 large-scale raw acquisition plan 和 `prediction_cutoff_time` policy 明确。odds raw 必须视为独立 market-pricing source，允许尽早做 raw history planning，但 odds features 在 cutoff-time policy 明确前保持 blocked；未经未来明确授权，不得运行 `odds_harvest_pipeline` 或任何 odds write path。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 
@@ -275,6 +277,7 @@ AI / Codex 默认只能执行：
 - 用户明确授权且只读 DB 的 `make data-prediction-write-dry-run MATCH_ID=<id>`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-dataset-status`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-training-dataset-dry-run`
+- 用户明确授权且 planning-only、不触网、不写 DB、不实现 parser/features/training/prediction 的 `make data-pageprops-v2-parser-boundary-leakage-plan SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=parser-boundary-leakage-acquisition-odds-roadmap ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no`
 - 不访问外网、不写 DB 的 `make data-acquisition-engines`
 - 不访问外网、不写 DB 的 `make data-acquisition-engine-audit`
 - 用户明确授权且只读本地 source manifest、不写 DB、不训练、不预测的 `make data-real-source-audit SOURCE_MANIFEST=<local json>`

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
         data-training-dry-run data-training-commit data-prediction-dry-run data-prediction-commit \
         data-training-feature-dry-run data-training-feature-commit \
         data-prediction-write-dry-run data-prediction-write-commit \
-        data-dataset-status data-raw-match-data-completeness-audit data-html-hydration-source-fidelity-live-compare data-raw-storage-strategy-revision-plan data-pageprops-v2-no-write-preview data-pageprops-v2-controlled-write-plan data-raw-match-data-versioned-schema-migration-preflight data-raw-match-data-versioned-schema-migration-execute data-raw-match-data-version-compatibility-audit data-pageprops-v2-single-target-controlled-write data-pageprops-v2-post-write-canonical-read-verification data-remaining-seeded-pageprops-v2-acquisition-preflight data-remaining-seeded-pageprops-v2-controlled-write data-all-seeded-pageprops-v2-canonical-read-verification data-pageprops-v2-raw-completeness-audit data-training-dataset-dry-run data-training-dataset-export \
+        data-dataset-status data-raw-match-data-completeness-audit data-html-hydration-source-fidelity-live-compare data-raw-storage-strategy-revision-plan data-pageprops-v2-no-write-preview data-pageprops-v2-controlled-write-plan data-raw-match-data-versioned-schema-migration-preflight data-raw-match-data-versioned-schema-migration-execute data-raw-match-data-version-compatibility-audit data-pageprops-v2-single-target-controlled-write data-pageprops-v2-post-write-canonical-read-verification data-remaining-seeded-pageprops-v2-acquisition-preflight data-remaining-seeded-pageprops-v2-controlled-write data-all-seeded-pageprops-v2-canonical-read-verification data-pageprops-v2-raw-completeness-audit data-pageprops-v2-parser-boundary-leakage-plan data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
@@ -323,6 +323,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-remaining-seeded-pageprops-v2-controlled-write SOURCE=fotmob ROUTE=html_hydration BASELINE_HASHES='<json>' CANDIDATE_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 NETWORK_AUTHORIZATION=yes FINAL_DB_WRITE_CONFIRMATION=yes ALLOW_DB_WRITE=yes ALLOW_RAW_MATCH_DATA_WRITE=yes ALLOW_MATCHES_WRITE=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no CONCURRENCY=1 RETRY=0 PRINT_BODY=no SAVE_BODY=no PRINT_FULL_JSON=no SAVE_FULL_JSON=no  # Phase 5.21L2M remaining 7 pageProps v2 controlled write, hash-gated sequential recapture, exactly 7 raw_match_data v2 rows, no parser/features/training/prediction"
 	@echo "  make data-all-seeded-pageprops-v2-canonical-read-verification SOURCE=fotmob TABLE=raw_match_data TARGET_EXTERNAL_IDS=4830746,4830747,4830748,4830750,4830751,4830752,4830753,4830754 EXPECTED_TARGET_VERSION=fotmob_pageprops_v2 FALLBACK_VERSION=fotmob_html_hyd_v1 EXPECTED_HASHES='<json>' ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2N SELECT-only canonical read verification for all 8 seeded matches, synthetic/unknown excluded, no DB write/network/parser/features/training"
 	@echo "  make data-pageprops-v2-raw-completeness-audit SOURCE=fotmob TABLE=raw_match_data TARGET_EXTERNAL_IDS=4830746,4830747,4830748,4830750,4830751,4830752,4830753,4830754 DATA_VERSION=fotmob_pageprops_v2 ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no PRINT_FULL_RAW_DATA=no SAVE_FULL_RAW_DATA=no  # Phase 5.21L2O SELECT-only pageProps v2 raw inventory/completeness audit for all 8 seeded matches, local raw_match_data only, no DB write/network/parser/features/training"
+	@echo "  make data-pageprops-v2-parser-boundary-leakage-plan SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=parser-boundary-leakage-acquisition-odds-roadmap ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2P planning-only parser boundary / leakage-safe planning with large-scale acquisition and odds raw roadmap"
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
@@ -373,6 +374,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  Phase 5.21L2J pageProps v2 single-target controlled write requires baseline hash + final confirmation, writes exactly one raw_match_data v2 row, and performs no matches/features/training/prediction writes."
 	@echo "  Phase 5.21L2K pageProps v2 post-write canonical read verification is SELECT-only: confirms selector picks v2 for 4830747, v1 fallback for remaining seeded matches, and synthetic/unknown exclusion; no DB write/network/parser/features/training."
 	@echo "  Phase 5.21L2L remaining seeded pageProps v2 acquisition preflight is no-write: targets only the 7 remaining seeded matches, recaptures sequentially, computes stable_pageprops_payload_v1 hashes, and defers controlled write/parser/features/training."
+	@echo "  Phase 5.21L2P parser boundary / leakage-safe planning is planning-only: current 8 seeded pageProps v2 rows are validation samples, not a training dataset; it defines parser module boundaries, prediction-cutoff leakage rules, large-scale acquisition planning, and odds raw roadmap without parser/features/training."
 	@echo "  Phase 5.20L2D hash stability audit is local-only: verify stable_raw_payload_v1, keep volatile _meta out of data_hash, no network, no DB writes."
 	@echo "  Remaining seeded matches require separate authorization, preflight, and controlled write phases."
 	@echo "  Phase 5.11L2 direct matchDetails endpoint returned 403; do not retry or change headers/routes before route audit authorization."
@@ -1414,6 +1416,22 @@ data-pageprops-v2-raw-completeness-audit: ## Run Phase 5.21L2O pageProps v2 raw 
 		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
 		--print-full-raw-data="$(or $(PRINT_FULL_RAW_DATA),no)" \
 		--save-full-raw-data="$(or $(SAVE_FULL_RAW_DATA),no)"
+
+data-pageprops-v2-parser-boundary-leakage-plan: ## Run Phase 5.21L2P parser boundary / leakage-safe planning. Planning-only, no network/write/parser/features/training.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(RAW_VERSION)" ] || [ -z "$(PLANNING_SCOPE)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=parser-boundary-leakage-acquisition-odds-roadmap"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/pageprops_v2_parser_boundary_leakage_plan.js \
+		--source="$(SOURCE)" \
+		--raw-version="$(RAW_VERSION)" \
+		--planning-scope="$(PLANNING_SCOPE)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-network="$(or $(ALLOW_NETWORK),no)" \
+		--allow-parser-implementation="$(or $(ALLOW_PARSER_IMPLEMENTATION),no)" \
+		--allow-feature-extraction="$(or $(ALLOW_FEATURE_EXTRACTION),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)"
 
 data-training-dataset-dry-run: ## Run SELECT-only training dataset readiness audit. Does not train, export, or write DB.
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/dataset_status_audit.js

--- a/docs/_reports/PAGEPROPS_V2_PARSER_BOUNDARY_LEAKAGE_PLAN_PHASE5_21L2P.md
+++ b/docs/_reports/PAGEPROPS_V2_PARSER_BOUNDARY_LEAKAGE_PLAN_PHASE5_21L2P.md
@@ -1,0 +1,485 @@
+# PageProps V2 Parser Boundary / Leakage Plan - Phase 5.21L2P
+
+## 1. Executive summary
+
+Phase 5.21L2O confirmed that all eight seeded Ligue 1 `fotmob_pageprops_v2` rows
+have high structural coverage, 8/8 core module presence, no suspicious small
+payloads, and no captcha / block / forbidden / placeholder markers.
+
+That result allows parser planning, but it does not justify parser
+implementation, feature extraction, training, or prediction.
+
+This phase is planning-only:
+
+- define parser module boundaries for pageProps v2
+- define leakage-safe policy by prediction horizon
+- plan large-scale pageProps v2 acquisition
+- plan early odds raw history integration as a separate source
+
+This phase does not implement a parser, does not write DB rows, does not touch
+FotMob or any odds source, and does not train a model.
+
+## 2. Current data status
+
+Read-only baseline confirmed for this phase:
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `raw_match_data`          |   18 |
+| `bookmaker_odds_history`  |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+Current `raw_match_data` version distribution:
+
+| data_version          | rows |
+| --------------------- | ---: |
+| `PHASE4.23`           |    1 |
+| `PHASE4.43_SYNTHETIC` |    1 |
+| `fotmob_html_hyd_v1`  |    8 |
+| `fotmob_pageprops_v2` |    8 |
+
+Current seeded state:
+
+- 8 seeded Ligue 1 matches already have `fotmob_pageprops_v2`
+- canonical selector chooses v2 for all 8 seeded matches
+- `bookmaker_odds_history` remains at 2 rows
+
+Important judgment:
+
+当前 8-10 场数据绝对不能用于训练模型。它们只能作为 raw pipeline validation
+set 和 parser design sampling，用于验证原始结构、边界与泄漏规则，不构成
+真实训练集。
+
+## 3. Parser boundary plan
+
+### `identity_metadata_parser`
+
+- Raw paths:
+    - `matchId`
+    - `general`
+    - `header`
+- Candidate outputs:
+    - `match_id`
+    - kickoff metadata
+    - home / away team identity
+    - league / season identity
+    - basic status metadata
+- Leakage tier:
+    - `metadata_only`
+- Pre-match usability:
+    - safe for joins, dedupe, scheduling and normalization
+    - not a direct predictive feature by itself
+- Optional handling:
+    - require only minimal identifiers
+    - deeper descriptive branches remain optional
+- Why not for training:
+    - identity fields are mainly metadata and should be excluded by default
+
+### `team_context_parser`
+
+- Raw paths:
+    - `header.teams`
+    - `general`
+    - `content.table`
+- Candidate outputs:
+    - league / season / round context
+    - team identity context
+    - standings snapshot features
+- Leakage tier:
+    - `conditional_pre_match_if_timestamped`
+- Pre-match usability:
+    - only if table snapshot is confirmed at or before `prediction_cutoff_time`
+- Optional handling:
+    - `content.table` must be optional-first
+- Why not always safe:
+    - standings or context snapshots taken after kickoff leak information
+
+### `h2h_parser`
+
+- Raw paths:
+    - `content.h2h`
+- Candidate outputs:
+    - historical H2H counts
+    - recent result summaries
+    - historical goal totals
+    - venue split history
+- Leakage tier:
+    - `conditional_pre_match_if_timestamped`
+- Pre-match usability:
+    - allowed only if referenced matches are historical and snapshot-safe
+- Optional handling:
+    - filter out undated, unresolved, current-match, or future-match entries
+- Why not always safe:
+    - H2H payloads can echo current fixture context or future-contaminated views
+
+### `lineup_parser`
+
+- Raw paths:
+    - `content.lineup`
+- Candidate outputs:
+    - confirmed starters
+    - bench depth
+    - formation
+    - coach context
+    - player availability signals
+- Leakage tier:
+    - `conditional_pre_match_if_timestamped`
+- Pre-match usability:
+    - only if `lineup_timestamp <= prediction_cutoff_time`
+    - excluded from `T_MINUS_24H` by default
+- Optional handling:
+    - fully optional-first because many leagues expose lineup late or not at all
+- Why not always safe:
+    - late lineup or in-match lineup branches are not valid for earlier horizons
+
+### `match_facts_parser`
+
+- Raw paths:
+    - `content.matchFacts`
+- Candidate outputs:
+    - goals, cards, substitutions, result-bearing facts, summary facts
+- Leakage tier:
+    - `post_match_only`
+    - `live_only`
+- Pre-match usability:
+    - not safe for pre-match training
+- Optional handling:
+    - isolated for live/post-match analytics only
+- Why not for training:
+    - contains direct outcome/event leakage
+
+### `stats_parser`
+
+- Raw paths:
+    - `content.stats`
+- Candidate outputs:
+    - team stat splits
+    - xG recap
+    - possession recap
+    - period aggregates
+- Leakage tier:
+    - `post_match_only`
+    - `live_only`
+- Pre-match usability:
+    - not safe for pre-match training
+- Optional handling:
+    - expect sparse or missing coverage outside richer leagues/statuses
+- Why not for training:
+    - stat aggregates are generated by the match itself
+
+### `player_stats_parser`
+
+- Raw paths:
+    - `content.playerStats`
+- Candidate outputs:
+    - player performance recap
+    - minutes played
+    - xG/xA recap
+    - player event summaries
+- Leakage tier:
+    - `post_match_only`
+    - `live_only`
+- Pre-match usability:
+    - not safe for pre-match training
+- Optional handling:
+    - parser must tolerate complete absence in colder leagues
+- Why not for training:
+    - direct player-match outcome leakage
+
+### `shotmap_parser`
+
+- Raw paths:
+    - `content.shotmap`
+- Candidate outputs:
+    - shot locations
+    - xG shot sequence
+    - chance quality recap
+- Leakage tier:
+    - `post_match_only`
+    - `live_only`
+- Pre-match usability:
+    - not safe for pre-match training
+- Optional handling:
+    - missing shotmap must not break parser in low-tier leagues
+- Why not for training:
+    - shot events are in-match or post-match outcomes
+
+### `momentum_parser`
+
+- Raw paths:
+    - `content.momentum`
+- Candidate outputs:
+    - momentum curve
+    - pressure swings
+    - period dominance summaries
+- Leakage tier:
+    - `live_only`
+    - `post_match_only`
+- Pre-match usability:
+    - not safe for pre-match training
+- Optional handling:
+    - treat as optional because many leagues/statuses will omit it
+- Why not for training:
+    - momentum is inherently in-match state
+
+### `seo_auxiliary_parser`
+
+- Raw paths:
+    - `seo`
+    - `seo.eventJSONLD`
+    - `seo.breadcrumbJSONLD`
+- Candidate outputs:
+    - canonical labels
+    - structured metadata
+    - kickoff cross-checks
+    - breadcrumb mapping
+- Leakage tier:
+    - `metadata_only`
+    - `auxiliary_only`
+- Pre-match usability:
+    - useful for metadata reconciliation and QA
+- Optional handling:
+    - treat as helper path, not core parser dependency
+- Why not for training:
+    - text/breadcrumb fields are mainly normalization metadata
+
+### `fallback_translations_parser`
+
+- Raw paths:
+    - `fallback`
+    - `translations`
+- Candidate outputs:
+    - label normalization
+    - localization mapping
+    - fallback markers
+- Leakage tier:
+    - `auxiliary_only`
+- Pre-match usability:
+    - normalization only
+- Optional handling:
+    - fully optional
+- Why not for training:
+    - not predictive; only useful for mapping and QA
+
+## 4. Leakage-safe feature policy
+
+Core rule:
+
+- `prediction_cutoff_time` is mandatory
+
+Feature availability must be evaluated relative to the selected cutoff time, not
+just the raw payload capture time. A pageProps v2 payload harvested after
+full-time can still contain both pre-match candidates and live/post-match
+leakage in the same JSON.
+
+Prediction horizons:
+
+- `T_MINUS_24H`
+- `T_MINUS_6H`
+- `T_MINUS_1H`
+- `CLOSING_OR_NEAR_KICKOFF`
+
+Mandatory rules:
+
+- no post-match or in-match data in pre-match models
+- no current match result / score / event outcome leakage
+- no closing odds in `T_MINUS_24H` model
+- no future H2H entries
+- no table snapshot after kickoff
+- lineup only allowed if `lineup_timestamp <= prediction_cutoff_time`
+- odds only allowed if `odds_timestamp <= prediction_cutoff_time`
+
+## 5. Large-scale acquisition roadmap
+
+Why expansion is required:
+
+- 8 seeded matches prove raw storage and selector behavior
+- they do not prove league-wide completeness
+- they do not support model training
+- training should wait for thousands or tens of thousands of matches
+
+Recommended execution order:
+
+1. build target inventory by league / season / status
+2. run no-write preflight
+3. run controlled write
+4. run post-write completeness audit
+5. publish per-league completeness profile
+6. only then review parser implementation scope
+
+Coverage strategy:
+
+- top leagues may show high module richness
+- mid-tier leagues may have mixed coverage
+- low-tier / obscure leagues may miss:
+    - lineup
+    - playerStats
+    - shotmap
+    - momentum
+    - stats
+    - stable table snapshots
+
+Key planning stance:
+
+- parser must be optional-first
+- do not assume Ligue 1 sample generalizes to all leagues
+- future parser/features must remain `data_version`-aware
+- source fidelity and completeness must be profiled per league / season
+
+## 6. Odds raw roadmap
+
+Source boundary:
+
+- FotMob pageProps v2 is a match-detail / factual raw source
+- FotMob does not provide canonical odds history for this project
+- odds must come from an independent market-pricing source
+- odds raw should not be mixed into FotMob `raw_match_data`
+- join should happen via `match_id`
+
+Why odds raw should be planned early:
+
+- historical odds are time-sensitive
+- opening / intermediate / near-kickoff snapshots are easy to lose
+- leakage-safe feature generation depends on preserving timestamped raw history
+
+Current read-only audit findings:
+
+- `bookmaker_odds_history` currently has 13 columns
+- key columns include:
+    - `match_id`
+    - `bookmaker_name`
+    - `market_type`
+    - `open_odds`
+    - `close_odds`
+    - `movement_trajectory`
+    - `alignment_meta`
+    - `source_html_path`
+    - `source_digest`
+    - `collected_at`
+- unique constraint:
+    - `(match_id, bookmaker_name, market_type)`
+- current shape is oriented around open/close + trajectory aggregates
+- this is useful for legacy aligned storage, but not yet a clean cutoff-time-first
+  raw snapshot contract
+
+Existing module audit:
+
+- `database/migrations/V12.5__create_bookmaker_odds_history.sql`
+- `database/migrations/V12.8__add_alignment_meta_to_bookmaker_odds_history.sql`
+- `scripts/ops/odds_harvest_pipeline.js`:
+    - legacy runtime
+    - imports Playwright and child process flow
+    - blocked for agent execution
+- `src/ml/features/odds_movement_features.py`:
+    - existing feature logic
+    - must remain blocked until raw odds timing/leakage policy is fixed
+
+Recommended future odds raw fields:
+
+- `match_id`
+- `source`
+- `bookmaker`
+- `market_type`
+- `selection`
+- `odds_decimal`
+- `collected_at`
+- `odds_timestamp` or `source_snapshot_at`
+- `kickoff_time`
+- `time_to_kickoff`
+- `raw_payload`
+- `data_hash`
+- `data_version`
+
+Future odds feature examples:
+
+- implied probabilities
+- market margin
+- consensus odds
+- movement between snapshots
+- opening / `T_MINUS_24H` / `T_MINUS_6H` / `T_MINUS_1H` / closing odds
+
+Leakage rules for future odds features:
+
+- only odds observed at or before `prediction_cutoff_time` are allowed
+- `T_MINUS_24H` model cannot use closing odds
+- near-kickoff model can use near-kickoff odds captured before kickoff
+
+This phase does not ingest odds, does not write `bookmaker_odds_history`, and
+does not generate odds features.
+
+## 7. Recommended next phases
+
+Recommended next phases:
+
+- `Phase 5.21L2Q`:
+    - large-scale pageProps v2 acquisition strategy planning
+    - still planning-only
+    - no DB write
+    - no network execution
+    - define league / season / target expansion
+    - define batch preflight / controlled write phases
+    - define coverage profile strategy
+- `Phase 5.22L2A`:
+    - odds raw schema / source / leakage policy planning and existing module audit
+    - no odds access
+    - no DB write
+    - inspect existing odds modules only
+    - plan raw odds history schema and timing policy
+- `Phase 5.22L2B`:
+    - odds raw controlled preflight small sample
+    - only after explicit future authorization
+
+Parser implementation should come only after:
+
+- parser boundary is reviewed and accepted
+- large-scale raw acquisition plan is accepted
+- odds timing / leakage policy is accepted
+
+## 8. Verification results
+
+Verification gates for this phase:
+
+- new planning test:
+    - `tests/unit/pageprops_v2_parser_boundary_leakage_plan.test.js`
+- existing safety regressions:
+    - `tests/unit/pageprops_v2_raw_completeness_audit.test.js`
+    - `tests/unit/all_seeded_pageprops_v2_canonical_read_verification.test.js`
+    - `tests/unit/RawMatchDataVersionSelector.test.js`
+- Makefile planning target:
+    - `make data-pageprops-v2-parser-boundary-leakage-plan ...`
+- full validation:
+    - `npm test`
+    - `npm run test:coverage`
+    - `eslint`
+    - `prettier --check`
+    - `git diff --check`
+- safety checks:
+    - DB row counts unchanged
+    - `tests/fixtures/l1-config-*` residue absent
+    - `docs/_staging_preview` absent
+    - PR CI green
+    - main push CI green
+
+## 9. Explicit non-execution
+
+This phase confirms that none of the following were executed:
+
+- no DB writes
+- no `raw_match_data` writes
+- no `bookmaker_odds_history` writes
+- no network / FotMob access
+- no odds access
+- no schema migration
+- no `matches` writes
+- no parser implementation
+- no feature extraction
+- no `l3_features` write
+- no `match_features_training` write
+- no training / prediction
+- no browser / proxy
+- no full raw_data print/save
+- no full pageProps print/save
+- no file deletion

--- a/scripts/ops/pageprops_v2_parser_boundary_leakage_plan.js
+++ b/scripts/ops/pageprops_v2_parser_boundary_leakage_plan.js
@@ -1,0 +1,663 @@
+#!/usr/bin/env node
+'use strict';
+
+const PHASE = 'PHASE5_21L2P_PAGEPROPS_V2_PARSER_BOUNDARY_LEAKAGE_PLAN';
+const SOURCE = 'fotmob';
+const RAW_VERSION = 'fotmob_pageprops_v2';
+const PLANNING_SCOPE = 'parser-boundary-leakage-acquisition-odds-roadmap';
+const PREDICTION_HORIZONS = Object.freeze(['T_MINUS_24H', 'T_MINUS_6H', 'T_MINUS_1H', 'CLOSING_OR_NEAR_KICKOFF']);
+const REQUIRED_NO_FLAGS = Object.freeze([
+    'allowDbWrite',
+    'allowNetwork',
+    'allowParserImplementation',
+    'allowFeatureExtraction',
+    'allowTraining',
+    'allowPrediction',
+]);
+const BLOCKED_TRUE_FLAGS = Object.freeze([
+    'execute',
+    'commit',
+    'touchFotmob',
+    'liveRequest',
+    'allowRawMatchDataWrite',
+    'allowOddsWrite',
+    'allowSchemaMigration',
+    'allowMatchesWrite',
+]);
+
+function normalizeText(value) {
+    return String(value ?? '').trim();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return { value: arg.slice(arg.indexOf('=') + 1), consumedNext: false };
+    }
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        rawVersion: null,
+        planningScope: null,
+        allowDbWrite: null,
+        allowNetwork: null,
+        allowParserImplementation: null,
+        allowFeatureExtraction: null,
+        allowTraining: null,
+        allowPrediction: null,
+        execute: false,
+        commit: false,
+        touchFotmob: false,
+        liveRequest: false,
+        allowRawMatchDataWrite: false,
+        allowOddsWrite: false,
+        allowSchemaMigration: false,
+        allowMatchesWrite: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        'raw-version': 'rawVersion',
+        raw_version: 'rawVersion',
+        'planning-scope': 'planningScope',
+        planning_scope: 'planningScope',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-network': 'allowNetwork',
+        allow_network: 'allowNetwork',
+        'allow-parser-implementation': 'allowParserImplementation',
+        allow_parser_implementation: 'allowParserImplementation',
+        'allow-feature-extraction': 'allowFeatureExtraction',
+        allow_feature_extraction: 'allowFeatureExtraction',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        execute: 'execute',
+        commit: 'commit',
+        'touch-fotmob': 'touchFotmob',
+        touch_fotmob: 'touchFotmob',
+        'live-request': 'liveRequest',
+        live_request: 'liveRequest',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-odds-write': 'allowOddsWrite',
+        allow_odds_write: 'allowOddsWrite',
+        'allow-schema-migration': 'allowSchemaMigration',
+        allow_schema_migration: 'allowSchemaMigration',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        help: 'help',
+        h: 'help',
+    };
+    const booleanKeys = new Set([
+        'allowDbWrite',
+        'allowNetwork',
+        'allowParserImplementation',
+        'allowFeatureExtraction',
+        'allowTraining',
+        'allowPrediction',
+        'execute',
+        'commit',
+        'touchFotmob',
+        'liveRequest',
+        'allowRawMatchDataWrite',
+        'allowOddsWrite',
+        'allowSchemaMigration',
+        'allowMatchesWrite',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+        options[optionKey] = booleanKeys.has(optionKey) ? normalizeBooleanFlag(value, true) : value;
+    }
+
+    return options;
+}
+
+function validatePlanningInput(input = {}) {
+    const errors = [];
+    const source = normalizeText(input.source).toLowerCase();
+    const rawVersion = normalizeText(input.rawVersion);
+    const planningScope = normalizeText(input.planningScope);
+
+    if (Array.isArray(input.unknown) && input.unknown.length > 0) {
+        errors.push(`unknown arguments: ${input.unknown.join(', ')}`);
+    }
+
+    if (!source) {
+        errors.push('missing source=fotmob');
+    } else if (source !== SOURCE) {
+        errors.push('source must be fotmob');
+    }
+    if (!rawVersion) {
+        errors.push('missing raw-version=fotmob_pageprops_v2');
+    } else if (rawVersion !== RAW_VERSION) {
+        errors.push('raw-version must be fotmob_pageprops_v2');
+    }
+    if (!planningScope) {
+        errors.push('missing planning-scope=parser-boundary-leakage-acquisition-odds-roadmap');
+    } else if (planningScope !== PLANNING_SCOPE) {
+        errors.push('planning-scope must be parser-boundary-leakage-acquisition-odds-roadmap');
+    }
+
+    for (const flagName of REQUIRED_NO_FLAGS) {
+        const normalizedValue = normalizeBooleanFlag(input[flagName]);
+        const cliName = flagName.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+        if (normalizedValue === true) {
+            errors.push(`${cliName}=yes is blocked`);
+            continue;
+        }
+        if (normalizedValue !== false) {
+            errors.push(`${cliName}=no is required`);
+        }
+    }
+
+    for (const flagName of BLOCKED_TRUE_FLAGS) {
+        if (normalizeBooleanFlag(input[flagName]) === true) {
+            const cliName = flagName.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+            errors.push(`${cliName}=yes is blocked`);
+        }
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value: {
+            source,
+            rawVersion,
+            planningScope,
+            allowDbWrite: false,
+            allowNetwork: false,
+            allowParserImplementation: false,
+            allowFeatureExtraction: false,
+            allowTraining: false,
+            allowPrediction: false,
+        },
+    };
+}
+
+function buildParserModulePlan() {
+    return [
+        {
+            parser_key: 'identity_metadata_parser',
+            raw_paths: ['matchId', 'general', 'header'],
+            candidate_outputs: [
+                'match_id',
+                'kickoff_time',
+                'home_team_identity',
+                'away_team_identity',
+                'league_identity',
+                'season_identity',
+                'basic_status_metadata',
+            ],
+            leakage_tier: 'metadata_only',
+            field_categories: {
+                safe_pre_match_candidate: [
+                    'matchId',
+                    'general.matchTimeUTC',
+                    'general.homeTeam.id',
+                    'general.awayTeam.id',
+                ],
+                metadata_only: ['general.leagueId', 'general.leagueName', 'header.status'],
+                exclude_from_training_by_default: ['identity labels used for joins/normalization only'],
+            },
+            pre_match_usability:
+                'safe for joins, dedupe, scheduling and normalization; not a direct predictive feature by itself',
+            optional_handling:
+                'require only minimal identifiers and kickoff metadata; deeper descriptive branches remain optional',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['safe identity metadata, not predictive by itself'],
+        },
+        {
+            parser_key: 'team_context_parser',
+            raw_paths: ['header.teams', 'general', 'content.table'],
+            candidate_outputs: [
+                'league_context',
+                'season_context',
+                'round_context',
+                'team_identity_context',
+                'table_snapshot_features',
+            ],
+            leakage_tier: 'conditional_pre_match_if_timestamped',
+            field_categories: {
+                safe_pre_match_candidate: ['general.leagueId', 'general.leagueName', 'general.parentLeagueName'],
+                conditional_pre_match_if_timestamped: [
+                    'content.table',
+                    'general.round',
+                    'header.teams form/context captured before cutoff',
+                ],
+                metadata_only: ['header.teams names and badges'],
+            },
+            timestamp_rule: 'table_snapshot_at <= prediction_cutoff_time',
+            pre_match_usability:
+                'usable only when standings/context snapshot is confirmed at or before prediction_cutoff_time',
+            optional_handling:
+                'optional-first; do not assume table or richer context exists outside top leagues or finished samples',
+            training_default: 'conditional_pre_match_if_timestamped',
+            notes: ['table snapshots after kickoff are forbidden in pre-match training'],
+        },
+        {
+            parser_key: 'h2h_parser',
+            raw_paths: ['content.h2h'],
+            candidate_outputs: [
+                'historical_h2h_counts',
+                'recent_h2h_results',
+                'historical_goal_totals',
+                'venue_split_history',
+            ],
+            leakage_tier: 'conditional_pre_match_if_timestamped',
+            field_categories: {
+                conditional_pre_match_if_timestamped: [
+                    'content.h2h.matches[] where historical_match_time < kickoff_time',
+                ],
+                exclude_from_training_by_default: [
+                    'undated or unresolved h2h entries',
+                    'branches that may include current/future match context',
+                ],
+            },
+            timestamp_rule: 'all referenced h2h matches must be historical and snapshot_at <= prediction_cutoff_time',
+            pre_match_usability:
+                'allowed only after filtering out current/future match entries and any snapshot taken after kickoff',
+            optional_handling:
+                'treat h2h as optional and aggressively filter incomplete or semantically ambiguous rows',
+            training_default: 'conditional_pre_match_if_timestamped',
+            notes: ['must ensure no current or future match is included'],
+        },
+        {
+            parser_key: 'lineup_parser',
+            raw_paths: ['content.lineup'],
+            candidate_outputs: [
+                'confirmed_starters',
+                'bench_depth',
+                'formation',
+                'coach_context',
+                'player_availability_signals',
+            ],
+            leakage_tier: 'conditional_pre_match_if_timestamped',
+            field_categories: {
+                conditional_pre_match_if_timestamped: [
+                    'content.lineup.homeTeam.starters',
+                    'content.lineup.awayTeam.starters',
+                    'content.lineup.formations',
+                ],
+                live_only: ['late in-match performance/event branches inside lineup payloads'],
+                exclude_from_training_by_default: ['unconfirmed lineups', 'late updates beyond selected horizon'],
+            },
+            timestamp_rule: 'lineup_timestamp <= prediction_cutoff_time',
+            pre_match_usability:
+                'usable only for horizons where the lineup is officially announced before the cutoff; excluded from T-24h by default',
+            optional_handling:
+                'optional-first because many leagues and statuses will miss confirmed lineups or only expose them near kickoff',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['otherwise treat lineup as live_only for pre-match modeling'],
+        },
+        {
+            parser_key: 'match_facts_parser',
+            raw_paths: ['content.matchFacts'],
+            candidate_outputs: ['event stream', 'goals/cards/substitutions', 'referee recap', 'match summary facts'],
+            leakage_tier: 'post_match_only',
+            field_categories: {
+                post_match_only: ['goals', 'cards', 'substitutions', 'result-bearing match facts'],
+                live_only: ['in-match events and evolving timelines'],
+                exclude_from_training_by_default: ['all matchFacts-derived outputs for pre-match models'],
+            },
+            pre_match_usability: 'not safe for pre-match training by default',
+            optional_handling: 'keep parser optional and isolated for future live/post-match analytics only',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['mostly post_match_only or live_only'],
+        },
+        {
+            parser_key: 'stats_parser',
+            raw_paths: ['content.stats'],
+            candidate_outputs: ['team stat splits', 'xG recap', 'possession recap', 'period aggregates'],
+            leakage_tier: 'post_match_only',
+            field_categories: {
+                post_match_only: ['full-time team statistics and period aggregates'],
+                live_only: ['in-match stat progression'],
+                exclude_from_training_by_default: ['stats-derived values for any pre-match horizon'],
+            },
+            pre_match_usability: 'not safe for pre-match training',
+            optional_handling: 'parser must tolerate missing stats in lower tiers and pre-match states',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['post_match_only or live_only'],
+        },
+        {
+            parser_key: 'player_stats_parser',
+            raw_paths: ['content.playerStats'],
+            candidate_outputs: ['player stat recap', 'minutes played', 'xG/xA recap', 'player event summaries'],
+            leakage_tier: 'post_match_only',
+            field_categories: {
+                post_match_only: ['player performance recaps and minutes played'],
+                live_only: ['in-match player event accumulators'],
+                exclude_from_training_by_default: ['all playerStats outputs for pre-match training'],
+            },
+            pre_match_usability: 'not safe for pre-match training',
+            optional_handling: 'assume playerStats may be absent in colder leagues and should not block parsing',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['playerStats should remain live/post-match only'],
+        },
+        {
+            parser_key: 'shotmap_parser',
+            raw_paths: ['content.shotmap'],
+            candidate_outputs: ['shot locations', 'xG shot sequence', 'chance quality recap'],
+            leakage_tier: 'post_match_only',
+            field_categories: {
+                post_match_only: ['resolved shot events and xG shot map'],
+                live_only: ['in-match shot feed'],
+                exclude_from_training_by_default: ['all shotmap outputs for pre-match models'],
+            },
+            pre_match_usability: 'not safe for pre-match training',
+            optional_handling: 'expect missing shotmap coverage in lower tiers and sparse competitions',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['shotmap is live/post-match only'],
+        },
+        {
+            parser_key: 'momentum_parser',
+            raw_paths: ['content.momentum'],
+            candidate_outputs: ['momentum curve', 'pressure swings', 'period dominance summaries'],
+            leakage_tier: 'live_only',
+            field_categories: {
+                live_only: ['minute-by-minute momentum and pressure curves'],
+                post_match_only: ['post-match summarized momentum'],
+                exclude_from_training_by_default: ['all momentum outputs for pre-match models'],
+            },
+            pre_match_usability: 'not safe for pre-match training',
+            optional_handling: 'treat as optional because many leagues or statuses may omit momentum entirely',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['momentum is live/post-match only'],
+        },
+        {
+            parser_key: 'seo_auxiliary_parser',
+            raw_paths: ['seo', 'seo.eventJSONLD', 'seo.breadcrumbJSONLD'],
+            candidate_outputs: [
+                'canonical labels',
+                'structured metadata',
+                'kickoff metadata cross-checks',
+                'breadcrumb mapping',
+            ],
+            leakage_tier: 'metadata_only',
+            field_categories: {
+                metadata_only: ['seo.eventJSONLD.startDate', 'seo.eventJSONLD.name'],
+                auxiliary_only: ['seo.breadcrumbJSONLD', 'slug/title normalization'],
+                exclude_from_training_by_default: ['SEO text and breadcrumb strings as direct model features'],
+            },
+            pre_match_usability:
+                'useful for metadata reconciliation and QA, not as direct predictive features by default',
+            optional_handling: 'treat SEO branches as optional helpers rather than core parser dependencies',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['metadata or auxiliary only'],
+        },
+        {
+            parser_key: 'fallback_translations_parser',
+            raw_paths: ['fallback', 'translations'],
+            candidate_outputs: ['label normalization', 'localization mapping', 'missing-field fallback markers'],
+            leakage_tier: 'auxiliary_only',
+            field_categories: {
+                auxiliary_only: ['translations.*', 'fallback flags and labels'],
+                exclude_from_training_by_default: ['localization strings and fallback flags as direct model features'],
+            },
+            pre_match_usability: 'use only for normalization/mapping; not predictive by default',
+            optional_handling: 'fully optional and never allowed to block parser success',
+            training_default: 'exclude_from_training_by_default',
+            notes: ['useful for mappings/normalization, not predictive feature input'],
+        },
+    ];
+}
+
+function buildPredictionHorizonPolicy() {
+    return {
+        prediction_time_cutoff_is_mandatory: true,
+        feature_availability_must_be_evaluated_relative_to_cutoff: true,
+        no_post_match_or_in_match_data_in_pre_match_model: true,
+        no_closing_odds_in_t_minus_24h_model: true,
+        no_current_match_result_score_or_event_outcome_leakage: true,
+        no_future_h2h_or_table_snapshot_after_kickoff: true,
+        lineup_timestamp_rule: 'lineup_timestamp <= prediction_cutoff_time',
+        odds_timestamp_rule: 'odds_timestamp <= prediction_cutoff_time',
+        table_snapshot_rule: 'table_snapshot_at <= prediction_cutoff_time',
+        h2h_future_leakage_rule:
+            'content.h2h entries must refer only to matches with event_time < kickoff_time and no current/future fixture echo',
+        prediction_horizons: [
+            {
+                horizon: 'T_MINUS_24H',
+                odds_rule: 'may use only snapshots captured at or before T_MINUS_24H; closing odds forbidden',
+            },
+            {
+                horizon: 'T_MINUS_6H',
+                odds_rule: 'may use only snapshots captured at or before T_MINUS_6H',
+            },
+            {
+                horizon: 'T_MINUS_1H',
+                odds_rule: 'may use only snapshots captured at or before T_MINUS_1H',
+            },
+            {
+                horizon: 'CLOSING_OR_NEAR_KICKOFF',
+                odds_rule: 'near-kickoff model may use near-kickoff odds only if captured before kickoff',
+            },
+        ],
+    };
+}
+
+function buildLargeScaleAcquisitionRoadmap() {
+    return {
+        current_8_matches_are_samples_not_training_set: true,
+        training_requires_large_scale_dataset: true,
+        future_expansion_axes: ['league', 'season', 'status'],
+        workflow: [
+            'batch target inventory',
+            'no-write preflight first',
+            'controlled write second',
+            'coverage profile by league/season',
+        ],
+        low_tier_league_risks: [
+            'missing lineup',
+            'missing playerStats',
+            'missing shotmap',
+            'missing momentum',
+            'missing stats',
+        ],
+        parser_must_be_optional_first: true,
+        no_assumption_seeded_ligue1_generalizes_to_all_leagues: true,
+    };
+}
+
+function buildOddsRawRoadmap() {
+    return {
+        fotmob_pageprops_role: 'match-detail/factual raw source',
+        odds_role: 'market-pricing raw source',
+        odds_should_be_stored_separately: true,
+        odds_storage_recommendation: 'bookmaker_odds_history or versioned odds raw table',
+        odds_raw_should_be_ingested_early: true,
+        odds_features_must_wait_for_cutoff_policy: true,
+        required_raw_fields: [
+            'match_id',
+            'source',
+            'bookmaker',
+            'market_type',
+            'selection',
+            'odds_decimal',
+            'collected_at',
+            'odds_timestamp',
+            'source_snapshot_at',
+            'kickoff_time',
+            'time_to_kickoff',
+            'raw_payload',
+            'data_hash',
+            'data_version',
+        ],
+        odds_feature_examples: [
+            'implied probabilities',
+            'market margin',
+            'consensus odds',
+            'movement between snapshots',
+            'opening / T-24h / T-6h / T-1h / closing odds',
+        ],
+        leakage_policy: {
+            odds_timestamp_rule: 'odds_timestamp <= prediction_cutoff_time',
+            t_minus_24h_rule: 'T_MINUS_24H model cannot use closing odds',
+            near_kickoff_rule: 'near-kickoff model can use near-kickoff odds',
+        },
+        existing_schema_audit: {
+            bookmaker_odds_history_row_count: 2,
+            columns: [
+                'match_id',
+                'bookmaker_name',
+                'market_type',
+                'open_odds',
+                'close_odds',
+                'movement_trajectory',
+                'alignment_meta',
+                'source_html_path',
+                'source_digest',
+                'collected_at',
+            ],
+            unique_constraint: '(match_id, bookmaker_name, market_type)',
+            finding:
+                'current schema is open/close + trajectory oriented, not yet cutoff-time-first raw snapshot design',
+        },
+        no_odds_ingestion_this_phase: true,
+    };
+}
+
+function buildPlanningOutput() {
+    return {
+        phase: PHASE,
+        planning_only: true,
+        db_write_executed: false,
+        network_executed: false,
+        parser_implementation_executed: false,
+        feature_extraction_executed: false,
+        training_executed: false,
+        prediction_executed: false,
+        filesystem_write_executed: false,
+        child_process_executed: false,
+        current_sample_notice: {
+            current_seeded_pageprops_v2_rows: 8,
+            training_dataset: false,
+            statement: 'current 8 matches are samples, not training data',
+        },
+        parser_module_plan: buildParserModulePlan(),
+        leakage_safe_feature_policy: buildPredictionHorizonPolicy(),
+        large_scale_pageprops_v2_acquisition_roadmap: buildLargeScaleAcquisitionRoadmap(),
+        odds_raw_roadmap: buildOddsRawRoadmap(),
+        recommended_next_phases: [
+            'Phase 5.21L2Q: large-scale pageProps v2 acquisition strategy planning',
+            'Phase 5.22L2A: odds raw schema / source / leakage policy planning and existing module audit',
+            'Phase 5.22L2B: odds raw controlled preflight small sample',
+        ],
+    };
+}
+
+function buildErrorOutput(errors = []) {
+    return {
+        phase: PHASE,
+        planning_only: true,
+        blocked: true,
+        errors,
+        db_write_executed: false,
+        network_executed: false,
+        parser_implementation_executed: false,
+        feature_extraction_executed: false,
+        training_executed: false,
+        prediction_executed: false,
+    };
+}
+
+function printUsage(io = process.stderr) {
+    io.write(
+        [
+            'Usage:',
+            '  node scripts/ops/pageprops_v2_parser_boundary_leakage_plan.js \\',
+            '    --source=fotmob \\',
+            '    --raw-version=fotmob_pageprops_v2 \\',
+            '    --planning-scope=parser-boundary-leakage-acquisition-odds-roadmap \\',
+            '    --allow-db-write=no \\',
+            '    --allow-network=no \\',
+            '    --allow-parser-implementation=no \\',
+            '    --allow-feature-extraction=no \\',
+            '    --allow-training=no \\',
+            '    --allow-prediction=no',
+            '',
+        ].join('\n')
+    );
+}
+
+function execute(argv = process.argv.slice(2), io = {}) {
+    const stdout = io.stdout || process.stdout;
+    const stderr = io.stderr || process.stderr;
+    const parsed = parseArgs(argv);
+
+    if (parsed.help) {
+        printUsage(stdout);
+        return 0;
+    }
+
+    const validation = validatePlanningInput(parsed);
+    if (!validation.ok) {
+        stderr.write(`${JSON.stringify(buildErrorOutput(validation.errors), null, 2)}\n`);
+        return 1;
+    }
+
+    stdout.write(`${JSON.stringify(buildPlanningOutput(), null, 2)}\n`);
+    return 0;
+}
+
+if (require.main === module) {
+    process.exitCode = execute();
+}
+
+module.exports = {
+    PHASE,
+    SOURCE,
+    RAW_VERSION,
+    PLANNING_SCOPE,
+    PREDICTION_HORIZONS,
+    parseArgs,
+    validatePlanningInput,
+    buildParserModulePlan,
+    buildPredictionHorizonPolicy,
+    buildLargeScaleAcquisitionRoadmap,
+    buildOddsRawRoadmap,
+    buildPlanningOutput,
+    execute,
+};

--- a/tests/unit/pageprops_v2_parser_boundary_leakage_plan.test.js
+++ b/tests/unit/pageprops_v2_parser_boundary_leakage_plan.test.js
@@ -1,0 +1,327 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+const path = require('node:path');
+const test = require('node:test');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const MODULE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/pageprops_v2_parser_boundary_leakage_plan.js');
+
+function loadFreshModule() {
+    delete require.cache[require.resolve(MODULE_PATH)];
+    return require(MODULE_PATH);
+}
+
+const mod = loadFreshModule();
+
+function validInput(overrides = {}) {
+    return {
+        source: 'fotmob',
+        rawVersion: 'fotmob_pageprops_v2',
+        planningScope: 'parser-boundary-leakage-acquisition-odds-roadmap',
+        allowDbWrite: false,
+        allowNetwork: false,
+        allowParserImplementation: false,
+        allowFeatureExtraction: false,
+        allowTraining: false,
+        allowPrediction: false,
+        execute: false,
+        commit: false,
+        touchFotmob: false,
+        liveRequest: false,
+        allowRawMatchDataWrite: false,
+        allowOddsWrite: false,
+        allowSchemaMigration: false,
+        allowMatchesWrite: false,
+        ...overrides,
+    };
+}
+
+function validArgv(overrides = {}) {
+    const base = {
+        source: 'fotmob',
+        'raw-version': 'fotmob_pageprops_v2',
+        'planning-scope': 'parser-boundary-leakage-acquisition-odds-roadmap',
+        'allow-db-write': 'no',
+        'allow-network': 'no',
+        'allow-parser-implementation': 'no',
+        'allow-feature-extraction': 'no',
+        'allow-training': 'no',
+        'allow-prediction': 'no',
+        ...overrides,
+    };
+    return Object.entries(base).flatMap(([key, value]) => [`--${key}`, value]);
+}
+
+function assertInvalid(overrides, pattern) {
+    const validation = mod.validatePlanningInput(validInput(overrides));
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), pattern);
+}
+
+function runPlan(argv = validArgv()) {
+    const stdout = [];
+    const stderr = [];
+    const exitCode = mod.execute(argv, {
+        stdout: { write: chunk => stdout.push(String(chunk)) },
+        stderr: { write: chunk => stderr.push(String(chunk)) },
+    });
+    const stdoutText = stdout.join('');
+    const stderrText = stderr.join('');
+    return {
+        exitCode,
+        stdout: stdoutText,
+        stderr: stderrText,
+        json: stdoutText ? JSON.parse(stdoutText) : null,
+        errorJson: stderrText ? JSON.parse(stderrText) : null,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalFetch = global.fetch;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by pageprops_v2_parser_boundary_leakage_plan`);
+    };
+
+    global.fetch = fail('global.fetch');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'playwright',
+            'playwright-core',
+            'puppeteer',
+            'child_process',
+            'node:child_process',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (
+            /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data|odds_harvest_pipeline|train|predict/i.test(
+                request
+            )
+        ) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        Module._load = originalLoad;
+    });
+}
+
+function loadWithBlockedImportPattern(t, pattern) {
+    const originalLoad = Module._load;
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (pattern.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+    t.after(() => {
+        Module._load = originalLoad;
+    });
+    return loadFreshModule();
+}
+
+function getModule(plan, parserKey) {
+    return plan.parser_module_plan.find(modulePlan => modulePlan.parser_key === parserKey);
+}
+
+test('valid input succeeds', () => {
+    assert.equal(mod.validatePlanningInput(validInput()).ok, true);
+});
+
+test('source missing fails', () => assertInvalid({ source: '' }, /missing source=fotmob/));
+test('source non-fotmob fails', () => assertInvalid({ source: 'other' }, /source must be fotmob/));
+test('raw-version missing fails', () => assertInvalid({ rawVersion: '' }, /missing raw-version=fotmob_pageprops_v2/));
+test('raw-version not fotmob_pageprops_v2 fails', () =>
+    assertInvalid({ rawVersion: 'fotmob_html_hyd_v1' }, /raw-version must be fotmob_pageprops_v2/));
+test('planning-scope missing fails', () =>
+    assertInvalid({ planningScope: '' }, /missing planning-scope=parser-boundary-leakage-acquisition-odds-roadmap/));
+test('wrong planning-scope fails', () =>
+    assertInvalid(
+        { planningScope: 'other-scope' },
+        /planning-scope must be parser-boundary-leakage-acquisition-odds-roadmap/
+    ));
+test('allow-db-write=yes blocked', () => assertInvalid({ allowDbWrite: true }, /allow-db-write=yes is blocked/));
+test('allow-network=yes blocked', () => assertInvalid({ allowNetwork: true }, /allow-network=yes is blocked/));
+test('allow-parser-implementation=yes blocked', () =>
+    assertInvalid({ allowParserImplementation: true }, /allow-parser-implementation=yes is blocked/));
+test('allow-feature-extraction=yes blocked', () =>
+    assertInvalid({ allowFeatureExtraction: true }, /allow-feature-extraction=yes is blocked/));
+test('allow-training=yes blocked', () => assertInvalid({ allowTraining: true }, /allow-training=yes is blocked/));
+test('allow-prediction=yes blocked', () => assertInvalid({ allowPrediction: true }, /allow-prediction=yes is blocked/));
+test('execute=yes blocked', () => assertInvalid({ execute: true }, /execute=yes is blocked/));
+test('commit=yes blocked', () => assertInvalid({ commit: true }, /commit=yes is blocked/));
+test('touch-fotmob=yes blocked', () => assertInvalid({ touchFotmob: true }, /touch-fotmob=yes is blocked/));
+test('live-request=yes blocked', () => assertInvalid({ liveRequest: true }, /live-request=yes is blocked/));
+test('allow-raw-match-data-write=yes blocked', () =>
+    assertInvalid({ allowRawMatchDataWrite: true }, /allow-raw-match-data-write=yes is blocked/));
+test('allow-odds-write=yes blocked', () => assertInvalid({ allowOddsWrite: true }, /allow-odds-write=yes is blocked/));
+test('allow-schema-migration=yes blocked', () =>
+    assertInvalid({ allowSchemaMigration: true }, /allow-schema-migration=yes is blocked/));
+test('allow-matches-write=yes blocked', () =>
+    assertInvalid({ allowMatchesWrite: true }, /allow-matches-write=yes is blocked/));
+
+test('plan contains identity_metadata_parser', () => {
+    assert.ok(getModule(runPlan().json, 'identity_metadata_parser'));
+});
+
+test('plan contains team_context_parser', () => {
+    assert.ok(getModule(runPlan().json, 'team_context_parser'));
+});
+
+test('plan contains h2h_parser', () => {
+    assert.ok(getModule(runPlan().json, 'h2h_parser'));
+});
+
+test('plan contains lineup_parser with conditional timestamp policy', () => {
+    const lineupParser = getModule(runPlan().json, 'lineup_parser');
+    assert.ok(lineupParser);
+    assert.equal(lineupParser.leakage_tier, 'conditional_pre_match_if_timestamped');
+    assert.match(lineupParser.timestamp_rule, /lineup_timestamp <= prediction_cutoff_time/);
+});
+
+test('plan marks shotmap as live/post_match only', () => {
+    const shotmapParser = getModule(runPlan().json, 'shotmap_parser');
+    assert.equal(shotmapParser.leakage_tier, 'post_match_only');
+    assert.ok(shotmapParser.field_categories.live_only.length > 0);
+});
+
+test('plan marks playerStats as live/post_match only', () => {
+    const playerStatsParser = getModule(runPlan().json, 'player_stats_parser');
+    assert.equal(playerStatsParser.leakage_tier, 'post_match_only');
+    assert.ok(playerStatsParser.field_categories.live_only.length > 0);
+});
+
+test('plan marks momentum as live/post_match only', () => {
+    const momentumParser = getModule(runPlan().json, 'momentum_parser');
+    assert.equal(momentumParser.leakage_tier, 'live_only');
+    assert.ok(momentumParser.field_categories.post_match_only.length > 0);
+});
+
+test('plan includes prediction horizons T-24h/T-6h/T-1h/closing', () => {
+    const horizons = runPlan()
+        .json.leakage_safe_feature_policy.prediction_horizons.map(entry => entry.horizon)
+        .sort();
+    assert.deepEqual(horizons, [...mod.PREDICTION_HORIZONS].sort());
+});
+
+test('plan includes odds raw roadmap', () => {
+    assert.ok(runPlan().json.odds_raw_roadmap);
+});
+
+test('plan says odds raw early, odds features later', () => {
+    const oddsRoadmap = runPlan().json.odds_raw_roadmap;
+    assert.equal(oddsRoadmap.odds_raw_should_be_ingested_early, true);
+    assert.equal(oddsRoadmap.odds_features_must_wait_for_cutoff_policy, true);
+});
+
+test('plan includes odds_timestamp <= prediction_cutoff_time rule', () => {
+    const policy = runPlan().json.leakage_safe_feature_policy;
+    assert.equal(policy.odds_timestamp_rule, 'odds_timestamp <= prediction_cutoff_time');
+});
+
+test('plan says current 8 matches are samples, not training set', () => {
+    const notice = runPlan().json.current_sample_notice;
+    assert.equal(notice.training_dataset, false);
+    assert.match(notice.statement, /not training data/);
+});
+
+test('plan includes large-scale acquisition roadmap', () => {
+    assert.ok(runPlan().json.large_scale_pageprops_v2_acquisition_roadmap);
+});
+
+test('plan includes low-tier league missing module risk', () => {
+    const risks = runPlan().json.large_scale_pageprops_v2_acquisition_roadmap.low_tier_league_risks;
+    assert.ok(risks.includes('missing lineup'));
+    assert.ok(risks.includes('missing playerStats'));
+});
+
+test('no DB write', () => {
+    assert.equal(runPlan().json.db_write_executed, false);
+});
+
+test('no network', () => {
+    assert.equal(runPlan().json.network_executed, false);
+});
+
+test('no parser implementation', () => {
+    assert.equal(runPlan().json.parser_implementation_executed, false);
+});
+
+test('no feature extraction', () => {
+    assert.equal(runPlan().json.feature_extraction_executed, false);
+});
+
+test('no fs write / mkdir except repo edits', t => {
+    installExecutionGuards(t);
+    const result = runPlan();
+    assert.equal(result.exitCode, 0);
+});
+
+test('no child_process spawn', t => {
+    installExecutionGuards(t);
+    const result = runPlan();
+    assert.equal(result.exitCode, 0);
+});
+
+test('no ProductionHarvester/raw ingest import', t => {
+    const freshModule = loadWithBlockedImportPattern(
+        t,
+        /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/i
+    );
+    assert.equal(typeof freshModule.execute, 'function');
+});
+
+test('no odds_harvest_pipeline import', t => {
+    const freshModule = loadWithBlockedImportPattern(t, /odds_harvest_pipeline/i);
+    assert.equal(typeof freshModule.execute, 'function');
+});
+
+test('no training/prediction import', t => {
+    const freshModule = loadWithBlockedImportPattern(t, /train|predict/i);
+    assert.equal(typeof freshModule.execute, 'function');
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.21L2P pageProps v2 parser boundary / leakage-safe planning with large-scale acquisition and odds raw roadmap.

Scope:
- Plans parser module boundaries based on pageProps v2 inventory
- Defines leakage-safe feature policy by prediction horizon
- Documents why current 8 seeded matches are validation samples, not a training set
- Adds large-scale pageProps v2 acquisition roadmap
- Adds odds raw history roadmap and timing/leakage policy
- Keeps parser/features/training deferred

Safety:
- No DB writes
- No raw_match_data writes
- No bookmaker_odds_history writes
- No network / FotMob access
- No odds access
- No schema migration
- No matches writes
- No parser implementation
- No feature extraction
- No l3_features / training table writes
- No training / prediction
- No browser/proxy
- No full raw_data print/save
- No file deletion

Validation:
- parser boundary planning tests passed
- raw completeness audit tests passed
- canonical read verification tests passed
- Makefile planning target passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed