### PR TITLE
ci: use official npm registry for production image build

### DIFF
--- a/.github/workflows/production-gate.yml
+++ b/.github/workflows/production-gate.yml
@@ -149,6 +149,7 @@ jobs:
         run: |
           docker buildx build \
             --file Dockerfile \
+            --build-arg NPM_REGISTRY=https://registry.npmjs.org \
             --cache-from type=gha,scope=production-image-buildx \
             --cache-to type=gha,scope=production-image-buildx,mode=min \
             .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,13 @@ FROM node:20-bookworm-slim AS node-builder
 WORKDIR /build
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ARG NPM_REGISTRY=https://registry.npmjs.org
 
 COPY package.json package-lock.json ./
 
-RUN npm ci --omit=dev --ignore-scripts \
+RUN npm config set registry "${NPM_REGISTRY}" \
+    && npm config set replace-registry-host always \
+    && npm ci --omit=dev --ignore-scripts \
     && npx playwright install chromium \
     && npm cache clean --force
 


### PR DESCRIPTION
## Summary
- use the workflow-provided official npm registry for the production Docker build
- force npm to replace lockfile registry hosts during production image npm ci

## Why
- main Production Gate Docker Build Validation failed twice after #1306 because registry.npmmirror.com returned 504/502 for yocto-queue
- this keeps the fix scoped to CI/package installation and does not change runtime data behavior

## Safety
- no data artifact changes
- no DB writes
- no raw_match_data inserts
- no matches writes
- no baseline acceptance or raw write authorization

## Validation
- git diff --check
- commit/pr gatekeeper hooks passed
