### PR TITLE
docs(data): plan pageProps v2 target identity reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,7 @@ data-help: ## Show safe data harvesting entrypoint policy
 	@echo "  make data-post-seed-matches-identity-raw-write-readiness-audit MANIFEST=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json SOURCE=fotmob LEAGUE_ID=53 LEAGUE_NAME=\"Ligue 1\" SEASON=2025/2026 BATCH_ID=fotmob-pageprops-v2-ligue1-2025-2026-profile-001 TARGET_COUNT=50 READINESS_AUDIT_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_CONTROLLED_WRITE=no ALLOW_NETWORK=no ALLOW_MATCH_DETAIL_FETCH=no ALLOW_SCHEMA_MIGRATION=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no  # Phase 5.21L2V2 SELECT-only post-seed readiness audit, verifies matches/FK/no v2 rows, no DB write/network/parser/features/training"
 	@echo "  make data-renewed-pageprops-v2-raw-write-execute MANIFEST=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json SOURCE=fotmob LEAGUE_ID=53 LEAGUE_NAME=\"Ligue 1\" SEASON=2025/2026 ROUTE=html_hydration RAW_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 BATCH_ID=fotmob-pageprops-v2-ligue1-2025-2026-profile-001 TARGET_COUNT=50 RENEWED_RAW_WRITE_AUTHORIZATION=yes FINAL_DB_WRITE_CONFIRMATION=yes NETWORK_AUTHORIZATION=yes MATCH_DETAIL_RECAPTURE_AUTHORIZATION=yes ALLOW_DB_WRITE=yes ALLOW_RAW_MATCH_DATA_WRITE=yes ALLOW_CONTROLLED_WRITE=yes ALLOW_MATCHES_WRITE=no ALLOW_BOOKMAKER_ODDS_WRITE=no ALLOW_FEATURE_WRITE=no ALLOW_SCHEMA_MIGRATION=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no CONCURRENCY=1 RETRY=0 PRINT_FULL_BODY=no SAVE_FULL_BODY=no PRINT_FULL_JSON=no SAVE_FULL_JSON=no PRINT_FULL_PAGEPROPS=no SAVE_FULL_PAGEPROPS=no REQUEST_DELAY_MS=750  # Phase 5.21L2V3 renewed controlled raw_match_data pageProps v2 write, post-seed FK-ready retry only"
 	@echo "  make data-renewed-pageprops-v2-baseline-proposal-plan MANIFEST=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json PROPOSAL_OUTPUT=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.renewed_baseline_proposal.phase521l2v3c.json SOURCE=fotmob LEAGUE_ID=53 LEAGUE_NAME=\"Ligue 1\" SEASON=2025/2026 ROUTE=html_hydration RAW_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 BATCH_ID=fotmob-pageprops-v2-ligue1-2025-2026-profile-001 TARGET_COUNT=50 PLANNING_AUTHORIZATION=yes NETWORK_AUTHORIZATION=yes MATCH_DETAIL_RECAPTURE_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_CONTROLLED_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_BOOKMAKER_ODDS_WRITE=no ALLOW_FEATURE_WRITE=no ALLOW_SCHEMA_MIGRATION=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no PRINT_FULL_BODY=no SAVE_FULL_BODY=no PRINT_FULL_JSON=no SAVE_FULL_JSON=no PRINT_FULL_PAGEPROPS=no SAVE_FULL_PAGEPROPS=no REPEAT_COUNT=2 REQUEST_DELAY_MS=750  # Phase 5.21L2V3C no-write renewed baseline proposal, hashes are review-only and not accepted baselines"
+	@echo "  make data-pageprops-v2-target-identity-reconciliation-plan MANIFEST=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json RENEWED_PROPOSAL=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.renewed_baseline_proposal.phase521l2v3c.json SOURCE=fotmob LEAGUE_ID=53 LEAGUE_NAME=\"Ligue 1\" SEASON=2025/2026 ROUTE=html_hydration RAW_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 BATCH_ID=fotmob-pageprops-v2-ligue1-2025-2026-profile-001 TARGET_COUNT=50 PLANNING_AUTHORIZATION=yes TARGET_IDENTITY_RECONCILIATION_AUTHORIZATION=yes NETWORK_AUTHORIZATION=yes MATCH_DETAIL_RECAPTURE_AUTHORIZATION=yes ALLOW_DB_WRITE=no ALLOW_RAW_MATCH_DATA_WRITE=no ALLOW_CONTROLLED_WRITE=no ALLOW_MATCHES_WRITE=no ALLOW_BOOKMAKER_ODDS_WRITE=no ALLOW_FEATURE_WRITE=no ALLOW_SCHEMA_MIGRATION=no ALLOW_PARSER_IMPLEMENTATION=no ALLOW_FEATURE_EXTRACTION=no ALLOW_TRAINING=no ALLOW_PREDICTION=no ALLOW_BROWSER_RUNTIME=no ALLOW_PROXY_RUNTIME=no PRINT_FULL_BODY=no SAVE_FULL_BODY=no PRINT_FULL_JSON=no SAVE_FULL_JSON=no PRINT_FULL_PAGEPROPS=no SAVE_FULL_PAGEPROPS=no RETRY=0 REQUEST_DELAY_MS=750  # Phase 5.21L2V3D no-write target identity reconciliation planning, mismatch blocks baseline acceptance/raw write retry"
 	@echo "  make data-training-dataset-dry-run"
 	@echo "  make data-acquisition-engines"
 	@echo "  make data-acquisition-engine-audit"
@@ -1818,6 +1819,60 @@ data-renewed-pageprops-v2-baseline-proposal-plan: ## Run Phase 5.21L2V3C no-writ
 		--branch="$(or $(BRANCH),)" \
 		--pr1276-state="$(or $(PR1276_STATE),)" \
 		--pr1276-url="$(or $(PR1276_URL),)"
