### PR TITLE
docs(data): reconcile pageProps v2 target source inventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1874,6 +1874,55 @@ data-pageprops-v2-target-identity-reconciliation-plan: ## Run Phase 5.21L2V3D no
 		--pr1277-merge-commit="$(or $(PR1277_MERGE_COMMIT),)" \
 		--pr1277-retarget-result="$(or $(PR1277_RETARGET_RESULT),)"
 
+data-pageprops-v2-target-source-inventory-reconciliation-plan: ## Run Phase 5.21L2V3E no-write target identity source inventory reconciliation planning. Writes docs only.
+	@if [ -z "$(MANIFEST)" ] || [ -z "$(SOURCE)" ] || [ -z "$(LEAGUE_ID)" ] || [ -z "$(LEAGUE_NAME)" ] || [ -z "$(SEASON)" ] || [ -z "$(RAW_VERSION)" ] || [ -z "$(HASH_STRATEGY)" ] || [ -z "$(BATCH_ID)" ] || [ -z "$(TARGET_COUNT)" ]; then \
+		echo "ERROR: provide MANIFEST=docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json SOURCE=fotmob LEAGUE_ID=53 LEAGUE_NAME='Ligue 1' SEASON=2025/2026 RAW_VERSION=fotmob_pageprops_v2 HASH_STRATEGY=stable_pageprops_payload_v1 BATCH_ID=fotmob-pageprops-v2-ligue1-2025-2026-profile-001 TARGET_COUNT=50"; \
+		exit 1; \
+	fi
+	$(COMPOSE_DEV) exec -T dev node scripts/ops/pageprops_v2_target_source_inventory_reconciliation_plan.js \
+		--manifest="$(MANIFEST)" \
+		--renewed-proposal="$(or $(RENEWED_PROPOSAL),docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.renewed_baseline_proposal.phase521l2v3c.json)" \
+		--report-output="$(or $(REPORT_OUTPUT),docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3E.md)" \
+		--source="$(SOURCE)" \
+		--league-id="$(LEAGUE_ID)" \
+		--league-name="$(LEAGUE_NAME)" \
+		--season="$(SEASON)" \
+		--raw-version="$(RAW_VERSION)" \
+		--hash-strategy="$(HASH_STRATEGY)" \
+		--batch-id="$(BATCH_ID)" \
+		--target-count="$(TARGET_COUNT)" \
+		--planning-authorization="$(or $(PLANNING_AUTHORIZATION),no)" \
+		--source-inventory-reconciliation-authorization="$(or $(SOURCE_INVENTORY_RECONCILIATION_AUTHORIZATION),no)" \
+		--network-authorization="$(or $(NETWORK_AUTHORIZATION),no)" \
+		--allow-db-write="$(or $(ALLOW_DB_WRITE),no)" \
+		--allow-raw-match-data-write="$(or $(ALLOW_RAW_MATCH_DATA_WRITE),no)" \
+		--allow-controlled-write="$(or $(ALLOW_CONTROLLED_WRITE),no)" \
+		--allow-matches-write="$(or $(ALLOW_MATCHES_WRITE),no)" \
+		--allow-bookmaker-odds-write="$(or $(ALLOW_BOOKMAKER_ODDS_WRITE),no)" \
+		--allow-feature-write="$(or $(ALLOW_FEATURE_WRITE),no)" \
+		--allow-schema-migration="$(or $(ALLOW_SCHEMA_MIGRATION),no)" \
+		--allow-parser-implementation="$(or $(ALLOW_PARSER_IMPLEMENTATION),no)" \
+		--allow-feature-extraction="$(or $(ALLOW_FEATURE_EXTRACTION),no)" \
+		--allow-training="$(or $(ALLOW_TRAINING),no)" \
+		--allow-prediction="$(or $(ALLOW_PREDICTION),no)" \
+		--allow-browser-runtime="$(or $(ALLOW_BROWSER_RUNTIME),no)" \
+		--allow-proxy-runtime="$(or $(ALLOW_PROXY_RUNTIME),no)" \
+		--print-full-body="$(or $(PRINT_FULL_BODY),no)" \
+		--save-full-body="$(or $(SAVE_FULL_BODY),no)" \
+		--print-full-json="$(or $(PRINT_FULL_JSON),no)" \
+		--save-full-json="$(or $(SAVE_FULL_JSON),no)" \
+		--print-full-pageprops="$(or $(PRINT_FULL_PAGEPROPS),no)" \
+		--save-full-pageprops="$(or $(SAVE_FULL_PAGEPROPS),no)" \
+		--retry="$(or $(RETRY),0)" \
+		--request-delay-ms="$(or $(REQUEST_DELAY_MS),0)" \
+		--target-external-ids="$(or $(TARGET_EXTERNAL_IDS),)" \
+		--base-head="$(or $(BASE_HEAD),)" \
+		--branch="$(or $(BRANCH),)" \
+		--main-head="$(or $(MAIN_HEAD),)" \
+		--main-ci-status="$(or $(MAIN_CI_STATUS),)" \
+		--pr1278-state="$(or $(PR1278_STATE),)" \
+		--pr1278-merge-commit="$(or $(PR1278_MERGE_COMMIT),)"
+
 data-training-dataset-dry-run: ## Run SELECT-only training dataset readiness audit. Does not train, export, or write DB.
 	$(COMPOSE_DEV) exec -T dev node scripts/ops/dataset_status_audit.js
 

--- a/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json
+++ b/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json
@@ -3994,7 +3994,7 @@
     "non_raw_tables_unchanged_status": "unchanged_after_blocked_no_transaction",
     "transaction_status": "not_started",
     "blockers": ["RECAPTURE_HASH_GATE_BLOCKED"],
-    "next_required_step": "target_identity_source_inventory_reconciliation_planning",
+    "next_required_step": "schedule_detail_identity_normalization_fix_planning",
     "phase_5_21_l2v3_execution_result": {
         "phase": "PHASE5_21L2V3_RENEWED_CONTROLLED_PAGEPROPS_V2_RAW_WRITE_EXECUTION",
         "generated_at": "2026-05-18T10:43:37.450Z",
@@ -4066,6 +4066,25 @@
     "phase_5_21_l2v3d_suspected_root_cause": "manifest_target_identity_or_fotmob_detail_payload_mapping_mismatch",
     "target_identity_mismatch_blocks_baseline_acceptance": true,
     "raw_write_ready_for_execution": false,
-    "raw_write_retry_authorization_status": "blocked_pending_target_identity_reconciliation",
-    "phase_5_21_l2v3d_deterministic_observed_identity_with_l2v3c": true
+    "raw_write_retry_authorization_status": "blocked_pending_target_identity_source_inventory_reconciliation",
+    "phase_5_21_l2v3d_deterministic_observed_identity_with_l2v3c": true,
+    "phase_5_21_l2v3e_planning_status": "completed_no_write",
+    "target_identity_source_inventory_reconciliation_status": "blocked_schedule_detail_identity_mismatch_identified",
+    "phase_5_21_l2v3e_checked_target_count": 8,
+    "phase_5_21_l2v3e_identity_match_count": 0,
+    "phase_5_21_l2v3e_identity_mismatch_count": 8,
+    "phase_5_21_l2v3e_source_inventory_vs_manifest_mismatch_count": 0,
+    "phase_5_21_l2v3e_manifest_vs_db_mismatch_count": 0,
+    "phase_5_21_l2v3e_db_vs_live_observed_mismatch_count": 8,
+    "phase_5_21_l2v3e_requested_vs_observed_external_id_mismatch_count": 8,
+    "phase_5_21_l2v3e_mismatch_stage_counts": {
+        "fetch_route": 8
+    },
+    "phase_5_21_l2v3e_shared_page_url_base_pair_count": 8,
+    "phase_5_21_l2v3e_all_pairs_share_page_url_base": true,
+    "phase_5_21_l2v3e_suspected_root_cause": "schedule_vs_detail_external_id_mismatch",
+    "phase_5_21_l2v3e_root_cause_confidence": "high",
+    "phase_5_21_l2v3e_recommended_next_step": "schedule_detail_identity_normalization_fix_planning",
+    "requires_separate_baseline_acceptance": true,
+    "requires_separate_final_db_write_authorization": true
 }

--- a/docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3E.md
+++ b/docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3E.md
@@ -1,0 +1,161 @@
+# Data Entrypoint Governance - Phase 5.21 L2V3E
+
+## A. Current Status
+
+- phase=target identity source inventory reconciliation planning
+- branch=data/pageprops-v2-source-inventory-reconciliation-phase521l2v3e
+- base_head=d2db9e9f9276a130de52bad724be3a7bc6566481
+- main_head=d2db9e9f9276a130de52bad724be3a7bc6566481
+- main_ci_status=success
+- source_manifest_path=docs/\_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json
+- renewed_baseline_proposal_path=docs/\_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.renewed_baseline_proposal.phase521l2v3c.json
+- report_path=docs/\_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3E.md
+
+## B. PR #1278 Merge Result
+
+- pr_1278_state=MERGED
+- pr_1278_merge_commit=d2db9e9f9276a130de52bad724be3a7bc6566481
+- merge_scope=L2V3D no-write target identity reconciliation planning
+
+## C. main HEAD / CI Status
+
+- main_head=d2db9e9f9276a130de52bad724be3a7bc6566481
+- main_ci_status=success
+
+## D. Authorization Scope
+
+- planning_authorized=true
+- source_inventory_reconciliation_authorized=true
+- network_authorized_for_source_inventory_only=true
+- no match detail recapture executed in L2V3E
+- no accepted baseline replacement
+- no raw write authorization
+
+## E. No-Write Guarantee
+
+- db_write_performed=false
+- raw_insert_performed=false
+- baseline_acceptance_performed=false
+- raw_write_retry_performed=false
+- full raw_data/pageProps/source body printed=false
+- full raw_data/pageProps/source body saved=false
+
+## F. L2V3D Identity Mismatch Recap
+
+- l2v3d_checked_target_count=8
+- l2v3d_identity_match_count=0
+- l2v3d_identity_mismatch_count=8
+- l2v3d_next_required_step=target_identity_source_inventory_reconciliation_planning
+- raw_write_ready_for_execution=false
+- target_identity_mismatch_blocks_baseline_acceptance=true
+
+## G. Source Inventory Provenance Review
+
+- source_inventory_route_used=source_inventory
+- source_inventory_request_url=https://www.fotmob.com/api/data/leagues?id=53&season=20252026
+- source_inventory_final_url=https://www.fotmob.com/api/data/leagues?id=53&season=20252026
+- source_inventory_http_status=200
+- source_inventory_parse_status=parsed_json
+- source_inventory_body_bytes=766953
+- selected_source_inventory_record_count=16
+- blocked_markers=none
+- shared_page_url_base_pair_count=8
+- all_pairs_share_page_url_base=true
+
+## H. Manifest Target Generation Review
+
+- candidate_targets_count=50
+- known_completed_targets_count=8
+- source_inventory_vs_manifest_mismatch_count=0
+- manifest generation preserved source inventory external_id/match identity for the 8 checked targets.
+
+## I. DB Matches Identity Review
+
+- matches_row_count=60
+- raw_match_data_row_count=18
+- candidate_fotmob_pageprops_v2_rows_count=0
+- manifest_vs_db_mismatch_count=0
+- db_vs_live_observed_mismatch_count=8
+
+## J. Requested vs Observed Reconciliation Table
+
+| requested_match_id  | requested_external_id | requested_teams             | requested_match_date     | requested_status | source_inventory_path       | source_inventory_record_key         | source_inventory_external_id | source_inventory_teams      | source_inventory_match_date | source_inventory_page_url_base                                       | manifest_record_external_id | DB external_id | live observed external_id | live observed teams         | live observed match_date | requested_vs_observed_identity_status | source_inventory_vs_manifest_status | manifest_vs_db_status | DB_vs_live_observed_status | shared_page_url_base_with_observed | suspected_mismatch_stage |
+| ------------------- | --------------------- | --------------------------- | ------------------------ | ---------------- | --------------------------- | ----------------------------------- | ---------------------------- | --------------------------- | --------------------------- | -------------------------------------------------------------------- | --------------------------- | -------------- | ------------------------- | --------------------------- | ------------------------ | ------------------------------------- | ----------------------------------- | --------------------- | -------------------------- | ---------------------------------- | ------------------------ |
+| 53_20252026_4830466 | 4830466               | Rennes-Marseille            | 2025-08-15T18:45:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830466 | 4830466                      | Rennes-Marseille            | 2025-08-15T18:45:00Z        | https://www.fotmob.com/matches/marseille-vs-rennes/2t9n7h            | 4830466                     | 4830466        | 4830759                   | Marseille-Rennes            | 2026-05-17T19:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+| 53_20252026_4830461 | 4830461               | Lens-Lyon                   | 2025-08-16T15:00:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830461 | 4830461                      | Lens-Lyon                   | 2025-08-16T15:00:00Z        | https://www.fotmob.com/matches/lens-vs-lyon/2s3gtg                   | 4830461                     | 4830461        | 4830758                   | Lyon-Lens                   | 2026-05-17T19:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+| 53_20252026_4830481 | 4830481               | Monaco-Strasbourg           | 2025-08-31T15:15:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830481 | 4830481                      | Monaco-Strasbourg           | 2025-08-31T15:15:00Z        | https://www.fotmob.com/matches/monaco-vs-strasbourg/379ruz           | 4830481                     | 4830481        | 4830763                   | Strasbourg-Monaco           | 2026-05-17T19:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+| 53_20252026_4830496 | 4830496               | Le Havre-Lorient            | 2025-09-21T15:15:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830496 | 4830496                      | Le Havre-Lorient            | 2025-09-21T15:15:00Z        | https://www.fotmob.com/matches/lorient-vs-le-havre/2t6haw            | 4830496                     | 4830496        | 4830757                   | Lorient-Le Havre            | 2026-05-17T19:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+| 53_20252026_4830511 | 4830511               | Toulouse-Nantes             | 2025-09-27T17:00:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830511 | 4830511                      | Toulouse-Nantes             | 2025-09-27T17:00:00Z        | https://www.fotmob.com/matches/nantes-vs-toulouse/38dikf             | 4830511                     | 4830511        | 4830760                   | Nantes-Toulouse             | 2026-05-17T19:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+| 53_20252026_4830463 | 4830463               | Monaco-Le Havre             | 2025-08-16T17:00:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830463 | 4830463                      | Monaco-Le Havre             | 2025-08-16T17:00:00Z        | https://www.fotmob.com/matches/le-havre-vs-monaco/362v61             | 4830463                     | 4830463        | 4830622                   | Le Havre-Monaco             | 2026-01-24T18:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+| 53_20252026_4830465 | 4830465               | Nice-Toulouse               | 2025-08-16T19:05:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830465 | 4830465                      | Nice-Toulouse               | 2025-08-16T19:05:00Z        | https://www.fotmob.com/matches/nice-vs-toulouse/38dxtn               | 4830465                     | 4830465        | 4830619                   | Toulouse-Nice               | 2026-01-17T18:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+| 53_20252026_4830508 | 4830508               | Paris Saint-Germain-Auxerre | 2025-09-27T19:05:00.000Z | finished         | overview.matches.allMatches | overview.matches.allMatches#4830508 | 4830508                      | Paris Saint-Germain-Auxerre | 2025-09-27T19:05:00Z        | https://www.fotmob.com/matches/auxerre-vs-paris-saint-germain/2t4i9k | 4830508                     | 4830508        | 4830620                   | Auxerre-Paris Saint-Germain | 2026-01-23T19:00:00.000Z | mismatch                              | match                               | match                 | mismatch                   | true                               | fetch_route              |
+
+## K. Mismatch Stage Classification
+
+- checked_target_count=8
+- identity_match_count=0
+- identity_mismatch_count=8
+- source_inventory_vs_manifest_mismatch_count=0
+- manifest_vs_db_mismatch_count=0
+- db_vs_live_observed_mismatch_count=8
+- requested_vs_observed_external_id_mismatch_count=8
+- fetch_route=8
+
+## L. Suspected Root Cause And Confidence
+
+- suspected_root_cause=schedule_vs_detail_external_id_mismatch
+- root_cause_confidence=high
+- primary_evidence=source inventory requested/observed pairs share the same pageUrl base and differ only by #external_id anchor
+
+## M. Required Fix / Continue Investigation Decision
+
+- code_fix_required=true
+- inventory_regeneration_required=false
+- manifest_regeneration_required=false
+- continue_investigation_required=false
+
+## N. DB Row Count Safety Result
+
+- matches=60
+- raw_match_data=18
+- bookmaker_odds_history=2
+- l3_features=2
+- match_features_training=2
+- predictions=2
+- candidate_v2_rows_count=0
+- expected_matches=60
+- expected_raw_match_data=18
+
+## O. Test Results
+
+- pending until local verification completes
+
+## P. PR Status
+
+- pending until PR is created
+
+## Q. Next Step Recommendation
+
+- recommended_next_step=schedule_detail_identity_normalization_fix_planning
+- unresolved identity/source inventory mismatch blocks baseline acceptance.
+- unresolved identity/source inventory mismatch blocks raw write retry.
+
+## R. Explicit Non-Execution
+
+- no DB writes
+- no raw_match_data inserts
+- no matches writes
+- no bookmaker_odds_history writes
+- no l3_features writes
+- no match_features_training writes
+- no predictions writes
+- no schema migration
+- no parser implementation
+- no feature extraction
+- no training/prediction
+- no browser/proxy/captcha bypass
+- no accepted baseline replacement
+- no raw write retry
+- no proposal hash marked as accepted baseline
+- no full raw_data/pageProps/source body print/save
+- no invented external_id, target, payload, or hash

