### PR TITLE
docs(data): plan large-scale pageProps v2 acquisition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@
 - Phase 5.21L2O 是 pageProps v2 raw inventory / completeness audit：只能 SELECT-only，只读本地 `raw_match_data` 中 8 条 seeded `fotmob_pageprops_v2`，不得触 FotMob/network、不得写 DB、不得保存或打印完整 `raw_data`/完整 `pageProps`。本阶段只允许做路径盘点、模块覆盖、可疑载荷和完整性 assessment；不得实现 parser/features/training。下一步应是 parser planning，不是 parser implementation。
 - Phase 5.21L2P 是 pageProps v2 parser boundary / leakage-safe planning：只能 planning-only，不得实现 parser、不得抽 features、不得写 `l3_features` / `match_features_training` / `predictions`、不得训练/预测、不得触 FotMob/network、不得写 DB。当前 8 条 seeded `fotmob_pageprops_v2` 仅是 raw pipeline / 结构 / parser design sampling，不构成训练数据集。
 - Phase 5.21L2P 起，parser implementation 必须等待 parser boundary / leakage policy review；features/training 必须等待 large-scale raw acquisition plan 和 `prediction_cutoff_time` policy 明确。odds raw 必须视为独立 market-pricing source，允许尽早做 raw history planning，但 odds features 在 cutoff-time policy 明确前保持 blocked；未经未来明确授权，不得运行 `odds_harvest_pipeline` 或任何 odds write path。
+- Phase 5.21L2Q 是 large-scale pageProps v2 acquisition strategy planning-only：它只能规划 future target inventory / preflight / controlled write / canonical verification / completeness audit 生命周期，不得触 FotMob/network、不得执行 raw acquisition、不得写 DB、不得实现 parser/features/training/prediction。低级别/冷门联赛必须先做 coverage profile，不能把 seeded Ligue 1 高覆盖样本泛化到所有联赛；future odds alignment 应保留稳定 `match_id` / `kickoff_time`，但 odds ingestion 仍保持独立路线。
 - 以下 engine core 不是 deprecated，也不得误删：`DiscoveryService`、`DiscoveryParser`、`DiscoveryAttributeMapper`、`DiscoveryDataValidator`、`L1ConfigManager`、`HttpClient`、`FotMobExtractor`、`BrowserProvider`、`FixtureRepository`。
 - 未完成 migration inventory 且未经用户批准前，不删除 legacy entrypoints。
 