+
+data-pageprops-v2-target-identity-reconciliation-plan: ## Run Phase 5.21L2V3D no-write target identity reconciliation planning. Writes docs only.
+	@if [ -z "$(MANIFEST)" ] || [ -z "$(SOURCE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(LEAGUE_NAME)" ] || [ -z "$(SEASON)" ] || [ -z "$(ROUTE)" ] || [ -z "$(RAW_VERSION)" ] || [ -z "$(HASH_STRATEGY)" ] || [ -z "$(BATCH_ID)" ] || [ -z "$(TARGET_COUNT)" ]; then \
+		echo "ERROR: provide MANIFEST=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json SOURCE=fotmob LEAGUE_ID=53 LEAGUE_NAME='Ligue 1' SEASON=2025/2026 ROUTE=html_hydration RAW_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 BATCH_ID=fotmob-pageprops-v2-ligue1-2025-2026-profile-001 TARGET_COUNT=50"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js \
+		--manifest="$(MANIFEST)" \
+		--renewed-proposal="$(or $(RENEWED_PROPOSAL),docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.renewed_baseline_proposal.phase521l2v3c.json)" \
+		--report-output="$(or $(REPORT_OUTPUT),docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3D.md)" \
+		--source="$(SOURCE)" \
+		--league-id="$(LEAGUE_ID)" \
+		--league-name="$(LEAGUE_NAME)" \
+		--season="$(SEASON)" \
+		--route="$(ROUTE)" \
+		--raw-version="$(RAW_VERSION)" \
+		--hash-strategy="$(HASH_STRATEGY)" \
+		--batch-id="$(BATCH_ID)" \
+		--target-count="$(TARGET_COUNT)" \
+		--planning-authorization="$(or $(PLANNING_AUTHORIZATION),no)" \
+		--target-identity-reconciliation-authorization="$(or $(TARGET_IDENTITY_RECONCILIATION_AUTHORIZATION),no)" \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--match-detail-recapture-authorization="$(or $(MATCH_DETAIL_RECAPTURE_AUTHORIZATION),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-controlled-write="$(or $(ALLOW_CONTROLLED_WRITE),no)" \
+		--allow-matches-write="$(or $(ALLOW_MATCHES_WRITE),no)" \
+		--allow-bookmaker-odds-write="$(or $(ALLOW_BOOKMAKER_ODDS_WRITE),no)" \
+		--allow-feature-write="$(or $(ALLOW_FEATURE_WRITE),no)" \
+		--allow-schema-migration="$(or $(ALLOW_SCHEMA_MIGRATION),no)" \
+		--allow-parser-implementation="$(or $(ALLOW_PARSER_IMPLEMENTATION),no)" \
+		--allow-feature-extraction="$(or $(ALLOW_FEATURE_EXTRACTION),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--print-full-body="$(or $(PRINT_FULL_BODY),no)" \
+		--save-full-body="$(or $(SAVE_FULL_BODY),no)" \
+		--print-full-json="$(or $(PRINT_FULL_JSON),no)" \
+		--save-full-json="$(or $(SAVE_FULL_JSON),no)" \
+		--print-full-pageprops="$(or $(PRINT_FULL_PAGEPROPS),no)" \
+		--save-full-pageprops="$(or $(SAVE_FULL_PAGEPROPS),no)" \
+		--retry="$(or $(RETRY),0)" \
+		--request-delay-ms="$(or $(REQUEST_DELAY_MS),750)" \
+		--target-external-ids="$(or $(TARGET_EXTERNAL_IDS),)" \
+		--base-head="$(or $(BASE_HEAD),)" \
+		--branch="$(or $(BRANCH),)" \
+		--main-head="$(or $(MAIN_HEAD),)" \
+		--main-ci-status="$(or $(MAIN_CI_STATUS),)" \
+		--pr1276-state="$(or $(PR1276_STATE),)" \
+		--pr1276-merge-commit="$(or $(PR1276_MERGE_COMMIT),)" \
+		--pr1277-state="$(or $(PR1277_STATE),)" \
+		--pr1277-merge-commit="$(or $(PR1277_MERGE_COMMIT),)" \
+		--pr1277-retarget-result="$(or $(PR1277_RETARGET_RESULT),)"
 
 data-training-dataset-dry-run: ## Run SELECT-only training dataset readiness audit. Does not train, export, or write DB.
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/dataset_status_audit.js

--- a/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json
+++ b/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json
@@ -3994,7 +3994,7 @@
     "non_raw_tables_unchanged_status": "unchanged_after_blocked_no_transaction",
     "transaction_status": "not_started",
     "blockers": ["RECAPTURE_HASH_GATE_BLOCKED"],
-    "next_required_step": "target_identity_reconciliation_planning",
+    "next_required_step": "target_identity_source_inventory_reconciliation_planning",
     "phase_5_21_l2v3_execution_result": {
         "phase": "PHASE5_21L2V3_RENEWED_CONTROLLED_PAGEPROPS_V2_RAW_WRITE_EXECUTION",
         "generated_at": "2026-05-18T10:43:37.450Z",
@@ -4049,5 +4049,23 @@
     "renewed_baseline_requires_separate_baseline_acceptance": true,
     "renewed_baseline_requires_separate_final_db_write_authorization": true,
     "phase_5_21_l2v3c_db_write_performed": false,
-    "phase_5_21_l2v3c_raw_insert_performed": false
+    "phase_5_21_l2v3c_raw_insert_performed": false,
+    "phase_5_21_l2v3d_planning_status": "completed_no_write",
+    "target_identity_reconciliation_status": "blocked_identity_mismatch_unresolved",
+    "phase_5_21_l2v3d_checked_target_count": 8,
+    "phase_5_21_l2v3d_identity_match_count": 0,
+    "phase_5_21_l2v3d_identity_mismatch_count": 8,
+    "phase_5_21_l2v3d_mismatch_type_counts": {
+        "requested_vs_observed_external_id_mismatch": 8
+    },
+    "phase_5_21_l2v3d_deterministic_with_l2v3c": false,
+    "phase_5_21_l2v3d_request_url_itself_wrong": false,
+    "phase_5_21_l2v3d_parser_extractor_wrong_indicated": false,
+    "phase_5_21_l2v3d_manifest_target_metadata_mismatch_indicated": true,
+    "phase_5_21_l2v3d_root_cause_status": "suspected_not_accepted",
+    "phase_5_21_l2v3d_suspected_root_cause": "manifest_target_identity_or_fotmob_detail_payload_mapping_mismatch",
+    "target_identity_mismatch_blocks_baseline_acceptance": true,
+    "raw_write_ready_for_execution": false,
+    "raw_write_retry_authorization_status": "blocked_pending_target_identity_reconciliation",
+    "phase_5_21_l2v3d_deterministic_observed_identity_with_l2v3c": true
 }

--- a/docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3D.md
+++ b/docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3D.md
@@ -1,0 +1,183 @@
+# Data Entrypoint Governance - Phase 5.21 L2V3D
+
+## A. Current Status
+
+- phase=target identity reconciliation planning
+- branch=data/pageprops-v2-target-identity-reconciliation-phase521l2v3d
+- base_head=f5e718728e32a5a6f2d54d3795e172222c80f7cd
+- main_head=f5e718728e32a5a6f2d54d3795e172222c80f7cd
+- main_ci_status=success
+- no_write=true
+
+## B. PR #1276 Merge Result
+
+- pr_1276_state=MERGED
+- pr_1276_merge_commit=0d371eb412cf3ee19a6f72adb57a41bb19298f82
+- merge_scope=L2V3 / L2V3B No-Go + hash drift review documentation
+
+## C. PR #1277 Rebase / Retarget / Merge Result
+
+- pr_1277_state=MERGED
+- pr_1277_merge_commit=f5e718728e32a5a6f2d54d3795e172222c80f7cd
+- pr_1277_retarget_result=retargeted_to_main_before_merge
+- merge_scope=L2V3C renewed baseline regeneration planning / no-write manifest proposal
+
+## D. Authorization Scope
+
+- planning_authorized=true
+- target_identity_reconciliation_authorized=true
+- network_recapture_authorized=true
+- scope limited to L2V3C mismatch targets only
+- no accepted baseline replacement
+- no raw write authorization
+- no DB write authorization
+
+## E. No-Write Guarantee
+
+- db_write_performed=false
+- raw_insert_performed=false
+- baseline_acceptance_performed=false
+- raw_write_retry_performed=false
+- full raw_data/pageProps/source body printed=false
+- full raw_data/pageProps/source body saved=false
+
+## F. L2V3C 8/8 Metadata Mismatch Recap
+
+- source_proposal=docs/\_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.renewed_baseline_proposal.phase521l2v3c.json
+- l2v3c_checked_target_count=8
+- l2v3c_metadata_target_mismatch_count=8
+- l2v3c_next_required_step=target_identity_reconciliation_planning
+- raw_write_ready_for_execution=false
+- requires_separate_baseline_acceptance=true
+- requires_separate_final_db_write_authorization=true
+
+## G. Target Identity Discovery Result
+
+- candidate_targets_count=50
+- known_completed_targets_count=8
+- checked_target_count=8
+- identity_match_count=0
+- identity_mismatch_count=8
+- deterministic_observed_identity_with_l2v3c=true
+- deterministic_observed_identity_with_l2v3c_count=8
+- deterministic_with_l2v3c=false
+- deterministic_with_l2v3c_count=4
+
+## H. Request URL / Route Construction Review
+
+- route=html_hydration
+- request_url_builder=buildFotMobMatchUrl(external_id)
+- request_url_pattern=https://www.fotmob.com/match/{external_id}
+- request_url_itself_wrong=false
+- canonical_redirect_detected=false
+
+## I. PageProps Extraction Review
+
+- extraction_path=**NEXT_DATA**.props.pageProps
+- stable_hash_function=computeStablePagePropsHash
+- hash_strategy=stable_pageprops_payload_v1
+- parser_extractor_wrong_indicated=false
+- full_pageProps_stored=false
+
+## J. Requested vs Observed Metadata Comparison Summary
+
+| requested_external_id | requested_match_id  | requested_teams             | requested_kickoff        | request_url_summary                  | request_url_id | final_url_summary                                                    | final_url_id | http_status | parsed | observed_external_id | observed_general_matchId | observed_teams              | observed_time_utc        | top_level_keys                                                                                    | body/pageProps_bytes | hash                                                             | identity_match | mismatch_type                              | safe_error_summary |
+| --------------------- | ------------------- | --------------------------- | ------------------------ | ------------------------------------ | -------------- | -------------------------------------------------------------------- | ------------ | ----------- | ------ | -------------------- | ------------------------ | --------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------- | -------------- | ------------------------------------------ | ------------------ |
+| 4830466               | 53_20252026_4830466 | Rennes-Marseille            | 2025-08-15T18:45:00.000Z | https://www.fotmob.com/match/4830466 | 4830466        | https://www.fotmob.com/matches/marseille-vs-rennes/2t9n7h            |              | 200         | true   | 4830759              | 4830759                  | Marseille-Rennes            | 2026-05-17T19:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 1115133/433072       | 6167789073021a8d0b12665d936fea1bbffd3c1df94cdc2698e41799ecbdac87 | false          | requested_vs_observed_external_id_mismatch |                    |
+| 4830461               | 53_20252026_4830461 | Lens-Lyon                   | 2025-08-16T15:00:00.000Z | https://www.fotmob.com/match/4830461 | 4830461        | https://www.fotmob.com/matches/lens-vs-lyon/2s3gtg                   |              | 200         | true   | 4830758              | 4830758                  | Lyon-Lens                   | 2026-05-17T19:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 1074095/359736       | ad52c79bb4fe28a3157853481ba6086a5e38105661ef4aafc74b69c401e16d3e | false          | requested_vs_observed_external_id_mismatch |                    |
+| 4830481               | 53_20252026_4830481 | Monaco-Strasbourg           | 2025-08-31T15:15:00.000Z | https://www.fotmob.com/match/4830481 | 4830481        | https://www.fotmob.com/matches/monaco-vs-strasbourg/379ruz           |              | 200         | true   | 4830763              | 4830763                  | Strasbourg-Monaco           | 2026-05-17T19:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 1169791/387820       | f539f5e777b48c5201564129dc883311a30e316a808fffd9ee738c919e00b7ea | false          | requested_vs_observed_external_id_mismatch |                    |
+| 4830496               | 53_20252026_4830496 | Le Havre-Lorient            | 2025-09-21T15:15:00.000Z | https://www.fotmob.com/match/4830496 | 4830496        | https://www.fotmob.com/matches/lorient-vs-le-havre/2t6haw            |              | 200         | true   | 4830757              | 4830757                  | Lorient-Le Havre            | 2026-05-17T19:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 1012024/318775       | e008134304764d741bd657916c4cee4ddf40dc850cdbd74a6ba903fbc196e701 | false          | requested_vs_observed_external_id_mismatch |                    |
+| 4830511               | 53_20252026_4830511 | Toulouse-Nantes             | 2025-09-27T17:00:00.000Z | https://www.fotmob.com/match/4830511 | 4830511        | https://www.fotmob.com/matches/nantes-vs-toulouse/38dikf             |              | 200         | true   | 4830760              | 4830760                  | Nantes-Toulouse             | 2026-05-17T19:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 716526/224249        | 16c077df7cf84c1bcae2a50e7fd1a90e31c3baee7a3014617a6c958aebea56db | false          | requested_vs_observed_external_id_mismatch |                    |
+| 4830463               | 53_20252026_4830463 | Monaco-Le Havre             | 2025-08-16T17:00:00.000Z | https://www.fotmob.com/match/4830463 | 4830463        | https://www.fotmob.com/matches/le-havre-vs-monaco/362v61             |              | 200         | true   | 4830622              | 4830622                  | Le Havre-Monaco             | 2026-01-24T18:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 950273/299409        | 519a171d16190df970026046d067f8acf10e9489e3d57a1c269278799199ea83 | false          | requested_vs_observed_external_id_mismatch |                    |
+| 4830465               | 53_20252026_4830465 | Nice-Toulouse               | 2025-08-16T19:05:00.000Z | https://www.fotmob.com/match/4830465 | 4830465        | https://www.fotmob.com/matches/nice-vs-toulouse/38dxtn               |              | 200         | true   | 4830619              | 4830619                  | Toulouse-Nice               | 2026-01-17T18:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 1150806/393053       | cec694ea6bf683cf815bfd68bf0db35ce427bd6203dd13031479579ce015ceeb | false          | requested_vs_observed_external_id_mismatch |                    |
+| 4830508               | 53_20252026_4830508 | Paris Saint-Germain-Auxerre | 2025-09-27T19:05:00.000Z | https://www.fotmob.com/match/4830508 | 4830508        | https://www.fotmob.com/matches/auxerre-vs-paris-saint-germain/2t4i9k |              | 200         | true   | 4830620              | 4830620                  | Auxerre-Paris Saint-Germain | 2026-01-23T19:00:00.000Z | content,fallback,fetchingLeagueData,general,hasPendingVAR,header,nav,ongoing,seo,ssr,translations | 957145/325341        | e511251e50e701e6d626bd7ff57620556a7654fe587e0828bae02bb36f2a231c | false          | requested_vs_observed_external_id_mismatch |                    |
+
+## K. Mismatch Classification
+
+- checked_target_count=8
+- identity_match_count=0
+- identity_mismatch_count=8
+- all_mismatches_same_pattern=true
+- identity_mismatch_pattern_deterministic=true
+- full_hash_and_identity_deterministic=false
+- requested_vs_observed_external_id_mismatch=8
+- response_canonical_data_wrong_or_unexpected=true
+- manifest_target_metadata_mismatch_indicated=true
+
+## L. Root Cause Status
+
+- root_cause_status=suspected_not_accepted
+- suspected_root_cause=manifest_target_identity_or_fotmob_detail_payload_mapping_mismatch
+- concrete_root_cause_confirmed=false
+
+## M. Required Fix / Continue Investigation Decision
+
+- baseline_acceptance_blocked=true
+- raw_write_retry_blocked=true
+- code_fix_required=false
+- manifest_or_source_inventory_reconciliation_required=true
+- continue_investigation_required=true
+
+## N. DB Row Count Safety Result
+
+- select_only_db_check=true
+- matches=60
+- raw_match_data=18
+- bookmaker_odds_history=2
+- l3_features=2
+- match_features_training=2
+- predictions=2
+- candidate_matches_found=8
+- candidate_fotmob_pageprops_v2_raw_rows=0
+- safety_status=passed_select_only_validation
+
+## O. Test Results
+
+- related_no_write_unit_suite=passed (632 tests)
+- npm_test=passed
+- npm_run_test_coverage=passed
+- coverage_lines_pct=89.81
+- coverage_functions_pct=85.09
+- coverage_branches_pct=80.02
+- npm_run_lint=passed
+- eslint_l2v3d_test_file=passed
+- prettier_changed_files=passed
+- git_diff_check=passed
+- l1_config_residue_absent=passed
+- docs\_\_staging_preview_absent=passed
+
+## P. PR Status
+
+- pr_number=1278
+- pr_title=docs(data): plan pageProps v2 target identity reconciliation
+- pr_base=main
+- pr_status=open
+- pr_ci_status=pending_pull_request_checks
+
+## Q. Next Step Recommendation
+
+- next_required_step=target_identity_source_inventory_reconciliation_planning
+- target identity mismatch blocks baseline acceptance.
+- raw write retry still requires separate final DB-write authorization after identity reconciliation.
+
+## R. Explicit Non-Execution
+
+- no DB writes
+- no raw_match_data inserts
+- no matches writes
+- no bookmaker_odds_history writes
+- no l3_features writes
+- no match_features_training writes
+- no predictions writes
+- no schema migration
+- no parser implementation
+- no feature extraction
+- no training/prediction
+- no browser/proxy/captcha bypass
+- no accepted baseline replacement
+- no raw write retry
+- no baseline_hash edits to pass a gate
+- no proposal hash marked as accepted baseline
+- no full raw_data/pageProps/source body print/save
+- no invented external_id, match target, payload, or hash
+- no L2V3/L2V3B/L2V3C evidence deletion

--- a/scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js
+++ b/scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js
@@ -1,0 +1,1162 @@
+#!/usr/bin/env node
+/* eslint-disable complexity, max-lines, max-statements */
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+    CANDIDATE_VERSION,
+    HASH_STRATEGY,
+    buildFotMobMatchUrl,
+    fetchHtml,
+    extractNextDataJsonFromHtml,
+    getPageProps,
+    computeStablePagePropsHash,
+    listJsonPaths,
+} = require('./pageprops_v2_no_write_preview');
+
+const PHASE = 'PHASE5_21L2V3D_TARGET_IDENTITY_RECONCILIATION_PLANNING';
+const MANIFEST_PATH = 'docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json';
+const RENEWED_PROPOSAL_PATH =
+    'docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.renewed_baseline_proposal.phase521l2v3c.json';
+const REPORT_PATH = 'docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3D.md';
+const SOURCE = 'fotmob';
+const ROUTE = 'html_hydration';
+const LEAGUE_ID = 53;
+const LEAGUE_NAME = 'Ligue 1';
+const SEASON = '2025/2026';
+const RAW_VERSION = CANDIDATE_VERSION;
+const BATCH_ID = 'fotmob-pageprops-v2-ligue1-2025-2026-profile-001';
+const TARGET_COUNT = 50;
+const KNOWN_COMPLETED_COUNT = 8;
+const EXPECTED_MISMATCH_COUNT = 8;
+const DEFAULT_REQUEST_DELAY_MS = 750;
+const REQUIRED_YES_FLAGS = Object.freeze([
+    'planningAuthorization',
+    'targetIdentityReconciliationAuthorization',
+    'networkAuthorization',
+    'matchDetailRecaptureAuthorization',
+]);
+const REQUIRED_NO_FLAGS = Object.freeze([
+    'allowDbWrite',
+    'allowRawMatchDataWrite',
+    'allowControlledWrite',
+    'allowMatchesWrite',
+    'allowBookmakerOddsWrite',
+    'allowFeatureWrite',
+    'allowSchemaMigration',
+    'allowParserImplementation',
+    'allowFeatureExtraction',
+    'allowTraining',
+    'allowPrediction',
+    'allowBrowserRuntime',
+    'allowProxyRuntime',
+    'printFullBody',
+    'saveFullBody',
+    'printFullJson',
+    'saveFullJson',
+    'printFullPageprops',
+    'saveFullPageprops',
+]);
+const BLOCKED_TRUE_FLAGS = Object.freeze([
+    'allowOddsWrite',
+    'executeWrite',
+    'commit',
+    'finalDbWriteConfirmation',
+    'acceptBaseline',
+    'acceptedBaseline',
+    'baselineAcceptanceAuthorization',
+    'rawWriteReadyForExecution',
+    'rawWriteRetryAuthorization',
+]);
+const EXPECTED_ROW_COUNTS = Object.freeze({
+    matches: 60,
+    raw_match_data: 18,
+    bookmaker_odds_history: 2,
+    l3_features: 2,
+    match_features_training: 2,
+    predictions: 2,
+});
+const ALLOWED_MANIFEST_NEXT_STEPS = Object.freeze([
+    'target_identity_reconciliation_planning',
+    'target_identity_source_inventory_reconciliation_planning',
+    'target_identity_reconciliation_follow_up_investigation',
+    'route_generation_fix_planning',
+    'renewed_baseline_acceptance_review_planning',
+]);
+
+function normalizeText(value) {
+    return String(value ?? '').trim();
+}
+
+function normalizeLower(value) {
+    return normalizeText(value).toLowerCase();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') return value;
+    if (value === null || value === undefined || value === '') return fallback;
+    const normalized = normalizeLower(value);
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') return fallback;
+    const normalized = normalizeText(value);
+    if (!/^\d+$/.test(normalized)) return Number.NaN;
+    return Number.parseInt(normalized, 10);
+}
+
+function parseCsv(value) {
+    return normalizeText(value)
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+}
+
+function toCamelKey(rawKey) {
+    return normalizeText(rawKey).replace(/[-_]([a-z0-9])/g, (_match, char) => char.toUpperCase());
+}
+
+function flagName(key) {
+    return key.replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return { value: arg.slice(arg.indexOf('=') + 1), consumedNext: false };
+    }
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        manifest: null,
+        renewedProposal: RENEWED_PROPOSAL_PATH,
+        reportOutput: REPORT_PATH,
+        source: null,
+        leagueId: null,
+        leagueName: null,
+        season: null,
+        route: null,
+        rawVersion: null,
+        hashStrategy: null,
+        batchId: null,
+        targetCount: null,
+        planningAuthorization: null,
+        targetIdentityReconciliationAuthorization: null,
+        networkAuthorization: null,
+        matchDetailRecaptureAuthorization: null,
+        allowDbWrite: null,
+        allowRawMatchDataWrite: null,
+        allowControlledWrite: null,
+        allowMatchesWrite: null,
+        allowBookmakerOddsWrite: null,
+        allowFeatureWrite: null,
+        allowSchemaMigration: null,
+        allowParserImplementation: null,
+        allowFeatureExtraction: null,
+        allowTraining: null,
+        allowPrediction: null,
+        allowBrowserRuntime: null,
+        allowProxyRuntime: null,
+        printFullBody: null,
+        saveFullBody: null,
+        printFullJson: null,
+        saveFullJson: null,
+        printFullPageprops: null,
+        saveFullPageprops: null,
+        allowOddsWrite: false,
+        executeWrite: false,
+        commit: false,
+        finalDbWriteConfirmation: false,
+        acceptBaseline: false,
+        acceptedBaseline: false,
+        baselineAcceptanceAuthorization: false,
+        rawWriteReadyForExecution: false,
+        rawWriteRetryAuthorization: false,
+        retry: 0,
+        requestDelayMs: DEFAULT_REQUEST_DELAY_MS,
+        targetExternalIds: null,
+        generatedAt: null,
+        baseHead: null,
+        branch: null,
+        mainHead: null,
+        mainCiStatus: null,
+        pr1276MergeCommit: null,
+        pr1276State: null,
+        pr1277MergeCommit: null,
+        pr1277State: null,
+        pr1277RetargetResult: null,
+        help: false,
+        unknown: [],
+    };
+    const knownKeys = new Set(Object.keys(options));
+    const booleanKeys = new Set([...REQUIRED_YES_FLAGS, ...REQUIRED_NO_FLAGS, ...BLOCKED_TRUE_FLAGS, 'help']);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const key = toCamelKey(rawKey);
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) index += 1;
+        if (!knownKeys.has(key)) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+        options[key] = booleanKeys.has(key) ? normalizeBooleanFlag(value, true) : value;
+    }
+    return options;
+}
+
+function normalizePlanningInput(input = {}) {
+    return {
+        manifest: normalizeText(input.manifest),
+        renewedProposal: normalizeText(input.renewedProposal) || RENEWED_PROPOSAL_PATH,
+        reportOutput: normalizeText(input.reportOutput) || REPORT_PATH,
+        source: normalizeLower(input.source),
+        leagueId: parseInteger(input.leagueId, null),
+        leagueName: normalizeText(input.leagueName),
+        season: normalizeText(input.season),
+        route: normalizeText(input.route),
+        rawVersion: normalizeText(input.rawVersion),
+        hashStrategy: normalizeText(input.hashStrategy),
+        batchId: normalizeText(input.batchId),
+        targetCount: parseInteger(input.targetCount, null),
+        planningAuthorization: normalizeBooleanFlag(input.planningAuthorization, undefined),
+        targetIdentityReconciliationAuthorization: normalizeBooleanFlag(
+            input.targetIdentityReconciliationAuthorization,
+            undefined
+        ),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, undefined),
+        matchDetailRecaptureAuthorization: normalizeBooleanFlag(input.matchDetailRecaptureAuthorization, undefined),
+        allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
+        allowControlledWrite: normalizeBooleanFlag(input.allowControlledWrite, undefined),
+        allowMatchesWrite: normalizeBooleanFlag(input.allowMatchesWrite, undefined),
+        allowBookmakerOddsWrite: normalizeBooleanFlag(input.allowBookmakerOddsWrite, undefined),
+        allowFeatureWrite: normalizeBooleanFlag(input.allowFeatureWrite, undefined),
+        allowSchemaMigration: normalizeBooleanFlag(input.allowSchemaMigration, undefined),
+        allowParserImplementation: normalizeBooleanFlag(input.allowParserImplementation, undefined),
+        allowFeatureExtraction: normalizeBooleanFlag(input.allowFeatureExtraction, undefined),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, undefined),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, undefined),
+        allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, undefined),
+        allowProxyRuntime: normalizeBooleanFlag(input.allowProxyRuntime, undefined),
+        printFullBody: normalizeBooleanFlag(input.printFullBody, undefined),
+        saveFullBody: normalizeBooleanFlag(input.saveFullBody, undefined),
+        printFullJson: normalizeBooleanFlag(input.printFullJson, undefined),
+        saveFullJson: normalizeBooleanFlag(input.saveFullJson, undefined),
+        printFullPageprops: normalizeBooleanFlag(input.printFullPageprops, undefined),
+        saveFullPageprops: normalizeBooleanFlag(input.saveFullPageprops, undefined),
+        allowOddsWrite: normalizeBooleanFlag(input.allowOddsWrite, false),
+        executeWrite: normalizeBooleanFlag(input.executeWrite, false),
+        commit: normalizeBooleanFlag(input.commit, false),
+        finalDbWriteConfirmation: normalizeBooleanFlag(input.finalDbWriteConfirmation, false),
+        acceptBaseline: normalizeBooleanFlag(input.acceptBaseline, false),
+        acceptedBaseline: normalizeBooleanFlag(input.acceptedBaseline, false),
+        baselineAcceptanceAuthorization: normalizeBooleanFlag(input.baselineAcceptanceAuthorization, false),
+        rawWriteReadyForExecution: normalizeBooleanFlag(input.rawWriteReadyForExecution, false),
+        rawWriteRetryAuthorization: normalizeBooleanFlag(input.rawWriteRetryAuthorization, false),
+        retry: parseInteger(input.retry, 0),
+        requestDelayMs: parseInteger(input.requestDelayMs, DEFAULT_REQUEST_DELAY_MS),
+        targetExternalIds: Array.isArray(input.targetExternalIds)
+            ? input.targetExternalIds.map(normalizeText).filter(Boolean)
+            : parseCsv(input.targetExternalIds),
+        generatedAt: normalizeText(input.generatedAt),
+        baseHead: normalizeText(input.baseHead),
+        branch: normalizeText(input.branch),
+        mainHead: normalizeText(input.mainHead),
+        mainCiStatus: normalizeText(input.mainCiStatus),
+        pr1276MergeCommit: normalizeText(input.pr1276MergeCommit),
+        pr1276State: normalizeText(input.pr1276State),
+        pr1277MergeCommit: normalizeText(input.pr1277MergeCommit),
+        pr1277State: normalizeText(input.pr1277State),
+        pr1277RetargetResult: normalizeText(input.pr1277RetargetResult),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function pushRequiredYes(errors, value, name) {
+    if (value === true) return;
+    errors.push(value === false ? `${name}=yes is required in Phase 5.21L2V3D` : `missing ${name}=yes`);
+}
+
+function pushRequiredNo(errors, value, name) {
+    if (value === false) return;
+    errors.push(value === true ? `${name}=yes is blocked in Phase 5.21L2V3D` : `missing ${name}=no`);
+}
+
+function requireExact(errors, actual, expected, name) {
+    if (!normalizeText(actual)) {
+        errors.push(`missing ${name}=${expected}`);
+        return;
+    }
+    if (normalizeText(actual) !== expected) errors.push(`${name} must be ${expected}`);
+}
+
+function validatePlanningInput(rawInput = {}) {
+    const input = normalizePlanningInput(rawInput);
+    const errors = [];
+    if (input.unknown.length > 0) errors.push(`unknown arguments: ${input.unknown.join(',')}`);
+    requireExact(errors, input.manifest, MANIFEST_PATH, 'manifest');
+    requireExact(errors, input.renewedProposal, RENEWED_PROPOSAL_PATH, 'renewed-proposal');
+    requireExact(errors, input.reportOutput, REPORT_PATH, 'report-output');
+    requireExact(errors, input.source, SOURCE, 'source');
+    if (input.leagueId !== LEAGUE_ID) errors.push(`league-id must be ${LEAGUE_ID}`);
+    requireExact(errors, input.leagueName, LEAGUE_NAME, 'league-name');
+    requireExact(errors, input.season, SEASON, 'season');
+    requireExact(errors, input.route, ROUTE, 'route');
+    requireExact(errors, input.rawVersion, RAW_VERSION, 'raw-version');
+    requireExact(errors, input.hashStrategy, HASH_STRATEGY, 'hash-strategy');
+    requireExact(errors, input.batchId, BATCH_ID, 'batch-id');
+    if (input.targetCount !== TARGET_COUNT) errors.push(`target-count must be ${TARGET_COUNT}`);
+    for (const key of REQUIRED_YES_FLAGS) pushRequiredYes(errors, input[key], flagName(key));
+    for (const key of REQUIRED_NO_FLAGS) pushRequiredNo(errors, input[key], flagName(key));
+    for (const key of BLOCKED_TRUE_FLAGS) {
+        if (input[key] === true) errors.push(`${flagName(key)}=yes is blocked in Phase 5.21L2V3D`);
+    }
+    if (input.retry !== 0) errors.push('retry must be 0');
+    if (!Number.isInteger(input.requestDelayMs) || input.requestDelayMs < 0) {
+        errors.push('request-delay-ms must be a non-negative integer');
+    }
+    return { ok: errors.length === 0, input, errors };
+}
+
+function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJsonFile(filePath, data) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 4)}\n`);
+}
+
+function writeReportFile(filePath, content) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+}
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeCandidateTarget(target = {}) {
+    return {
+        ...target,
+        match_id: normalizeText(target.match_id),
+        external_id: normalizeText(target.external_id),
+        home_team: normalizeText(target.home_team),
+        away_team: normalizeText(target.away_team),
+        kickoff_time: normalizeText(target.kickoff_time || target.match_date),
+        match_date: normalizeText(target.match_date || target.kickoff_time),
+        status: normalizeLower(target.status),
+        baseline_hash: normalizeLower(target.baseline_hash),
+        preflight_status: normalizeText(target.preflight_status),
+        matches_seed_status: normalizeText(target.matches_seed_status),
+        source_url: target.source_url || null,
+    };
+}
+
+function validateManifestGate(manifest = {}) {
+    const errors = [];
+    const candidates = Array.isArray(manifest.candidate_targets)
+        ? manifest.candidate_targets.map(normalizeCandidateTarget)
+        : [];
+    if (normalizeText(manifest.batch_id) !== BATCH_ID) errors.push('manifest batch_id mismatch');
+    if (normalizeLower(manifest.source) !== SOURCE) errors.push('manifest source mismatch');
+    if (normalizeText(manifest.route) !== ROUTE) errors.push('manifest route mismatch');
+    if (normalizeText(manifest.raw_data_version) !== RAW_VERSION) errors.push('manifest raw_data_version mismatch');
+    if (normalizeText(manifest.hash_strategy) !== HASH_STRATEGY) errors.push('manifest hash_strategy mismatch');
+    if (candidates.length !== TARGET_COUNT) errors.push(`candidate_targets must contain ${TARGET_COUNT} targets`);
+    if (
+        !Array.isArray(manifest.known_completed_targets) ||
+        manifest.known_completed_targets.length !== KNOWN_COMPLETED_COUNT
+    ) {
+        errors.push(`known_completed_targets must contain ${KNOWN_COMPLETED_COUNT} targets`);
+    }
+    if (normalizeText(manifest.phase_5_21_l2v3c_planning_status) !== 'completed_no_write') {
+        errors.push('phase_5_21_l2v3c_planning_status must be completed_no_write');
+    }
+    if (Number(manifest.phase_5_21_l2v3c_metadata_target_mismatch_count || 0) !== EXPECTED_MISMATCH_COUNT) {
+        errors.push(`phase_5_21_l2v3c_metadata_target_mismatch_count must be ${EXPECTED_MISMATCH_COUNT}`);
+    }
+    if (!ALLOWED_MANIFEST_NEXT_STEPS.includes(normalizeText(manifest.next_required_step))) {
+        errors.push('next_required_step must be target identity reconciliation planning or a prior L2V3D outcome');
+    }
+    if (manifest.renewed_baseline_requires_separate_baseline_acceptance !== true) {
+        errors.push('renewed_baseline_requires_separate_baseline_acceptance must be true');
+    }
+    if (manifest.renewed_baseline_requires_separate_final_db_write_authorization !== true) {
+        errors.push('renewed_baseline_requires_separate_final_db_write_authorization must be true');
+    }
+    if (manifest.raw_write_ready_for_execution === true) {
+        errors.push('raw_write_ready_for_execution must not be true');
+    }
+    for (const target of candidates) {
+        const expectedMatchId = `${LEAGUE_ID}_20252026_${target.external_id}`;
+        if (!/^\d+$/.test(target.external_id)) errors.push(`external_id must be numeric for ${target.match_id}`);
+        if (target.match_id !== expectedMatchId) errors.push(`match_id convention mismatch for ${target.external_id}`);
+        if (!/^[a-f0-9]{64}$/.test(target.baseline_hash)) {
+            errors.push(`baseline_hash invalid for ${target.external_id}`);
+        }
+        if (target.preflight_status !== 'hash_baseline_ready') {
+            errors.push(`preflight_status must be hash_baseline_ready for ${target.external_id}`);
+        }
+        if (target.matches_seed_status !== 'inserted_matches_identity') {
+            errors.push(`matches_seed_status must be inserted_matches_identity for ${target.external_id}`);
+        }
+    }
+    return {
+        ok: errors.length === 0,
+        errors,
+        candidates,
+        candidate_targets_count: candidates.length,
+        known_completed_targets_count: Array.isArray(manifest.known_completed_targets)
+            ? manifest.known_completed_targets.length
+            : 0,
+    };
+}
+
+function validateRenewedProposalGate(proposal = {}) {
+    const errors = [];
+    const checkedTargets = Array.isArray(proposal.checked_targets) ? proposal.checked_targets : [];
+    if (proposal.proposal_phase !== 'Phase 5.21L2V3C') errors.push('proposal_phase must be Phase 5.21L2V3C');
+    if (proposal.no_write !== true) errors.push('proposal no_write must be true');
+    if (proposal.db_write_performed !== false) errors.push('proposal db_write_performed must be false');
+    if (proposal.raw_insert_performed !== false) errors.push('proposal raw_insert_performed must be false');
+    if (Number(proposal.summary?.metadata_target_mismatch_count || 0) !== EXPECTED_MISMATCH_COUNT) {
+        errors.push(`proposal metadata_target_mismatch_count must be ${EXPECTED_MISMATCH_COUNT}`);
+    }
+    if (proposal.summary?.next_required_step !== 'target_identity_reconciliation_planning') {
+        errors.push('proposal next_required_step must be target_identity_reconciliation_planning');
+    }
+    if (proposal.recommendation?.raw_write_ready_for_execution !== false) {
+        errors.push('proposal raw_write_ready_for_execution must be false');
+    }
+    if (proposal.recommendation?.requires_separate_baseline_acceptance !== true) {
+        errors.push('proposal requires_separate_baseline_acceptance must be true');
+    }
+    if (proposal.recommendation?.requires_separate_final_db_write_authorization !== true) {
+        errors.push('proposal requires_separate_final_db_write_authorization must be true');
+    }
+    if (checkedTargets.length !== EXPECTED_MISMATCH_COUNT) {
+        errors.push(`proposal checked_targets must contain ${EXPECTED_MISMATCH_COUNT} targets`);
+    }
+    for (const target of checkedTargets) {
+        if (target.hash_status !== 'metadata_target_mismatch') {
+            errors.push(`proposal target ${target.external_id} must be metadata_target_mismatch`);
+        }
+        if (target.metadata_identity_status !== 'metadata_target_mismatch') {
+            errors.push(`proposal target ${target.external_id} metadata_identity_status must be mismatch`);
+        }
+    }
+    return { ok: errors.length === 0, errors, checkedTargets };
+}
+
+function safeUrlSummary(rawUrl) {
+    const value = normalizeText(rawUrl);
+    if (!value) return null;
+    try {
+        const url = new URL(value);
+        return `${url.origin}${url.pathname}${url.hash || ''}`;
+    } catch (_error) {
+        return value.split('?')[0].slice(0, 200);
+    }
+}
+
+function externalIdFromUrl(rawUrl) {
+    const value = normalizeText(rawUrl);
+    if (!value) return null;
+    try {
+        const url = new URL(value);
+        const hashMatch = url.hash.match(/(\d{6,})/);
+        if (hashMatch) return hashMatch[1];
+        const pathMatch = url.pathname.match(/\/match\/(?:[^/]+\/)*(\d{6,})(?:\/)?$/);
+        if (pathMatch) return pathMatch[1];
+        const searchMatch = url.search.match(/(?:matchId|id)=(\d{6,})/i);
+        return searchMatch?.[1] || null;
+    } catch (_error) {
+        const match = value.match(/\/match\/(?:[^/]+\/)*(\d{6,})(?:[/?#]|$)/);
+        return match?.[1] || null;
+    }
+}
+
+function normalizeComparableDate(value) {
+    const text = normalizeText(value);
+    if (!text) return '';
+    const date = new Date(text);
+    if (Number.isNaN(date.getTime())) return text;
+    return date.toISOString();
+}
+
+function teamsMatch(requested = {}, observed = {}) {
+    const requestedHome = normalizeLower(requested.home_team);
+    const requestedAway = normalizeLower(requested.away_team);
+    const observedHome = normalizeLower(observed.home_team);
+    const observedAway = normalizeLower(observed.away_team);
+    return Boolean(requestedHome && requestedAway && requestedHome === observedHome && requestedAway === observedAway);
+}
+
+function datesMatch(requested = {}, observed = {}) {
+    const requestedDate = normalizeComparableDate(requested.kickoff_time || requested.match_date);
+    const observedDate = normalizeComparableDate(observed.match_time_utc);
+    return Boolean(requestedDate && observedDate && requestedDate === observedDate);
+}
+
+function extractSafeIdentityFromPageProps(pageProps = {}) {
+    if (!isPlainObject(pageProps)) {
+        return {
+            external_id: null,
+            match_identifier_fields: {},
+            home_team: null,
+            away_team: null,
+            match_name: null,
+            match_time_utc: null,
+            status: null,
+            league_id: null,
+        };
+    }
+    const general = isPlainObject(pageProps.general) ? pageProps.general : {};
+    const header = isPlainObject(pageProps.header) ? pageProps.header : {};
+    const teams = Array.isArray(header.teams) ? header.teams : [];
+    const externalId = normalizeText(general.matchId || general.matchID || general.id || pageProps.matchId);
+    return {
+        external_id: externalId || null,
+        match_identifier_fields: {
+            general_matchId: normalizeText(general.matchId) || null,
+            general_matchID: normalizeText(general.matchID) || null,
+            general_id: normalizeText(general.id) || null,
+            top_level_matchId: normalizeText(pageProps.matchId) || null,
+        },
+        home_team: normalizeText(teams[0]?.name || header.homeTeam?.name || header.homeTeam) || null,
+        away_team: normalizeText(teams[1]?.name || header.awayTeam?.name || header.awayTeam) || null,
+        match_name: normalizeText(general.matchName) || null,
+        match_time_utc: normalizeText(general.matchTimeUTCDate || general.matchTimeUTC) || null,
+        status: normalizeText(general.matchStatus || general.status || header.status) || null,
+        league_id: normalizeText(general.leagueId || general.parentLeagueId) || null,
+    };
+}
+
+function observedExternalIdSuffix(identity = {}) {
+    const observed = normalizeText(identity.external_id);
+    return observed.match(/(\d+)$/)?.[1] || observed || null;
+}
+
+function classifyDiagnostic(diagnostic = {}) {
+    const reasons = [];
+    if (diagnostic.request_url_external_id && diagnostic.request_url_external_id !== diagnostic.requested_external_id) {
+        return {
+            mismatch_type: 'route_generation_mismatch',
+            reasons: ['request URL id differs from target external_id'],
+        };
+    }
+    if (diagnostic.final_url_external_id && diagnostic.final_url_external_id !== diagnostic.requested_external_id) {
+        reasons.push('final URL id differs from target external_id');
+        return { mismatch_type: 'canonical_redirect_mismatch', reasons };
+    }
+    if (!diagnostic.parsed) {
+        return { mismatch_type: 'unknown', reasons: ['pageProps was not parsed'] };
+    }
+    if (diagnostic.observed_external_id && diagnostic.observed_external_id !== diagnostic.requested_external_id) {
+        reasons.push('pageProps identity external_id differs from requested external_id');
+        if (!diagnostic.team_match || !diagnostic.date_match) {
+            reasons.push('observed team/date metadata differs from manifest target metadata');
+        }
+        return { mismatch_type: 'requested_vs_observed_external_id_mismatch', reasons };
+    }
+    if (!diagnostic.team_match || !diagnostic.date_match) {
+        return {
+            mismatch_type: 'team_date_status_mismatch',
+            reasons: ['external_id matched but team/date metadata differed'],
+        };
+    }
+    return { mismatch_type: 'identity_match', reasons: [] };
+}
+
+function summarizeTopLevelKeys(pageProps = {}) {
+    return isPlainObject(pageProps) ? Object.keys(pageProps).sort() : [];
+}
+
+function jsonByteLength(value = {}) {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+async function sleep(ms) {
+    if (!ms) return;
+    await new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+
+async function resolveFetchResult(target = {}, requestUrl, index, dependencies = {}) {
+    const byExternalId = dependencies.fetchResultsByExternalId || {};
+    if (byExternalId[target.external_id]) return byExternalId[target.external_id];
+    if (Array.isArray(dependencies.fetchResults) && dependencies.fetchResults[index]) {
+        return dependencies.fetchResults[index];
+    }
+    const fetchHtmlFn = dependencies.fetchHtmlFn || fetchHtml;
+    return fetchHtmlFn(requestUrl, { fetchFn: dependencies.fetchFn });
+}
+
+async function diagnoseTarget(target = {}, proposalTarget = {}, index = 0, input = {}, dependencies = {}) {
+    if (index > 0) await sleep(input.requestDelayMs);
+    const requestedExternalId = normalizeText(target.external_id);
+    const builtRequestUrl = buildFotMobMatchUrl(requestedExternalId);
+    const fetchResult = await resolveFetchResult(target, builtRequestUrl, index, dependencies);
+    const requestUrl = fetchResult.request_url || builtRequestUrl;
+    const finalUrl = fetchResult.final_url || requestUrl;
+    const base = {
+        requested_external_id: requestedExternalId,
+        requested_match_id: target.match_id,
+        requested_home_team: target.home_team || null,
+        requested_away_team: target.away_team || null,
+        requested_kickoff_time: target.kickoff_time || target.match_date || null,
+        requested_status: target.status || null,
+        request_url_summary: safeUrlSummary(requestUrl),
+        request_url_external_id: externalIdFromUrl(requestUrl),
+        final_url_summary: safeUrlSummary(finalUrl),
+        final_url_external_id: externalIdFromUrl(finalUrl),
+        http_status: Number(fetchResult.http_status || fetchResult.status || 0),
+        parsed: false,
+        observed_external_id: null,
+        observed_match_identifier_fields: {},
+        observed_home_team: null,
+        observed_away_team: null,
+        observed_match_name: null,
+        observed_match_time_utc: null,
+        observed_status: null,
+        observed_league_id: null,
+        top_level_keys_summary: [],
+        body_byte_length: Number(fetchResult.body_byte_length || 0),
+        pageprops_json_byte_length: null,
+        pageProps_path_count: null,
+        pageProps_content_path_count: null,
+        hash: null,
+        l2v3c_previous_hash: proposalTarget.renewed_candidate_hash || null,
+        l2v3c_previous_observed_external_id:
+            proposalTarget.attempts?.[0]?.metadata_identity_observed?.external_id || null,
+        identity_match: false,
+        team_match: false,
+        date_match: false,
+        mismatch_type: 'unknown',
+        mismatch_type_reasons: [],
+        deterministic_observed_identity_with_l2v3c: false,
+        deterministic_with_l2v3c: false,
+        safe_error_summary: fetchResult.error || null,
+    };
+    if (!fetchResult.ok || Number(fetchResult.http_status || 0) !== 200) {
+        return { ...base, safe_error_summary: fetchResult.error || 'HTTP_NON_200' };
+    }
+    const extraction = extractNextDataJsonFromHtml(fetchResult.body);
+    if (!extraction.ok) {
+        return { ...base, safe_error_summary: extraction.error || 'NEXT_DATA_PARSE_FAILED' };
+    }
+    const pageProps = getPageProps(extraction.data);
+    if (!pageProps) {
+        return { ...base, safe_error_summary: 'PAGE_PROPS_NOT_FOUND' };
+    }
+    const identity = extractSafeIdentityFromPageProps(pageProps);
+    const observedId = observedExternalIdSuffix(identity);
+    const pagePropsPaths = listJsonPaths(pageProps);
+    const contentPaths = listJsonPaths(isPlainObject(pageProps.content) ? pageProps.content : {});
+    const hash = computeStablePagePropsHash(pageProps);
+    const parsed = {
+        ...base,
+        parsed: true,
+        observed_external_id: observedId,
+        observed_match_identifier_fields: identity.match_identifier_fields,
+        observed_home_team: identity.home_team,
+        observed_away_team: identity.away_team,
+        observed_match_name: identity.match_name,
+        observed_match_time_utc: identity.match_time_utc,
+        observed_status: identity.status,
+        observed_league_id: identity.league_id,
+        top_level_keys_summary: summarizeTopLevelKeys(pageProps),
+        pageprops_json_byte_length: jsonByteLength(pageProps),
+        pageProps_path_count: pagePropsPaths.length,
+        pageProps_content_path_count: contentPaths.length,
+        hash,
+        identity_match: Boolean(observedId && observedId === requestedExternalId),
+        team_match: teamsMatch(target, identity),
+        date_match: datesMatch(target, identity),
+        deterministic_with_l2v3c:
+            Boolean(proposalTarget.renewed_candidate_hash && proposalTarget.renewed_candidate_hash === hash) &&
+            Boolean(proposalTarget.attempts?.[0]?.metadata_identity_observed?.external_id === observedId),
+        deterministic_observed_identity_with_l2v3c:
+            Boolean(proposalTarget.attempts?.[0]?.metadata_identity_observed?.external_id) &&
+            proposalTarget.attempts?.[0]?.metadata_identity_observed?.external_id === observedId,
+        safe_error_summary: null,
+    };
+    const classification = classifyDiagnostic(parsed);
+    return {
+        ...parsed,
+        mismatch_type: classification.mismatch_type,
+        mismatch_type_reasons: classification.reasons,
+    };
+}
+
+function selectMismatchTargets(manifestGate = {}, proposalGate = {}, requestedExternalIds = []) {
+    const candidatesByExternalId = new Map(
+        (manifestGate.candidates || []).map(target => [normalizeText(target.external_id), target])
+    );
+    const proposalByExternalId = new Map(
+        (proposalGate.checkedTargets || []).map(target => [normalizeText(target.external_id), target])
+    );
+    const selectedIds =
+        requestedExternalIds.length > 0
+            ? requestedExternalIds
+            : (proposalGate.checkedTargets || []).map(target => normalizeText(target.external_id));
+    const uniqueIds = [...new Set(selectedIds.map(normalizeText).filter(Boolean))];
+    const errors = [];
+    const pairs = [];
+    for (const externalId of uniqueIds) {
+        const target = candidatesByExternalId.get(externalId);
+        const proposalTarget = proposalByExternalId.get(externalId);
+        if (!target) errors.push(`target ${externalId} missing from manifest candidate_targets`);
+        if (!proposalTarget) errors.push(`target ${externalId} missing from L2V3C mismatch proposal`);
+        if (target && proposalTarget) pairs.push({ target, proposalTarget });
+    }
+    return { ok: errors.length === 0, errors, pairs, selected_external_ids: uniqueIds };
+}
+
+function countBy(values = []) {
+    return values.reduce((acc, value) => {
+        const key = normalizeText(value) || 'unknown';
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+    }, {});
+}
+
+function inferRootCause(summary = {}, diagnostics = []) {
+    if (summary.identity_mismatch_count === 0) {
+        return {
+            root_cause_status: 'not_applicable',
+            suspected_root_cause: 'identity_reconciled',
+            next_required_step: 'renewed_baseline_acceptance_review_planning',
+        };
+    }
+    if (summary.request_url_itself_wrong === true) {
+        return {
+            root_cause_status: 'confirmed_route_generation_mismatch',
+            suspected_root_cause: 'route_generation_mismatch',
+            next_required_step: 'route_generation_fix_planning',
+        };
+    }
+    if (summary.canonical_redirect_detected === true) {
+        return {
+            root_cause_status: 'suspected_not_accepted',
+            suspected_root_cause: 'fotmob_canonical_redirect_or_detail_route_identity_mismatch',
+            next_required_step: 'target_identity_source_inventory_reconciliation_planning',
+        };
+    }
+    const allObservedMismatch = diagnostics.every(
+        item => item.mismatch_type === 'requested_vs_observed_external_id_mismatch'
+    );
+    if (allObservedMismatch) {
+        return {
+            root_cause_status: 'suspected_not_accepted',
+            suspected_root_cause: 'manifest_target_identity_or_fotmob_detail_payload_mapping_mismatch',
+            next_required_step: 'target_identity_source_inventory_reconciliation_planning',
+        };
+    }
+    return {
+        root_cause_status: 'unknown',
+        suspected_root_cause: 'unknown',
+        next_required_step: 'target_identity_reconciliation_follow_up_investigation',
+    };
+}
+
+function buildSummary({ diagnostics = [], input = {}, manifestGate = {}, proposalGate = {}, generatedAt } = {}) {
+    const mismatchTypeCounts = countBy(diagnostics.map(item => item.mismatch_type));
+    const identityMatchCount = diagnostics.filter(item => item.identity_match === true).length;
+    const identityMismatchCount = diagnostics.length - identityMatchCount;
+    const deterministicCount = diagnostics.filter(item => item.deterministic_with_l2v3c === true).length;
+    const deterministicIdentityCount = diagnostics.filter(
+        item => item.deterministic_observed_identity_with_l2v3c === true
+    ).length;
+    const requestUrlItselfWrong = diagnostics.some(item => item.mismatch_type === 'route_generation_mismatch');
+    const canonicalRedirectDetected = diagnostics.some(item => item.mismatch_type === 'canonical_redirect_mismatch');
+    const parserExtractorWrongIndicated = diagnostics.some(
+        item => item.mismatch_type === 'pageprops_extraction_wrong_node'
+    );
+    const manifestTargetMetadataMismatchIndicated = diagnostics.some(
+        item =>
+            item.mismatch_type === 'requested_vs_observed_external_id_mismatch' &&
+            (!item.team_match || !item.date_match)
+    );
+    const baseSummary = {
+        phase: PHASE,
+        generated_at: generatedAt,
+        branch: input.branch || null,
+        base_head: input.baseHead || null,
+        main_head: input.mainHead || null,
+        main_ci_status: input.mainCiStatus || null,
+        pr_1276_state: input.pr1276State || null,
+        pr_1276_merge_commit: input.pr1276MergeCommit || null,
+        pr_1277_state: input.pr1277State || null,
+        pr_1277_merge_commit: input.pr1277MergeCommit || null,
+        pr_1277_retarget_result: input.pr1277RetargetResult || null,
+        source_manifest_path: input.manifest,
+        renewed_baseline_proposal_path: input.renewedProposal,
+        report_path: input.reportOutput,
+        no_write: true,
+        db_write_performed: false,
+        raw_insert_performed: false,
+        baseline_acceptance_performed: false,
+        raw_write_retry_performed: false,
+        candidate_targets_count: manifestGate.candidate_targets_count,
+        l2v3c_metadata_target_mismatch_count: proposalGate.checkedTargets?.length || 0,
+        checked_target_count: diagnostics.length,
+        identity_match_count: identityMatchCount,
+        identity_mismatch_count: identityMismatchCount,
+        mismatch_type_counts: mismatchTypeCounts,
+        deterministic_observed_identity_with_l2v3c_count: deterministicIdentityCount,
+        deterministic_observed_identity_with_l2v3c:
+            diagnostics.length > 0 && deterministicIdentityCount === diagnostics.length,
+        deterministic_with_l2v3c_count: deterministicCount,
+        deterministic_with_l2v3c: diagnostics.length > 0 && deterministicCount === diagnostics.length,
+        all_mismatches_same_pattern: Object.keys(mismatchTypeCounts).length === 1,
+        request_url_itself_wrong: requestUrlItselfWrong,
+        canonical_redirect_detected: canonicalRedirectDetected,
+        response_canonical_data_wrong_or_unexpected: identityMismatchCount > 0,
+        parser_extractor_wrong_indicated: parserExtractorWrongIndicated,
+        manifest_target_metadata_mismatch_indicated: manifestTargetMetadataMismatchIndicated,
+        raw_write_ready_for_execution: false,
+        requires_separate_baseline_acceptance: true,
+        requires_separate_final_db_write_authorization: true,
+    };
+    return { ...baseSummary, ...inferRootCause(baseSummary, diagnostics) };
+}
+
+function buildUpdatedManifest(manifest = {}, summary = {}) {
+    return {
+        ...manifest,
+        phase_5_21_l2v3d_planning_status: 'completed_no_write',
+        target_identity_reconciliation_status:
+            summary.identity_mismatch_count > 0
+                ? 'blocked_identity_mismatch_unresolved'
+                : 'identity_reconciled_no_write',
+        phase_5_21_l2v3d_checked_target_count: summary.checked_target_count,
+        phase_5_21_l2v3d_identity_match_count: summary.identity_match_count,
+        phase_5_21_l2v3d_identity_mismatch_count: summary.identity_mismatch_count,
+        phase_5_21_l2v3d_mismatch_type_counts: summary.mismatch_type_counts,
+        phase_5_21_l2v3d_deterministic_observed_identity_with_l2v3c: summary.deterministic_observed_identity_with_l2v3c,
+        phase_5_21_l2v3d_deterministic_with_l2v3c: summary.deterministic_with_l2v3c,
+        phase_5_21_l2v3d_request_url_itself_wrong: summary.request_url_itself_wrong,
+        phase_5_21_l2v3d_parser_extractor_wrong_indicated: summary.parser_extractor_wrong_indicated,
+        phase_5_21_l2v3d_manifest_target_metadata_mismatch_indicated:
+            summary.manifest_target_metadata_mismatch_indicated,
+        phase_5_21_l2v3d_root_cause_status: summary.root_cause_status,
+        phase_5_21_l2v3d_suspected_root_cause: summary.suspected_root_cause,
+        target_identity_mismatch_blocks_baseline_acceptance: summary.identity_mismatch_count > 0,
+        renewed_baseline_requires_separate_baseline_acceptance: true,
+        renewed_baseline_requires_separate_final_db_write_authorization: true,
+        raw_write_ready_for_execution: false,
+        raw_write_retry_authorization_status: 'blocked_pending_target_identity_reconciliation',
+        next_required_step: summary.next_required_step,
+    };
+}
+
+function tableRows(rows = []) {
+    return rows.join('\n');
+}
+
+function buildComparisonRows(diagnostics = []) {
+    return diagnostics.map(
+        item =>
+            `| ${item.requested_external_id} | ${item.requested_match_id} | ${item.requested_home_team}-${item.requested_away_team} | ${item.requested_kickoff_time} | ${item.request_url_summary || ''} | ${item.request_url_external_id || ''} | ${item.final_url_summary || ''} | ${item.final_url_external_id || ''} | ${item.http_status} | ${item.parsed} | ${item.observed_external_id || ''} | ${item.observed_match_identifier_fields?.general_matchId || ''} | ${item.observed_home_team || ''}-${item.observed_away_team || ''} | ${item.observed_match_time_utc || ''} | ${item.top_level_keys_summary.join(',')} | ${item.body_byte_length || 0}/${item.pageprops_json_byte_length || 0} | ${item.hash || ''} | ${item.identity_match} | ${item.mismatch_type} | ${item.safe_error_summary || ''} |`
+    );
+}
+
+function buildReport({ summary = {}, diagnostics = [], manifestGate = {}, proposalGate = {} } = {}) {
+    const comparisonRows = buildComparisonRows(diagnostics);
+    const mismatchTypeLines = Object.entries(summary.mismatch_type_counts || {}).map(
+        ([type, count]) => `- ${type}=${count}`
+    );
+    return `# Data Entrypoint Governance - Phase 5.21 L2V3D
+
+## A. Current Status
+
+- phase=target identity reconciliation planning
+- branch=${summary.branch || 'unknown'}
+- base_head=${summary.base_head || 'unknown'}
+- main_head=${summary.main_head || 'unknown'}
+- main_ci_status=${summary.main_ci_status || 'unknown'}
+- no_write=true
+
+## B. PR #1276 Merge Result
+
+- pr_1276_state=${summary.pr_1276_state || 'MERGED'}
+- pr_1276_merge_commit=${summary.pr_1276_merge_commit || 'unknown'}
+- merge_scope=L2V3 / L2V3B No-Go + hash drift review documentation
+
+## C. PR #1277 Rebase / Retarget / Merge Result
+
+- pr_1277_state=${summary.pr_1277_state || 'MERGED'}
+- pr_1277_merge_commit=${summary.pr_1277_merge_commit || 'unknown'}
+- pr_1277_retarget_result=${summary.pr_1277_retarget_result || 'retargeted_to_main_before_merge'}
+- merge_scope=L2V3C renewed baseline regeneration planning / no-write manifest proposal
+
+## D. Authorization Scope
+
+- planning_authorized=true
+- target_identity_reconciliation_authorized=true
+- network_recapture_authorized=true
+- scope limited to L2V3C mismatch targets only
+- no accepted baseline replacement
+- no raw write authorization
+- no DB write authorization
+
+## E. No-Write Guarantee
+
+- db_write_performed=false
+- raw_insert_performed=false
+- baseline_acceptance_performed=false
+- raw_write_retry_performed=false
+- full raw_data/pageProps/source body printed=false
+- full raw_data/pageProps/source body saved=false
+
+## F. L2V3C 8/8 Metadata Mismatch Recap
+
+- source_proposal=${summary.renewed_baseline_proposal_path}
+- l2v3c_checked_target_count=${summary.l2v3c_metadata_target_mismatch_count}
+- l2v3c_metadata_target_mismatch_count=${proposalGate.checkedTargets?.length || 0}
+- l2v3c_next_required_step=target_identity_reconciliation_planning
+- raw_write_ready_for_execution=false
+- requires_separate_baseline_acceptance=true
+- requires_separate_final_db_write_authorization=true
+
+## G. Target Identity Discovery Result
+
+- candidate_targets_count=${manifestGate.candidate_targets_count || 0}
+- known_completed_targets_count=${manifestGate.known_completed_targets_count || 0}
+- checked_target_count=${summary.checked_target_count}
+- identity_match_count=${summary.identity_match_count}
+- identity_mismatch_count=${summary.identity_mismatch_count}
+- deterministic_observed_identity_with_l2v3c=${summary.deterministic_observed_identity_with_l2v3c}
+- deterministic_observed_identity_with_l2v3c_count=${summary.deterministic_observed_identity_with_l2v3c_count}
+- deterministic_with_l2v3c=${summary.deterministic_with_l2v3c}
+- deterministic_with_l2v3c_count=${summary.deterministic_with_l2v3c_count}
+
+## H. Request URL / Route Construction Review
+
+- route=${ROUTE}
+- request_url_builder=buildFotMobMatchUrl(external_id)
+- request_url_pattern=https://www.fotmob.com/match/{external_id}
+- request_url_itself_wrong=${summary.request_url_itself_wrong}
+- canonical_redirect_detected=${summary.canonical_redirect_detected}
+
+## I. PageProps Extraction Review
+
+- extraction_path=__NEXT_DATA__.props.pageProps
+- stable_hash_function=computeStablePagePropsHash
+- hash_strategy=${HASH_STRATEGY}
+- parser_extractor_wrong_indicated=${summary.parser_extractor_wrong_indicated}
+- full_pageProps_stored=false
+
+## J. Requested vs Observed Metadata Comparison Summary
+
+| requested_external_id | requested_match_id | requested_teams | requested_kickoff | request_url_summary | request_url_id | final_url_summary | final_url_id | http_status | parsed | observed_external_id | observed_general_matchId | observed_teams | observed_time_utc | top_level_keys | body/pageProps_bytes | hash | identity_match | mismatch_type | safe_error_summary |
+| --------------------- | ------------------ | --------------- | ----------------- | ------------------- | -------------- | ----------------- | ------------ | ----------- | ------ | -------------------- | ------------------------ | -------------- | ----------------- | -------------- | -------------------- | ---- | -------------- | ------------- | ------------------ |
+${tableRows(comparisonRows)}
+
+## K. Mismatch Classification
+
+- checked_target_count=${summary.checked_target_count}
+- identity_match_count=${summary.identity_match_count}
+- identity_mismatch_count=${summary.identity_mismatch_count}
+- all_mismatches_same_pattern=${summary.all_mismatches_same_pattern}
+- identity_mismatch_pattern_deterministic=${summary.deterministic_observed_identity_with_l2v3c}
+- full_hash_and_identity_deterministic=${summary.deterministic_with_l2v3c}
+${tableRows(mismatchTypeLines)}
+- response_canonical_data_wrong_or_unexpected=${summary.response_canonical_data_wrong_or_unexpected}
+- manifest_target_metadata_mismatch_indicated=${summary.manifest_target_metadata_mismatch_indicated}
+
+## L. Root Cause Status
+
+- root_cause_status=${summary.root_cause_status}
+- suspected_root_cause=${summary.suspected_root_cause}
+- concrete_root_cause_confirmed=${summary.root_cause_status?.startsWith('confirmed') === true}
+
+## M. Required Fix / Continue Investigation Decision
+
+- baseline_acceptance_blocked=true
+- raw_write_retry_blocked=true
+- code_fix_required=${summary.request_url_itself_wrong || summary.parser_extractor_wrong_indicated}
+- manifest_or_source_inventory_reconciliation_required=${summary.manifest_target_metadata_mismatch_indicated}
+- continue_investigation_required=${summary.root_cause_status !== 'confirmed_route_generation_mismatch'}
+
+## N. DB Row Count Safety Result
+
+- DB row counts must be verified with a separate SELECT-only check.
+- expected_matches=${EXPECTED_ROW_COUNTS.matches}
+- expected_raw_match_data=${EXPECTED_ROW_COUNTS.raw_match_data}
+- expected_bookmaker_odds_history=${EXPECTED_ROW_COUNTS.bookmaker_odds_history}
+- expected_l3_features=${EXPECTED_ROW_COUNTS.l3_features}
+- expected_match_features_training=${EXPECTED_ROW_COUNTS.match_features_training}
+- expected_predictions=${EXPECTED_ROW_COUNTS.predictions}
+- candidate_fotmob_pageprops_v2_raw_rows_expected=0
+- safety_status=pending_select_only_validation
+
+## O. Test Results
+
+- pending until local verification completes
+
+## P. PR Status
+
+- pending until PR is created
+
+## Q. Next Step Recommendation
+
+- next_required_step=${summary.next_required_step}
+- target identity mismatch blocks baseline acceptance.
+- raw write retry still requires separate final DB-write authorization after identity reconciliation.
+
+## R. Explicit Non-Execution
+
+- no DB writes
+- no raw_match_data inserts
+- no matches writes
+- no bookmaker_odds_history writes
+- no l3_features writes
+- no match_features_training writes
+- no predictions writes
+- no schema migration
+- no parser implementation
+- no feature extraction
+- no training/prediction
+- no browser/proxy/captcha bypass
+- no accepted baseline replacement
+- no raw write retry
+- no baseline_hash edits to pass a gate
+- no proposal hash marked as accepted baseline
+- no full raw_data/pageProps/source body print/save
+- no invented external_id, match target, payload, or hash
+- no L2V3/L2V3B/L2V3C evidence deletion
+`;
+}
+
+async function diagnoseTargets(pairs = [], input = {}, dependencies = {}) {
+    const diagnostics = [];
+    for (let index = 0; index < pairs.length; index += 1) {
+        const { target, proposalTarget } = pairs[index];
+        diagnostics.push(await diagnoseTarget(target, proposalTarget, index, input, dependencies));
+    }
+    return diagnostics;
+}
+
+async function runPlanning(rawInput = {}, dependencies = {}) {
+    const validation = validatePlanningInput(rawInput);
+    if (!validation.ok) return { ok: false, status: 2, errors: validation.errors };
+    const input = validation.input;
+    const generatedAt = input.generatedAt || dependencies.generatedAt || new Date().toISOString();
+    const manifest = dependencies.manifest || (dependencies.readJsonFile || readJsonFile)(input.manifest);
+    const proposal = dependencies.renewedProposal || (dependencies.readJsonFile || readJsonFile)(input.renewedProposal);
+    const manifestGate = validateManifestGate(manifest);
+    if (!manifestGate.ok) return { ok: false, status: 3, errors: manifestGate.errors, manifest_gate: manifestGate };
+    const proposalGate = validateRenewedProposalGate(proposal);
+    if (!proposalGate.ok) return { ok: false, status: 4, errors: proposalGate.errors, proposal_gate: proposalGate };
+    const selection = selectMismatchTargets(manifestGate, proposalGate, input.targetExternalIds);
+    if (!selection.ok) return { ok: false, status: 5, errors: selection.errors };
+    const diagnostics = await diagnoseTargets(selection.pairs, input, dependencies);
+    const summary = buildSummary({ diagnostics, input, manifestGate, proposalGate, generatedAt });
+    const updatedManifest = buildUpdatedManifest(manifest, summary);
+    const report = buildReport({ summary, diagnostics, manifestGate, proposalGate });
+    if (dependencies.writeManifest !== false) {
+        (dependencies.writeManifestFile || dependencies.writeJsonFile || writeJsonFile)(
+            input.manifest,
+            updatedManifest
+        );
+    }
+    if (dependencies.writeReport !== false) {
+        (dependencies.writeReportFile || writeReportFile)(input.reportOutput, report);
+    }
+    return {
+        ok: true,
+        status: 0,
+        summary,
+        diagnostics,
+        updated_manifest: updatedManifest,
+        report,
+        manifest_gate: manifestGate,
+        proposal_gate: proposalGate,
+        selected_external_ids: selection.selected_external_ids,
+    };
+}
+
+async function runCli(argv = process.argv.slice(2), dependencies = {}) {
+    const args = parseArgs(argv);
+    if (args.help) {
+        process.stdout.write(
+            `Usage: node scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js --manifest=${MANIFEST_PATH} --renewed-proposal=${RENEWED_PROPOSAL_PATH} ...\n`
+        );
+        return { status: 0 };
+    }
+    const result = await runPlanning(args, dependencies);
+    const output = result.ok
+        ? {
+              ok: true,
+              status: result.status,
+              summary: result.summary,
+              selected_external_ids: result.selected_external_ids,
+          }
+        : { ok: false, status: result.status, errors: result.errors };
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    return { status: result.status };
+}
+
+module.exports = {
+    PHASE,
+    MANIFEST_PATH,
+    RENEWED_PROPOSAL_PATH,
+    REPORT_PATH,
+    SOURCE,
+    ROUTE,
+    LEAGUE_ID,
+    LEAGUE_NAME,
+    SEASON,
+    BATCH_ID,
+    RAW_VERSION,
+    HASH_STRATEGY,
+    TARGET_COUNT,
+    EXPECTED_MISMATCH_COUNT,
+    EXPECTED_ROW_COUNTS,
+    parseArgs,
+    normalizeBooleanFlag,
+    validatePlanningInput,
+    validateManifestGate,
+    validateRenewedProposalGate,
+    extractSafeIdentityFromPageProps,
+    classifyDiagnostic,
+    selectMismatchTargets,
+    diagnoseTarget,
+    diagnoseTargets,
+    buildSummary,
+    buildUpdatedManifest,
+    buildReport,
+    runPlanning,
+    runCli,
+};
+
+if (require.main === module) {
+    runCli()
+        .then(result => {
+            process.exitCode = result.status;
+        })
+        .catch(error => {
+            process.stderr.write(`${error.stack || error.message}\n`);
+            process.exitCode = 1;
+        });
+}

--- a/tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js
+++ b/tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js
@@ -1,0 +1,785 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const MODULE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js');
+const PREVIEW_PATH = path.join(PROJECT_ROOT, 'scripts/ops/pageprops_v2_no_write_preview.js');
+const RAW_WRITE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/renewed_pageprops_v2_raw_write_execute.js');
+
+function loadFreshModule() {
+    delete require.cache[require.resolve(MODULE_PATH)];
+    return require(MODULE_PATH);
+}
+
+const mod = loadFreshModule();
+const preview = require(PREVIEW_PATH);
+const rawWrite = require(RAW_WRITE_PATH);
+
+const MISMATCH_IDS = Object.freeze([
+    '4830466',
+    '4830461',
+    '4830481',
+    '4830496',
+    '4830511',
+    '4830463',
+    '4830465',
+    '4830508',
+]);
+
+const OBSERVED = Object.freeze({
+    4830466: ['4830759', 'Marseille', 'Rennes', '2026-05-17T19:00:00.000Z'],
+    4830461: ['4830758', 'Lyon', 'Lens', '2026-05-17T19:00:00.000Z'],
+    4830481: ['4830763', 'Strasbourg', 'Monaco', '2026-05-17T19:00:00.000Z'],
+    4830496: ['4830757', 'Lorient', 'Le Havre', '2026-05-17T19:00:00.000Z'],
+    4830511: ['4830760', 'Nantes', 'Toulouse', '2026-05-17T19:00:00.000Z'],
+    4830463: ['4830622', 'Le Havre', 'Monaco', '2026-01-24T18:00:00.000Z'],
+    4830465: ['4830619', 'Toulouse', 'Nice', '2026-01-17T18:00:00.000Z'],
+    4830508: ['4830620', 'Auxerre', 'Paris Saint-Germain', '2026-01-23T19:00:00.000Z'],
+});
+
+function fakePageProps(externalId, overrides = {}) {
+    const observed = OBSERVED[externalId] || [
+        externalId,
+        `Home ${externalId}`,
+        `Away ${externalId}`,
+        '2025-08-15T18:45:00.000Z',
+    ];
+    return {
+        content: {
+            matchFacts: { infoBox: { Tournament: 'Ligue 1' } },
+            stats: { Periods: { All: { stats: [{ key: 'Expected goals', stats: [1.2, 0.8] }] } } },
+            DO_NOT_SAVE_FULL_PAGEPROPS: 'secret-marker',
+        },
+        fallback: false,
+        general: {
+            matchId: observed[0],
+            leagueId: 53,
+            matchName: `${observed[1]}-vs-${observed[2]}`,
+            matchTimeUTCDate: observed[3],
+        },
+        header: { teams: [{ name: observed[1] }, { name: observed[2] }] },
+        nav: { locale: 'en' },
+        ongoing: false,
+        seo: { eventJSONLD: { '@type': 'SportsEvent' } },
+        ssr: true,
+        translations: { ok: true },
+        ...overrides,
+    };
+}
+
+function fakeHtml(externalId, pageProps = fakePageProps(externalId)) {
+    return `<html><body><script id="__NEXT_DATA__" type="application/json">${JSON.stringify({
+        props: { pageProps },
+    })}</script></body></html>`;
+}
+
+function fetchResultFor(requestedExternalId, pageProps = fakePageProps(requestedExternalId), overrides = {}) {
+    const body = fakeHtml(requestedExternalId, pageProps);
+    return {
+        ok: overrides.ok ?? true,
+        request_url: `https://www.fotmob.com/match/${requestedExternalId}`,
+        final_url: overrides.final_url || `https://www.fotmob.com/match/${requestedExternalId}`,
+        http_status: overrides.http_status ?? 200,
+        content_type: 'text/html; charset=utf-8',
+        body_byte_length: Buffer.byteLength(body, 'utf8'),
+        body_sha256: `body-sha-${requestedExternalId}`,
+        body,
+        error: overrides.error,
+    };
+}
+
+function hashFor(externalId) {
+    return preview.computeStablePagePropsHash(fakePageProps(externalId));
+}
+
+function candidate(externalId, overrides = {}) {
+    return {
+        target_id: `${mod.BATCH_ID}:53_20252026_${externalId}`,
+        batch_id: mod.BATCH_ID,
+        source: 'fotmob',
+        route: 'html_hydration',
+        raw_data_version: 'fotmob_pageprops_v2',
+        hash_strategy: 'stable_pageprops_payload_v1',
+        match_id: `53_20252026_${externalId}`,
+        external_id: externalId,
+        league_id: 53,
+        league_name: 'Ligue 1',
+        season: '2025/2026',
+        home_team: `Home ${externalId}`,
+        away_team: `Away ${externalId}`,
+        kickoff_time: '2025-08-15T18:45:00.000Z',
+        match_date: '2025-08-15T18:45:00.000Z',
+        status: 'finished',
+        preflight_status: 'hash_baseline_ready',
+        baseline_hash: hashFor(externalId),
+        write_plan_status: 'eligible_for_insert',
+        write_status: 'blocked_missing_matches_fk_prerequisite',
+        write_execution_status: 'RECAPTURE_HASH_GATE_BLOCKED',
+        matches_seed_status: 'inserted_matches_identity',
+        failure_reason: 'blocked_missing_matches_fk_prerequisite',
+        source_inventory_route: 'source_inventory',
+        source_url: null,
+        ...overrides,
+    };
+}
+
+function candidates50() {
+    const filler = Array.from({ length: 42 }, (_, index) => String(4900000 + index));
+    return [...MISMATCH_IDS, ...filler].map(externalId => candidate(externalId));
+}
+
+function knownCompleted() {
+    return ['4830746', '4830747', '4830748', '4830750', '4830751', '4830752', '4830753', '4830754'].map(externalId => ({
+        target_id: `${mod.BATCH_ID}:53_20252026_${externalId}`,
+        external_id: externalId,
+        match_id: `53_20252026_${externalId}`,
+    }));
+}
+
+function manifest(overrides = {}) {
+    return {
+        batch_id: mod.BATCH_ID,
+        source: 'fotmob',
+        route: 'html_hydration',
+        raw_data_version: 'fotmob_pageprops_v2',
+        hash_strategy: 'stable_pageprops_payload_v1',
+        league: { league_id: 53, league_name: 'Ligue 1', season: '2025/2026' },
+        known_completed_targets: knownCompleted(),
+        candidate_targets: candidates50(),
+        phase_5_21_l2v3c_planning_status: 'completed_no_write',
+        phase_5_21_l2v3c_metadata_target_mismatch_count: 8,
+        next_required_step: 'target_identity_reconciliation_planning',
+        required_next_step: 'renewed_controlled_pageprops_v2_raw_write_execution_blocked_review',
+        renewed_baseline_requires_separate_baseline_acceptance: true,
+        renewed_baseline_requires_separate_final_db_write_authorization: true,
+        raw_write_retry_readiness_status: 'ready_for_renewed_authorization',
+        raw_match_data_write_status: 'not_executed',
+        matches_identity_seed_execution_status: 'completed',
+        post_seed_matches_identity_verification_status: 'completed',
+        raw_write_fk_prerequisite_status: 'satisfied',
+        eligible_raw_insert_count: 50,
+        expected_raw_match_data_after_retry: 68,
+        ...overrides,
+    };
+}
+
+function proposalTarget(externalId, overrides = {}) {
+    const pageProps = fakePageProps(externalId);
+    const observed = OBSERVED[externalId];
+    return {
+        target_id: `${mod.BATCH_ID}:53_20252026_${externalId}`,
+        match_id: `53_20252026_${externalId}`,
+        external_id: externalId,
+        old_baseline_hash: hashFor(externalId),
+        renewed_candidate_hash: preview.computeStablePagePropsHash(pageProps),
+        hash_status: 'metadata_target_mismatch',
+        repeated_hash_stability: 'stable_current_hash',
+        metadata_identity_status: 'metadata_target_mismatch',
+        attempts: [
+            {
+                attempt: 1,
+                match_id: `53_20252026_${externalId}`,
+                external_id: externalId,
+                http_status: 200,
+                parsed: true,
+                stable_hash: preview.computeStablePagePropsHash(pageProps),
+                metadata_identity_status: 'metadata_target_mismatch',
+                metadata_identity_observed: {
+                    external_id: observed?.[0] || externalId,
+                    home_team: observed?.[1] || `Home ${externalId}`,
+                    away_team: observed?.[2] || `Away ${externalId}`,
+                    match_time_utc: observed?.[3] || '2025-08-15T18:45:00.000Z',
+                },
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function renewedProposal(overrides = {}) {
+    return {
+        proposal_phase: 'Phase 5.21L2V3C',
+        proposal_status: 'renewed_baseline_review_required',
+        no_write: true,
+        db_write_performed: false,
+        raw_insert_performed: false,
+        summary: {
+            metadata_target_mismatch_count: 8,
+            next_required_step: 'target_identity_reconciliation_planning',
+        },
+        recommendation: {
+            raw_write_ready_for_execution: false,
+            requires_human_review: true,
+            requires_separate_baseline_acceptance: true,
+            requires_separate_final_db_write_authorization: true,
+        },
+        checked_targets: MISMATCH_IDS.map(externalId => proposalTarget(externalId)),
+        ...overrides,
+    };
+}
+
+function validInput(overrides = {}) {
+    return {
+        manifest: mod.MANIFEST_PATH,
+        renewedProposal: mod.RENEWED_PROPOSAL_PATH,
+        reportOutput: mod.REPORT_PATH,
+        source: 'fotmob',
+        leagueId: 53,
+        leagueName: 'Ligue 1',
+        season: '2025/2026',
+        route: 'html_hydration',
+        rawVersion: 'fotmob_pageprops_v2',
+        hashStrategy: 'stable_pageprops_payload_v1',
+        batchId: mod.BATCH_ID,
+        targetCount: 50,
+        planningAuthorization: true,
+        targetIdentityReconciliationAuthorization: true,
+        networkAuthorization: true,
+        matchDetailRecaptureAuthorization: true,
+        allowDbWrite: false,
+        allowRawMatchDataWrite: false,
+        allowControlledWrite: false,
+        allowMatchesWrite: false,
+        allowBookmakerOddsWrite: false,
+        allowFeatureWrite: false,
+        allowSchemaMigration: false,
+        allowParserImplementation: false,
+        allowFeatureExtraction: false,
+        allowTraining: false,
+        allowPrediction: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        printFullBody: false,
+        saveFullBody: false,
+        printFullJson: false,
+        saveFullJson: false,
+        printFullPageprops: false,
+        saveFullPageprops: false,
+        retry: 0,
+        requestDelayMs: 0,
+        generatedAt: '2026-05-18T00:00:00.000Z',
+        baseHead: 'f5e718728e32a5a6f2d54d3795e172222c80f7cd',
+        branch: 'data/pageprops-v2-target-identity-reconciliation-phase521l2v3d',
+        mainHead: 'f5e718728e32a5a6f2d54d3795e172222c80f7cd',
+        mainCiStatus: 'success',
+        pr1276State: 'MERGED',
+        pr1276MergeCommit: '0d371eb412cf3ee19a6f72adb57a41bb19298f82',
+        pr1277State: 'MERGED',
+        pr1277MergeCommit: 'f5e718728e32a5a6f2d54d3795e172222c80f7cd',
+        pr1277RetargetResult: 'retargeted_to_main_before_merge',
+        ...overrides,
+    };
+}
+
+test('valid L2V3D run stays no-write and classifies unresolved identity mismatches', async () => {
+    const writes = [];
+    const result = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchHtmlFn: url => fetchResultFor(url.split('/').pop()),
+        writeJsonFile: (filePath, data) => writes.push({ filePath, data }),
+        writeReportFile: (filePath, data) => writes.push({ filePath, data }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.summary.no_write, true);
+    assert.equal(result.summary.db_write_performed, false);
+    assert.equal(result.summary.raw_insert_performed, false);
+    assert.equal(result.summary.baseline_acceptance_performed, false);
+    assert.equal(result.summary.raw_write_retry_performed, false);
+    assert.equal(result.summary.checked_target_count, 8);
+    assert.equal(result.summary.identity_mismatch_count, 8);
+    assert.equal(result.summary.mismatch_type_counts.requested_vs_observed_external_id_mismatch, 8);
+    assert.equal(result.summary.request_url_itself_wrong, false);
+    assert.equal(result.summary.deterministic_observed_identity_with_l2v3c, true);
+    assert.equal(result.summary.raw_write_ready_for_execution, false);
+    assert.equal(result.summary.requires_separate_baseline_acceptance, true);
+    assert.equal(result.summary.requires_separate_final_db_write_authorization, true);
+    assert.equal(result.updated_manifest.raw_write_ready_for_execution, false);
+    assert.equal(result.updated_manifest.target_identity_mismatch_blocks_baseline_acceptance, true);
+    assert.equal(writes.length, 2);
+});
+
+test('write, baseline acceptance and raw retry flags are blocked', () => {
+    for (const [key, value] of [
+        ['allowDbWrite', true],
+        ['allowRawMatchDataWrite', true],
+        ['allowControlledWrite', true],
+        ['allowMatchesWrite', true],
+        ['allowBookmakerOddsWrite', true],
+        ['allowFeatureWrite', true],
+        ['allowSchemaMigration', true],
+        ['allowParserImplementation', true],
+        ['allowFeatureExtraction', true],
+        ['allowTraining', true],
+        ['allowPrediction', true],
+        ['allowBrowserRuntime', true],
+        ['allowProxyRuntime', true],
+        ['finalDbWriteConfirmation', true],
+        ['executeWrite', true],
+        ['commit', true],
+        ['acceptBaseline', true],
+        ['acceptedBaseline', true],
+        ['baselineAcceptanceAuthorization', true],
+        ['rawWriteReadyForExecution', true],
+        ['rawWriteRetryAuthorization', true],
+    ]) {
+        const result = mod.validatePlanningInput(validInput({ [key]: value }));
+        assert.equal(result.ok, false, `${key} should be blocked`);
+    }
+});
+
+test('input, manifest and renewed proposal gates fail closed before recapture', async () => {
+    const invalidInput = mod.validatePlanningInput(validInput({ retry: 1, unknown: ['mystery'] }));
+    assert.equal(invalidInput.ok, false);
+    assert.match(invalidInput.errors.join('\n'), /retry must be 0/);
+    assert.match(invalidInput.errors.join('\n'), /unknown arguments/);
+
+    const invalidManifest = await mod.runPlanning(validInput(), {
+        manifest: manifest({ phase_5_21_l2v3c_metadata_target_mismatch_count: 0 }),
+        renewedProposal: renewedProposal(),
+        fetchHtmlFn: () => {
+            throw new Error('must not fetch');
+        },
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(invalidManifest.ok, false);
+    assert.equal(invalidManifest.status, 3);
+
+    const invalidProposal = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal({ recommendation: { raw_write_ready_for_execution: true } }),
+        fetchHtmlFn: () => {
+            throw new Error('must not fetch');
+        },
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(invalidProposal.ok, false);
+    assert.equal(invalidProposal.status, 4);
+});
+
+test('argument parsing and validation cover unknown, positional and default branches', () => {
+    const parsed = mod.parseArgs([
+        '--manifest',
+        mod.MANIFEST_PATH,
+        '--source=fotmob',
+        '--planning-authorization=maybe',
+        '--allow-db-write',
+        '--target-external-ids=4830466,4830466,4830461',
+        '--unknown-flag=yes',
+        'loose',
+    ]);
+
+    assert.equal(parsed.manifest, mod.MANIFEST_PATH);
+    assert.equal(parsed.source, 'fotmob');
+    assert.equal(parsed.planningAuthorization, true);
+    assert.equal(parsed.allowDbWrite, true);
+    assert.equal(parsed.targetExternalIds, '4830466,4830466,4830461');
+    assert.deepEqual(parsed.unknown, ['unknown-flag', 'loose']);
+    assert.equal(mod.normalizeBooleanFlag('bogus', false), false);
+
+    const missing = mod.validatePlanningInput({});
+    assert.equal(missing.ok, false);
+    assert.match(missing.errors.join('\n'), /missing manifest/);
+    assert.match(missing.errors.join('\n'), /missing planning-authorization=yes/);
+
+    const invalid = mod.validatePlanningInput(
+        validInput({
+            manifest: 'wrong.json',
+            renewedProposal: 'wrong-proposal.json',
+            reportOutput: 'wrong-report.md',
+            source: 'other',
+            leagueId: 54,
+            leagueName: 'Other',
+            season: '2024/2025',
+            route: 'api',
+            rawVersion: 'v1',
+            hashStrategy: 'raw',
+            batchId: 'wrong',
+            targetCount: 49,
+            requestDelayMs: -1,
+        })
+    );
+    assert.equal(invalid.ok, false);
+    assert.match(invalid.errors.join('\n'), /manifest must be/);
+    assert.match(invalid.errors.join('\n'), /renewed-proposal must be/);
+    assert.match(invalid.errors.join('\n'), /report-output must be/);
+    assert.match(invalid.errors.join('\n'), /league-id must be 53/);
+    assert.match(invalid.errors.join('\n'), /request-delay-ms/);
+});
+
+test('manifest and proposal gates report malformed metadata', () => {
+    const malformedManifest = manifest({
+        batch_id: 'wrong',
+        source: 'other',
+        route: 'api',
+        raw_data_version: 'v1',
+        hash_strategy: 'raw',
+        known_completed_targets: [],
+        phase_5_21_l2v3c_planning_status: 'missing',
+        phase_5_21_l2v3c_metadata_target_mismatch_count: 0,
+        next_required_step: 'wrong_step',
+        renewed_baseline_requires_separate_baseline_acceptance: false,
+        renewed_baseline_requires_separate_final_db_write_authorization: false,
+        raw_write_ready_for_execution: true,
+        candidate_targets: [
+            candidate('bad', {
+                match_id: 'wrong',
+                baseline_hash: 'not-a-hash',
+                preflight_status: 'missing',
+                matches_seed_status: 'missing',
+            }),
+        ],
+    });
+    const manifestGate = mod.validateManifestGate(malformedManifest);
+    assert.equal(manifestGate.ok, false);
+    assert.match(manifestGate.errors.join('\n'), /manifest batch_id mismatch/);
+    assert.match(manifestGate.errors.join('\n'), /known_completed_targets/);
+    assert.match(manifestGate.errors.join('\n'), /raw_write_ready_for_execution/);
+    assert.match(manifestGate.errors.join('\n'), /external_id must be numeric/);
+
+    const proposalGate = mod.validateRenewedProposalGate(
+        renewedProposal({
+            proposal_phase: 'wrong',
+            no_write: false,
+            db_write_performed: true,
+            raw_insert_performed: true,
+            summary: { metadata_target_mismatch_count: 0, next_required_step: 'wrong' },
+            recommendation: {
+                raw_write_ready_for_execution: true,
+                requires_separate_baseline_acceptance: false,
+                requires_separate_final_db_write_authorization: false,
+            },
+            checked_targets: [
+                proposalTarget('4830466', { hash_status: 'stable_match', metadata_identity_status: 'ok' }),
+            ],
+        })
+    );
+    assert.equal(proposalGate.ok, false);
+    assert.match(proposalGate.errors.join('\n'), /proposal_phase/);
+    assert.match(proposalGate.errors.join('\n'), /raw_write_ready_for_execution/);
+    assert.match(proposalGate.errors.join('\n'), /checked_targets/);
+    assert.match(proposalGate.errors.join('\n'), /must be metadata_target_mismatch/);
+});
+
+test('selection detects missing manifest or proposal targets and dedupes requested ids', () => {
+    const manifestGate = mod.validateManifestGate(manifest());
+    const proposalGate = mod.validateRenewedProposalGate(renewedProposal());
+    const selected = mod.selectMismatchTargets(manifestGate, proposalGate, ['4830466', '4830466', '9999999']);
+
+    assert.equal(selected.ok, false);
+    assert.deepEqual(selected.selected_external_ids, ['4830466', '9999999']);
+    assert.match(selected.errors.join('\n'), /9999999/);
+
+    const missingProposal = mod.selectMismatchTargets(manifestGate, { checkedTargets: [] }, ['4830466']);
+    assert.equal(missingProposal.ok, false);
+    assert.match(missingProposal.errors.join('\n'), /missing from L2V3C mismatch proposal/);
+});
+
+test('route and canonical redirect mismatches receive specific classification', async () => {
+    const target = candidate('4830466');
+    const proposal = proposalTarget('4830466');
+
+    const wrongRoute = await mod.diagnoseTarget(target, proposal, 0, validInput(), {
+        fetchHtmlFn: () => fetchResultFor('9999999'),
+    });
+    assert.equal(wrongRoute.mismatch_type, 'route_generation_mismatch');
+
+    const redirect = await mod.diagnoseTarget(target, proposal, 0, validInput(), {
+        fetchHtmlFn: () =>
+            fetchResultFor('4830466', fakePageProps('4830466'), {
+                final_url: 'https://www.fotmob.com/match/4830759',
+            }),
+    });
+    assert.equal(redirect.mismatch_type, 'canonical_redirect_mismatch');
+});
+
+test('diagnostics cover fetch failure, invalid HTML and missing pageProps safely', async () => {
+    const target = candidate('4830466');
+    const proposal = proposalTarget('4830466');
+
+    const httpFailure = await mod.diagnoseTarget(target, proposal, 0, validInput(), {
+        fetchResultsByExternalId: {
+            4830466: {
+                ok: false,
+                request_url: 'https://www.fotmob.com/match/4830466',
+                final_url: 'https://www.fotmob.com/match/4830466',
+                http_status: 403,
+                body_byte_length: 0,
+                error: 'HTTP_403',
+            },
+        },
+    });
+    assert.equal(httpFailure.parsed, false);
+    assert.equal(httpFailure.safe_error_summary, 'HTTP_403');
+
+    const invalidHtml = await mod.diagnoseTarget(target, proposal, 0, validInput(), {
+        fetchResults: [
+            {
+                ok: true,
+                request_url: 'https://www.fotmob.com/match/4830466',
+                final_url: 'https://www.fotmob.com/match/4830466',
+                http_status: 200,
+                body_byte_length: 17,
+                body: '<html></html>',
+            },
+        ],
+    });
+    assert.equal(invalidHtml.safe_error_summary, 'NO_NEXT_DATA');
+
+    const missingPageProps = await mod.diagnoseTarget(target, proposal, 0, validInput(), {
+        fetchHtmlFn: () => {
+            const body = `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify({
+                props: {},
+            })}</script>`;
+            return {
+                ok: true,
+                request_url: 'https://www.fotmob.com/match/4830466',
+                final_url: 'https://www.fotmob.com/match/4830466?matchId=4830466',
+                http_status: 200,
+                body_byte_length: body.length,
+                body,
+            };
+        },
+    });
+    assert.equal(missingPageProps.safe_error_summary, 'PAGE_PROPS_NOT_FOUND');
+});
+
+test('identity reconciliation can pass only when external_id, teams and date all match', async () => {
+    const pageProps = fakePageProps('4830466', {
+        general: {
+            matchId: '4830466',
+            leagueId: 53,
+            matchName: 'Rennes-vs-Marseille',
+            matchTimeUTCDate: '2025-08-15T18:45:00.000Z',
+        },
+        header: { teams: [{ name: 'Rennes' }, { name: 'Marseille' }] },
+    });
+    const target = candidate('4830466', {
+        home_team: 'Rennes',
+        away_team: 'Marseille',
+        kickoff_time: '2025-08-15T18:45:00.000Z',
+    });
+    const diagnostic = await mod.diagnoseTarget(target, proposalTarget('4830466'), 0, validInput(), {
+        fetchHtmlFn: () => fetchResultFor('4830466', pageProps),
+    });
+
+    assert.equal(diagnostic.identity_match, true);
+    assert.equal(diagnostic.team_match, true);
+    assert.equal(diagnostic.date_match, true);
+    assert.equal(diagnostic.mismatch_type, 'identity_match');
+});
+
+test('classification and summary cover identity, team-date and unknown branches', () => {
+    assert.deepEqual(mod.extractSafeIdentityFromPageProps(null), {
+        external_id: null,
+        match_identifier_fields: {},
+        home_team: null,
+        away_team: null,
+        match_name: null,
+        match_time_utc: null,
+        status: null,
+        league_id: null,
+    });
+    assert.equal(
+        mod.classifyDiagnostic({
+            parsed: false,
+            requested_external_id: '1',
+        }).mismatch_type,
+        'unknown'
+    );
+    assert.equal(
+        mod.classifyDiagnostic({
+            parsed: true,
+            requested_external_id: '1',
+            observed_external_id: '1',
+            team_match: false,
+            date_match: true,
+        }).mismatch_type,
+        'team_date_status_mismatch'
+    );
+
+    const identitySummary = mod.buildSummary({
+        diagnostics: [
+            {
+                identity_match: true,
+                mismatch_type: 'identity_match',
+                deterministic_observed_identity_with_l2v3c: true,
+                deterministic_with_l2v3c: true,
+            },
+        ],
+        input: validInput(),
+        manifestGate: { candidate_targets_count: 50 },
+        proposalGate: { checkedTargets: [proposalTarget('4830466')] },
+        generatedAt: '2026-05-18T00:00:00.000Z',
+    });
+    assert.equal(identitySummary.root_cause_status, 'not_applicable');
+    assert.equal(identitySummary.next_required_step, 'renewed_baseline_acceptance_review_planning');
+
+    const unknownSummary = mod.buildSummary({
+        diagnostics: [
+            {
+                identity_match: false,
+                mismatch_type: 'team_date_status_mismatch',
+                deterministic_observed_identity_with_l2v3c: false,
+                deterministic_with_l2v3c: false,
+            },
+        ],
+        input: validInput(),
+        manifestGate: { candidate_targets_count: 50 },
+        proposalGate: { checkedTargets: [proposalTarget('4830466')] },
+        generatedAt: '2026-05-18T00:00:00.000Z',
+    });
+    assert.equal(unknownSummary.root_cause_status, 'unknown');
+    assert.equal(unknownSummary.next_required_step, 'target_identity_reconciliation_follow_up_investigation');
+});
+
+test('report and manifest do not contain full raw_data, pageProps or source body markers', async () => {
+    const result = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchHtmlFn: url => fetchResultFor(url.split('/').pop()),
+        writeManifest: false,
+        writeReport: false,
+    });
+    const manifestText = JSON.stringify(result.updated_manifest);
+    const reportText = result.report;
+
+    assert.equal(manifestText.includes('secret-marker'), false);
+    assert.equal(manifestText.includes('DO_NOT_SAVE_FULL_PAGEPROPS'), false);
+    assert.equal(reportText.includes('secret-marker'), false);
+    assert.equal(reportText.includes('DO_NOT_SAVE_FULL_PAGEPROPS'), false);
+    assert.equal(reportText.includes('<html>'), false);
+    assert.equal(reportText.includes('__NEXT_DATA__'), true);
+});
+
+test('runPlanning can use file readers and default writers through injected safe functions', async () => {
+    const writes = [];
+    const result = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        readJsonFile: filePath => {
+            if (filePath === mod.MANIFEST_PATH) return manifest();
+            if (filePath === mod.RENEWED_PROPOSAL_PATH) return renewedProposal();
+            throw new Error(`unexpected read ${filePath}`);
+        },
+        fetchHtmlFn: url => fetchResultFor(url.split('/').pop()),
+        writeJsonFile: (filePath, data) => writes.push({ filePath, data }),
+        writeReportFile: (filePath, data) => writes.push({ filePath, data }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(writes.length, 2);
+    assert.equal(writes[0].filePath, mod.MANIFEST_PATH);
+    assert.equal(writes[1].filePath, mod.REPORT_PATH);
+});
+
+test('unresolved identity proposal is not executable by raw write runner', async () => {
+    const result = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchHtmlFn: url => fetchResultFor(url.split('/').pop()),
+        writeManifest: false,
+        writeReport: false,
+    });
+    const gate = rawWrite.validateManifestGate(result.updated_manifest);
+
+    assert.equal(result.updated_manifest.raw_write_ready_for_execution, false);
+    assert.equal(
+        result.updated_manifest.next_required_step,
+        'target_identity_source_inventory_reconciliation_planning'
+    );
+    assert.equal(gate.ok, false);
+    assert.match(gate.errors.join('\n'), /required_next_step/);
+});
+
+test('runCli prints only safe JSON summary', async () => {
+    const stdout = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = chunk => {
+        stdout.push(String(chunk));
+        return true;
+    };
+    try {
+        const help = await mod.runCli(['--help']);
+        assert.equal(help.status, 0);
+        assert.match(stdout.join(''), /Usage:/);
+
+        stdout.length = 0;
+        const result = await mod.runCli(
+            [
+                `--manifest=${mod.MANIFEST_PATH}`,
+                `--renewed-proposal=${mod.RENEWED_PROPOSAL_PATH}`,
+                `--report-output=${mod.REPORT_PATH}`,
+                '--source=fotmob',
+                '--league-id=53',
+                '--league-name=Ligue 1',
+                '--season=2025/2026',
+                '--route=html_hydration',
+                '--raw-version=fotmob_pageprops_v2',
+                '--hash-strategy=stable_pageprops_payload_v1',
+                `--batch-id=${mod.BATCH_ID}`,
+                '--target-count=50',
+                '--planning-authorization=yes',
+                '--target-identity-reconciliation-authorization=yes',
+                '--network-authorization=yes',
+                '--match-detail-recapture-authorization=yes',
+                '--allow-db-write=no',
+                '--allow-raw-match-data-write=no',
+                '--allow-controlled-write=no',
+                '--allow-matches-write=no',
+                '--allow-bookmaker-odds-write=no',
+                '--allow-feature-write=no',
+                '--allow-schema-migration=no',
+                '--allow-parser-implementation=no',
+                '--allow-feature-extraction=no',
+                '--allow-training=no',
+                '--allow-prediction=no',
+                '--allow-browser-runtime=no',
+                '--allow-proxy-runtime=no',
+                '--print-full-body=no',
+                '--save-full-body=no',
+                '--print-full-json=no',
+                '--save-full-json=no',
+                '--print-full-pageprops=no',
+                '--save-full-pageprops=no',
+                '--target-external-ids=4830466',
+                '--retry=0',
+                '--request-delay-ms=0',
+            ],
+            {
+                manifest: manifest(),
+                renewedProposal: renewedProposal(),
+                fetchHtmlFn: url => fetchResultFor(url.split('/').pop()),
+                writeManifest: false,
+                writeReport: false,
+            }
+        );
+        assert.equal(result.status, 0);
+        assert.match(stdout.join(''), /"ok": true/);
+        assert.equal(stdout.join('').includes('secret-marker'), false);
+        assert.equal(stdout.join('').includes('<html>'), false);
+    } finally {
+        process.stdout.write = originalWrite;
+    }
+});
+
+test('runCli emits controlled failure summary for invalid input', async () => {
+    const stdout = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = chunk => {
+        stdout.push(String(chunk));
+        return true;
+    };
+    try {
+        const result = await mod.runCli(['--manifest=wrong']);
+        assert.equal(result.status, 2);
+        assert.match(stdout.join(''), /"ok": false/);
+        assert.match(stdout.join(''), /manifest must be/);
+    } finally {
+        process.stdout.write = originalWrite;
+    }
+});


### PR DESCRIPTION
## Summary
- add Phase 5.21L2V3D no-write target identity reconciliation planning entrypoint, report, and tests
- record L2V3D manifest metadata showing 8/8 identity mismatches remain blocked
- document that requested URLs are built from `/match/{external_id}`, while observed pageProps identities still resolve to different matches

## Safety
- no DB writes
- no raw_match_data inserts
- no matches writes
- no accepted baseline replacement
- no raw write authorization or retry
- target identity mismatch still blocks baseline acceptance
- separate final DB-write authorization is still required for any future raw write retry

## Findings
- checked_target_count=8
- identity_match_count=0
- identity_mismatch_count=8
- mismatch_type_counts=requested_vs_observed_external_id_mismatch: 8
- request_url_itself_wrong=false
- canonical_redirect_detected=false
- parser_extractor_wrong_indicated=false
- suspected_root_cause=manifest_target_identity_or_fotmob_detail_payload_mapping_mismatch
- next_required_step=target_identity_source_inventory_reconciliation_planning

## Validation
- make data-pageprops-v2-target-identity-reconciliation-plan ... (Phase 5.21L2V3D no-write run)
- docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js tests/unit/renewed_pageprops_v2_baseline_proposal_plan.test.js tests/unit/renewed_pageprops_v2_raw_write_execute.test.js tests/unit/post_seed_matches_identity_raw_write_readiness_audit.test.js tests/unit/controlled_matches_identity_seed_execute.test.js tests/unit/controlled_matches_identity_seed_prerequisite_plan.test.js tests/unit/single_league_pageprops_v2_controlled_write_execute.test.js tests/unit/single_league_pageprops_v2_controlled_write_plan.test.js tests/unit/single_league_small_batch_pageprops_v2_preflight.test.js tests/unit/FotMobRawDetailFetcher.test.js tests/unit/RawMatchDataVersionSelector.test.js tests/unit/pageprops_v2_no_write_preview.test.js
- docker compose -f docker-compose.dev.yml exec -T dev npm test
- docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage
- docker compose -f docker-compose.dev.yml exec -T dev npm run lint
- docker compose -f docker-compose.dev.yml exec -T dev npx eslint tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js
- docker compose -f docker-compose.dev.yml exec -T dev npx prettier --write scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3D.md
- git diff --check
- SELECT-only DB row count check: matches=60, raw_match_data=18, candidate fotmob_pageprops_v2 rows=0