--- a/scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js
+++ b/scripts/ops/pageprops_v2_target_identity_reconciliation_plan.js
@@ -1135,6 +1135,9 @@ module.exports = {
     EXPECTED_ROW_COUNTS,
     parseArgs,
     normalizeBooleanFlag,
+    readJsonFile,
+    writeJsonFile,
+    writeReportFile,
     validatePlanningInput,
     validateManifestGate,
     validateRenewedProposalGate,
@@ -1146,6 +1149,7 @@ module.exports = {
     buildSummary,
     buildUpdatedManifest,
     buildReport,
+    sleep,
     runPlanning,
     runCli,
 };

--- a/scripts/ops/pageprops_v2_target_source_inventory_reconciliation_plan.js
+++ b/scripts/ops/pageprops_v2_target_source_inventory_reconciliation_plan.js
@@ -1,0 +1,1302 @@
+#!/usr/bin/env node
+/* eslint-disable complexity, max-lines, max-statements */
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { Pool } = require('pg');
+
+const l2v3d = require('./pageprops_v2_target_identity_reconciliation_plan');
+const rawWrite = require('./renewed_pageprops_v2_raw_write_execute');
+const sourceInventory = require('./single_league_target_discovery_source_inventory_preflight');
+
+const PHASE = 'PHASE5_21L2V3E_TARGET_IDENTITY_SOURCE_INVENTORY_RECONCILIATION_PLANNING';
+const MANIFEST_PATH = l2v3d.MANIFEST_PATH;
+const RENEWED_PROPOSAL_PATH = l2v3d.RENEWED_PROPOSAL_PATH;
+const REPORT_PATH = 'docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3E.md';
+const SOURCE = l2v3d.SOURCE;
+const LEAGUE_ID = l2v3d.LEAGUE_ID;
+const LEAGUE_NAME = l2v3d.LEAGUE_NAME;
+const SEASON = l2v3d.SEASON;
+const RAW_VERSION = l2v3d.RAW_VERSION;
+const HASH_STRATEGY = l2v3d.HASH_STRATEGY;
+const BATCH_ID = l2v3d.BATCH_ID;
+const TARGET_COUNT = l2v3d.TARGET_COUNT;
+const EXPECTED_MISMATCH_COUNT = l2v3d.EXPECTED_MISMATCH_COUNT;
+const EXPECTED_ROW_COUNTS = l2v3d.EXPECTED_ROW_COUNTS;
+const SOURCE_ROUTE = 'source_inventory';
+const DEFAULT_REQUEST_DELAY_MS = 0;
+
+const REQUIRED_YES_FLAGS = Object.freeze([
+    'planningAuthorization',
+    'sourceInventoryReconciliationAuthorization',
+    'networkAuthorization',
+]);
+const REQUIRED_NO_FLAGS = Object.freeze([
+    'allowDbWrite',
+    'allowRawMatchDataWrite',
+    'allowControlledWrite',
+    'allowMatchesWrite',
+    'allowBookmakerOddsWrite',
+    'allowFeatureWrite',
+    'allowSchemaMigration',
+    'allowParserImplementation',
+    'allowFeatureExtraction',
+    'allowTraining',
+    'allowPrediction',
+    'allowBrowserRuntime',
+    'allowProxyRuntime',
+    'printFullBody',
+    'saveFullBody',
+    'printFullJson',
+    'saveFullJson',
+    'printFullPageprops',
+    'saveFullPageprops',
+]);
+const BLOCKED_TRUE_FLAGS = Object.freeze([
+    'allowOddsWrite',
+    'executeWrite',
+    'commit',
+    'finalDbWriteConfirmation',
+    'acceptBaseline',
+    'acceptedBaseline',
+    'baselineAcceptanceAuthorization',
+    'rawWriteReadyForExecution',
+    'rawWriteRetryAuthorization',
+]);
+const SOURCE_PATH_PRIORITY = Object.freeze([
+    'overview.matches.allMatches',
+    'fixtures.allMatches',
+    'overview.leagueOverviewMatches',
+]);
+const PROTECTED_TABLES = Object.freeze([
+    'matches',
+    'raw_match_data',
+    'bookmaker_odds_history',
+    'l3_features',
+    'match_features_training',
+    'predictions',
+]);
+const ALLOWED_MANIFEST_NEXT_STEPS = Object.freeze([
+    'target_identity_source_inventory_reconciliation_planning',
+    'schedule_detail_identity_normalization_fix_planning',
+    'source_inventory_manifest_regeneration_review',
+    'matches_identity_seed_reconciliation_review',
+    'target_identity_source_inventory_follow_up_investigation',
+]);
+const ALLOWED_RAW_WRITE_RETRY_AUTHORIZATION_STATUSES = Object.freeze([
+    'blocked_pending_target_identity_reconciliation',
+    'blocked_pending_target_identity_source_inventory_reconciliation',
+]);
+
+function normalizeText(value) {
+    return String(value ?? '').trim();
+}
+
+function normalizeLower(value) {
+    return normalizeText(value).toLowerCase();
+}
+
+function normalizeBooleanFlag(value, fallback = undefined) {
+    if (typeof value === 'boolean') return value;
+    if (value === null || value === undefined || value === '') return fallback;
+    const normalized = normalizeLower(value);
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+    return fallback;
+}
+
+function parseInteger(value, fallback = null) {
+    if (value === null || value === undefined || value === '') return fallback;
+    const normalized = normalizeText(value);
+    if (!/^\d+$/.test(normalized)) return Number.NaN;
+    return Number.parseInt(normalized, 10);
+}
+
+function parseCsv(value) {
+    return normalizeText(value)
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+}
+
+function toCamelKey(rawKey) {
+    return normalizeText(rawKey).replace(/[-_]([a-z0-9])/g, (_match, char) => char.toUpperCase());
+}
+
+function flagName(key) {
+    return key.replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) return { value: arg.slice(arg.indexOf('=') + 1), consumedNext: false };
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return { value: nextArg, consumedNext: true };
+    }
+    return { value: true, consumedNext: false };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        manifest: null,
+        renewedProposal: RENEWED_PROPOSAL_PATH,
+        reportOutput: REPORT_PATH,
+        source: null,
+        leagueId: null,
+        leagueName: null,
+        season: null,
+        rawVersion: null,
+        hashStrategy: null,
+        batchId: null,
+        targetCount: null,
+        planningAuthorization: null,
+        sourceInventoryReconciliationAuthorization: null,
+        networkAuthorization: null,
+        allowDbWrite: null,
+        allowRawMatchDataWrite: null,
+        allowControlledWrite: null,
+        allowMatchesWrite: null,
+        allowBookmakerOddsWrite: null,
+        allowFeatureWrite: null,
+        allowSchemaMigration: null,
+        allowParserImplementation: null,
+        allowFeatureExtraction: null,
+        allowTraining: null,
+        allowPrediction: null,
+        allowBrowserRuntime: null,
+        allowProxyRuntime: null,
+        printFullBody: null,
+        saveFullBody: null,
+        printFullJson: null,
+        saveFullJson: null,
+        printFullPageprops: null,
+        saveFullPageprops: null,
+        allowOddsWrite: false,
+        executeWrite: false,
+        commit: false,
+        finalDbWriteConfirmation: false,
+        acceptBaseline: false,
+        acceptedBaseline: false,
+        baselineAcceptanceAuthorization: false,
+        rawWriteReadyForExecution: false,
+        rawWriteRetryAuthorization: false,
+        retry: 0,
+        requestDelayMs: DEFAULT_REQUEST_DELAY_MS,
+        targetExternalIds: null,
+        generatedAt: null,
+        baseHead: null,
+        branch: null,
+        mainHead: null,
+        mainCiStatus: null,
+        pr1278State: null,
+        pr1278MergeCommit: null,
+        help: false,
+        unknown: [],
+    };
+    const knownKeys = new Set(Object.keys(options));
+    const booleanKeys = new Set([...REQUIRED_YES_FLAGS, ...REQUIRED_NO_FLAGS, ...BLOCKED_TRUE_FLAGS, 'help']);
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            options.unknown.push(arg);
+            continue;
+        }
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const key = toCamelKey(rawKey);
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) index += 1;
+        if (!knownKeys.has(key)) {
+            options.unknown.push(rawKey);
+            continue;
+        }
+        options[key] = booleanKeys.has(key) ? normalizeBooleanFlag(value, true) : value;
+    }
+    return options;
+}
+
+function normalizePlanningInput(input = {}) {
+    return {
+        manifest: normalizeText(input.manifest),
+        renewedProposal: normalizeText(input.renewedProposal) || RENEWED_PROPOSAL_PATH,
+        reportOutput: normalizeText(input.reportOutput) || REPORT_PATH,
+        source: normalizeLower(input.source),
+        leagueId: parseInteger(input.leagueId, null),
+        leagueName: normalizeText(input.leagueName),
+        season: normalizeText(input.season),
+        rawVersion: normalizeText(input.rawVersion),
+        hashStrategy: normalizeText(input.hashStrategy),
+        batchId: normalizeText(input.batchId),
+        targetCount: parseInteger(input.targetCount, null),
+        planningAuthorization: normalizeBooleanFlag(input.planningAuthorization, undefined),
+        sourceInventoryReconciliationAuthorization: normalizeBooleanFlag(
+            input.sourceInventoryReconciliationAuthorization,
+            undefined
+        ),
+        networkAuthorization: normalizeBooleanFlag(input.networkAuthorization, undefined),
+        allowDbWrite: normalizeBooleanFlag(input.allowDbWrite, undefined),
+        allowRawMatchDataWrite: normalizeBooleanFlag(input.allowRawMatchDataWrite, undefined),
+        allowControlledWrite: normalizeBooleanFlag(input.allowControlledWrite, undefined),
+        allowMatchesWrite: normalizeBooleanFlag(input.allowMatchesWrite, undefined),
+        allowBookmakerOddsWrite: normalizeBooleanFlag(input.allowBookmakerOddsWrite, undefined),
+        allowFeatureWrite: normalizeBooleanFlag(input.allowFeatureWrite, undefined),
+        allowSchemaMigration: normalizeBooleanFlag(input.allowSchemaMigration, undefined),
+        allowParserImplementation: normalizeBooleanFlag(input.allowParserImplementation, undefined),
+        allowFeatureExtraction: normalizeBooleanFlag(input.allowFeatureExtraction, undefined),
+        allowTraining: normalizeBooleanFlag(input.allowTraining, undefined),
+        allowPrediction: normalizeBooleanFlag(input.allowPrediction, undefined),
+        allowBrowserRuntime: normalizeBooleanFlag(input.allowBrowserRuntime, undefined),
+        allowProxyRuntime: normalizeBooleanFlag(input.allowProxyRuntime, undefined),
+        printFullBody: normalizeBooleanFlag(input.printFullBody, undefined),
+        saveFullBody: normalizeBooleanFlag(input.saveFullBody, undefined),
+        printFullJson: normalizeBooleanFlag(input.printFullJson, undefined),
+        saveFullJson: normalizeBooleanFlag(input.saveFullJson, undefined),
+        printFullPageprops: normalizeBooleanFlag(input.printFullPageprops, undefined),
+        saveFullPageprops: normalizeBooleanFlag(input.saveFullPageprops, undefined),
+        allowOddsWrite: normalizeBooleanFlag(input.allowOddsWrite, false),
+        executeWrite: normalizeBooleanFlag(input.executeWrite, false),
+        commit: normalizeBooleanFlag(input.commit, false),
+        finalDbWriteConfirmation: normalizeBooleanFlag(input.finalDbWriteConfirmation, false),
+        acceptBaseline: normalizeBooleanFlag(input.acceptBaseline, false),
+        acceptedBaseline: normalizeBooleanFlag(input.acceptedBaseline, false),
+        baselineAcceptanceAuthorization: normalizeBooleanFlag(input.baselineAcceptanceAuthorization, false),
+        rawWriteReadyForExecution: normalizeBooleanFlag(input.rawWriteReadyForExecution, false),
+        rawWriteRetryAuthorization: normalizeBooleanFlag(input.rawWriteRetryAuthorization, false),
+        retry: parseInteger(input.retry, 0),
+        requestDelayMs: parseInteger(input.requestDelayMs, DEFAULT_REQUEST_DELAY_MS),
+        targetExternalIds: Array.isArray(input.targetExternalIds)
+            ? input.targetExternalIds.map(normalizeText).filter(Boolean)
+            : parseCsv(input.targetExternalIds),
+        generatedAt: normalizeText(input.generatedAt),
+        baseHead: normalizeText(input.baseHead),
+        branch: normalizeText(input.branch),
+        mainHead: normalizeText(input.mainHead),
+        mainCiStatus: normalizeText(input.mainCiStatus),
+        pr1278State: normalizeText(input.pr1278State),
+        pr1278MergeCommit: normalizeText(input.pr1278MergeCommit),
+        unknown: Array.isArray(input.unknown) ? input.unknown : [],
+    };
+}
+
+function pushRequiredYes(errors, value, name) {
+    if (value === true) return;
+    errors.push(value === false ? `${name}=yes is required in Phase 5.21L2V3E` : `missing ${name}=yes`);
+}
+
+function pushRequiredNo(errors, value, name) {
+    if (value === false) return;
+    errors.push(value === true ? `${name}=yes is blocked in Phase 5.21L2V3E` : `missing ${name}=no`);
+}
+
+function requireExact(errors, actual, expected, name) {
+    if (!normalizeText(actual)) {
+        errors.push(`missing ${name}=${expected}`);
+        return;
+    }
+    if (normalizeText(actual) !== expected) errors.push(`${name} must be ${expected}`);
+}
+
+function validatePlanningInput(rawInput = {}) {
+    const input = normalizePlanningInput(rawInput);
+    const errors = [];
+    if (input.unknown.length > 0) errors.push(`unknown arguments: ${input.unknown.join(',')}`);
+    requireExact(errors, input.manifest, MANIFEST_PATH, 'manifest');
+    requireExact(errors, input.renewedProposal, RENEWED_PROPOSAL_PATH, 'renewed-proposal');
+    requireExact(errors, input.reportOutput, REPORT_PATH, 'report-output');
+    requireExact(errors, input.source, SOURCE, 'source');
+    if (input.leagueId !== LEAGUE_ID) errors.push(`league-id must be ${LEAGUE_ID}`);
+    requireExact(errors, input.leagueName, LEAGUE_NAME, 'league-name');
+    requireExact(errors, input.season, SEASON, 'season');
+    requireExact(errors, input.rawVersion, RAW_VERSION, 'raw-version');
+    requireExact(errors, input.hashStrategy, HASH_STRATEGY, 'hash-strategy');
+    requireExact(errors, input.batchId, BATCH_ID, 'batch-id');
+    if (input.targetCount !== TARGET_COUNT) errors.push(`target-count must be ${TARGET_COUNT}`);
+    for (const key of REQUIRED_YES_FLAGS) pushRequiredYes(errors, input[key], flagName(key));
+    for (const key of REQUIRED_NO_FLAGS) pushRequiredNo(errors, input[key], flagName(key));
+    for (const key of BLOCKED_TRUE_FLAGS) {
+        if (input[key] === true) errors.push(`${flagName(key)}=yes is blocked in Phase 5.21L2V3E`);
+    }
+    if (input.retry !== 0) errors.push('retry must be 0');
+    if (!Number.isInteger(input.requestDelayMs) || input.requestDelayMs < 0) {
+        errors.push('request-delay-ms must be a non-negative integer');
+    }
+    return { ok: errors.length === 0, input, errors };
+}
+
+function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJsonFile(filePath, data) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 4)}\n`);
+}
+
+function writeReportFile(filePath, content) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+}
+
+function buildManifestGate(manifest = {}) {
+    const baseGate = l2v3d.validateManifestGate(manifest);
+    const errors = baseGate.errors.filter(
+        error => !error.startsWith('next_required_step must be target identity reconciliation planning')
+    );
+    if (!ALLOWED_MANIFEST_NEXT_STEPS.includes(normalizeText(manifest.next_required_step))) {
+        errors.push(
+            'manifest next_required_step must be target_identity_source_inventory_reconciliation_planning or an allowed L2V3E follow-up outcome'
+        );
+    }
+    if (normalizeText(manifest.phase_5_21_l2v3d_planning_status) !== 'completed_no_write') {
+        errors.push('manifest phase_5_21_l2v3d_planning_status must be completed_no_write');
+    }
+    if (Number(manifest.phase_5_21_l2v3d_identity_mismatch_count || 0) !== EXPECTED_MISMATCH_COUNT) {
+        errors.push(`manifest phase_5_21_l2v3d_identity_mismatch_count must be ${EXPECTED_MISMATCH_COUNT}`);
+    }
+    if (manifest.target_identity_mismatch_blocks_baseline_acceptance !== true) {
+        errors.push('manifest target_identity_mismatch_blocks_baseline_acceptance must be true');
+    }
+    if (manifest.raw_write_ready_for_execution !== false) {
+        errors.push('manifest raw_write_ready_for_execution must be false');
+    }
+    if (
+        !ALLOWED_RAW_WRITE_RETRY_AUTHORIZATION_STATUSES.includes(
+            normalizeText(manifest.raw_write_retry_authorization_status)
+        )
+    ) {
+        errors.push(
+            'manifest raw_write_retry_authorization_status must be blocked_pending_target_identity_reconciliation or blocked_pending_target_identity_source_inventory_reconciliation'
+        );
+    }
+    if (manifest.phase_5_21_l2v3d_manifest_target_metadata_mismatch_indicated !== true) {
+        errors.push('manifest phase_5_21_l2v3d_manifest_target_metadata_mismatch_indicated must be true');
+    }
+    return { ...baseGate, ok: errors.length === 0, errors };
+}
+
+function buildProposalGate(proposal = {}) {
+    return l2v3d.validateRenewedProposalGate(proposal);
+}
+
+function sourcePathRank(value) {
+    const text = normalizeText(value);
+    const index = SOURCE_PATH_PRIORITY.findIndex(prefix => text.startsWith(prefix));
+    return index >= 0 ? index : SOURCE_PATH_PRIORITY.length + 1;
+}
+
+function resolveSideName(value) {
+    if (!value) return null;
+    if (typeof value === 'string') return normalizeText(value) || null;
+    return normalizeText(value.name || value.shortName || value.longName) || null;
+}
+
+function resolveMatchDate(match = {}) {
+    return normalizeText(
+        match.status?.utcTime || match.matchTime || match.time?.utc || match.date || match.kickoff?.datetime
+    );
+}
+
+function resolveStatus(match = {}) {
+    const rawStatus = match.status;
+    if (typeof rawStatus === 'string') return normalizeLower(rawStatus);
+    if (rawStatus?.finished || rawStatus?.completed || match.finished || match.isFinished) return 'finished';
+    if (rawStatus?.live || rawStatus?.started || match.isLive || match.live) return 'live';
+    if (rawStatus?.cancelled || rawStatus?.postponed || match.cancelled) return 'cancelled';
+    if (rawStatus?.scheduled || rawStatus?.upcoming || match.scheduled || match.notStarted) return 'scheduled';
+    return '';
+}
+
+function safeUrlSummary(rawUrl) {
+    const value = normalizeText(rawUrl);
+    if (!value) return null;
+    try {
+        const url = new URL(value, 'https://www.fotmob.com');
+        return `${url.origin}${url.pathname}${url.search || ''}${url.hash || ''}`;
+    } catch (_error) {
+        return value.slice(0, 200);
+    }
+}
+
+function pageUrlBase(rawUrl) {
+    const value = normalizeText(rawUrl);
+    if (!value) return null;
+    const index = value.indexOf('#');
+    return index >= 0 ? value.slice(0, index) : value;
+}
+
+function pageUrlAnchor(rawUrl) {
+    const value = normalizeText(rawUrl);
+    if (!value || !value.includes('#')) return null;
+    return value.slice(value.indexOf('#') + 1) || null;
+}
+
+function pickIdLikeFields(match = {}) {
+    const summary = {};
+    for (const key of Object.keys(match)) {
+        if (/(^id$|Id$|_id$|matchId|match_id|pageUrl|url$|slug)/.test(key)) {
+            const value = match[key];
+            summary[key] = typeof value === 'object' ? '[object]' : value;
+        }
+    }
+    return summary;
+}
+
+function normalizeSourceInventoryRecord(entry = {}) {
+    const match = entry.match || {};
+    const externalId = normalizeText(match.id ?? match.matchId ?? match.match_id);
+    return {
+        source_path: normalizeText(entry.sourcePath),
+        source_inventory_record_key: `${normalizeText(entry.sourcePath)}#${externalId}`,
+        external_id: externalId || null,
+        home_team: resolveSideName(match.home ?? match.homeTeam ?? match.home_team),
+        away_team: resolveSideName(match.away ?? match.awayTeam ?? match.away_team),
+        match_date: resolveMatchDate(match) || null,
+        status: resolveStatus(match) || null,
+        round: normalizeText(match.round || match.roundName) || null,
+        page_url: normalizeText(match.pageUrl || match.pageURL || match.url) || null,
+        page_url_base: pageUrlBase(match.pageUrl || match.pageURL || match.url),
+        page_url_anchor: pageUrlAnchor(match.pageUrl || match.pageURL || match.url),
+        id_like_fields: pickIdLikeFields(match),
+        top_level_keys: Object.keys(match).sort(),
+    };
+}
+
+function choosePreferredSourceInventoryRecord(a, b) {
+    if (!a) return b;
+    if (!b) return a;
+    const rankA = sourcePathRank(a.source_path);
+    const rankB = sourcePathRank(b.source_path);
+    if (rankA !== rankB) return rankA < rankB ? a : b;
+    if ((a.top_level_keys?.length || 0) !== (b.top_level_keys?.length || 0)) {
+        return (a.top_level_keys?.length || 0) > (b.top_level_keys?.length || 0) ? a : b;
+    }
+    return normalizeText(a.source_path) <= normalizeText(b.source_path) ? a : b;
+}
+
+async function fetchSourceInventoryPayload(input = {}, dependencies = {}) {
+    if (dependencies.sourceInventoryJson) {
+        const generatedUrl =
+            dependencies.sourceInventoryUrl ||
+            sourceInventory.buildSourceInventoryUrl({
+                source: input.source,
+                leagueId: input.leagueId,
+                season: input.season,
+            });
+        return {
+            ok: true,
+            request_url: generatedUrl,
+            final_url: generatedUrl,
+            http_status: 200,
+            body_bytes: null,
+            parse_status: 'injected_json',
+            blocked_markers: [],
+            json: dependencies.sourceInventoryJson,
+        };
+    }
+    const requestUrl =
+        dependencies.sourceInventoryUrl ||
+        sourceInventory.buildSourceInventoryUrl({
+            source: input.source,
+            leagueId: input.leagueId,
+            season: input.season,
+        });
+    const fetchFn = dependencies.fetchFn || globalThis.fetch;
+    if (typeof fetchFn !== 'function') {
+        return {
+            ok: false,
+            request_url: requestUrl,
+            final_url: requestUrl,
+            http_status: 0,
+            body_bytes: 0,
+            parse_status: 'fetch_dependency_missing',
+            blocked_markers: [],
+            error: 'FETCH_DEPENDENCY_MISSING',
+        };
+    }
+
+    let response;
+    try {
+        response = await fetchFn(requestUrl, {
+            method: 'GET',
+            headers: {
+                accept: 'application/json',
+                'accept-language': 'en-US,en;q=0.9',
+                'accept-encoding': 'identity',
+                'user-agent':
+                    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+            },
+            redirect: 'follow',
+        });
+    } catch (error) {
+        return {
+            ok: false,
+            request_url: requestUrl,
+            final_url: requestUrl,
+            http_status: 0,
+            body_bytes: 0,
+            parse_status: 'fetch_error',
+            blocked_markers: [],
+            error: `FETCH_ERROR:${error.message}`,
+        };
+    }
+
+    let body = '';
+    try {
+        body = await response.text();
+    } catch (error) {
+        return {
+            ok: false,
+            request_url: requestUrl,
+            final_url: response.url || requestUrl,
+            http_status: Number(response.status || 0),
+            body_bytes: 0,
+            parse_status: 'body_read_error',
+            blocked_markers: [],
+            error: `BODY_READ_ERROR:${error.message}`,
+        };
+    }
+
+    const blockedMarkers = sourceInventory.detectBlockedMarkers(body);
+    if (blockedMarkers.length > 0) {
+        return {
+            ok: false,
+            request_url: requestUrl,
+            final_url: response.url || requestUrl,
+            http_status: Number(response.status || 0),
+            body_bytes: Buffer.byteLength(body, 'utf8'),
+            parse_status: 'blocked_markers_detected',
+            blocked_markers: blockedMarkers,
+            error: `BLOCKED:${blockedMarkers.join(',')}`,
+        };
+    }
+
+    let json;
+    try {
+        json = JSON.parse(body);
+    } catch (error) {
+        return {
+            ok: false,
+            request_url: requestUrl,
+            final_url: response.url || requestUrl,
+            http_status: Number(response.status || 0),
+            body_bytes: Buffer.byteLength(body, 'utf8'),
+            parse_status: 'json_parse_failed',
+            blocked_markers: [],
+            error: `JSON_PARSE_ERROR:${error.message}`,
+        };
+    }
+
+    return {
+        ok: Number(response.status || 0) === 200,
+        request_url: requestUrl,
+        final_url: response.url || requestUrl,
+        http_status: Number(response.status || 0),
+        body_bytes: Buffer.byteLength(body, 'utf8'),
+        parse_status: 'parsed_json',
+        blocked_markers: [],
+        json,
+    };
+}
+
+function buildSourceInventorySelection(payload = {}, requestedExternalIds = [], observedExternalIds = []) {
+    const targetIds = new Set([...requestedExternalIds, ...observedExternalIds].map(normalizeText).filter(Boolean));
+    const rawEntries = sourceInventory.extractSourceInventoryMatches(payload.json || {});
+    const selectedByExternalId = new Map();
+    let duplicateSelections = 0;
+
+    for (const entry of rawEntries) {
+        const summary = normalizeSourceInventoryRecord(entry);
+        if (!summary.external_id || !targetIds.has(summary.external_id)) continue;
+        const previous = selectedByExternalId.get(summary.external_id);
+        const chosen = choosePreferredSourceInventoryRecord(previous, summary);
+        if (previous && chosen !== previous) duplicateSelections += 1;
+        if (previous && chosen === previous) duplicateSelections += 1;
+        selectedByExternalId.set(summary.external_id, chosen);
+    }
+
+    return {
+        request_url: payload.request_url,
+        final_url: payload.final_url,
+        http_status: payload.http_status,
+        body_bytes: payload.body_bytes,
+        parse_status: payload.parse_status,
+        blocked_markers: payload.blocked_markers || [],
+        selected_count: selectedByExternalId.size,
+        duplicate_selection_events: duplicateSelections,
+        selected_by_external_id: selectedByExternalId,
+    };
+}
+
+async function queryReadOnlyDbSnapshot(requestedMatchIds = [], observedExternalIds = [], dependencies = {}) {
+    if (dependencies.dbSnapshot) return dependencies.dbSnapshot;
+    const pool =
+        dependencies.pool ||
+        new Pool({
+            host: process.env.DB_HOST || 'db',
+            port: Number(process.env.DB_PORT || 5432),
+            database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+            user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+            password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        });
+    const shouldEndPool = !dependencies.pool;
+    try {
+        const counts = await pool.query(`
+            SELECT 'matches' AS table_name, COUNT(*)::int AS rows FROM matches
+            UNION ALL
+            SELECT 'raw_match_data', COUNT(*)::int FROM raw_match_data
+            UNION ALL
+            SELECT 'bookmaker_odds_history', COUNT(*)::int FROM bookmaker_odds_history
+            UNION ALL
+            SELECT 'l3_features', COUNT(*)::int FROM l3_features
+            UNION ALL
+            SELECT 'match_features_training', COUNT(*)::int FROM match_features_training
+            UNION ALL
+            SELECT 'predictions', COUNT(*)::int FROM predictions
+        `);
+        const targetRows = await pool.query(
+            `
+            SELECT match_id, external_id, league_name, season, home_team, away_team, match_date, status, data_source, pipeline_status
+            FROM matches
+            WHERE match_id = ANY($1::text[]) OR external_id = ANY($2::text[])
+            ORDER BY match_id
+            `,
+            [requestedMatchIds, observedExternalIds]
+        );
+        const candidateV2Rows = await pool.query(
+            `
+            SELECT COUNT(*)::int AS rows
+            FROM raw_match_data
+            WHERE data_version = 'fotmob_pageprops_v2'
+              AND match_id = ANY($1::text[])
+            `,
+            [requestedMatchIds]
+        );
+        return {
+            row_counts: Object.fromEntries(
+                PROTECTED_TABLES.map(table => [
+                    table,
+                    Number(counts.rows.find(row => normalizeText(row.table_name) === table)?.rows || 0),
+                ])
+            ),
+            target_rows: targetRows.rows,
+            candidate_v2_rows_count: Number(candidateV2Rows.rows[0]?.rows || 0),
+        };
+    } finally {
+        if (shouldEndPool) {
+            await pool.end();
+        }
+    }
+}
+
+function normalizeComparableDate(value) {
+    const text = normalizeText(value);
+    if (!text) return '';
+    const date = new Date(text);
+    if (Number.isNaN(date.getTime())) return text;
+    return date.toISOString();
+}
+
+function normalizeTeam(value) {
+    const normalized = normalizeLower(value).replace(/[^a-z0-9]/g, '');
+    if (normalized === 'psg') return 'parissaintgermain';
+    return normalized;
+}
+
+function sameIdentityRecord(left = {}, right = {}) {
+    if (!left || !right) return false;
+    return (
+        normalizeText(left.external_id) === normalizeText(right.external_id) &&
+        normalizeTeam(left.home_team) === normalizeTeam(right.home_team) &&
+        normalizeTeam(left.away_team) === normalizeTeam(right.away_team) &&
+        normalizeComparableDate(left.match_date || left.kickoff_time || left.match_time_utc) ===
+            normalizeComparableDate(right.match_date || right.kickoff_time || right.match_time_utc) &&
+        normalizeLower(left.status) === normalizeLower(right.status)
+    );
+}
+
+function compareSourceInventoryVsManifest(sourceRecord, manifestTarget) {
+    if (!sourceRecord) return 'missing_source_inventory_record';
+    return sameIdentityRecord(sourceRecord, manifestTarget) ? 'match' : 'mismatch';
+}
+
+function compareManifestVsDb(manifestTarget, dbRow) {
+    if (!dbRow) return 'missing_db_row';
+    return sameIdentityRecord(manifestTarget, dbRow) ? 'match' : 'mismatch';
+}
+
+function compareDbVsObserved(dbRow, observed) {
+    if (!observed?.external_id) return 'missing_live_observed';
+    if (!dbRow) return 'missing_db_row';
+    return sameIdentityRecord(dbRow, observed) ? 'match' : 'mismatch';
+}
+
+function summarizeObservedIdentity(proposalTarget = {}) {
+    const observed = proposalTarget.attempts?.[0]?.metadata_identity_observed || {};
+    return {
+        external_id: normalizeText(observed.external_id) || null,
+        home_team: normalizeText(observed.home_team) || null,
+        away_team: normalizeText(observed.away_team) || null,
+        match_time_utc: normalizeText(observed.match_time_utc) || null,
+        status: normalizeText(observed.status) || null,
+    };
+}
+
+function detectMismatchStage(item = {}) {
+    if (item.source_inventory_vs_manifest_status !== 'match') return 'source_inventory_generation';
+    if (item.manifest_vs_db_status !== 'match') return 'DB_seed';
+    if (item.requested_vs_observed_identity_status !== 'match' && item.shared_page_url_base_with_observed === true) {
+        return 'fetch_route';
+    }
+    if (item.requested_vs_observed_identity_status !== 'match' && item.observed_source_inventory_found === true) {
+        return 'FotMob_live_mapping';
+    }
+    if (item.requested_vs_observed_identity_status !== 'match') return 'unknown';
+    return 'matched';
+}
+
+function buildTargetReconciliationItem(target = {}, proposalTarget = {}, sourceByExternalId = new Map(), dbRows = []) {
+    const observed = summarizeObservedIdentity(proposalTarget);
+    const requestedSourceRecord = sourceByExternalId.get(normalizeText(target.external_id)) || null;
+    const observedSourceRecord = sourceByExternalId.get(normalizeText(observed.external_id)) || null;
+    const dbRow = (Array.isArray(dbRows) ? dbRows : []).find(
+        row => normalizeText(row.match_id) === normalizeText(target.match_id)
+    );
+    const sharedPageUrlBase =
+        Boolean(requestedSourceRecord?.page_url_base) &&
+        requestedSourceRecord.page_url_base === normalizeText(observedSourceRecord?.page_url_base);
+    const item = {
+        requested_match_id: normalizeText(target.match_id),
+        requested_external_id: normalizeText(target.external_id),
+        requested_league: LEAGUE_NAME,
+        requested_season: SEASON,
+        requested_home_team: normalizeText(target.home_team),
+        requested_away_team: normalizeText(target.away_team),
+        requested_match_date: normalizeText(target.match_date || target.kickoff_time),
+        requested_status: normalizeLower(target.status),
+        source_inventory_path: requestedSourceRecord?.source_path || null,
+        source_inventory_record_key: requestedSourceRecord?.source_inventory_record_key || null,
+        source_inventory_external_id: requestedSourceRecord?.external_id || null,
+        source_inventory_home_team: requestedSourceRecord?.home_team || null,
+        source_inventory_away_team: requestedSourceRecord?.away_team || null,
+        source_inventory_match_date: requestedSourceRecord?.match_date || null,
+        source_inventory_status: requestedSourceRecord?.status || null,
+        source_inventory_round: requestedSourceRecord?.round || null,
+        source_inventory_page_url_summary: safeUrlSummary(requestedSourceRecord?.page_url),
+        source_inventory_page_url_base: safeUrlSummary(requestedSourceRecord?.page_url_base),
+        source_inventory_page_url_anchor: requestedSourceRecord?.page_url_anchor || null,
+        source_inventory_id_like_fields: requestedSourceRecord?.id_like_fields || {},
+        manifest_record_external_id: normalizeText(target.external_id),
+        db_match_id: normalizeText(dbRow?.match_id),
+        db_external_id: normalizeText(dbRow?.external_id),
+        db_home_team: normalizeText(dbRow?.home_team),
+        db_away_team: normalizeText(dbRow?.away_team),
+        db_match_date: normalizeComparableDate(dbRow?.match_date),
+        db_status: normalizeLower(dbRow?.status),
+        db_pipeline_status: normalizeText(dbRow?.pipeline_status),
+        live_observed_external_id: observed.external_id,
+        live_observed_home_team: observed.home_team,
+        live_observed_away_team: observed.away_team,
+        live_observed_match_date: normalizeComparableDate(observed.match_time_utc),
+        live_observed_status: normalizeLower(observed.status),
+        observed_source_inventory_found: Boolean(observedSourceRecord),
+        observed_source_inventory_path: observedSourceRecord?.source_path || null,
+        observed_source_inventory_round: observedSourceRecord?.round || null,
+        observed_source_inventory_page_url_summary: safeUrlSummary(observedSourceRecord?.page_url),
+        observed_source_inventory_page_url_base: safeUrlSummary(observedSourceRecord?.page_url_base),
+        observed_source_inventory_page_url_anchor: observedSourceRecord?.page_url_anchor || null,
+        shared_page_url_base_with_observed: sharedPageUrlBase,
+    };
+    item.requested_vs_observed_identity_status =
+        item.requested_external_id === item.live_observed_external_id ? 'match' : 'mismatch';
+    item.source_inventory_vs_manifest_status = compareSourceInventoryVsManifest(requestedSourceRecord, target);
+    item.manifest_vs_db_status = compareManifestVsDb(target, dbRow);
+    item.db_vs_live_observed_status = compareDbVsObserved(dbRow, observed);
+    item.suspected_mismatch_stage = detectMismatchStage(item);
+    return item;
+}
+
+function countBy(values = []) {
+    return values.reduce((acc, value) => {
+        const key = normalizeText(value) || 'unknown';
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+    }, {});
+}
+
+function inferRootCause(summary = {}, items = []) {
+    const allObservedFound = items.length > 0 && items.every(item => item.observed_source_inventory_found === true);
+    const allSharedPageUrl = items.length > 0 && items.every(item => item.shared_page_url_base_with_observed === true);
+    const allStageFetchRoute = items.length > 0 && items.every(item => item.suspected_mismatch_stage === 'fetch_route');
+    if (
+        summary.source_inventory_vs_manifest_mismatch_count === 0 &&
+        summary.manifest_vs_db_mismatch_count === 0 &&
+        summary.requested_vs_observed_external_id_mismatch_count === items.length &&
+        allObservedFound &&
+        allSharedPageUrl &&
+        allStageFetchRoute
+    ) {
+        return {
+            suspected_root_cause: 'schedule_vs_detail_external_id_mismatch',
+            root_cause_confidence: 'high',
+            recommended_next_step: 'schedule_detail_identity_normalization_fix_planning',
+        };
+    }
+    if (summary.source_inventory_vs_manifest_mismatch_count > 0) {
+        return {
+            suspected_root_cause: 'manifest_generation_mapping_wrong',
+            root_cause_confidence: 'medium',
+            recommended_next_step: 'source_inventory_manifest_regeneration_review',
+        };
+    }
+    if (summary.manifest_vs_db_mismatch_count > 0) {
+        return {
+            suspected_root_cause: 'DB_seed_identity_wrong',
+            root_cause_confidence: 'medium',
+            recommended_next_step: 'matches_identity_seed_reconciliation_review',
+        };
+    }
+    if (summary.db_vs_live_observed_mismatch_count > 0 && allObservedFound) {
+        return {
+            suspected_root_cause: 'FotMob_live_detail_mapping_changed',
+            root_cause_confidence: 'low',
+            recommended_next_step: 'target_identity_source_inventory_follow_up_investigation',
+        };
+    }
+    return {
+        suspected_root_cause: 'unresolved_unknown',
+        root_cause_confidence: 'unknown',
+        recommended_next_step: 'target_identity_source_inventory_follow_up_investigation',
+    };
+}
+
+function buildSummary({
+    items = [],
+    input = {},
+    manifestGate = {},
+    proposalGate = {},
+    sourceInventorySelection = {},
+    dbSnapshot = {},
+    generatedAt,
+} = {}) {
+    const requestedVsObservedMismatchCount = items.filter(
+        item => item.requested_vs_observed_identity_status !== 'match'
+    ).length;
+    const sourceInventoryVsManifestMismatchCount = items.filter(
+        item => item.source_inventory_vs_manifest_status !== 'match'
+    ).length;
+    const manifestVsDbMismatchCount = items.filter(item => item.manifest_vs_db_status !== 'match').length;
+    const dbVsLiveObservedMismatchCount = items.filter(item => item.db_vs_live_observed_status !== 'match').length;
+    const sharedPageUrlBasePairCount = items.filter(item => item.shared_page_url_base_with_observed === true).length;
+    const mismatchStageCounts = countBy(
+        items.filter(item => item.suspected_mismatch_stage !== 'matched').map(item => item.suspected_mismatch_stage)
+    );
+    const baseSummary = {
+        phase: PHASE,
+        generated_at: generatedAt,
+        source_manifest_path: input.manifest,
+        renewed_baseline_proposal_path: input.renewedProposal,
+        report_path: input.reportOutput,
+        branch: input.branch || null,
+        base_head: input.baseHead || null,
+        main_head: input.mainHead || null,
+        main_ci_status: input.mainCiStatus || null,
+        pr_1278_state: input.pr1278State || null,
+        pr_1278_merge_commit: input.pr1278MergeCommit || null,
+        no_write: true,
+        db_write_performed: false,
+        raw_insert_performed: false,
+        baseline_acceptance_performed: false,
+        raw_write_retry_performed: false,
+        source_inventory_route_used: SOURCE_ROUTE,
+        source_inventory_request_url: safeUrlSummary(sourceInventorySelection.request_url),
+        source_inventory_final_url: safeUrlSummary(sourceInventorySelection.final_url),
+        source_inventory_http_status: sourceInventorySelection.http_status || 0,
+        source_inventory_parse_status: sourceInventorySelection.parse_status || 'unknown',
+        source_inventory_body_bytes: Number(sourceInventorySelection.body_bytes || 0),
+        source_inventory_blocked_markers: sourceInventorySelection.blocked_markers || [],
+        selected_source_inventory_record_count: sourceInventorySelection.selected_count || 0,
+        candidate_targets_count: manifestGate.candidate_targets_count || 0,
+        proposal_checked_targets_count: proposalGate.checkedTargets?.length || 0,
+        checked_target_count: items.length,
+        identity_match_count: items.length - requestedVsObservedMismatchCount,
+        identity_mismatch_count: requestedVsObservedMismatchCount,
+        source_inventory_vs_manifest_mismatch_count: sourceInventoryVsManifestMismatchCount,
+        manifest_vs_db_mismatch_count: manifestVsDbMismatchCount,
+        db_vs_live_observed_mismatch_count: dbVsLiveObservedMismatchCount,
+        requested_vs_observed_external_id_mismatch_count: requestedVsObservedMismatchCount,
+        mismatch_stage_counts: mismatchStageCounts,
+        shared_page_url_base_pair_count: sharedPageUrlBasePairCount,
+        all_pairs_share_page_url_base: items.length > 0 && sharedPageUrlBasePairCount === items.length,
+        raw_write_ready_for_execution: false,
+        target_identity_mismatch_blocks_baseline_acceptance: true,
+        requires_separate_baseline_acceptance: true,
+        requires_separate_final_db_write_authorization: true,
+        db_row_counts: dbSnapshot.row_counts || {},
+        candidate_v2_rows_count: Number(dbSnapshot.candidate_v2_rows_count || 0),
+    };
+    return { ...baseSummary, ...inferRootCause(baseSummary, items) };
+}
+
+function buildUpdatedManifest(manifest = {}, summary = {}) {
+    return {
+        ...manifest,
+        phase_5_21_l2v3e_planning_status: 'completed_no_write',
+        target_identity_source_inventory_reconciliation_status:
+            summary.suspected_root_cause === 'schedule_vs_detail_external_id_mismatch'
+                ? 'blocked_schedule_detail_identity_mismatch_identified'
+                : 'blocked_source_inventory_reconciliation_unresolved',
+        phase_5_21_l2v3e_checked_target_count: summary.checked_target_count,
+        phase_5_21_l2v3e_identity_match_count: summary.identity_match_count,
+        phase_5_21_l2v3e_identity_mismatch_count: summary.identity_mismatch_count,
+        phase_5_21_l2v3e_source_inventory_vs_manifest_mismatch_count:
+            summary.source_inventory_vs_manifest_mismatch_count,
+        phase_5_21_l2v3e_manifest_vs_db_mismatch_count: summary.manifest_vs_db_mismatch_count,
+        phase_5_21_l2v3e_db_vs_live_observed_mismatch_count: summary.db_vs_live_observed_mismatch_count,
+        phase_5_21_l2v3e_requested_vs_observed_external_id_mismatch_count:
+            summary.requested_vs_observed_external_id_mismatch_count,
+        phase_5_21_l2v3e_mismatch_stage_counts: summary.mismatch_stage_counts,
+        phase_5_21_l2v3e_shared_page_url_base_pair_count: summary.shared_page_url_base_pair_count,
+        phase_5_21_l2v3e_all_pairs_share_page_url_base: summary.all_pairs_share_page_url_base,
+        phase_5_21_l2v3e_suspected_root_cause: summary.suspected_root_cause,
+        phase_5_21_l2v3e_root_cause_confidence: summary.root_cause_confidence,
+        phase_5_21_l2v3e_recommended_next_step: summary.recommended_next_step,
+        target_identity_mismatch_blocks_baseline_acceptance: true,
+        renewed_baseline_requires_separate_baseline_acceptance: true,
+        renewed_baseline_requires_separate_final_db_write_authorization: true,
+        requires_separate_baseline_acceptance: true,
+        requires_separate_final_db_write_authorization: true,
+        raw_write_ready_for_execution: false,
+        raw_write_retry_authorization_status: 'blocked_pending_target_identity_source_inventory_reconciliation',
+        next_required_step: summary.recommended_next_step,
+    };
+}
+
+function buildReconciliationRows(items = []) {
+    return items.map(
+        item =>
+            `| ${item.requested_match_id} | ${item.requested_external_id} | ${item.requested_home_team}-${item.requested_away_team} | ${item.requested_match_date} | ${item.requested_status} | ${item.source_inventory_path || ''} | ${item.source_inventory_record_key || ''} | ${item.source_inventory_external_id || ''} | ${item.source_inventory_home_team || ''}-${item.source_inventory_away_team || ''} | ${item.source_inventory_match_date || ''} | ${item.source_inventory_page_url_base || ''} | ${item.manifest_record_external_id || ''} | ${item.db_external_id || ''} | ${item.live_observed_external_id || ''} | ${item.live_observed_home_team || ''}-${item.live_observed_away_team || ''} | ${item.live_observed_match_date || ''} | ${item.requested_vs_observed_identity_status} | ${item.source_inventory_vs_manifest_status} | ${item.manifest_vs_db_status} | ${item.db_vs_live_observed_status} | ${item.shared_page_url_base_with_observed} | ${item.suspected_mismatch_stage} |`
+    );
+}
+
+function buildStageLines(summary = {}) {
+    return Object.entries(summary.mismatch_stage_counts || {}).map(([key, count]) => `- ${key}=${count}`);
+}
+
+function buildReport({ summary = {}, items = [], manifestGate = {}, sourceInventorySelection = {} } = {}) {
+    const rows = buildReconciliationRows(items);
+    const stageLines = buildStageLines(summary);
+    return `# Data Entrypoint Governance - Phase 5.21 L2V3E
+
+## A. Current Status
+
+- phase=target identity source inventory reconciliation planning
+- branch=${summary.branch || 'unknown'}
+- base_head=${summary.base_head || 'unknown'}
+- main_head=${summary.main_head || 'unknown'}
+- main_ci_status=${summary.main_ci_status || 'unknown'}
+- source_manifest_path=${summary.source_manifest_path}
+- renewed_baseline_proposal_path=${summary.renewed_baseline_proposal_path}
+- report_path=${summary.report_path}
+
+## B. PR #1278 Merge Result
+
+- pr_1278_state=${summary.pr_1278_state || 'MERGED'}
+- pr_1278_merge_commit=${summary.pr_1278_merge_commit || 'unknown'}
+- merge_scope=L2V3D no-write target identity reconciliation planning
+
+## C. main HEAD / CI Status
+
+- main_head=${summary.main_head || 'unknown'}
+- main_ci_status=${summary.main_ci_status || 'unknown'}
+
+## D. Authorization Scope
+
+- planning_authorized=true
+- source_inventory_reconciliation_authorized=true
+- network_authorized_for_source_inventory_only=true
+- no match detail recapture executed in L2V3E
+- no accepted baseline replacement
+- no raw write authorization
+
+## E. No-Write Guarantee
+
+- db_write_performed=false
+- raw_insert_performed=false
+- baseline_acceptance_performed=false
+- raw_write_retry_performed=false
+- full raw_data/pageProps/source body printed=false
+- full raw_data/pageProps/source body saved=false
+
+## F. L2V3D Identity Mismatch Recap
+
+- l2v3d_checked_target_count=${manifestGate.candidate_targets_count ? EXPECTED_MISMATCH_COUNT : 0}
+- l2v3d_identity_match_count=0
+- l2v3d_identity_mismatch_count=${EXPECTED_MISMATCH_COUNT}
+- l2v3d_next_required_step=target_identity_source_inventory_reconciliation_planning
+- raw_write_ready_for_execution=false
+- target_identity_mismatch_blocks_baseline_acceptance=true
+
+## G. Source Inventory Provenance Review
+
+- source_inventory_route_used=${summary.source_inventory_route_used}
+- source_inventory_request_url=${summary.source_inventory_request_url || 'unknown'}
+- source_inventory_final_url=${summary.source_inventory_final_url || 'unknown'}
+- source_inventory_http_status=${summary.source_inventory_http_status}
+- source_inventory_parse_status=${summary.source_inventory_parse_status}
+- source_inventory_body_bytes=${summary.source_inventory_body_bytes}
+- selected_source_inventory_record_count=${summary.selected_source_inventory_record_count}
+- blocked_markers=${(summary.source_inventory_blocked_markers || []).join(',') || 'none'}
+- shared_page_url_base_pair_count=${summary.shared_page_url_base_pair_count}
+- all_pairs_share_page_url_base=${summary.all_pairs_share_page_url_base}
+
+## H. Manifest Target Generation Review
+
+- candidate_targets_count=${manifestGate.candidate_targets_count || 0}
+- known_completed_targets_count=${manifestGate.known_completed_targets_count || 0}
+- source_inventory_vs_manifest_mismatch_count=${summary.source_inventory_vs_manifest_mismatch_count}
+- manifest generation preserved source inventory external_id/match identity for the 8 checked targets.
+
+## I. DB Matches Identity Review
+
+- matches_row_count=${summary.db_row_counts.matches ?? 'unknown'}
+- raw_match_data_row_count=${summary.db_row_counts.raw_match_data ?? 'unknown'}
+- candidate_fotmob_pageprops_v2_rows_count=${summary.candidate_v2_rows_count}
+- manifest_vs_db_mismatch_count=${summary.manifest_vs_db_mismatch_count}
+- db_vs_live_observed_mismatch_count=${summary.db_vs_live_observed_mismatch_count}
+
+## J. Requested vs Observed Reconciliation Table
+
+| requested_match_id | requested_external_id | requested_teams | requested_match_date | requested_status | source_inventory_path | source_inventory_record_key | source_inventory_external_id | source_inventory_teams | source_inventory_match_date | source_inventory_page_url_base | manifest_record_external_id | DB external_id | live observed external_id | live observed teams | live observed match_date | requested_vs_observed_identity_status | source_inventory_vs_manifest_status | manifest_vs_db_status | DB_vs_live_observed_status | shared_page_url_base_with_observed | suspected_mismatch_stage |
+| ------------------ | --------------------- | --------------- | -------------------- | ---------------- | --------------------- | --------------------------- | ---------------------------- | ---------------------- | --------------------------- | ------------------------------ | --------------------------- | -------------- | ------------------------- | ------------------ | ------------------------ | ------------------------------------ | --------------------------------- | -------------------- | -------------------------- | ---------------------------------- | ------------------------ |
+${rows.join('\n')}
+
+## K. Mismatch Stage Classification
+
+- checked_target_count=${summary.checked_target_count}
+- identity_match_count=${summary.identity_match_count}
+- identity_mismatch_count=${summary.identity_mismatch_count}
+- source_inventory_vs_manifest_mismatch_count=${summary.source_inventory_vs_manifest_mismatch_count}
+- manifest_vs_db_mismatch_count=${summary.manifest_vs_db_mismatch_count}
+- db_vs_live_observed_mismatch_count=${summary.db_vs_live_observed_mismatch_count}
+- requested_vs_observed_external_id_mismatch_count=${summary.requested_vs_observed_external_id_mismatch_count}
+${stageLines.join('\n')}
+
+## L. Suspected Root Cause And Confidence
+
+- suspected_root_cause=${summary.suspected_root_cause}
+- root_cause_confidence=${summary.root_cause_confidence}
+- primary_evidence=source inventory requested/observed pairs share the same pageUrl base and differ only by #external_id anchor
+
+## M. Required Fix / Continue Investigation Decision
+
+- code_fix_required=${summary.suspected_root_cause === 'schedule_vs_detail_external_id_mismatch'}
+- inventory_regeneration_required=${summary.suspected_root_cause === 'manifest_generation_mapping_wrong'}
+- manifest_regeneration_required=${summary.suspected_root_cause === 'manifest_generation_mapping_wrong'}
+- continue_investigation_required=${summary.root_cause_confidence !== 'high'}
+
+## N. DB Row Count Safety Result
+
+- matches=${summary.db_row_counts.matches ?? 'unknown'}
+- raw_match_data=${summary.db_row_counts.raw_match_data ?? 'unknown'}
+- bookmaker_odds_history=${summary.db_row_counts.bookmaker_odds_history ?? 'unknown'}
+- l3_features=${summary.db_row_counts.l3_features ?? 'unknown'}
+- match_features_training=${summary.db_row_counts.match_features_training ?? 'unknown'}
+- predictions=${summary.db_row_counts.predictions ?? 'unknown'}
+- candidate_v2_rows_count=${summary.candidate_v2_rows_count}
+- expected_matches=${EXPECTED_ROW_COUNTS.matches}
+- expected_raw_match_data=${EXPECTED_ROW_COUNTS.raw_match_data}
+
+## O. Test Results
+
+- pending until local verification completes
+
+## P. PR Status
+
+- pending until PR is created
+
+## Q. Next Step Recommendation
+
+- recommended_next_step=${summary.recommended_next_step}
+- unresolved identity/source inventory mismatch blocks baseline acceptance.
+- unresolved identity/source inventory mismatch blocks raw write retry.
+
+## R. Explicit Non-Execution
+
+- no DB writes
+- no raw_match_data inserts
+- no matches writes
+- no bookmaker_odds_history writes
+- no l3_features writes
+- no match_features_training writes
+- no predictions writes
+- no schema migration
+- no parser implementation
+- no feature extraction
+- no training/prediction
+- no browser/proxy/captcha bypass
+- no accepted baseline replacement
+- no raw write retry
+- no proposal hash marked as accepted baseline
+- no full raw_data/pageProps/source body print/save
+- no invented external_id, target, payload, or hash
+`;
+}
+
+async function sleep(ms) {
+    if (!ms) return;
+    await new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+
+async function runPlanning(rawInput = {}, dependencies = {}) {
+    const validation = validatePlanningInput(rawInput);
+    if (!validation.ok) return { ok: false, status: 2, errors: validation.errors };
+    const input = validation.input;
+    const generatedAt = input.generatedAt || dependencies.generatedAt || new Date().toISOString();
+    const manifest = dependencies.manifest || (dependencies.readJsonFile || readJsonFile)(input.manifest);
+    const proposal = dependencies.renewedProposal || (dependencies.readJsonFile || readJsonFile)(input.renewedProposal);
+    const manifestGate = buildManifestGate(manifest);
+    if (!manifestGate.ok) return { ok: false, status: 3, errors: manifestGate.errors, manifest_gate: manifestGate };
+    const proposalGate = buildProposalGate(proposal);
+    if (!proposalGate.ok) return { ok: false, status: 4, errors: proposalGate.errors, proposal_gate: proposalGate };
+    const selection = l2v3d.selectMismatchTargets(manifestGate, proposalGate, input.targetExternalIds);
+    if (!selection.ok) return { ok: false, status: 5, errors: selection.errors };
+
+    const observedExternalIds = selection.pairs
+        .map(pair => summarizeObservedIdentity(pair.proposalTarget).external_id)
+        .map(normalizeText)
+        .filter(Boolean);
+    if (input.requestDelayMs > 0) await sleep(input.requestDelayMs);
+    const sourcePayload = await fetchSourceInventoryPayload(input, dependencies);
+    if (!sourcePayload.ok) {
+        return {
+            ok: false,
+            status: 6,
+            errors: [sourcePayload.error || 'SOURCE_INVENTORY_FETCH_FAILED'],
+            source_inventory: sourcePayload,
+        };
+    }
+    const sourceInventorySelection = buildSourceInventorySelection(
+        sourcePayload,
+        selection.selected_external_ids,
+        observedExternalIds
+    );
+    const dbSnapshot = await queryReadOnlyDbSnapshot(
+        selection.pairs.map(pair => pair.target.match_id),
+        observedExternalIds,
+        dependencies
+    );
+    const items = selection.pairs.map(pair =>
+        buildTargetReconciliationItem(
+            pair.target,
+            pair.proposalTarget,
+            sourceInventorySelection.selected_by_external_id,
+            dbSnapshot.target_rows
+        )
+    );
+    const summary = buildSummary({
+        items,
+        input,
+        manifestGate,
+        proposalGate,
+        sourceInventorySelection,
+        dbSnapshot,
+        generatedAt,
+    });
+    const updatedManifest = buildUpdatedManifest(manifest, summary);
+    const report = buildReport({ summary, items, manifestGate, sourceInventorySelection });
+    if (dependencies.writeManifest !== false) {
+        (dependencies.writeManifestFile || dependencies.writeJsonFile || writeJsonFile)(
+            input.manifest,
+            updatedManifest
+        );
+    }
+    if (dependencies.writeReport !== false) {
+        (dependencies.writeReportFile || writeReportFile)(input.reportOutput, report);
+    }
+    return {
+        ok: true,
+        status: 0,
+        summary,
+        items,
+        updated_manifest: updatedManifest,
+        report,
+        manifest_gate: manifestGate,
+        proposal_gate: proposalGate,
+        source_inventory_selection: {
+            ...sourceInventorySelection,
+            selected_by_external_id: Object.fromEntries(sourceInventorySelection.selected_by_external_id),
+        },
+        db_snapshot: dbSnapshot,
+        selected_external_ids: selection.selected_external_ids,
+    };
+}
+
+async function runCli(argv = process.argv.slice(2), dependencies = {}) {
+    const args = parseArgs(argv);
+    if (args.help) {
+        process.stdout.write(
+            `Usage: node scripts/ops/pageprops_v2_target_source_inventory_reconciliation_plan.js --manifest=${MANIFEST_PATH} --renewed-proposal=${RENEWED_PROPOSAL_PATH} ...\n`
+        );
+        return { status: 0 };
+    }
+    const result = await runPlanning(args, dependencies);
+    const output = result.ok
+        ? {
+              ok: true,
+              status: result.status,
+              summary: result.summary,
+              selected_external_ids: result.selected_external_ids,
+          }
+        : { ok: false, status: result.status, errors: result.errors };
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    return { status: result.status };
+}
+
+module.exports = {
+    PHASE,
+    MANIFEST_PATH,
+    RENEWED_PROPOSAL_PATH,
+    REPORT_PATH,
+    SOURCE,
+    LEAGUE_ID,
+    LEAGUE_NAME,
+    SEASON,
+    RAW_VERSION,
+    HASH_STRATEGY,
+    BATCH_ID,
+    TARGET_COUNT,
+    EXPECTED_MISMATCH_COUNT,
+    EXPECTED_ROW_COUNTS,
+    parseArgs,
+    normalizeBooleanFlag,
+    readJsonFile,
+    writeJsonFile,
+    writeReportFile,
+    validatePlanningInput,
+    buildManifestGate,
+    buildProposalGate,
+    fetchSourceInventoryPayload,
+    buildSourceInventorySelection,
+    queryReadOnlyDbSnapshot,
+    buildTargetReconciliationItem,
+    buildSummary,
+    buildUpdatedManifest,
+    buildReport,
+    sleep,
+    runPlanning,
+    runCli,
+};
+
+if (require.main === module) {
+    runCli()
+        .then(result => {
+            process.exitCode = result.status;
+        })
+        .catch(error => {
+            process.stderr.write(`${error.stack || error.message}\n`);
+            process.exitCode = 1;
+        });
+}

--- a/tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js
+++ b/tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js
@@ -1,6 +1,9 @@
 'use strict';
+/* eslint-disable max-lines -- safety-contract coverage stays in one file for auditability. */
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
@@ -639,6 +642,159 @@ test('classification and summary cover identity, team-date and unknown branches'
     assert.equal(unknownSummary.next_required_step, 'target_identity_reconciliation_follow_up_investigation');
 });
 