@@ -278,6 +279,7 @@ AI / Codex 默认只能执行：
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-dataset-status`
 - 只读 DB 且不训练、不预测、不导出、不加载模型 artifact 的 `make data-training-dataset-dry-run`
 - 用户明确授权且 planning-only、不触网、不写 DB、不实现 parser/features/training/prediction 的 `make data-pageprops-v2-parser-boundary-leakage-plan SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=parser-boundary-leakage-acquisition-odds-roadmap ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no`
+- 用户明确授权且 planning-only、不触网、不执行 raw acquisition、不写 DB、不实现 parser/features/training/prediction 的 `make data-large-scale-pageprops-v2-acquisition-strategy-plan SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=large-scale-acquisition-strategy ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_RAW_ACQUISITION=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no`
 - 不访问外网、不写 DB 的 `make data-acquisition-engines`
 - 不访问外网、不写 DB 的 `make data-acquisition-engine-audit`
 - 用户明确授权且只读本地 source manifest、不写 DB、不训练、不预测的 `make data-real-source-audit SOURCE_MANIFEST=<local json>`

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
         data-training-dry-run data-training-commit data-prediction-dry-run data-prediction-commit \
         data-training-feature-dry-run data-training-feature-commit \
         data-prediction-write-dry-run data-prediction-write-commit \
-        data-dataset-status data-raw-match-data-completeness-audit data-html-hydration-source-fidelity-live-compare data-raw-storage-strategy-revision-plan data-pageprops-v2-no-write-preview data-pageprops-v2-controlled-write-plan data-raw-match-data-versioned-schema-migration-preflight data-raw-match-data-versioned-schema-migration-execute data-raw-match-data-version-compatibility-audit data-pageprops-v2-single-target-controlled-write data-pageprops-v2-post-write-canonical-read-verification data-remaining-seeded-pageprops-v2-acquisition-preflight data-remaining-seeded-pageprops-v2-controlled-write data-all-seeded-pageprops-v2-canonical-read-verification data-pageprops-v2-raw-completeness-audit data-pageprops-v2-parser-boundary-leakage-plan data-training-dataset-dry-run data-training-dataset-export \
+        data-dataset-status data-raw-match-data-completeness-audit data-html-hydration-source-fidelity-live-compare data-raw-storage-strategy-revision-plan data-pageprops-v2-no-write-preview data-pageprops-v2-controlled-write-plan data-raw-match-data-versioned-schema-migration-preflight data-raw-match-data-versioned-schema-migration-execute data-raw-match-data-version-compatibility-audit data-pageprops-v2-single-target-controlled-write data-pageprops-v2-post-write-canonical-read-verification data-remaining-seeded-pageprops-v2-acquisition-preflight data-remaining-seeded-pageprops-v2-controlled-write data-all-seeded-pageprops-v2-canonical-read-verification data-pageprops-v2-raw-completeness-audit data-pageprops-v2-parser-boundary-leakage-plan data-large-scale-pageprops-v2-acquisition-strategy-plan data-training-dataset-dry-run data-training-dataset-export \
         data-acquisition-engines data-acquisition-engine-audit \
         data-l1-discovery-preview data-l1-discovery-candidates-preview data-l1-discovery-candidates-network-preview data-l1-discovery-commit \
         data-l1-matches-seed-commit-plan data-l1-matches-seed-commit-authorization data-l1-matches-seed-commit-execution-preflight data-l1-matches-seed-commit-execute data-l1-matches-seed-commit \
@@ -324,6 +324,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-all-seeded-pageprops-v2-canonical-read-verification SOURCE=fotmob TABLE=raw_match_data TARGET_EXTERNAL_IDS=4830746,4830747,4830748,4830750,4830751,4830752,4830753,4830754 EXPECTED_TARGET_VERSION=fotmob_pageprops_v2 FALLBACK_VERSION=fotmob_html_hyd_v1 EXPECTED_HASHES='<json>' ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2N SELECT-only canonical read verification for all 8 seeded matches, synthetic/unknown excluded, no DB write/network/parser/features/training"
 	@echo "  make data-pageprops-v2-raw-completeness-audit SOURCE=fotmob TABLE=raw_match_data TARGET_EXTERNAL_IDS=4830746,4830747,4830748,4830750,4830751,4830752,4830753,4830754 DATA_VERSION=fotmob_pageprops_v2 ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_FEATURES=no ALLOW_TRAINING=no ALLOW_PREDICTION=no PRINT_FULL_RAW_DATA=no SAVE_FULL_RAW_DATA=no  # Phase 5.21L2O SELECT-only pageProps v2 raw inventory/completeness audit for all 8 seeded matches, local raw_match_data only, no DB write/network/parser/features/training"
 	@echo "  make data-pageprops-v2-parser-boundary-leakage-plan SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=parser-boundary-leakage-acquisition-odds-roadmap ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2P planning-only parser boundary / leakage-safe planning with large-scale acquisition and odds raw roadmap"
+	@echo "  make data-large-scale-pageprops-v2-acquisition-strategy-plan SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=large-scale-acquisition-strategy ALLOW_DB_WRITE=no ALLOW_NETWORK=no ALLOW_RAW_ACQUISITION=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2Q planning-only large-scale pageProps v2 acquisition strategy, no DB write/network/raw acquisition/parser/features/training"
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
@@ -1428,6 +1429,23 @@ data-pageprops-v2-parser-boundary-leakage-plan: ## Run Phase 5.21L2P parser boun
 		--planning-scope="$(PLANNING_SCOPE)" \
 		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
 		--allow-network="$(or $(ALLOW_NETWORK),no)" \
+		--allow-parser-implementation="$(or $(ALLOW_PARSER_IMPLEMENTATION),no)" \
+		--allow-feature-extraction="$(or $(ALLOW_FEATURE_EXTRACTION),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)"
+
+data-large-scale-pageprops-v2-acquisition-strategy-plan: ## Run Phase 5.21L2Q large-scale pageProps v2 acquisition strategy planning. Planning-only, no network/raw acquisition/write/parser/features/training.
+	@if [ -z "$(SOURCE)" ] || [ -z "$(RAW_VERSION)" ] || [ -z "$(PLANNING_SCOPE)" ]; then \
+		echo "ERROR: provide SOURCE=fotmob RAW_VERSION=fotmob_pageprops_v2 PLANNING_SCOPE=large-scale-acquisition-strategy"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/large_scale_pageprops_v2_acquisition_strategy_plan.js \
+		--source="$(SOURCE)" \
+		--raw-version="$(RAW_VERSION)" \
+		--planning-scope="$(PLANNING_SCOPE)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-network="$(or $(ALLOW_NETWORK),no)" \
+		--allow-raw-acquisition="$(or $(ALLOW_RAW_ACQUISITION),no)" \
 		--allow-parser-implementation="$(or $(ALLOW_PARSER_IMPLEMENTATION),no)" \
 		--allow-feature-extraction="$(or $(ALLOW_FEATURE_EXTRACTION),no)" \
 		--allow-training="$(or $(ALLOW_TRAINING),no)" \

--- a/docs/_reports/LARGE_SCALE_PAGEPROPS_V2_ACQUISITION_STRATEGY_PLAN_PHASE5_21L2Q.md
+++ b/docs/_reports/LARGE_SCALE_PAGEPROPS_V2_ACQUISITION_STRATEGY_PLAN_PHASE5_21L2Q.md
@@ -1,0 +1,449 @@
+# Large-Scale PageProps V2 Acquisition Strategy Plan - Phase 5.21L2Q
+
+## 1. Executive summary
+
+当前 8 场 `fotmob_pageprops_v2` 仍然只是 validation samples，不是训练集。
+
+Phase 5.21L2M/N/O/P 已经证明 pageProps v2 raw storage、canonical selector、raw
+completeness audit、parser boundary planning 和 leakage-safe planning 路径已经跑通。
+
+本阶段的重点不是采集，而是规划如何从这 8 场 seeded validation samples 安全扩展到几千 /
+几万场 pageProps v2 raw 数据。
+
+本阶段严格保持 planning-only：
+
+- 不采集
+- 不触网
+- 不写库
+- 不实现 parser / features / training
+
+## 2. Current validated baseline
+
+只读确认基线：
+
+| table                     | rows |
+| ------------------------- | ---: |
+| `matches`                 |   10 |
+| `raw_match_data`          |   18 |
+| `bookmaker_odds_history`  |    2 |
+| `l3_features`             |    2 |
+| `match_features_training` |    2 |
+| `predictions`             |    2 |
+
+当前 `raw_match_data` data_version 分布：
+
+| data_version          | rows |
+| --------------------- | ---: |
+| `PHASE4.23`           |    1 |
+| `PHASE4.43_SYNTHETIC` |    1 |
+| `fotmob_html_hyd_v1`  |    8 |
+| `fotmob_pageprops_v2` |    8 |
+
+已验证状态：
+
+- 8 个 seeded Ligue 1 matches 都已有 `fotmob_pageprops_v2`
+- canonical read 对这 8 场全部选择 v2
+- completeness audit 显示 seeded Ligue 1 sample 为 high coverage
+
+限制必须明确：
+
+- 当前 8 场只证明 pageProps v2 pipeline 在 seeded sample 上技术可行
+- 它们不构成训练集
+- 它们也不能外推为“所有联赛都具备同样 coverage”
+
+## 3. Expansion tiers
+
+### Tier 0 current seeded validation
+
+- Purpose:
+    - 保留当前 8 场 seeded Ligue 1 作为技术验证基线
+- Estimated scale:
+    - 8 场
+- Expected risk:
+    - 技术风险低，但代表性风险高
+- Required preflight:
+    - 无新增 live preflight；只保留现有 baseline
+- Required completeness audit:
+    - 已完成
+- Go/no-go gate:
+    - 只能作为 validation baseline，不得视为训练数据
+
+### Tier 1 single-league single-season small batch
+
+- Purpose:
+    - 在同联赛同赛季上验证 inventory -> preflight -> write -> audit 全链路
+- Estimated scale:
+    - 每批 20-50 场
+- Priority:
+    - 先扩 `Ligue 1 / 2025/2026`
+    - 先 finished slices，再把 scheduled status 作为独立 profile slice
+- Expected risk:
+    - 中等，主要是 inventory / version state / hash gate 风险
+- Required preflight:
+    - future no-write preflight，逐目标生成 `stable_pageprops_payload_v1`
+      baseline
+- Required completeness audit:
+    - 每批写后都做 completeness audit 和 seeded baseline 对照
+- Go/no-go gate:
+    - 只有连续多批 preflight/write/canonical/audit 全绿后，才允许进入 Tier 2
+
+### Tier 2 top European multi-season
+
+- Purpose:
+    - 在顶级联赛和 recent seasons 上扩大样本规模
+- Estimated scale:
+    - 几百到几千场，仍然按批次推进
+- Priority:
+    - `Ligue 1 / EPL / La Liga / Bundesliga / Serie A`
+    - 优先 recent seasons，例如 `2025/2026`、`2024/2025`、`2023/2024`
+- Expected risk:
+    - 跨联赛、跨赛季 coverage variance
+- Required preflight:
+    - 仍按 league/season/status slice 做 no-write preflight
+- Required completeness audit:
+    - 每个 league-season 都必须产出 coverage profile
+- Go/no-go gate:
+    - 没有 repeated green audits，不得放大 batch
+
+### Tier 3 second-tier / broader UEFA
+
+- Purpose:
+    - 测试更广泛 UEFA 和 second-tier leagues 的结构稳定性
+- Estimated scale:
+    - 按联赛分波次进入，通常每波几百场以内
+- Priority:
+    - `Championship / 2. Bundesliga / Ligue 2 / Segunda / Serie B`
+- Expected risk:
+    - coverage variance 更高，advanced modules 缺失概率更高
+- Required preflight:
+    - 联赛专属 preflight slice
+- Required completeness audit:
+    - 每个 second-tier league 单独出 profile
+- Go/no-go gate:
+    - 没有 league-specific completeness profile，不得进入更大范围写入
+
+### Tier 4 low-tier / obscure leagues
+
+- Purpose:
+    - 先回答“这些联赛是否足够完整到值得 parser assumptions”
+- Estimated scale:
+    - 小样本 profile-only，取 profile batch 区间下限
+- Expected risk:
+    - 缺失 `lineup / playerStats / shotmap / momentum / stats / table` 风险最高
+- Required preflight:
+    - 只能先做 profile-only sample planning
+- Required completeness audit:
+    - 必须先完成 league-specific completeness profile
+- Go/no-go gate:
+    - 在 coverage 未证明前，不得进入 advanced parser/feature assumptions
+
+## 4. Batch acquisition lifecycle
+
+未来大规模 acquisition 应固定为以下生命周期：
+
+1. `target inventory`
+2. `existing-version audit`
+3. `no-write preflight`
+4. `stable_pageprops_payload_v1` baseline hash capture
+5. `controlled write`
+6. `post-write canonical verification`
+7. `raw completeness audit`
+8. `coverage profile update`
+9. `parser eligibility decision`
+
+关键要求：
+
+- inventory 必须先确定 exact scope
+- existing versions / duplicate targets 必须先审计
+- write 前必须先有 stable baseline hash
+- write 后必须先 canonical verify，再 completeness audit
+- 没有 coverage profile，就不能进入下一个扩展 tier
+
+## 5. Target inventory design
+
+未来 inventory 至少应保存以下字段：
+
+- `match_id`
+- `external_id`
+- `league_id`
+- `season`
+- `home_team`
+- `away_team`
+- `kickoff_time`
+- `status`
+- `source`
+- `route`
+- `data_version`
+- `batch_id`
+- `priority`
+- `existing_versions`
+- `expected_coverage_tier`
+- `acquisition_state`
+
+设计原则：
+
+- `match_id` 必须保持稳定，作为 raw version 和未来 odds join 的主键锚点
+- `external_id` 必须保留 source-native identity
+- `league_id` 必须显式持久化，不能只依赖 display `league_name`
+- `kickoff_time` 必须可稳定复用，不能只作为显示字段
+- `existing_versions` 必须在 preflight 前就审计清楚
+- `acquisition_state` 必须能表达：
+    - planned
+    - preflight_ready
+    - preflight_blocked
+    - write_authorized
+    - written
+    - canonical_verified
+    - completeness_profiled
+    - manual_review
+
+当前只读 schema 观察到一个重要限制：
+
+- `matches` 当前有 `league_name` 和 `match_date`
+- 但没有独立 `league_id` 字段
+- 因此 `Phase 5.21L2R` 必须先决定 future acquisition inventory/staging doc
+  如何显式保存 source-native `league_id` 和 `kickoff_time`
+
+## 6. Safety policy
+
+安全策略必须固定：
+
+- 不允许 direct bulk write
+- 不允许 uncontrolled harvest
+- first batch 必须小
+- `profile batch` 建议 `20-50`
+- `controlled write batch` 建议 `20-100`
+- 更大 batch 只有在 repeated green audits 后才允许讨论
+- 初始 `concurrency=1`
+- 初始 `retry=0`
+- `stable_pageprops_payload_v1` hash gate 是硬门禁
+- 任何 hash drift 都必须阻断目标；若多目标漂移，则阻断整批
+- 任何 systemic `403/captcha/forbidden` 都必须阻断整批
+- 所有 writes 必须 batch 或 target-group 事务化
+- 除非未来明确授权 reduced scope，否则不允许 partial write
+- full body / full JSON 默认不得打印、不得保存
+
+失败处理矩阵：
+
+- `403 / captcha / forbidden`
+    - stop whole batch
+    - no retry
+    - require route-health review
+- `invalid hydration`
+    - block target
+    - no write
+    - route to source-fidelity review
+- `hash drift`
+    - block target immediately
+    - repeated drift blocks batch and requires fresh preflight baseline
+- `duplicate target`
+    - block before preflight/write
+- `post-write mismatch`
+    - stop rollout
+    - run SELECT-only canonical reconciliation
+    - do not proceed to next batch
+
+## 7. Coverage profile policy
+
+coverage profile 必须按 `league / season / status` 输出，而不是只看全局均值。
+
+每个 tracked module 都应输出：
+
+- `present_count`
+- `missing_count`
+- `coverage_percent`
+- `sample_size`
+- `coverage_tier`
+
+tracked modules：
+
+- `content`
+- `content.lineup`
+- `content.matchFacts`
+- `content.playerStats`
+- `content.shotmap`
+- `content.stats`
+- `content.h2h`
+- `content.table`
+- `content.momentum`
+- `seo`
+- `fallback`
+- `translations`
+- `header`
+- `general`
+- `nav`
+- `ssr`
+- `fetchingLeagueData`
+- `hasPendingVAR`
+
+coverage tier 分类：
+
+- `high_coverage`
+- `medium_coverage`
+- `sparse_coverage`
+- `unusable_for_advanced_parser`
+
+profile 还必须附带：
+
+- module coverage
+- path coverage
+- missing core modules
+- suspicious payloads
+- league/season/status profile summary
+
+关键判断：
+
+- 当前 seeded Ligue 1 sample 可以是 `high_coverage`
+- 但这个结论不能默认复制到 EPL、Serie B、Ligue 2、低级别联赛或 scheduled/live statuses
+
+## 8. Low-tier league risk policy
+
+低级别 / 冷门联赛默认按高风险处理：
+
+- 不能假设 `lineup` 一定存在
+- 不能假设 `playerStats` 一定存在
+- 不能假设 `shotmap` 一定存在
+- 不能假设 `momentum` 一定存在
+- 不能假设 `stats` 一定存在
+- 不能假设 `table` snapshot 一定稳定可用
+
+因此：
+
+- parser 必须 optional-first
+- feature groups 必须 coverage-aware
+- 缺少 `shotmap` 的联赛，仍可能支持基础 metadata / table / h2h features
+- 缺少 `table` snapshots 的联赛，可能需要直接排除 table-based features
+- missing advanced modules 不应导致 raw ingestion 失败
+
+最重要的是：
+
+不能把当前 8 场 Ligue 1 high coverage sample 当作所有联赛都高覆盖的证据。
+
+## 9. Source fidelity / data version policy
+
+未来 source fidelity / version policy 必须保持：
+
+- canonical raw version：`fotmob_pageprops_v2`
+- fallback / legacy：`fotmob_html_hyd_v1`
+- `PHASE4.43_SYNTHETIC` / `PHASE4.23` / unknown 默认排除
+- canonical hash strategy：`stable_pageprops_payload_v1`
+- v2 `raw_data` shape：`_meta + matchId + pageProps`
+- source route 必须记录
+- body sha 只能作为 metadata，不参与 canonical payload hash gate
+- 未经明确授权，不得 rewrite 已有 rows
+
+## 10. Odds alignment readiness
+
+L2Q 不做 odds ingestion。
+
+但 large-scale match inventory 现在就必须为未来 odds join 做准备：
+
+- `match_id` 必须稳定
+- `kickoff_time` 必须可靠
+- `league / season / team identity` 必须可归一化
+- odds raw 不应混入 `raw_match_data`
+- future odds raw 应通过 `match_id + prediction_cutoff_time / odds_timestamp` 对齐
+
+这意味着 future acquisition inventory 至少要为 odds alignment 保留：
+
+- `match_id`
+- `external_id`
+- `league_id`
+- `season`
+- `home_team`
+- `away_team`
+- `kickoff_time`
+- `status`
+- `source`
+- `route`
+
+odds raw 仍应进入独立路线，而不是在 L2Q 阶段混进 FotMob raw planning。
+
+## 11. Recommended next phases
+
+推荐下一阶段：
+
+### Phase 5.21L2R
+
+`large-scale acquisition target inventory planning / schema-readiness audit`
+
+要求：
+
+- no DB write
+- no network
+- no raw acquisition execution
+- inspect `matches` schema and source mapping
+- decide how to represent future acquisition candidates
+- define target inventory schema or staging doc
+- still no FotMob access
+
+### Phase 5.21L2S
+
+`single-league small-batch pageProps v2 acquisition preflight`
+
+要求：
+
+- only after explicit network authorization
+- no DB write
+- e.g. small batch `20-50`
+- collect hashes / coverage summary only
+
+### Phase 5.22L2A
+
+`odds raw schema / source / leakage policy planning and existing module audit`
+
+要求：
+
+- parallel track
+- no odds access
+- no DB write
+
+## 12. Verification results
+
+本阶段验证项：
+
+- new planning tests:
+    - `tests/unit/large_scale_pageprops_v2_acquisition_strategy_plan.test.js`
+- previous planning tests:
+    - `tests/unit/pageprops_v2_parser_boundary_leakage_plan.test.js`
+- raw completeness tests:
+    - `tests/unit/pageprops_v2_raw_completeness_audit.test.js`
+- canonical read tests:
+    - `tests/unit/all_seeded_pageprops_v2_canonical_read_verification.test.js`
+    - `tests/unit/RawMatchDataVersionSelector.test.js`
+- Makefile planning target:
+    - `make data-large-scale-pageprops-v2-acquisition-strategy-plan ...`
+- full test gates:
+    - `npm test`
+    - `npm run test:coverage`
+- quality:
+    - `eslint`
+    - `prettier --check`
+    - `git diff --check`
+- safety:
+    - DB row counts unchanged
+    - `tests/fixtures/l1-config-*` residue absent
+    - `docs/_staging_preview` absent
+    - PR CI green before merge
+    - main push CI green after merge
+
+## 13. Explicit non-execution
+
+本阶段明确未执行：
+
+- no DB writes
+- no `raw_match_data` writes
+- no `bookmaker_odds_history` writes
+- no network / FotMob access
+- no odds access
+- no raw acquisition
+- no schema migration
+- no `matches` writes
+- no parser implementation
+- no feature extraction
+- no `l3_features` write
+- no `match_features_training` write
+- no training / prediction
+- no browser / proxy
+- no full raw_data print / save
+- no file deletion

--- a/scripts/ops/large_scale_pageprops_v2_acquisition_strategy_plan.js
+++ b/scripts/ops/large_scale_pageprops_v2_acquisition_strategy_plan.js
@@ -1,0 +1,787 @@
+#!/usr/bin/env node
+'use strict';
+
+const PHASE = 'PHASE5_21L2Q_LARGE_SCALE_PAGEPROPS_V2_ACQUISITION_STRATEGY_PLAN';
+const SOURCE = 'fotmob';
+const RAW_VERSION = 'fotmob_pageprops_v2';
+const PLANNING_SCOPE = 'large-scale-acquisition-strategy';
+const EXPECTED_ROW_COUNTS = Object.freeze({
+    matches: 10,
+    raw_match_data: 18,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+const EXPECTED_DISTRIBUTION = Object.freeze({
+    'PHASE4.23': 1,
+    'PHASE4.43_SYNTHETIC': 1,
+    fotmob_html_hyd_v1: 8,
+    fotmob_pageprops_v2: 8,
+});
+const COVERAGE_MODULE_PATHS = Object.freeze([
+    'content',
+    'content.lineup',
+    'content.matchFacts',
+    'content.playerStats',
+    'content.shotmap',
+    'content.stats',
+    'content.h2h',
+    'content.table',
+    'content.momentum',
+    'seo',
+    'fallback',
+    'translations',
+    'header',
+    'general',
+    'nav',
+    'ssr',
+    'fetchingLeagueData',
+    'hasPendingVAR',
+]);
+const REQUIRED_NO_FLAGS = Object.freeze([
+    'allowDbWrite',
+    'allowNetwork',
+    'allowRawAcquisition',
+    'allowParserImplementation',
+    'allowFeatureExtraction',
+    'allowTraining',
+    'allowPrediction',
+]);
+const BLOCKED_TRUE_FLAGS = Object.freeze([
+    'execute',
+    'commit',
+    'touchFotmob',
+    'liveRequest',
+    'allowRawMatchDataWrite',
+    'allowSchemaMigration',
+    'allowMatchesWrite',
+    'allowOddsWrite',
+]);
+
+function normalizeText(value) {
+    return String(value ?? '').trim();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return fallback;
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return { value: arg.slice(arg.indexOf('=') + 1), consumedNext: false };
+    }
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        source: null,
+        rawVersion: null,
+        planningScope: null,
+        allowDbWrite: null,
+        allowNetwork: null,
+        allowRawAcquisition: null,
+        allowParserImplementation: null,
+        allowFeatureExtraction: null,
+        allowTraining: null,
+        allowPrediction: null,
+        execute: false,
+        commit: false,
+        touchFotmob: false,
+        liveRequest: false,
+        allowRawMatchDataWrite: false,
+        allowSchemaMigration: false,
+        allowMatchesWrite: false,
+        allowOddsWrite: false,
+        help: false,
+        unknown: [],
+    };
+    const keyMap = {
+        source: 'source',
+        'raw-version': 'rawVersion',
+        raw_version: 'rawVersion',
+        'planning-scope': 'planningScope',
+        planning_scope: 'planningScope',
+        'allow-db-write': 'allowDbWrite',
+        allow_db_write: 'allowDbWrite',
+        'allow-network': 'allowNetwork',
+        allow_network: 'allowNetwork',
+        'allow-raw-acquisition': 'allowRawAcquisition',
+        allow_raw_acquisition: 'allowRawAcquisition',
+        'allow-parser-implementation': 'allowParserImplementation',
+        allow_parser_implementation: 'allowParserImplementation',
+        'allow-feature-extraction': 'allowFeatureExtraction',
+        allow_feature_extraction: 'allowFeatureExtraction',
+        'allow-training': 'allowTraining',
+        allow_training: 'allowTraining',
+        'allow-prediction': 'allowPrediction',
+        allow_prediction: 'allowPrediction',
+        execute: 'execute',
+        commit: 'commit',
+        'touch-fotmob': 'touchFotmob',
+        touch_fotmob: 'touchFotmob',
+        'live-request': 'liveRequest',
+        live_request: 'liveRequest',
+        'allow-raw-match-data-write': 'allowRawMatchDataWrite',
+        allow_raw_match_data_write: 'allowRawMatchDataWrite',
+        'allow-schema-migration': 'allowSchemaMigration',
+        allow_schema_migration: 'allowSchemaMigration',
+        'allow-matches-write': 'allowMatchesWrite',
+        allow_matches_write: 'allowMatchesWrite',
+        'allow-odds-write': 'allowOddsWrite',
+        allow_odds_write: 'allowOddsWrite',
+        help: 'help',
+        h: 'help',
+    };
+    const booleanKeys = new Set([
+        'allowDbWrite',
+        'allowNetwork',
+        'allowRawAcquisition',
+        'allowParserImplementation',
+        'allowFeatureExtraction',
+        'allowTraining',
+        'allowPrediction',
+        'execute',
+        'commit',
+        'touchFotmob',
+        'liveRequest',
+        'allowRawMatchDataWrite',
+        'allowSchemaMigration',
+        'allowMatchesWrite',
+        'allowOddsWrite',
+        'help',
+    ]);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+        if (!optionKey) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+        options[optionKey] = booleanKeys.has(optionKey) ? normalizeBooleanFlag(value, true) : value;
+    }
+
+    return options;
+}
+
+function validatePlanningInput(input = {}) {
+    const errors = [];
+    const source = normalizeText(input.source).toLowerCase();
+    const rawVersion = normalizeText(input.rawVersion);
+    const planningScope = normalizeText(input.planningScope);
+
+    if (Array.isArray(input.unknown) && input.unknown.length > 0) {
+        errors.push(`unknown arguments: ${input.unknown.join(', ')}`);
+    }
+
+    if (!source) {
+        errors.push('missing source=fotmob');
+    } else if (source !== SOURCE) {
+        errors.push('source must be fotmob');
+    }
+    if (!rawVersion) {
+        errors.push('missing raw-version=fotmob_pageprops_v2');
+    } else if (rawVersion !== RAW_VERSION) {
+        errors.push('raw-version must be fotmob_pageprops_v2');
+    }
+    if (!planningScope) {
+        errors.push('missing planning-scope=large-scale-acquisition-strategy');
+    } else if (planningScope !== PLANNING_SCOPE) {
+        errors.push('planning-scope must be large-scale-acquisition-strategy');
+    }
+
+    for (const flagName of REQUIRED_NO_FLAGS) {
+        const normalizedValue = normalizeBooleanFlag(input[flagName]);
+        const cliName = flagName.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+        if (normalizedValue === true) {
+            errors.push(`${cliName}=yes is blocked`);
+            continue;
+        }
+        if (normalizedValue !== false) {
+            errors.push(`${cliName}=no is required`);
+        }
+    }
+
+    for (const flagName of BLOCKED_TRUE_FLAGS) {
+        if (normalizeBooleanFlag(input[flagName]) === true) {
+            const cliName = flagName.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+            errors.push(`${cliName}=yes is blocked`);
+        }
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+        value: {
+            source,
+            rawVersion,
+            planningScope,
+            allowDbWrite: false,
+            allowNetwork: false,
+            allowRawAcquisition: false,
+            allowParserImplementation: false,
+            allowFeatureExtraction: false,
+            allowTraining: false,
+            allowPrediction: false,
+        },
+    };
+}
+
+function buildCurrentStateSummary() {
+    return {
+        current_8_seeded_matches_are_validation_samples_not_training_data: true,
+        current_pageprops_v2_pipeline_is_technically_validated: true,
+        canonical_read_selects_v2_for_all_8_seeded_matches: true,
+        raw_completeness_audit_shows_high_coverage_for_seeded_ligue1_sample: true,
+        must_not_be_generalized_to_all_leagues: true,
+        current_db_baseline: EXPECTED_ROW_COUNTS,
+        raw_match_data_data_version_distribution: EXPECTED_DISTRIBUTION,
+        limitation_statement:
+            'the seeded Ligue 1 sample validates the pageProps v2 storage/selector/completeness path but does not prove cross-league coverage or training readiness',
+        status_priority_note:
+            'future expansion should profile finished matches first, keep scheduled slices separate, and continue to block live acquisition until explicitly authorized',
+    };
+}
+
+function buildTargetExpansionTiers() {
+    return [
+        {
+            tier: 'TIER_0_CURRENT_SEEDED_VALIDATION',
+            label: 'Tier 0 current seeded validation',
+            purpose: 'preserve the 8-match seeded baseline as the technical validation reference set',
+            estimated_scale: '8 matches',
+            priority_scope: {
+                leagues: ['Ligue 1'],
+                seasons: ['2025/2026'],
+                statuses: ['finished'],
+            },
+            expected_risk: 'low technical risk, high representativeness risk',
+            required_preflight: 'none beyond existing seeded baselines already completed in L2L/L2M/L2N/L2O',
+            required_completeness_audit: 'already completed for the seeded sample',
+            go_no_go_gate: 'validation-only reference; never treat Tier 0 as training data',
+        },
+        {
+            tier: 'TIER_1_SINGLE_LEAGUE_SINGLE_SEASON',
+            label: 'Tier 1 single-league single-season',
+            purpose: 'validate inventory -> preflight -> write -> audit cycle on one controlled expansion slice',
+            estimated_scale: '20-50 matches per initial batch',
+            priority_scope: {
+                leagues: ['Ligue 1'],
+                seasons: ['2025/2026'],
+                statuses: ['finished first', 'scheduled only in separate profile slices'],
+            },
+            expected_risk: 'moderate operational risk, low-to-moderate schema risk',
+            required_preflight:
+                'explicit no-write preflight with stable_pageprops_payload_v1 baselines for every target',
+            required_completeness_audit: 'per-batch completeness audit and seeded-sample comparison before scale-up',
+            go_no_go_gate:
+                'only proceed to larger same-league batches after preflight/write/canonical/audit all stay green',
+        },
+        {
+            tier: 'TIER_2_TOP_EUROPEAN_MULTI_SEASON',
+            label: 'Tier 2 top European multi-season',
+            purpose: 'expand across top leagues and recent seasons once Tier 1 repeatedly passes',
+            estimated_scale: 'hundreds to low thousands of matches across multiple batches',
+            priority_scope: {
+                leagues: ['Ligue 1', 'EPL', 'La Liga', 'Bundesliga', 'Serie A'],
+                seasons: ['2025/2026', '2024/2025', '2023/2024'],
+                statuses: ['finished first', 'scheduled slices only after schema/timing readiness review'],
+            },
+            expected_risk: 'mixed coverage and season-to-season variance, still batch-gated',
+            required_preflight: 'batch-level target inventory and conservative serial preflight by league-season slice',
+            required_completeness_audit: 'publish league+season coverage profiles before widening season breadth',
+            go_no_go_gate: 'only scale after repeated green audits and no systemic 403/hash-drift issues',
+        },
+        {
+            tier: 'TIER_3_BROADER_UEFA_SECOND_TIER',
+            label: 'Tier 3 broader UEFA / second-tier',
+            purpose: 'test broader competition diversity while explicitly measuring module sparsity risk',
+            estimated_scale: 'hundreds per wave after league-specific profile approval',
+            priority_scope: {
+                leagues: ['Championship', '2. Bundesliga', 'Ligue 2', 'Segunda', 'Serie B'],
+                seasons: ['recent completed seasons first'],
+                statuses: ['finished first'],
+            },
+            expected_risk: 'higher coverage variance and league-specific module gaps',
+            required_preflight:
+                'league-specific preflight slices with duplicate/version audit before any write approval',
+            required_completeness_audit:
+                'mandatory per-league completeness profile before broader expansion inside that league family',
+            go_no_go_gate:
+                'no broader rollout inside a second-tier family until the first slice produces an accepted coverage profile',
+        },
+        {
+            tier: 'TIER_4_LOW_TIER_OBSCURE_LEAGUES',
+            label: 'Tier 4 low-tier / obscure leagues',
+            purpose: 'measure whether low-tier competitions are even usable for advanced parser coverage assumptions',
+            estimated_scale: 'small profile-only samples at the low end of the 20-50 range',
+            priority_scope: {
+                leagues: ['low-tier domestic leagues', 'obscure regional competitions'],
+                seasons: ['single recent season first'],
+                statuses: ['finished first'],
+            },
+            expected_risk: 'highest risk for missing lineup/playerStats/shotmap/momentum/stats/table modules',
+            required_preflight: 'profile-only no-write sample before any controlled write request',
+            required_completeness_audit: 'league-specific profile required; parser remains optional-first',
+            go_no_go_gate: 'no advanced-parser assumption unless the profile proves acceptable coverage',
+        },
+    ];
+}
+
+function buildBatchAcquisitionLifecycle() {
+    return [
+        {
+            step: 1,
+            key: 'target_inventory_planning',
+            description:
+                'generate deterministic candidate inventory by league / season / status with explicit target priority',
+            hard_gate: 'inventory must have stable identity fields before any future preflight request',
+        },
+        {
+            step: 2,
+            key: 'duplicate_existing_version_audit',
+            description: 'audit duplicate targets, existing versions, and unexpected v2 presence before any live step',
+            hard_gate: 'duplicates or unresolved version state block the target before preflight',
+        },
+        {
+            step: 3,
+            key: 'no_write_live_preflight',
+            description: 'future authorized no-write preflight recaptures pageProps candidates without DB write',
+            hard_gate: 'no preflight execution without explicit network authorization',
+        },
+        {
+            step: 4,
+            key: 'stable_pageprops_payload_v1_baseline_hash_capture',
+            description: 'capture stable_pageprops_payload_v1 baselines for every target in the authorized batch',
+            hard_gate: 'baseline hash must exist for every write candidate',
+        },
+        {
+            step: 5,
+            key: 'controlled_write_after_explicit_confirmation',
+            description: 'run controlled write only after explicit final confirmation and exact-scope authorization',
+            hard_gate: 'hash gate, target scope, and transactional write policy must all pass',
+        },
+        {
+            step: 6,
+            key: 'post_write_canonical_read_verification',
+            description: 'verify canonical selector chooses fotmob_pageprops_v2 after write',
+            hard_gate: 'post-write canonical mismatch blocks further rollout',
+        },
+        {
+            step: 7,
+            key: 'raw_completeness_audit',
+            description: 'run local completeness audit for the written slice and inspect module/path coverage',
+            hard_gate: 'unexpected degradation or suspicious payloads block the next expansion wave',
+        },
+        {
+            step: 8,
+            key: 'league_season_status_coverage_profile_update',
+            description: 'publish/update league / season / status coverage profile from audit results',
+            hard_gate: 'new tier rollout requires an explicit coverage profile update',
+        },
+        {
+            step: 9,
+            key: 'parser_eligibility_decision',
+            description:
+                'decide whether the acquired slice is eligible for future parser planning at that coverage tier',
+            hard_gate:
+                'parser/features/training stay blocked until coverage profile and leakage policy reviews are accepted',
+        },
+    ];
+}
+
+function buildTargetInventoryDesign() {
+    return {
+        schema_readiness_note:
+            'current read-only matches baseline exposes league_name and match_date but not a standalone league_id column; Phase 5.21L2R should define how future acquisition inventory preserves source-native league_id and kickoff_time aliases before any live FotMob expansion',
+        candidate_sources: [
+            'existing matches rows that already have stable match_id/external_id metadata',
+            'future controlled L1 seeding outputs for new league/season/date windows',
+            'manually reviewed staging documents for broader multi-season expansion',
+        ],
+        inventory_fields: [
+            { name: 'match_id', purpose: 'stable internal join key for raw versions and future odds alignment' },
+            { name: 'external_id', purpose: 'source-native FotMob match identifier' },
+            {
+                name: 'league_id',
+                purpose: 'source-native competition identifier preserved independently of display name',
+            },
+            { name: 'season', purpose: 'season partition used for batching and profile aggregation' },
+            { name: 'home_team', purpose: 'team identity needed for audit readability and future normalization' },
+            { name: 'away_team', purpose: 'team identity needed for audit readability and future normalization' },
+            { name: 'kickoff_time', purpose: 'stable kickoff anchor for future cutoff-time and odds alignment work' },
+            { name: 'status', purpose: 'finished vs scheduled vs postponed handling' },
+            { name: 'source', purpose: 'raw source family, fixed to fotmob for this workflow' },
+            { name: 'route', purpose: 'source route, expected html_hydration for pageProps v2' },
+            { name: 'data_version', purpose: 'target raw version, fixed to fotmob_pageprops_v2' },
+            { name: 'batch_id', purpose: 'deterministic acquisition batch identifier' },
+            { name: 'priority', purpose: 'target ordering inside controlled batches' },
+            { name: 'existing_versions', purpose: 'current raw versions already stored for the match' },
+            { name: 'expected_coverage_tier', purpose: 'expected profile class before write' },
+            {
+                name: 'acquisition_state',
+                purpose: 'planned/preflight_ready/written/profiled/manual_review lifecycle state',
+            },
+        ],
+        inventory_generation_rules: [
+            'sort inventory deterministically by priority, league, season, kickoff_time, external_id',
+            'track finished, scheduled, postponed, and cancelled targets in separate status slices',
+            'preserve route=html_hydration and data_version=fotmob_pageprops_v2 in every future candidate inventory row',
+            'record existing raw version state before any authorized preflight is requested',
+        ],
+        duplicate_detection_rules: [
+            'block duplicate (match_id, data_version) targets before preflight',
+            'block duplicate (source, external_id, route, data_version) targets before preflight',
+            'surface existing fotmob_pageprops_v2 rows as skip/manual-review candidates instead of rewriting them',
+        ],
+        cancellation_postponement_handling: [
+            'carry source status and kickoff changes in inventory metadata instead of silently overwriting older planning state',
+            'split rescheduled matches into fresh batch ids when kickoff_time changes materially',
+            'keep cancelled/postponed targets out of the same write scope as finished historical backfill',
+        ],
+        finished_vs_scheduled_match_handling: [
+            'prioritize finished matches for completeness profiling and post-write audit stability',
+            'treat scheduled matches as separate status slices because module coverage is structurally different before kickoff',
+            'keep live matches blocked unless a future phase explicitly authorizes them',
+        ],
+    };
+}
+
+function buildBatchSizingAndSafetyPolicy() {
+    return {
+        first_batch_should_be_small: true,
+        suggested_batch_sizes: {
+            profile_batch: '20-50 matches',
+            controlled_write_batch: '20-100 matches',
+            large_batch_gate: 'allow larger batches only after repeated green preflight/canonical/audit cycles',
+        },
+        rate_limit_and_concurrency_policy: {
+            initial_mode: 'serial only (concurrency=1)',
+            future_rate_limit:
+                'keep future live requests low-rate and human-reviewed; do not open parallel browser/proxy runtimes',
+        },
+        retry_policy: {
+            default: 'retry=0',
+            future_escalation_rule:
+                'allow only conservative per-target retry after explicit authorization and route-health evidence',
+        },
+        hash_gate_required: true,
+        hash_strategy: 'stable_pageprops_payload_v1',
+        hash_drift_policy: 'any hash drift blocks the target; repeated or multi-target drift blocks the batch',
+        systemic_403_captcha_policy:
+            'systemic 403/captcha/forbidden markers stop the entire batch and require route-health review',
+        invalid_hydration_policy:
+            'invalid or truncated hydration blocks the target and routes it to manual source-fidelity review',
+        duplicate_target_policy:
+            'duplicate target or unexpected existing v2 presence blocks the target before any write scope is approved',
+        transaction_policy:
+            'all writes must be transactional per authorized batch or per explicitly defined small target group',
+        partial_write_policy:
+            'no partial write unless the user explicitly authorizes a reduced scope after reviewing blockers',
+        missing_module_policy:
+            'missing optional modules feed coverage profiling and do not fail ingestion by default; missing core structures block the target',
+        post_write_mismatch_policy:
+            'any post-write canonical mismatch blocks further rollout until SELECT-only reconciliation succeeds',
+        full_body_json_policy: 'full HTML body and full pageProps JSON must never be printed or saved by default',
+    };
+}
+
+function buildCoverageProfileStrategy() {
+    return {
+        profile_dimensions: ['league', 'season', 'status'],
+        output_metrics: ['present_count', 'missing_count', 'coverage_percent', 'sample_size', 'coverage_tier'],
+        coverage_tier_labels: ['high_coverage', 'medium_coverage', 'sparse_coverage', 'unusable_for_advanced_parser'],
+        coverage_tier_guidance: {
+            high_coverage: 'module is broadly present in the slice and core structure looks healthy',
+            medium_coverage: 'module is often present but not reliable enough for default assumptions',
+            sparse_coverage: 'module exists only in a minority of targets and should remain optional-only',
+            unusable_for_advanced_parser:
+                'coverage is too weak or core structure is degraded for advanced parser assumptions',
+        },
+        module_output_schema: COVERAGE_MODULE_PATHS.map(modulePath => ({
+            module_path: modulePath,
+            required_metrics: ['present_count', 'missing_count', 'coverage_percent', 'sample_size', 'coverage_tier'],
+        })),
+        suspicious_payload_checks: [
+            'unexpectedly small payloads',
+            'captcha/block/forbidden/placeholder markers',
+            'invalid hydration payloads',
+            'missing core top-level structures',
+            'league-season-status slices with abnormal module loss',
+        ],
+        league_season_status_profile_update_rule:
+            'every completed write batch must update a coverage profile keyed by league + season + status before broader rollout',
+        current_seeded_sample_warning:
+            'the seeded Ligue 1 slice is high coverage, but that result must not be generalized to all leagues or statuses',
+    };
+}
+
+function buildLowTierObscureLeagueRiskPolicy() {
+    return {
+        low_tier_leagues_may_not_have_full_module_coverage: true,
+        do_not_assume_lineup_playerStats_shotmap_momentum_stats_exist: true,
+        parser_must_use_optional_first_design: true,
+        feature_groups_must_be_coverage_aware: true,
+        leagues_without_shotmap_can_still_support_basic_safe_features: true,
+        leagues_without_table_snapshots_may_be_excluded_from_table_based_features: true,
+        missing_advanced_modules_should_not_fail_ingestion: true,
+        profile_only_sampling_rule:
+            'start new low-tier leagues with small profile-only samples and require a league-specific completeness profile before wider write planning',
+        no_ligue1_generalization: true,
+    };
+}
+
+function buildDataVersionSourceFidelityPolicy() {
+    return {
+        canonical_raw_version: 'fotmob_pageprops_v2',
+        legacy_fallback_version: 'fotmob_html_hyd_v1',
+        synthetic_unknown_excluded_by_default: true,
+        canonical_selector_priority: ['fotmob_pageprops_v2', 'fotmob_html_hyd_v1'],
+        data_hash_strategy: 'stable_pageprops_payload_v1',
+        raw_data_shape: '_meta + matchId + pageProps',
+        source_route_must_be_recorded: true,
+        body_sha_metadata_only: true,
+        writer_conflict_target: '(match_id, data_version)',
+        no_rewrite_of_existing_rows_without_explicit_authorization: true,
+    };
+}
+
+function buildMatchIdentityAndOddsAlignmentReadiness() {
+    return {
+        odds_ingestion_this_phase: false,
+        stable_match_id_is_critical: true,
+        kickoff_time_must_be_reliable: true,
+        league_season_team_identity_must_be_normalized: true,
+        odds_raw_should_not_be_mixed_into_raw_match_data: true,
+        future_odds_join_strategy:
+            'future odds raw should join on stable match_id while respecting prediction_cutoff_time / odds_timestamp semantics',
+        inventory_metadata_required_for_odds_alignment: [
+            'match_id',
+            'external_id',
+            'league_id',
+            'season',
+            'home_team',
+            'away_team',
+            'kickoff_time',
+            'status',
+            'source',
+            'route',
+        ],
+        current_schema_readiness_note:
+            'Phase 5.21L2R should decide how future acquisition inventory stores source-native league_id and kickoff_time without relying only on display labels such as league_name',
+    };
+}
+
+function buildFailureStrategyMatrix() {
+    return [
+        {
+            failure: 'systemic_403_or_captcha',
+            response: 'stop the entire batch, do not retry, and require route-health review before any next attempt',
+        },
+        {
+            failure: 'invalid_hydration',
+            response: 'block the target, skip any write, and route it to source-fidelity/manual review',
+        },
+        {
+            failure: 'hash_drift',
+            response:
+                'block the target immediately; if drift appears repeatedly or across multiple targets, stop the batch and require a fresh preflight baseline',
+        },
+        {
+            failure: 'missing_modules',
+            response:
+                'record module loss in the coverage profile; missing optional modules do not fail ingestion by default, but missing core modules mark the target unusable',
+        },
+        {
+            failure: 'duplicate_target_or_existing_unexpected_v2',
+            response: 'block before preflight/write and require manual dedupe/version audit',
+        },
+        {
+            failure: 'post_write_mismatch',
+            response:
+                'stop further rollout, run SELECT-only canonical reconciliation, and do not advance to the next batch until resolved',
+        },
+    ];
+}
+
+function buildBlockingPolicy() {
+    return {
+        parser_features_training_remain_blocked: true,
+        block_conditions: [
+            'do not implement parser logic until large-scale acquisition coverage tiers and completeness profiles are reviewed',
+            'do not generate features until prediction_cutoff_time policy and module-level leakage rules are accepted',
+            'do not train or predict until large-scale raw coverage and leakage-safe policy are both approved',
+        ],
+    };
+}
+
+function buildRecommendedNextPhases() {
+    return [
+        {
+            phase: 'Phase 5.21L2R',
+            title: 'large-scale acquisition target inventory planning / schema-readiness audit',
+            constraints: ['no DB write', 'no network', 'no raw acquisition execution', 'still no FotMob access'],
+            purpose:
+                'inspect matches schema and source mapping, decide how to represent future acquisition candidates, and define target inventory schema or staging documentation',
+        },
+        {
+            phase: 'Phase 5.21L2S',
+            title: 'single-league small-batch pageProps v2 acquisition preflight',
+            constraints: [
+                'only after explicit network authorization',
+                'no DB write',
+                'small batch 20-50',
+                'collect hashes and coverage summary only',
+            ],
+            purpose:
+                'run the first same-league/same-season no-write preflight and measure stability before any controlled write request',
+        },
+        {
+            phase: 'Phase 5.22L2A',
+            title: 'odds raw schema / source / leakage policy planning and existing module audit',
+            constraints: ['parallel track', 'no odds access', 'no DB write'],
+            purpose:
+                'keep odds ingestion separate while planning raw odds history schema, source readiness, and cutoff-time policy',
+        },
+    ];
+}
+
+function buildPlanningOutput() {
+    return {
+        phase: PHASE,
+        planning_only: true,
+        db_write_executed: false,
+        network_executed: false,
+        raw_acquisition_executed: false,
+        parser_implementation_executed: false,
+        feature_extraction_executed: false,
+        training_executed: false,
+        prediction_executed: false,
+        filesystem_write_executed: false,
+        child_process_executed: false,
+        current_state_summary: buildCurrentStateSummary(),
+        target_expansion_tiers: buildTargetExpansionTiers(),
+        batch_acquisition_lifecycle: buildBatchAcquisitionLifecycle(),
+        target_inventory_design: buildTargetInventoryDesign(),
+        batch_sizing_and_safety_policy: buildBatchSizingAndSafetyPolicy(),
+        coverage_profile_strategy: buildCoverageProfileStrategy(),
+        low_tier_obscure_league_risk_policy: buildLowTierObscureLeagueRiskPolicy(),
+        data_version_source_fidelity_policy: buildDataVersionSourceFidelityPolicy(),
+        match_identity_and_odds_alignment_readiness: buildMatchIdentityAndOddsAlignmentReadiness(),
+        failure_strategy_matrix: buildFailureStrategyMatrix(),
+        blocking_policy: buildBlockingPolicy(),
+        recommended_next_phases: buildRecommendedNextPhases(),
+    };
+}
+
+function buildErrorOutput(errors = []) {
+    return {
+        phase: PHASE,
+        planning_only: true,
+        blocked: true,
+        errors,
+        db_write_executed: false,
+        network_executed: false,
+        raw_acquisition_executed: false,
+        parser_implementation_executed: false,
+        feature_extraction_executed: false,
+        training_executed: false,
+        prediction_executed: false,
+    };
+}
+
+function printUsage(io = process.stderr) {
+    io.write(
+        [
+            'Usage:',
+            '  node scripts/ops/large_scale_pageprops_v2_acquisition_strategy_plan.js \\',
+            '    --source=fotmob \\',
+            '    --raw-version=fotmob_pageprops_v2 \\',
+            '    --planning-scope=large-scale-acquisition-strategy \\',
+            '    --allow-db-write=no \\',
+            '    --allow-network=no \\',
+            '    --allow-raw-acquisition=no \\',
+            '    --allow-parser-implementation=no \\',
+            '    --allow-feature-extraction=no \\',
+            '    --allow-training=no \\',
+            '    --allow-prediction=no',
+            '',
+        ].join('\n')
+    );
+}
+
+function execute(argv = process.argv.slice(2), io = {}) {
+    const stdout = io.stdout || process.stdout;
+    const stderr = io.stderr || process.stderr;
+    const parsed = parseArgs(argv);
+
+    if (parsed.help) {
+        printUsage(stdout);
+        return 0;
+    }
+
+    const validation = validatePlanningInput(parsed);
+    if (!validation.ok) {
+        stderr.write(`${JSON.stringify(buildErrorOutput(validation.errors), null, 2)}\n`);
+        return 1;
+    }
+
+    stdout.write(`${JSON.stringify(buildPlanningOutput(), null, 2)}\n`);
+    return 0;
+}
+
+if (require.main === module) {
+    process.exitCode = execute();
+}
+
+module.exports = {
+    PHASE,
+    SOURCE,
+    RAW_VERSION,
+    PLANNING_SCOPE,
+    COVERAGE_MODULE_PATHS,
+    parseArgs,
+    validatePlanningInput,
+    buildCurrentStateSummary,
+    buildTargetExpansionTiers,
+    buildBatchAcquisitionLifecycle,
+    buildTargetInventoryDesign,
+    buildBatchSizingAndSafetyPolicy,
+    buildCoverageProfileStrategy,
+    buildLowTierObscureLeagueRiskPolicy,
+    buildDataVersionSourceFidelityPolicy,
+    buildMatchIdentityAndOddsAlignmentReadiness,
+    buildFailureStrategyMatrix,
+    buildBlockingPolicy,
+    buildRecommendedNextPhases,
+    buildPlanningOutput,
+    execute,
+};

--- a/tests/unit/large_scale_pageprops_v2_acquisition_strategy_plan.test.js
+++ b/tests/unit/large_scale_pageprops_v2_acquisition_strategy_plan.test.js
@@ -1,0 +1,345 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+const path = require('node:path');
+const test = require('node:test');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const MODULE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/large_scale_pageprops_v2_acquisition_strategy_plan.js');
+
+function loadFreshModule() {
+    delete require.cache[require.resolve(MODULE_PATH)];
+    return require(MODULE_PATH);
+}
+
+const mod = loadFreshModule();
+
+function validInput(overrides = {}) {
+    return {
+        source: 'fotmob',
+        rawVersion: 'fotmob_pageprops_v2',
+        planningScope: 'large-scale-acquisition-strategy',
+        allowDbWrite: false,
+        allowNetwork: false,
+        allowRawAcquisition: false,
+        allowParserImplementation: false,
+        allowFeatureExtraction: false,
+        allowTraining: false,
+        allowPrediction: false,
+        execute: false,
+        commit: false,
+        touchFotmob: false,
+        liveRequest: false,
+        allowRawMatchDataWrite: false,
+        allowSchemaMigration: false,
+        allowMatchesWrite: false,
+        allowOddsWrite: false,
+        ...overrides,
+    };
+}
+
+function validArgv(overrides = {}) {
+    const base = {
+        source: 'fotmob',
+        'raw-version': 'fotmob_pageprops_v2',
+        'planning-scope': 'large-scale-acquisition-strategy',
+        'allow-db-write': 'no',
+        'allow-network': 'no',
+        'allow-raw-acquisition': 'no',
+        'allow-parser-implementation': 'no',
+        'allow-feature-extraction': 'no',
+        'allow-training': 'no',
+        'allow-prediction': 'no',
+        ...overrides,
+    };
+    return Object.entries(base).flatMap(([key, value]) => [`--${key}`, value]);
+}
+
+function assertInvalid(overrides, pattern) {
+    const validation = mod.validatePlanningInput(validInput(overrides));
+    assert.equal(validation.ok, false);
+    assert.match(validation.errors.join('\n'), pattern);
+}
+
+function runPlan(argv = validArgv()) {
+    const stdout = [];
+    const stderr = [];
+    const exitCode = mod.execute(argv, {
+        stdout: { write: chunk => stdout.push(String(chunk)) },
+        stderr: { write: chunk => stderr.push(String(chunk)) },
+    });
+    const stdoutText = stdout.join('');
+    const stderrText = stderr.join('');
+    return {
+        exitCode,
+        stdout: stdoutText,
+        stderr: stderrText,
+        json: stdoutText ? JSON.parse(stdoutText) : null,
+        errorJson: stderrText ? JSON.parse(stderrText) : null,
+    };
+}
+
+function installExecutionGuards(t) {
+    const originalFetch = global.fetch;
+    const originalWriteFile = fs.writeFile;
+    const originalWriteFileSync = fs.writeFileSync;
+    const originalMkdir = fs.mkdir;
+    const originalMkdirSync = fs.mkdirSync;
+    const originalCreateWriteStream = fs.createWriteStream;
+    const originalSpawn = childProcess.spawn;
+    const originalExec = childProcess.exec;
+    const originalExecFile = childProcess.execFile;
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    const originalLoad = Module._load;
+    const fail = name => () => {
+        throw new Error(`${name} should not be called by large_scale_pageprops_v2_acquisition_strategy_plan`);
+    };
+
+    global.fetch = fail('global.fetch');
+    fs.writeFile = fail('fs.writeFile');
+    fs.writeFileSync = fail('fs.writeFileSync');
+    fs.mkdir = fail('fs.mkdir');
+    fs.mkdirSync = fail('fs.mkdirSync');
+    fs.createWriteStream = fail('fs.createWriteStream');
+    childProcess.spawn = fail('child_process.spawn');
+    childProcess.exec = fail('child_process.exec');
+    childProcess.execFile = fail('child_process.execFile');
+    http.request = fail('http.request');
+    https.request = fail('https.request');
+    Module._load = function patchedLoad(request, parent, isMain) {
+        const blockedImports = new Set([
+            'playwright',
+            'playwright-core',
+            'puppeteer',
+            'child_process',
+            'node:child_process',
+            'http',
+            'node:http',
+            'https',
+            'node:https',
+        ]);
+        if (blockedImports.has(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        if (
+            /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data|odds_harvest_pipeline|train|predict/i.test(
+                request
+            )
+        ) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    t.after(() => {
+        global.fetch = originalFetch;
+        fs.writeFile = originalWriteFile;
+        fs.writeFileSync = originalWriteFileSync;
+        fs.mkdir = originalMkdir;
+        fs.mkdirSync = originalMkdirSync;
+        fs.createWriteStream = originalCreateWriteStream;
+        childProcess.spawn = originalSpawn;
+        childProcess.exec = originalExec;
+        childProcess.execFile = originalExecFile;
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+        Module._load = originalLoad;
+    });
+}
+
+function loadWithBlockedImportPattern(t, pattern) {
+    const originalLoad = Module._load;
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (pattern.test(request)) {
+            throw new Error(`blocked import: ${request}`);
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+    t.after(() => {
+        Module._load = originalLoad;
+    });
+    return loadFreshModule();
+}
+
+test('valid input succeeds', () => {
+    assert.equal(mod.validatePlanningInput(validInput()).ok, true);
+});
+
+test('source missing fails', () => assertInvalid({ source: '' }, /missing source=fotmob/));
+test('source non-fotmob fails', () => assertInvalid({ source: 'other' }, /source must be fotmob/));
+test('raw-version missing fails', () => assertInvalid({ rawVersion: '' }, /missing raw-version=fotmob_pageprops_v2/));
+test('raw-version not fotmob_pageprops_v2 fails', () =>
+    assertInvalid({ rawVersion: 'fotmob_html_hyd_v1' }, /raw-version must be fotmob_pageprops_v2/));
+test('planning-scope missing fails', () =>
+    assertInvalid({ planningScope: '' }, /missing planning-scope=large-scale-acquisition-strategy/));
+test('wrong planning-scope fails', () =>
+    assertInvalid({ planningScope: 'other-scope' }, /planning-scope must be large-scale-acquisition-strategy/));
+test('allow-db-write=yes blocked', () => assertInvalid({ allowDbWrite: true }, /allow-db-write=yes is blocked/));
+test('allow-network=yes blocked', () => assertInvalid({ allowNetwork: true }, /allow-network=yes is blocked/));
+test('allow-raw-acquisition=yes blocked', () =>
+    assertInvalid({ allowRawAcquisition: true }, /allow-raw-acquisition=yes is blocked/));
+test('allow-parser-implementation=yes blocked', () =>
+    assertInvalid({ allowParserImplementation: true }, /allow-parser-implementation=yes is blocked/));
+test('allow-feature-extraction=yes blocked', () =>
+    assertInvalid({ allowFeatureExtraction: true }, /allow-feature-extraction=yes is blocked/));
+test('allow-training=yes blocked', () => assertInvalid({ allowTraining: true }, /allow-training=yes is blocked/));
+test('allow-prediction=yes blocked', () => assertInvalid({ allowPrediction: true }, /allow-prediction=yes is blocked/));
+test('execute=yes blocked', () => assertInvalid({ execute: true }, /execute=yes is blocked/));
+test('commit=yes blocked', () => assertInvalid({ commit: true }, /commit=yes is blocked/));
+test('touch-fotmob=yes blocked', () => assertInvalid({ touchFotmob: true }, /touch-fotmob=yes is blocked/));
+test('live-request=yes blocked', () => assertInvalid({ liveRequest: true }, /live-request=yes is blocked/));
+test('allow-raw-match-data-write=yes blocked', () =>
+    assertInvalid({ allowRawMatchDataWrite: true }, /allow-raw-match-data-write=yes is blocked/));
+test('allow-schema-migration=yes blocked', () =>
+    assertInvalid({ allowSchemaMigration: true }, /allow-schema-migration=yes is blocked/));
+test('allow-matches-write=yes blocked', () =>
+    assertInvalid({ allowMatchesWrite: true }, /allow-matches-write=yes is blocked/));
+test('allow-odds-write=yes blocked', () => assertInvalid({ allowOddsWrite: true }, /allow-odds-write=yes is blocked/));
+
+test('plan says current 8 matches are samples, not training data', () => {
+    const summary = runPlan().json.current_state_summary;
+    assert.equal(summary.current_8_seeded_matches_are_validation_samples_not_training_data, true);
+    assert.match(summary.limitation_statement, /not .*training/i);
+});
+
+test('plan includes tier 0 current seeded validation', () => {
+    const tiers = runPlan().json.target_expansion_tiers.map(entry => entry.tier);
+    assert.ok(tiers.includes('TIER_0_CURRENT_SEEDED_VALIDATION'));
+});
+
+test('plan includes tier 1 single-league single-season', () => {
+    const tiers = runPlan().json.target_expansion_tiers.map(entry => entry.tier);
+    assert.ok(tiers.includes('TIER_1_SINGLE_LEAGUE_SINGLE_SEASON'));
+});
+
+test('plan includes tier 2 top European multi-season', () => {
+    const tiers = runPlan().json.target_expansion_tiers.map(entry => entry.tier);
+    assert.ok(tiers.includes('TIER_2_TOP_EUROPEAN_MULTI_SEASON'));
+});
+
+test('plan includes tier 3 broader UEFA / second-tier', () => {
+    const tiers = runPlan().json.target_expansion_tiers.map(entry => entry.tier);
+    assert.ok(tiers.includes('TIER_3_BROADER_UEFA_SECOND_TIER'));
+});
+
+test('plan includes tier 4 low-tier / obscure league risk', () => {
+    const tiers = runPlan().json.target_expansion_tiers.map(entry => entry.tier);
+    assert.ok(tiers.includes('TIER_4_LOW_TIER_OBSCURE_LEAGUES'));
+});
+
+test('plan includes batch lifecycle', () => {
+    const lifecycle = runPlan().json.batch_acquisition_lifecycle;
+    assert.equal(lifecycle.length, 9);
+    assert.equal(lifecycle[0].key, 'target_inventory_planning');
+    assert.equal(lifecycle[8].key, 'parser_eligibility_decision');
+});
+
+test('plan includes target inventory design', () => {
+    const design = runPlan().json.target_inventory_design;
+    const fieldNames = design.inventory_fields.map(field => field.name);
+    assert.ok(fieldNames.includes('match_id'));
+    assert.ok(fieldNames.includes('external_id'));
+    assert.ok(fieldNames.includes('league_id'));
+    assert.ok(fieldNames.includes('kickoff_time'));
+    assert.ok(fieldNames.includes('existing_versions'));
+    assert.ok(fieldNames.includes('expected_coverage_tier'));
+    assert.ok(fieldNames.includes('acquisition_state'));
+});
+
+test('plan includes batch sizing policy', () => {
+    const policy = runPlan().json.batch_sizing_and_safety_policy;
+    assert.equal(policy.first_batch_should_be_small, true);
+    assert.equal(policy.suggested_batch_sizes.profile_batch, '20-50 matches');
+    assert.equal(policy.suggested_batch_sizes.controlled_write_batch, '20-100 matches');
+});
+
+test('plan includes coverage profile strategy', () => {
+    const strategy = runPlan().json.coverage_profile_strategy;
+    const modulePaths = strategy.module_output_schema.map(moduleEntry => moduleEntry.module_path);
+    assert.ok(modulePaths.includes('content'));
+    assert.ok(modulePaths.includes('content.shotmap'));
+    assert.ok(modulePaths.includes('header'));
+    assert.ok(modulePaths.includes('fetchingLeagueData'));
+});
+
+test('plan includes low-tier missing module risk', () => {
+    const policy = runPlan().json.low_tier_obscure_league_risk_policy;
+    assert.equal(policy.low_tier_leagues_may_not_have_full_module_coverage, true);
+    assert.equal(policy.do_not_assume_lineup_playerStats_shotmap_momentum_stats_exist, true);
+    assert.equal(policy.missing_advanced_modules_should_not_fail_ingestion, true);
+});
+
+test('plan includes data version/source fidelity policy', () => {
+    const policy = runPlan().json.data_version_source_fidelity_policy;
+    assert.equal(policy.canonical_raw_version, 'fotmob_pageprops_v2');
+    assert.equal(policy.legacy_fallback_version, 'fotmob_html_hyd_v1');
+    assert.equal(policy.data_hash_strategy, 'stable_pageprops_payload_v1');
+});
+
+test('plan includes odds alignment readiness', () => {
+    const readiness = runPlan().json.match_identity_and_odds_alignment_readiness;
+    assert.equal(readiness.odds_ingestion_this_phase, false);
+    assert.equal(readiness.stable_match_id_is_critical, true);
+    assert.match(readiness.future_odds_join_strategy, /match_id/i);
+});
+
+test('plan recommends L2R target inventory planning', () => {
+    const phases = runPlan().json.recommended_next_phases.map(entry => entry.phase);
+    assert.ok(phases.includes('Phase 5.21L2R'));
+});
+
+test('plan recommends L2S small-batch preflight', () => {
+    const phases = runPlan().json.recommended_next_phases.map(entry => entry.phase);
+    assert.ok(phases.includes('Phase 5.21L2S'));
+});
+
+test('no DB write', () => {
+    assert.equal(runPlan().json.db_write_executed, false);
+});
+
+test('no network', () => {
+    assert.equal(runPlan().json.network_executed, false);
+});
+
+test('no raw acquisition', () => {
+    assert.equal(runPlan().json.raw_acquisition_executed, false);
+});
+
+test('no parser implementation', () => {
+    assert.equal(runPlan().json.parser_implementation_executed, false);
+});
+
+test('no feature extraction', () => {
+    assert.equal(runPlan().json.feature_extraction_executed, false);
+});
+
+test('no training/prediction', () => {
+    const plan = runPlan().json;
+    assert.equal(plan.training_executed, false);
+    assert.equal(plan.prediction_executed, false);
+});
+
+test('no child_process spawn', t => {
+    installExecutionGuards(t);
+    const result = runPlan();
+    assert.equal(result.exitCode, 0);
+});
+
+test('no ProductionHarvester/raw ingest import', t => {
+    const freshModule = loadWithBlockedImportPattern(
+        t,
+        /ProductionHarvester|raw_match_data_local_ingest|backfill_historical_raw_match_data/i
+    );
+    assert.equal(typeof freshModule.execute, 'function');
+});
+
+test('no odds_harvest_pipeline import', t => {
+    const freshModule = loadWithBlockedImportPattern(t, /odds_harvest_pipeline/i);
+    assert.equal(typeof freshModule.execute, 'function');
+});


### PR DESCRIPTION
## Summary

Adds Phase 5.21L2Q large-scale pageProps v2 acquisition strategy planning.

Scope:
- Plans how to expand from 8 seeded pageProps v2 validation samples to large-scale raw data
- Defines expansion tiers by league / season / coverage risk
- Defines target inventory, batch preflight/write lifecycle, coverage profile strategy, and safety gates
- Documents low-tier league missing-module risks
- Keeps parser/features/training deferred
- Keeps odds ingestion separate while preserving match identity readiness for future odds joins

Safety:
- No DB writes
- No raw_match_data writes
- No bookmaker_odds_history writes
- No network / FotMob access
- No odds access
- No raw acquisition execution
- No schema migration
- No matches writes
- No parser implementation
- No feature extraction
- No l3_features / training table writes
- No training / prediction
- No browser/proxy
- No full raw_data print/save
- No file deletion

Validation:
- large-scale acquisition strategy tests passed
- parser boundary planning tests passed
- raw completeness audit tests passed
- canonical read verification tests passed
- Makefile planning target passed
- npm test passed
- npm run test:coverage passed
- DB row counts unchanged
- l1-config residue absent
- no staging preview directory created
- eslint / prettier / git diff --check passed