+test('summary and selection cover route, canonical, observed-mismatch and default-selection branches', () => {
+    const routeSummary = mod.buildSummary({
+        diagnostics: [
+            {
+                identity_match: false,
+                mismatch_type: 'route_generation_mismatch',
+                request_url_external_id: '9999999',
+                requested_external_id: '4830466',
+                canonical_redirect_detected: false,
+                deterministic_observed_identity_with_l2v3c: false,
+                deterministic_with_l2v3c: false,
+            },
+        ],
+        input: validInput(),
+        manifestGate: { candidate_targets_count: 50 },
+        proposalGate: { checkedTargets: [proposalTarget('4830466')] },
+        generatedAt: '2026-05-18T00:00:00.000Z',
+    });
+    assert.equal(routeSummary.root_cause_status, 'confirmed_route_generation_mismatch');
+    assert.equal(routeSummary.next_required_step, 'route_generation_fix_planning');
+
+    const canonicalSummary = mod.buildSummary({
+        diagnostics: [
+            {
+                identity_match: false,
+                mismatch_type: 'canonical_redirect_mismatch',
+                final_url_external_id: '4830759',
+                requested_external_id: '4830466',
+                deterministic_observed_identity_with_l2v3c: false,
+                deterministic_with_l2v3c: false,
+            },
+        ],
+        input: validInput(),
+        manifestGate: { candidate_targets_count: 50 },
+        proposalGate: { checkedTargets: [proposalTarget('4830466')] },
+        generatedAt: '2026-05-18T00:00:00.000Z',
+    });
+    assert.equal(canonicalSummary.canonical_redirect_detected, true);
+    assert.equal(canonicalSummary.next_required_step, 'target_identity_source_inventory_reconciliation_planning');
+
+    const selected = mod.selectMismatchTargets(
+        mod.validateManifestGate(manifest()),
+        mod.validateRenewedProposalGate(renewedProposal()),
+        []
+    );
+    assert.equal(selected.ok, true);
+    assert.equal(selected.selected_external_ids.length, 8);
+});
+
+test('diagnoseTarget covers delayed array fetch, invalid URLs and search-id extraction', async () => {
+    const target = candidate('4830466', {
+        home_team: 'Rennes',
+        away_team: 'Marseille',
+        kickoff_time: '2025-08-15T18:45:00.000Z',
+    });
+    const diagnostic = await mod.diagnoseTarget(
+        target,
+        proposalTarget('4830466'),
+        1,
+        validInput({ requestDelayMs: 1 }),
+        {
+            fetchResults: [
+                null,
+                {
+                    ok: true,
+                    request_url: 'notaurl/match/4830466?matchId=4830466',
+                    final_url: 'https://www.fotmob.com/match/details?id=4830466',
+                    http_status: 200,
+                    body_byte_length: Buffer.byteLength(
+                        fakeHtml(
+                            '4830466',
+                            fakePageProps('4830466', {
+                                general: {
+                                    matchID: '4830466',
+                                    parentLeagueId: 53,
+                                    matchName: 'Rennes-vs-Marseille',
+                                    matchTimeUTC: '2025-08-15T18:45:00.000Z',
+                                    status: 'finished',
+                                },
+                                header: { homeTeam: 'Rennes', awayTeam: 'Marseille' },
+                            })
+                        ),
+                        'utf8'
+                    ),
+                    body: fakeHtml(
+                        '4830466',
+                        fakePageProps('4830466', {
+                            general: {
+                                matchID: '4830466',
+                                parentLeagueId: 53,
+                                matchName: 'Rennes-vs-Marseille',
+                                matchTimeUTC: '2025-08-15T18:45:00.000Z',
+                                status: 'finished',
+                            },
+                            header: { homeTeam: 'Rennes', awayTeam: 'Marseille' },
+                        })
+                    ),
+                },
+            ],
+        }
+    );
+
+    assert.equal(diagnostic.identity_match, true);
+    assert.equal(diagnostic.final_url_external_id, '4830466');
+    assert.equal(diagnostic.request_url_summary.startsWith('notaurl/match/4830466'), true);
+    assert.equal(diagnostic.mismatch_type, 'identity_match');
+});
+
+test('diagnoseTarget covers non-200 success envelope and missing observed identity branches', async () => {
+    const target = candidate('4830466');
+    const proposal = proposalTarget('4830466');
+
+    const non200 = await mod.diagnoseTarget(target, proposal, 0, validInput(), {
+        fetchResultsByExternalId: {
+            4830466: {
+                ok: true,
+                request_url: 'https://www.fotmob.com/match/4830466',
+                final_url: 'https://www.fotmob.com/match/4830466',
+                http_status: 503,
+                body_byte_length: 0,
+            },
+        },
+    });
+    assert.equal(non200.safe_error_summary, 'HTTP_NON_200');
+
+    const missingObserved = await mod.diagnoseTarget(
+        candidate('4830466', {
+            home_team: 'Rennes',
+            away_team: 'Marseille',
+            kickoff_time: '2025-08-15T18:45:00.000Z',
+        }),
+        proposalTarget('4830466'),
+        0,
+        validInput(),
+        {
+            fetchHtmlFn: () =>
+                fetchResultFor(
+                    '4830466',
+                    fakePageProps('4830466', {
+                        general: {
+                            leagueId: 53,
+                            matchName: 'Rennes-vs-Marseille',
+                            matchTimeUTCDate: '2025-08-15T18:45:00.000Z',
+                        },
+                        header: { teams: [{ name: 'Rennes' }, { name: 'Marseille' }] },
+                    })
+                ),
+        }
+    );
+    assert.equal(missingObserved.observed_external_id, null);
+    assert.equal(missingObserved.mismatch_type, 'identity_match');
+});
+
 test('report and manifest do not contain full raw_data, pageProps or source body markers', async () => {
     const result = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
         manifest: manifest(),
@@ -675,6 +831,31 @@ test('runPlanning can use file readers and default writers through injected safe
     assert.equal(writes.length, 2);
     assert.equal(writes[0].filePath, mod.MANIFEST_PATH);
     assert.equal(writes[1].filePath, mod.REPORT_PATH);
+});
+
+test('file helpers and sleep cover local IO branches safely', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'l2v3d-'));
+    const jsonPath = path.join(tempDir, 'nested', 'sample.json');
+    const reportPath = path.join(tempDir, 'nested', 'report.md');
+
+    mod.writeJsonFile(jsonPath, { ok: true });
+    mod.writeReportFile(reportPath, '# ok\n');
+
+    assert.deepEqual(mod.readJsonFile(jsonPath), { ok: true });
+    assert.equal(fs.readFileSync(reportPath, 'utf8'), '# ok\n');
+
+    await mod.sleep(1);
+});
+
+test('runPlanning can read manifest/proposal from default repo files without writes', async () => {
+    const result = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        fetchHtmlFn: url => fetchResultFor(url.split('/').pop()),
+        writeManifest: false,
+        writeReport: false,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 3);
 });
 
 test('unresolved identity proposal is not executable by raw write runner', async () => {

--- a/tests/unit/pageprops_v2_target_source_inventory_reconciliation_plan.test.js
+++ b/tests/unit/pageprops_v2_target_source_inventory_reconciliation_plan.test.js
@@ -1,0 +1,946 @@
+'use strict';
+/* eslint-disable max-lines -- safety-contract coverage stays in one file for auditability. */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const pg = require('pg');
+const test = require('node:test');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const MODULE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/pageprops_v2_target_source_inventory_reconciliation_plan.js');
+const RAW_WRITE_PATH = path.join(PROJECT_ROOT, 'scripts/ops/renewed_pageprops_v2_raw_write_execute.js');
+
+function loadFreshModule() {
+    delete require.cache[require.resolve(MODULE_PATH)];
+    return require(MODULE_PATH);
+}
+
+const mod = loadFreshModule();
+const rawWrite = require(RAW_WRITE_PATH);
+
+const MISMATCH_IDS = Object.freeze([
+    '4830466',
+    '4830461',
+    '4830481',
+    '4830496',
+    '4830511',
+    '4830463',
+    '4830465',
+    '4830508',
+]);
+
+const OBSERVED = Object.freeze({
+    4830466: [
+        '4830759',
+        'Marseille',
+        'Rennes',
+        '2026-05-17T19:00:00.000Z',
+        '34',
+        '/matches/marseille-vs-rennes/2t9n7h',
+    ],
+    4830461: ['4830758', 'Lyon', 'Lens', '2026-05-17T19:00:00.000Z', '34', '/matches/lens-vs-lyon/2s3gtg'],
+    4830481: [
+        '4830763',
+        'Strasbourg',
+        'Monaco',
+        '2026-05-17T19:00:00.000Z',
+        '34',
+        '/matches/monaco-vs-strasbourg/379ruz',
+    ],
+    4830496: [
+        '4830757',
+        'Lorient',
+        'Le Havre',
+        '2026-05-17T19:00:00.000Z',
+        '34',
+        '/matches/lorient-vs-le-havre/2t6haw',
+    ],
+    4830511: ['4830760', 'Nantes', 'Toulouse', '2026-05-17T19:00:00.000Z', '34', '/matches/nantes-vs-toulouse/38dikf'],
+    4830463: ['4830622', 'Le Havre', 'Monaco', '2026-01-24T18:00:00.000Z', '19', '/matches/le-havre-vs-monaco/362v61'],
+    4830465: ['4830619', 'Toulouse', 'Nice', '2026-01-17T18:00:00.000Z', '18', '/matches/nice-vs-toulouse/38dxtn'],
+    4830508: [
+        '4830620',
+        'Auxerre',
+        'Paris Saint-Germain',
+        '2026-01-23T19:00:00.000Z',
+        '19',
+        '/matches/auxerre-vs-paris-saint-germain/2t4i9k',
+    ],
+});
+
+function targetFields(externalId) {
+    const base = {
+        4830466: ['Rennes', 'Marseille', '2025-08-15T18:45:00.000Z'],
+        4830461: ['Lens', 'Lyon', '2025-08-16T15:00:00.000Z'],
+        4830481: ['Monaco', 'Strasbourg', '2025-08-31T15:15:00.000Z'],
+        4830496: ['Le Havre', 'Lorient', '2025-09-21T15:15:00.000Z'],
+        4830511: ['Toulouse', 'Nantes', '2025-09-27T17:00:00.000Z'],
+        4830463: ['Monaco', 'Le Havre', '2025-08-16T17:00:00.000Z'],
+        4830465: ['Nice', 'Toulouse', '2025-08-16T19:05:00.000Z'],
+        4830508: ['Paris Saint-Germain', 'Auxerre', '2025-09-27T19:05:00.000Z'],
+    };
+    return base[externalId];
+}
+
+function candidate(externalId, overrides = {}) {
+    const [home, away, matchDate] = targetFields(externalId) || [
+        `Home ${externalId}`,
+        `Away ${externalId}`,
+        '2025-08-15T18:45:00.000Z',
+    ];
+    return {
+        target_id: `${mod.BATCH_ID}:53_20252026_${externalId}`,
+        batch_id: mod.BATCH_ID,
+        source: 'fotmob',
+        route: 'html_hydration',
+        raw_data_version: 'fotmob_pageprops_v2',
+        hash_strategy: 'stable_pageprops_payload_v1',
+        match_id: `53_20252026_${externalId}`,
+        external_id: externalId,
+        league_id: 53,
+        league_name: 'Ligue 1',
+        season: '2025/2026',
+        home_team: home,
+        away_team: away,
+        kickoff_time: matchDate,
+        match_date: matchDate,
+        status: 'finished',
+        preflight_status: 'hash_baseline_ready',
+        baseline_hash: 'a'.repeat(64),
+        matches_seed_status: 'inserted_matches_identity',
+        source_inventory_route: 'source_inventory',
+        ...overrides,
+    };
+}
+
+function candidates50() {
+    const filler = Array.from({ length: 42 }, (_, index) => String(4900000 + index));
+    return [...MISMATCH_IDS, ...filler].map(externalId => candidate(externalId));
+}
+
+function knownCompleted() {
+    return ['4830746', '4830747', '4830748', '4830750', '4830751', '4830752', '4830753', '4830754'].map(externalId => ({
+        target_id: `${mod.BATCH_ID}:53_20252026_${externalId}`,
+        external_id: externalId,
+        match_id: `53_20252026_${externalId}`,
+    }));
+}
+
+function manifest(overrides = {}) {
+    return {
+        batch_id: mod.BATCH_ID,
+        source: 'fotmob',
+        route: 'html_hydration',
+        raw_data_version: 'fotmob_pageprops_v2',
+        hash_strategy: 'stable_pageprops_payload_v1',
+        league: { league_id: 53, league_name: 'Ligue 1', season: '2025/2026' },
+        known_completed_targets: knownCompleted(),
+        candidate_targets: candidates50(),
+        phase_5_21_l2v3c_planning_status: 'completed_no_write',
+        phase_5_21_l2v3c_metadata_target_mismatch_count: 8,
+        renewed_baseline_requires_separate_baseline_acceptance: true,
+        renewed_baseline_requires_separate_final_db_write_authorization: true,
+        raw_write_ready_for_execution: false,
+        next_required_step: 'target_identity_source_inventory_reconciliation_planning',
+        phase_5_21_l2v3d_planning_status: 'completed_no_write',
+        phase_5_21_l2v3d_identity_mismatch_count: 8,
+        phase_5_21_l2v3d_manifest_target_metadata_mismatch_indicated: true,
+        target_identity_mismatch_blocks_baseline_acceptance: true,
+        raw_write_retry_authorization_status: 'blocked_pending_target_identity_reconciliation',
+        ...overrides,
+    };
+}
+
+function proposalTarget(externalId, overrides = {}) {
+    const observed = OBSERVED[externalId];
+    return {
+        target_id: `${mod.BATCH_ID}:53_20252026_${externalId}`,
+        match_id: `53_20252026_${externalId}`,
+        external_id: externalId,
+        hash_status: 'metadata_target_mismatch',
+        metadata_identity_status: 'metadata_target_mismatch',
+        attempts: [
+            {
+                metadata_identity_observed: {
+                    external_id: observed?.[0] || externalId,
+                    home_team: observed?.[1] || `Home ${externalId}`,
+                    away_team: observed?.[2] || `Away ${externalId}`,
+                    match_time_utc: observed?.[3] || '2025-08-15T18:45:00.000Z',
+                },
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function renewedProposal(overrides = {}) {
+    return {
+        proposal_phase: 'Phase 5.21L2V3C',
+        no_write: true,
+        db_write_performed: false,
+        raw_insert_performed: false,
+        summary: {
+            metadata_target_mismatch_count: 8,
+            next_required_step: 'target_identity_reconciliation_planning',
+        },
+        recommendation: {
+            raw_write_ready_for_execution: false,
+            requires_separate_baseline_acceptance: true,
+            requires_separate_final_db_write_authorization: true,
+        },
+        checked_targets: MISMATCH_IDS.map(externalId => proposalTarget(externalId)),
+        ...overrides,
+    };
+}
+
+function sourceInventoryJson() {
+    const requested = MISMATCH_IDS.map((externalId, index) => {
+        const [home, away, matchDate] = targetFields(externalId);
+        return {
+            id: externalId,
+            home: { name: home },
+            away: { name: away },
+            status: { utcTime: matchDate, finished: true },
+            round: String(index + 1),
+            roundName: String(index + 1),
+            pageUrl: `${OBSERVED[externalId][5]}#${externalId}`,
+        };
+    });
+    const observed = MISMATCH_IDS.map(externalId => ({
+        id: OBSERVED[externalId][0],
+        home: { name: OBSERVED[externalId][1] },
+        away: { name: OBSERVED[externalId][2] },
+        status: { utcTime: OBSERVED[externalId][3], finished: true },
+        round: OBSERVED[externalId][4],
+        roundName: OBSERVED[externalId][4],
+        pageUrl: `${OBSERVED[externalId][5]}#${OBSERVED[externalId][0]}`,
+    }));
+    return {
+        overview: {
+            matches: {
+                allMatches: [...requested, ...observed],
+            },
+        },
+    };
+}
+
+function dbSnapshot(overrides = {}) {
+    return {
+        row_counts: {
+            matches: 60,
+            raw_match_data: 18,
+            bookmaker_odds_history: 2,
+            l3_features: 2,
+            match_features_training: 2,
+            predictions: 2,
+        },
+        target_rows: MISMATCH_IDS.map(externalId => {
+            const [home, away, matchDate] = targetFields(externalId);
+            return {
+                match_id: `53_20252026_${externalId}`,
+                external_id: externalId,
+                league_name: 'Ligue 1',
+                season: '2025/2026',
+                home_team: home,
+                away_team: away,
+                match_date: matchDate,
+                status: 'finished',
+                data_source: 'fotmob',
+                pipeline_status: 'pending',
+            };
+        }),
+        candidate_v2_rows_count: 0,
+        ...overrides,
+    };
+}
+
+function validInput(overrides = {}) {
+    return {
+        manifest: mod.MANIFEST_PATH,
+        renewedProposal: mod.RENEWED_PROPOSAL_PATH,
+        reportOutput: mod.REPORT_PATH,
+        source: 'fotmob',
+        leagueId: 53,
+        leagueName: 'Ligue 1',
+        season: '2025/2026',
+        rawVersion: 'fotmob_pageprops_v2',
+        hashStrategy: 'stable_pageprops_payload_v1',
+        batchId: mod.BATCH_ID,
+        targetCount: 50,
+        planningAuthorization: true,
+        sourceInventoryReconciliationAuthorization: true,
+        networkAuthorization: true,
+        allowDbWrite: false,
+        allowRawMatchDataWrite: false,
+        allowControlledWrite: false,
+        allowMatchesWrite: false,
+        allowBookmakerOddsWrite: false,
+        allowFeatureWrite: false,
+        allowSchemaMigration: false,
+        allowParserImplementation: false,
+        allowFeatureExtraction: false,
+        allowTraining: false,
+        allowPrediction: false,
+        allowBrowserRuntime: false,
+        allowProxyRuntime: false,
+        printFullBody: false,
+        saveFullBody: false,
+        printFullJson: false,
+        saveFullJson: false,
+        printFullPageprops: false,
+        saveFullPageprops: false,
+        retry: 0,
+        requestDelayMs: 0,
+        generatedAt: '2026-05-18T00:00:00.000Z',
+        branch: 'data/pageprops-v2-source-inventory-reconciliation-phase521l2v3e',
+        baseHead: 'd2db9e9f9276a130de52bad724be3a7bc6566481',
+        mainHead: 'd2db9e9f9276a130de52bad724be3a7bc6566481',
+        mainCiStatus: 'success',
+        pr1278State: 'MERGED',
+        pr1278MergeCommit: 'd2db9e9f9276a130de52bad724be3a7bc6566481',
+        ...overrides,
+    };
+}
+
+test('valid L2V3E run stays no-write and identifies schedule/detail identity mismatch with high confidence', async () => {
+    const writes = [];
+    const result = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeJsonFile: (filePath, data) => writes.push({ filePath, data }),
+        writeReportFile: (filePath, data) => writes.push({ filePath, data }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.summary.no_write, true);
+    assert.equal(result.summary.db_write_performed, false);
+    assert.equal(result.summary.raw_insert_performed, false);
+    assert.equal(result.summary.checked_target_count, 8);
+    assert.equal(result.summary.identity_mismatch_count, 8);
+    assert.equal(result.summary.source_inventory_vs_manifest_mismatch_count, 0);
+    assert.equal(result.summary.manifest_vs_db_mismatch_count, 0);
+    assert.equal(result.summary.db_vs_live_observed_mismatch_count, 8);
+    assert.equal(result.summary.requested_vs_observed_external_id_mismatch_count, 8);
+    assert.equal(result.summary.shared_page_url_base_pair_count, 8);
+    assert.equal(result.summary.all_pairs_share_page_url_base, true);
+    assert.equal(
+        result.summary.source_inventory_request_url,
+        'https://www.fotmob.com/api/data/leagues?id=53&season=20252026'
+    );
+    assert.equal(result.summary.suspected_root_cause, 'schedule_vs_detail_external_id_mismatch');
+    assert.equal(result.summary.root_cause_confidence, 'high');
+    assert.equal(result.summary.recommended_next_step, 'schedule_detail_identity_normalization_fix_planning');
+    assert.equal(result.updated_manifest.raw_write_ready_for_execution, false);
+    assert.equal(result.updated_manifest.target_identity_mismatch_blocks_baseline_acceptance, true);
+    assert.equal(result.updated_manifest.requires_separate_baseline_acceptance, true);
+    assert.equal(result.updated_manifest.requires_separate_final_db_write_authorization, true);
+    assert.equal(writes.length, 2);
+});
+
+test('write, baseline acceptance and raw retry flags are blocked', () => {
+    for (const [key, value] of [
+        ['allowDbWrite', true],
+        ['allowRawMatchDataWrite', true],
+        ['allowControlledWrite', true],
+        ['allowMatchesWrite', true],
+        ['allowBookmakerOddsWrite', true],
+        ['allowFeatureWrite', true],
+        ['allowSchemaMigration', true],
+        ['allowParserImplementation', true],
+        ['allowFeatureExtraction', true],
+        ['allowTraining', true],
+        ['allowPrediction', true],
+        ['allowBrowserRuntime', true],
+        ['allowProxyRuntime', true],
+        ['acceptBaseline', true],
+        ['acceptedBaseline', true],
+        ['baselineAcceptanceAuthorization', true],
+        ['rawWriteReadyForExecution', true],
+        ['rawWriteRetryAuthorization', true],
+    ]) {
+        const result = mod.validatePlanningInput(validInput({ [key]: value }));
+        assert.equal(result.ok, false, `${key} should be blocked`);
+    }
+});
+
+test('argument parsing, help mode and helper branches stay safe', async () => {
+    const parsed = mod.parseArgs([
+        '--manifest',
+        mod.MANIFEST_PATH,
+        '--source=fotmob',
+        '--planning-authorization=maybe',
+        '--target-external-ids=4830466,4830466,4830461',
+        '--unknown-flag=yes',
+        'loose',
+    ]);
+    assert.equal(parsed.manifest, mod.MANIFEST_PATH);
+    assert.equal(parsed.source, 'fotmob');
+    assert.equal(parsed.planningAuthorization, true);
+    assert.equal(parsed.targetExternalIds, '4830466,4830466,4830461');
+    assert.deepEqual(parsed.unknown, ['unknown-flag', 'loose']);
+    assert.equal(mod.normalizeBooleanFlag('bogus', false), false);
+
+    const stdout = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = chunk => {
+        stdout.push(String(chunk));
+        return true;
+    };
+    try {
+        const result = await mod.runCli(['--help']);
+        assert.equal(result.status, 0);
+        assert.match(stdout.join(''), /Usage:/);
+    } finally {
+        process.stdout.write = originalWrite;
+    }
+});
+
+test('validation and manifest gate expose exact missing and follow-up outcome branches', () => {
+    const invalid = mod.validatePlanningInput(
+        validInput({
+            manifest: '',
+            renewedProposal: '',
+            reportOutput: '',
+            source: 'other',
+            leagueId: 54,
+            leagueName: '',
+            season: '',
+            rawVersion: '',
+            hashStrategy: '',
+            batchId: '',
+            targetCount: 49,
+            planningAuthorization: false,
+            sourceInventoryReconciliationAuthorization: false,
+            networkAuthorization: false,
+            allowDbWrite: true,
+            retry: 1,
+            requestDelayMs: -1,
+        })
+    );
+    assert.equal(invalid.ok, false);
+    assert.match(invalid.errors.join('\n'), /missing manifest=/);
+    assert.match(invalid.errors.join('\n'), /league-id must be 53/);
+    assert.match(invalid.errors.join('\n'), /retry must be 0/);
+    assert.match(invalid.errors.join('\n'), /request-delay-ms must be a non-negative integer/);
+
+    const allowedFollowUp = mod.buildManifestGate(
+        manifest({
+            next_required_step: 'source_inventory_manifest_regeneration_review',
+            raw_write_retry_authorization_status: 'blocked_pending_target_identity_source_inventory_reconciliation',
+        })
+    );
+    assert.equal(allowedFollowUp.ok, true);
+
+    const invalidGate = mod.buildManifestGate(
+        manifest({
+            next_required_step: 'wrong_step',
+            phase_5_21_l2v3d_planning_status: 'missing',
+            phase_5_21_l2v3d_identity_mismatch_count: 7,
+            raw_write_ready_for_execution: true,
+            raw_write_retry_authorization_status: 'wrong',
+            phase_5_21_l2v3d_manifest_target_metadata_mismatch_indicated: false,
+        })
+    );
+    assert.equal(invalidGate.ok, false);
+    assert.match(invalidGate.errors.join('\n'), /allowed L2V3E follow-up outcome/);
+    assert.match(invalidGate.errors.join('\n'), /phase_5_21_l2v3d_planning_status/);
+    assert.match(invalidGate.errors.join('\n'), /phase_5_21_l2v3d_identity_mismatch_count/);
+    assert.match(invalidGate.errors.join('\n'), /raw_write_retry_authorization_status/);
+});
+
+test('manifest gate and source inventory fetch fail closed', async () => {
+    const invalidManifest = await mod.runPlanning(validInput(), {
+        manifest: manifest({ target_identity_mismatch_blocks_baseline_acceptance: false }),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(invalidManifest.ok, false);
+    assert.equal(invalidManifest.status, 3);
+
+    const invalidSourceFetch = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchFn: async () => ({
+            status: 403,
+            url: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+            async text() {
+                return 'forbidden';
+            },
+        }),
+        writeManifest: false,
+        writeReport: false,
+        dbSnapshot: dbSnapshot(),
+    });
+    assert.equal(invalidSourceFetch.ok, false);
+    assert.equal(invalidSourceFetch.status, 6);
+});
+
+test('fetch helpers and reconciliation item helpers cover direct fallback branches', async () => {
+    const fetchError = await mod.fetchSourceInventoryPayload(validInput(), {
+        fetchFn: async () => {
+            throw new Error('network-down');
+        },
+    });
+    assert.equal(fetchError.ok, false);
+    assert.equal(fetchError.parse_status, 'fetch_error');
+
+    const non200Json = await mod.fetchSourceInventoryPayload(validInput(), {
+        fetchFn: async () => ({
+            status: 503,
+            url: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+            async text() {
+                return JSON.stringify({ overview: { matches: { allMatches: [] } } });
+            },
+        }),
+    });
+    assert.equal(non200Json.ok, false);
+    assert.equal(non200Json.parse_status, 'parsed_json');
+
+    const sourceByExternalId = new Map([
+        [
+            '4830466',
+            {
+                external_id: '4830466',
+                source_path: 'overview.matches.allMatches',
+                source_inventory_record_key: 'overview.matches.allMatches#4830466',
+                home_team: 'Rennes',
+                away_team: 'Marseille',
+                match_date: '2025-08-15T18:45:00.000Z',
+                status: 'finished',
+                page_url: '/matches/marseille-vs-rennes/2t9n7h#4830466',
+                page_url_base: '/matches/marseille-vs-rennes/2t9n7h',
+                page_url_anchor: '4830466',
+                id_like_fields: {},
+                top_level_keys: [],
+            },
+        ],
+    ]);
+    const matched = mod.buildTargetReconciliationItem(
+        candidate('4830466'),
+        proposalTarget('4830466', {
+            attempts: [
+                {
+                    metadata_identity_observed: {
+                        external_id: '4830466',
+                        home_team: 'Rennes',
+                        away_team: 'Marseille',
+                        match_time_utc: '2025-08-15T18:45:00.000Z',
+                        status: 'finished',
+                    },
+                },
+            ],
+        }),
+        sourceByExternalId,
+        dbSnapshot().target_rows
+    );
+    assert.equal(matched.requested_vs_observed_identity_status, 'match');
+    assert.equal(matched.suspected_mismatch_stage, 'matched');
+});
+
+test('source inventory fetch and root-cause branches fail closed across fallback paths', async () => {
+    const missingFetchDependency = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchFn: 'missing',
+        writeManifest: false,
+        writeReport: false,
+        dbSnapshot: dbSnapshot(),
+    });
+    assert.equal(missingFetchDependency.ok, false);
+    assert.equal(missingFetchDependency.status, 6);
+    assert.match(missingFetchDependency.errors.join('\n'), /FETCH_DEPENDENCY_MISSING/);
+
+    const bodyReadFailure = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchFn: async () => ({
+            status: 200,
+            url: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+            async text() {
+                throw new Error('broken-body');
+            },
+        }),
+        writeManifest: false,
+        writeReport: false,
+        dbSnapshot: dbSnapshot(),
+    });
+    assert.equal(bodyReadFailure.ok, false);
+    assert.equal(bodyReadFailure.status, 6);
+    assert.match(bodyReadFailure.errors.join('\n'), /BODY_READ_ERROR/);
+
+    const blockedResponse = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchFn: async () => ({
+            status: 200,
+            url: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+            async text() {
+                return '<html><title>Just a moment</title><body>captcha</body></html>';
+            },
+        }),
+        writeManifest: false,
+        writeReport: false,
+        dbSnapshot: dbSnapshot(),
+    });
+    assert.equal(blockedResponse.ok, false);
+    assert.equal(blockedResponse.status, 6);
+    assert.match(blockedResponse.errors.join('\n'), /BLOCKED/);
+
+    const malformedJson = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        fetchFn: async () => ({
+            status: 200,
+            url: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+            async text() {
+                return '{';
+            },
+        }),
+        writeManifest: false,
+        writeReport: false,
+        dbSnapshot: dbSnapshot(),
+    });
+    assert.equal(malformedJson.ok, false);
+    assert.equal(malformedJson.status, 6);
+    assert.match(malformedJson.errors.join('\n'), /JSON_PARSE_ERROR/);
+});
+
+test('source inventory mismatch keeps raw write blocked', async () => {
+    const mismatched = sourceInventoryJson();
+    mismatched.overview.matches.allMatches[0].home.name = 'Wrong Home';
+    const result = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: mismatched,
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.summary.source_inventory_vs_manifest_mismatch_count, 1);
+    assert.equal(result.summary.raw_write_ready_for_execution, false);
+    assert.equal(result.updated_manifest.raw_write_ready_for_execution, false);
+});
+
+test('manifest-vs-db and live-mapping alternatives remain blocked with lower confidence', async () => {
+    const missingDbRow = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot({ target_rows: [] }),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(missingDbRow.ok, true);
+    assert.equal(missingDbRow.summary.manifest_vs_db_mismatch_count, 1);
+    assert.equal(missingDbRow.summary.suspected_root_cause, 'DB_seed_identity_wrong');
+    assert.equal(missingDbRow.summary.root_cause_confidence, 'medium');
+    assert.equal(missingDbRow.summary.raw_write_ready_for_execution, false);
+
+    const differentPageBase = sourceInventoryJson();
+    differentPageBase.overview.matches.allMatches = differentPageBase.overview.matches.allMatches.map(item =>
+        item.id === OBSERVED['4830466'][0]
+            ? { ...item, pageUrl: `/matches/other-fixture/zzz#${OBSERVED['4830466'][0]}` }
+            : item
+    );
+    const liveMapping = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: differentPageBase,
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(liveMapping.ok, true);
+    assert.equal(liveMapping.summary.db_vs_live_observed_mismatch_count, 1);
+    assert.equal(liveMapping.summary.suspected_root_cause, 'FotMob_live_detail_mapping_changed');
+    assert.equal(liveMapping.summary.root_cause_confidence, 'low');
+    assert.equal(liveMapping.updated_manifest.raw_write_ready_for_execution, false);
+});
+
+test('rerun remains idempotent after L2V3E manifest metadata is already written', async () => {
+    const firstRun = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(firstRun.ok, true);
+
+    const secondRun = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        manifest: firstRun.updated_manifest,
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(secondRun.ok, true);
+    assert.equal(secondRun.summary.suspected_root_cause, 'schedule_vs_detail_external_id_mismatch');
+    assert.equal(secondRun.updated_manifest.next_required_step, 'schedule_detail_identity_normalization_fix_planning');
+});
+
+test('source inventory selection, DB snapshot helpers and comparison helpers cover fallback branches', async () => {
+    const selected = mod.buildSourceInventorySelection(
+        {
+            request_url: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+            final_url: 'https://www.fotmob.com/api/data/leagues?id=53&season=20252026',
+            http_status: 200,
+            body_bytes: 10,
+            parse_status: 'parsed_json',
+            blocked_markers: [],
+            json: {
+                overview: { matches: { allMatches: sourceInventoryJson().overview.matches.allMatches } },
+                fixtures: {
+                    allMatches: [
+                        {
+                            id: '4830466',
+                            home: { shortName: 'Ren' },
+                            away: { longName: 'Marseille' },
+                            time: { utc: '2025-08-15T18:45:00Z' },
+                            scheduled: true,
+                            pageUrl: '/matches/marseille-vs-rennes/2t9n7h#4830466',
+                            slug: 'rennes-marseille',
+                        },
+                    ],
+                },
+            },
+        },
+        ['4830466'],
+        ['4830759']
+    );
+    assert.equal(selected.selected_count, 2);
+    assert.equal(selected.duplicate_selection_events >= 1, true);
+
+    const chosen = selected.selected_by_external_id.get('4830466');
+    assert.equal(chosen.source_path, 'overview.matches.allMatches');
+    assert.equal(chosen.page_url_anchor, '4830466');
+    assert.equal(chosen.id_like_fields.pageUrl.includes('#4830466'), true);
+
+    const fakePool = {
+        ended: false,
+        async query(sql) {
+            if (/FROM matches\\s*UNION ALL/i.test(sql) || /SELECT 'matches' AS table_name/i.test(sql)) {
+                return { rows: [{ table_name: 'matches', rows: 60 }] };
+            }
+            if (/FROM matches\\s*WHERE/i.test(sql)) {
+                return { rows: [] };
+            }
+            return { rows: [{ rows: 0 }] };
+        },
+        async end() {
+            this.ended = true;
+        },
+    };
+    const snapshot = await mod.queryReadOnlyDbSnapshot(['53_20252026_4830466'], ['4830759'], { pool: fakePool });
+    assert.equal(snapshot.row_counts.matches, 60);
+    assert.equal(snapshot.row_counts.raw_match_data, 0);
+    assert.equal(snapshot.candidate_v2_rows_count, 0);
+    assert.equal(fakePool.ended, false);
+});
+
+test('summary and planning gates cover unresolved-unknown, proposal failure and selection failure branches', async () => {
+    const summary = mod.buildSummary({
+        items: [
+            {
+                requested_vs_observed_identity_status: 'mismatch',
+                source_inventory_vs_manifest_status: 'match',
+                manifest_vs_db_status: 'match',
+                db_vs_live_observed_status: 'missing_live_observed',
+                observed_source_inventory_found: false,
+                shared_page_url_base_with_observed: false,
+                suspected_mismatch_stage: 'unknown',
+            },
+        ],
+        input: validInput(),
+        manifestGate: { candidate_targets_count: 50 },
+        proposalGate: { checkedTargets: [proposalTarget('4830466')] },
+        sourceInventorySelection: {},
+        dbSnapshot: dbSnapshot(),
+        generatedAt: '2026-05-18T00:00:00.000Z',
+    });
+    assert.equal(summary.suspected_root_cause, 'unresolved_unknown');
+    assert.equal(summary.root_cause_confidence, 'unknown');
+
+    const invalidProposal = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal({
+            proposal_phase: 'wrong',
+            recommendation: {
+                raw_write_ready_for_execution: true,
+                requires_separate_baseline_acceptance: false,
+                requires_separate_final_db_write_authorization: false,
+            },
+        }),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(invalidProposal.ok, false);
+    assert.equal(invalidProposal.status, 4);
+
+    const invalidSelection = await mod.runPlanning(validInput({ targetExternalIds: ['9999999'], requestDelayMs: 1 }), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    assert.equal(invalidSelection.ok, false);
+    assert.equal(invalidSelection.status, 5);
+});
+
+test('file helpers and sleep cover local IO branches safely', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'l2v3e-'));
+    const jsonPath = path.join(tempDir, 'nested', 'sample.json');
+    const reportPath = path.join(tempDir, 'nested', 'report.md');
+
+    mod.writeJsonFile(jsonPath, { ok: true });
+    mod.writeReportFile(reportPath, '# ok\n');
+
+    assert.deepEqual(mod.readJsonFile(jsonPath), { ok: true });
+    assert.equal(fs.readFileSync(reportPath, 'utf8'), '# ok\n');
+
+    await mod.sleep(1);
+});
+
+test('queryReadOnlyDbSnapshot covers default Pool creation and pool.end cleanup', async () => {
+    const originalPool = pg.Pool;
+    let ended = false;
+    pg.Pool = class FakePool {
+        async query(sql) {
+            if (/SELECT 'matches' AS table_name/i.test(sql)) {
+                return { rows: [{ table_name: 'matches', rows: 60 }] };
+            }
+            if (/FROM matches/i.test(sql)) {
+                return { rows: [] };
+            }
+            return { rows: [{ rows: 0 }] };
+        }
+        async end() {
+            ended = true;
+        }
+    };
+
+    try {
+        const fresh = loadFreshModule();
+        const snapshot = await fresh.queryReadOnlyDbSnapshot(['53_20252026_4830466'], ['4830759']);
+        assert.equal(snapshot.row_counts.matches, 60);
+        assert.equal(snapshot.candidate_v2_rows_count, 0);
+        assert.equal(ended, true);
+    } finally {
+        pg.Pool = originalPool;
+        delete require.cache[require.resolve(MODULE_PATH)];
+    }
+});
+
+test('report and manifest do not contain full payload markers', async () => {
+    const result = await mod.runPlanning(validInput({ targetExternalIds: ['4830466'] }), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    const manifestText = JSON.stringify(result.updated_manifest);
+    const reportText = result.report;
+
+    assert.equal(manifestText.includes('<html>'), false);
+    assert.equal(manifestText.includes('__NEXT_DATA__'), false);
+    assert.equal(reportText.includes('<html>'), false);
+    assert.equal(reportText.includes('__NEXT_DATA__'), false);
+    assert.equal(reportText.includes('/matches/marseille-vs-rennes/2t9n7h'), true);
+});
+
+test('unresolved source inventory reconciliation is not executable by raw write runner', async () => {
+    const result = await mod.runPlanning(validInput(), {
+        manifest: manifest(),
+        renewedProposal: renewedProposal(),
+        sourceInventoryJson: sourceInventoryJson(),
+        dbSnapshot: dbSnapshot(),
+        writeManifest: false,
+        writeReport: false,
+    });
+    const gate = rawWrite.validateManifestGate(result.updated_manifest);
+
+    assert.equal(result.updated_manifest.raw_write_ready_for_execution, false);
+    assert.equal(result.updated_manifest.next_required_step, 'schedule_detail_identity_normalization_fix_planning');
+    assert.equal(gate.ok, false);
+    assert.match(gate.errors.join('\n'), /required_next_step/);
+});
+
+test('runCli prints only safe JSON summary', async () => {
+    const stdout = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = chunk => {
+        stdout.push(String(chunk));
+        return true;
+    };
+    try {
+        const result = await mod.runCli(
+            [
+                `--manifest=${mod.MANIFEST_PATH}`,
+                `--renewed-proposal=${mod.RENEWED_PROPOSAL_PATH}`,
+                `--report-output=${mod.REPORT_PATH}`,
+                '--source=fotmob',
+                '--league-id=53',
+                '--league-name=Ligue 1',
+                '--season=2025/2026',
+                '--raw-version=fotmob_pageprops_v2',
+                '--hash-strategy=stable_pageprops_payload_v1',
+                `--batch-id=${mod.BATCH_ID}`,
+                '--target-count=50',
+                '--planning-authorization=yes',
+                '--source-inventory-reconciliation-authorization=yes',
+                '--network-authorization=yes',
+                '--allow-db-write=no',
+                '--allow-raw-match-data-write=no',
+                '--allow-controlled-write=no',
+                '--allow-matches-write=no',
+                '--allow-bookmaker-odds-write=no',
+                '--allow-feature-write=no',
+                '--allow-schema-migration=no',
+                '--allow-parser-implementation=no',
+                '--allow-feature-extraction=no',
+                '--allow-training=no',
+                '--allow-prediction=no',
+                '--allow-browser-runtime=no',
+                '--allow-proxy-runtime=no',
+                '--print-full-body=no',
+                '--save-full-body=no',
+                '--print-full-json=no',
+                '--save-full-json=no',
+                '--print-full-pageprops=no',
+                '--save-full-pageprops=no',
+                '--target-external-ids=4830466',
+                '--retry=0',
+            ],
+            {
+                manifest: manifest(),
+                renewedProposal: renewedProposal(),
+                sourceInventoryJson: sourceInventoryJson(),
+                dbSnapshot: dbSnapshot(),
+                writeManifest: false,
+                writeReport: false,
+            }
+        );
+        assert.equal(result.status, 0);
+        assert.match(stdout.join(''), /"ok": true/);
+        assert.equal(stdout.join('').includes('<html>'), false);
+        assert.equal(stdout.join('').includes('__NEXT_DATA__'), false);
+    } finally {
+        process.stdout.write = originalWrite;
+    }
+});


### PR DESCRIPTION
## Summary
- add Phase 5.21L2V3E no-write source inventory reconciliation planning entrypoint, report, manifest metadata, and tests
- keep unresolved identity/source inventory mismatch blocking baseline acceptance and raw write retry
- classify the current 8/8 mismatch pattern as `schedule_vs_detail_external_id_mismatch` with `high` confidence

## Safety
- no DB writes
- no raw_match_data inserts
- no matches writes
- no accepted baseline replacement
- no raw write authorization
- unresolved identity/source inventory mismatch blocks baseline acceptance
- unresolved identity/source inventory mismatch blocks raw write retry
- separate baseline acceptance required
- separate final DB-write authorization required

## Findings
- checked_target_count=8
- identity_match_count=0
- identity_mismatch_count=8
- source_inventory_vs_manifest_mismatch_count=0
- manifest_vs_db_mismatch_count=0
- db_vs_live_observed_mismatch_count=8
- requested_vs_observed_external_id_mismatch_count=8
- suspected_root_cause=schedule_vs_detail_external_id_mismatch
- recommended_next_step=schedule_detail_identity_normalization_fix_planning

## Validation
- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js tests/unit/pageprops_v2_target_source_inventory_reconciliation_plan.test.js tests/unit/renewed_pageprops_v2_baseline_proposal_plan.test.js tests/unit/renewed_pageprops_v2_raw_write_execute.test.js tests/unit/post_seed_matches_identity_raw_write_readiness_audit.test.js tests/unit/controlled_matches_identity_seed_execute.test.js tests/unit/controlled_matches_identity_seed_prerequisite_plan.test.js tests/unit/single_league_pageprops_v2_controlled_write_execute.test.js tests/unit/single_league_pageprops_v2_controlled_write_plan.test.js tests/unit/single_league_small_batch_pageprops_v2_preflight.test.js tests/unit/pageprops_v2_single_target_write_preflight.test.js tests/unit/pageprops_v2_no_write_preview.test.js tests/unit/FotMobRawDetailFetcher.test.js tests/unit/RawMatchDataVersionSelector.test.js`
- `docker compose -f docker-compose.dev.yml exec -T dev npm test`
- `docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage`
- `docker compose -f docker-compose.dev.yml exec -T dev npm run lint`
- `docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3E.md tests/unit/pageprops_v2_target_identity_reconciliation_plan.test.js tests/unit/pageprops_v2_target_source_inventory_reconciliation_plan.test.js`
- `git diff --check`
