### PR TITLE
docs(agents): enforce runtime implementation workflow guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,88 +1,81 @@
-## 📋 Pull Request 详情
+## PR Type
 
-### 🎯 变更类型
-请选择适用的类型：
-- [ ] 🐛 Bug修复 (Bug fix)
-- [ ] ✨ 新功能 (New feature)
-- [ ] 🔧 代码重构 (Refactoring)
-- [ ] 📚 文档更新 (Documentation)
-- [ ] 🎨 样式调整 (Style changes)
-- [ ] ⚡ 性能优化 (Performance improvement)
-- [ ] 🔒 安全修复 (Security fix)
-- [ ] 🚀 部署相关 (Deployment)
+选择一个主类型：
 
-### 📝 变更描述
-简要描述此次变更的内容：
+- [ ] runtime-code-change
+- [ ] governance-only
+- [ ] docs-only
+- [ ] test-only
+- [ ] ci-fix
+- [ ] data-artifact
 
-### 🔗 相关Issue
-关闭的Issue: Closes #(issue number)
+## Runtime Behavior
 
-### 🧪 测试情况
-- [ ] 所有现有测试通过
-- [ ] 添加了新的测试用例
-- [ ] 手动测试已完成
-- [ ] 测试覆盖率达到80%以上
+- Runtime code change included: yes / no
+- Runtime code paths changed: n/a
+- Runtime behavior changed: n/a
 
-### 📸 截图/演示
-如果有UI变更，请提供截图或GIF演示：
+如果这是 implementation phase 但没有 runtime code change，默认 No-Go。请说明原因、blocker 和人工确认：
 
-### ✅ 检查清单
-代码质量：
-- [ ] 代码已通过lint检查 (black, flake8)
-- [ ] 代码已通过类型检查 (mypy)
-- [ ] 代码已通过安全扫描 (bandit)
-- [ ] 添加了适当的注释和文档字符串
-- [ ] 变量和函数命名清晰易懂
+- Explanation:
+- Human confirmation:
 
-功能完整性：
-- [ ] 功能按预期工作
-- [ ] 处理了错误情况
-- [ ] 添加了适当的日志记录
-- [ ] API文档已更新（如适用）
+## Artifact Scope
 
-数据库变更（如适用）：
-- [ ] 数据库迁移脚本已创建
-- [ ] 迁移脚本已测试
-- [ ] 考虑了向后兼容性
-- [ ] 更新了数据库文档
+- Docs/report/manifest changes included: yes / no
+- Added/modified report lines:
+- Added/modified manifest lines:
+- Copies full historical state: yes / no
+- Includes large artifact: yes / no
+- Large artifact justification, if any:
 
-部署相关：
-- [ ] 环境变量已文档化
-- [ ] Docker构建成功
-- [ ] 健康检查端点正常工作
-- [ ] 考虑了部署对生产环境的影响
+## Business Progress
 
-### 🎯 部署计划
-- [ ] 需要停机维护
-- [ ] 可以热部署
-- [ ] 需要数据库迁移
-- [ ] 需要更新环境变量
-- [ ] 需要清除缓存
+- Business progress:
+- Blocker removed:
+- Blocker remaining:
+- Next step:
 
-### 📋 测试指南
-为reviewer提供测试此PR的步骤：
+## Safety Status
 
-1. 
-2. 
-3. 
+- no live fetch: yes / no / n/a
+- no detail fetch: yes / no / n/a
+- no network request: yes / no / n/a
+- no DB writes: yes / no / n/a
+- no raw_match_data inserts: yes / no / n/a
+- no matches writes: yes / no / n/a
+- no matches.external_id changes: yes / no / n/a
+- no raw write execution: yes / no / n/a
+- no re-acceptance execution: yes / no / n/a
+- no suspension reversal: yes / no / n/a
+- no rollback execution: yes / no / n/a
+- no parser/features/training/prediction: yes / no / n/a
+- no full body/raw_data/pageProps saved or printed: yes / no / n/a
 
-### 💭 其他说明
-添加任何reviewer需要知道的其他信息：
+If any answer is `no`, list the explicit authorization, scope, command, and verification:
 
----
+- Authorization details:
 
-### 📊 代码统计
-- 新增行数: 
-- 删除行数: 
-- 修改文件数: 
-- 新增测试数: 
+## Tests Run
 
-### 🔄 后续工作
-此PR完成后的后续计划：
-- [ ] 
-- [ ] 
-- [ ] 
+- [ ] lint
+- [ ] unit tests
+- [ ] coverage
+- [ ] formatter
+- [ ] git diff --check
+- [ ] hidden/bidi scan
+- [ ] full payload marker scan
+- [ ] DB SELECT-only safety check, if applicable
+- [ ] other:
 
----
+Commands and results:
 
-**感谢您的贡献！** 🎉 
+```text
+
+```
+
+## Review Notes
+
+- Reviewer focus:
+- Residual risk:
+- Follow-up PR, if any:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,18 @@
 8. 修改后要做与改动范围相匹配的验证。
 9. 数据收割、ETL、Recon、Backfill、Odds、L3/ELO 相关入口默认必须走 `make data-*` 安全门禁。
 10. DB schema migration 默认必须走 `make data-schema-*` 安全门禁，禁止直接执行 migration apply。
+11. implementation phase 必须包含实际 runtime code behavior change；
+    不得只用 `docs/_reports`、`docs/_manifests`、tests 或 proposal metadata 替代实现。
+12. 如果无法安全完成 runtime code change，必须 No-Go 并说明 blocker；
+    不得用继续新增 report / manifest phase snapshot 伪装业务推进。
+13. PR 必须声明 PR type、runtime behavior 是否变化、business progress、剩余 blocker，
+    以及 no-live-fetch / no-DB-write / no-raw-write 状态。
+14. 连续 governance-only PR 超过 1 个，或 implementation PR 没有 runtime behavior change，
+    必须先人工确认后再继续。
+15. report / manifest 必须最小化；
+    大型治理 artifact、完整历史状态复制和无限 phase snapshot 不得默认提交到 `main`。
+16. 测试必须优先验证系统行为；
+    文档字段断言只能作为辅助，不得替代 runtime behavior coverage。
 
 ### 2.2 默认工作方式
 
@@ -107,6 +119,17 @@
 - 不硬编码应进入配置系统的参数。
 - 不添加未被请求的功能。
 - 不因为“顺手”移动核心模块边界。
+- 不把 implementation phase 降级成 docs-only / report-only / manifest-only / test-only PR。
+- 不默认提交大型 phase snapshot、完整历史 manifest 复制或无限增长的治理 artifact。
+
+### 2.4 Agent workflow hardening
+
+详细规则见 `docs/AGENT_WORKFLOW.md`。默认执行原则：
+
+- 代码解决问题，测试证明问题，文档解释问题。
+- live fetch、detail fetch、network request、DB write、`raw_match_data` write、re-acceptance、rollback、schema migration 仍必须逐项单独授权。
+- `docs/_reports` 与 `docs/_manifests` 只记录必要 delta 和当前有效状态；不得替代 runtime 实现。
+- PR reviewer 必须能从模板中直接判断：PR type、runtime code paths、artifact 体积、business progress、blocker 变化和安全边界。
 
 ---
 

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -1,0 +1,169 @@
+# Agent Workflow Hardening
+
+本文件约束 Codex / AI agent 在本仓库中的工程作业方式。目标是防止 implementation phase 退化为文档堆叠，防止 report / manifest 失控膨胀，并让每个 PR 都能明确回答：解决了什么系统问题、代码行为是否变化、还剩什么 blocker。
+
+## 1. 核心原则
+
+- 代码解决问题，测试证明问题，文档解释问题。
+- implementation phase 必须推动 runtime 行为变化。
+- docs、reports、manifests、proposal metadata 不能替代 implementation。
+- 每个 PR 必须声明 PR type、business progress、安全边界和剩余 blocker。
+- 变更范围必须可 review；禁止把大型 phase snapshot 当作默认推进方式。
+
+## 2. PR 类型
+
+每个 PR 必须选择且只选择一个主类型：
+
+- `runtime-code-change`: 修改 runtime code path，并改变可执行系统行为。
+- `governance-only`: 只调整规则、流程、runbook、模板或作业约束。
+- `docs-only`: 只更新说明性文档，不改变流程规则和系统行为。
+- `test-only`: 只新增或修正测试，不改变 runtime 代码。
+- `ci-fix`: 只修复 CI、lint、format、dependency gate 或构建配置。
+- `data-artifact`: 只更新已授权的数据 artifact、manifest delta 或 source-controlled metadata。
+
+辅助类型可以在 PR body 说明，但不能掩盖主类型。例如 implementation phase 如果没有 runtime code behavior change，不能标成 `runtime-code-change`。
+
+## 3. Implementation PR 验收标准
+
+implementation PR 必须同时满足：
+
+- 修改 runtime code path，例如 `src/`、`scripts/ops/`、配置加载、门禁入口或真实执行路径。
+- PR body 明确列出改动的 runtime code paths。
+- 行为变化可以被 reviewer 从 diff 中验证。
+- 测试优先覆盖行为结果、阻断条件、边界输入和失败路径。
+- docs / reports / manifests 只作为结果说明或必要 metadata，不作为主要交付物。
+
+以下情况默认 No-Go：
+
+- 只修改 `docs/_reports`、`docs/_manifests`、tests 或 proposal metadata。
+- 只新增 phase report，没有改变实际执行路径。
+- 只把字段名加入文档或测试 allowlist，没有修复导致 blocker 的代码。
+- 无法安全实现 runtime change，却用 report 宣称 implementation 完成。
+
+如果确实不能安全改 runtime code，必须停止并输出 No-Go 报告，说明 blocker、风险、需要的授权或设计决策。
+
+## 4. Governance-only PR 限制
+
+governance-only PR 允许建立规则、模板、runbook 或安全边界，但必须满足：
+
+- PR body 明确写 `no runtime code changed`。
+- 不声称解除业务 blocker。
+- 不把 recommended next step 推进成 implementation done。
+- 不创建大型 phase snapshot。
+- 不把 governance artifact 写成事实执行结果。
+
+连续 governance-only PR 超过 1 个时，必须人工确认是否继续治理路线。没有人工确认时，应停止并做 architecture review 或转入真正的 runtime implementation。
+
+## 5. Docs / Report / Manifest 体积规则
+
+新增或修改 artifact 必须最小化：
+
+- report 只记录本阶段 delta、关键结论、验证命令和剩余 blocker。
+- manifest 优先记录 current effective state，不复制完整历史状态。
+- phase artifact 只记录该 phase 的输入、输出和 delta。
+- 不得为每个微小状态变化复制整份大型 manifest。
+- 大型 raw body、完整 pageProps、完整 source body 不得提交到 git。
+- 大型诊断输出应优先作为 CI artifact、本地临时文件或 archive 方案，并单独说明保留策略。
+
+PR 模板必须披露：
+
+- 新增/修改 report 行数。
+- 新增/修改 manifest 行数。
+- 是否复制完整历史状态。
+- 是否包含 large artifact。
+- 如果包含 large artifact，必须说明为什么不能最小化。
+
+## 6. Current State Manifest 原则
+
+source-controlled manifest 应表达当前有效状态，而不是无限增长的阶段日志。
+
+推荐结构：
+
+- 顶层保存当前 batch、source、route、data_version、hash_strategy 和 next required action。
+- per-target 保存当前有效 identity、baseline、blocker 和安全状态。
+- 历史 phase 只保存必要引用、hash 或短摘要。
+- 已废弃字段保留时必须标记 deprecated，并说明 reader 是否仍使用。
+
+禁止结构：
+
+- 每个 phase 都把全部 targets、历史状态和所有字段完整复制一遍。
+- 为了通过测试而保留无实际 reader 的冗余字段。
+- 在 manifest 中保存 full payload、full body、full pageProps 或敏感来源内容。
+
+## 7. Large Artifact 归档原则
+
+大型 artifact 不应默认进入 `main`。如必须保留：
+
+- 先判断是否可以只保留 hash、row count、schema summary、sample path 或 CI artifact link。
+- 如果必须 source-control，必须使用 archive 路径或明确的 retention policy。
+- archive 变更不得和 runtime implementation 混在同一个 PR，除非它是该实现的必要输入。
+- 不做大规模历史清理，除非用户明确要求并单独开 PR。
+
+## 8. Testing 原则
+
+测试应优先证明系统行为：
+
+- 对 runtime-code-change，至少覆盖成功路径、阻断路径和关键安全边界。
+- 对 data gate，覆盖 no-write、no-network、no-full-payload-print/save、hash gate、identity gate。
+- 对 DB 相关变更，写入前必须有 SELECT-only preflight；写入必须单独授权。
+- 对 docs-only / governance-only，可以做 markdown、link、template 或 policy lint，但不得声称业务逻辑被验证。
+
+文档字段测试从严：
+
+- 只允许验证对系统 reader、gate 或 reviewer 有实际意义的字段。
+- 不得用 allowlist 扩张掩盖真实 blocker。
+- 不得把 recommended next step 字段变化当作业务推进证明。
+
+## 9. Stopping Rules
+
+出现以下任一情况必须停止，输出 No-Go 或 architecture review：
+
+- implementation phase 没有 runtime behavior change。
+- 连续 planning / governance 阶段没有移除 blocker。
+- report / manifest 行数增长明显超过代码改动，且无法证明必要性。
+- 测试主要验证文档字段，而不是 runtime behavior。
+- PR body 无法说明 business progress 或 blocker removed。
+- 下一步需要 live fetch、detail fetch、network request、DB write、raw write、re-acceptance、rollback 或 schema migration，但缺少明确授权。
+
+## 10. Safety Disclosure
+
+所有相关 PR 必须明确声明：
+
+- no live fetch / detail fetch / network request 状态。
+- no DB write / no raw_match_data insert / no matches write 状态。
+- no raw write execution 状态。
+- no re-acceptance / suspension reversal / rollback 状态。
+- no parser / features / training / prediction 状态。
+- 是否保存或打印 full body、full JSON、full raw_data、full pageProps。
+
+如果某项被执行，必须列出授权来源、命令、范围、写入表、row count 和回滚/验证结果。
+
+## 11. Review Expectations
+
+reviewer 应能在 PR 中快速看到：
+
+- PR type。
+- runtime behavior 是否变化。
+- 改了哪些 runtime code paths。
+- business progress 是什么。
+- blocker removed 是什么。
+- blocker remaining 是什么。
+- artifact 是否最小化。
+- 测试是否证明行为。
+- 安全边界是否保持。
+
+如果这些信息缺失，PR 默认不应合并。
+
+## 12. Workflow Sequence
+
+默认顺序：
+
+1. 读现有代码、规则、manifest 和相关测试。
+2. 确认 PR type 与授权边界。
+3. 对 implementation，先改 runtime 行为，再补行为测试。
+4. 只写必要 docs / manifest delta。
+5. 运行范围匹配的验证。
+6. 填写 PR 模板，明确 business progress 和剩余 blocker。
+7. CI green 后再合并。
+
+这套顺序不能绕过既有 L1/L2/L3、DB、raw write、network、schema migration 授权规则。

--- a/docs/_manifests/README.md
+++ b/docs/_manifests/README.md
@@ -1,0 +1,21 @@
+# Manifest Management
+
+`docs/_manifests` 保存 source-controlled metadata，不是无限增长的 phase snapshot 仓库。
+
+## Rules
+
+- 优先维护 current effective state。
+- phase artifact 只记录本阶段 delta、输入、输出、hash 和 blocker。
+- 不复制完整历史 manifest，除非 reviewer 无法用较小 delta 重建必要上下文。
+- 不保存 full body、full JSON、full raw_data 或 full pageProps。
+- 大型 artifact 默认不进入 `main`；优先使用 hash、row count、schema summary、sample path 或 CI artifact。
+- manifest 字段必须有 reader、gate 或 review 价值；不得为了测试 allowlist 继续堆字段。
+- historical artifact 清理或 archive 重构必须单独授权，不和普通 implementation PR 混做。
+
+## Preferred Shape
+
+- current batch/source/route/data_version/hash_strategy
+- current per-target identity/baseline/blocker state
+- accepted baseline hash or proposal hash, with status
+- next required action
+- short references to historical reports or phase artifacts


### PR DESCRIPTION
## PR Type

- governance-only

## Summary

- establishes agent workflow guardrails
- implementation phases must include runtime code behavior changes
- docs/report/manifest cannot substitute for implementation
- PRs must declare type and business progress
- report/manifest bloat is constrained
- testing should prioritize runtime behavior over document field assertions
- manifest management now prefers current effective state and small phase deltas

## Runtime Behavior

- no runtime code changed in this workflow PR
- runtime code paths changed: n/a
- runtime behavior changed: no

## Safety

- no live fetch
- no detail fetch
- no network request
- no DB writes
- no raw_match_data inserts
- no matches writes
- no matches.external_id changes
- no raw write execution
- no re-acceptance execution
- no suspension reversal
- no rollback execution
- no FotMob data ingestion changes
- no parser/features/training/prediction
- no full body/raw_data/pageProps saved or printed

## Business Progress

- establishes workflow guardrails before resuming L2V3AX
- blocker removed: agent workflow now explicitly blocks implementation phases without runtime behavior change
- blocker remaining: L2V3AX controlled no-write identity contract regression planning is still not executed in this PR
- next step after this workflow PR is L2V3AX controlled no-write identity contract regression planning

## Artifact Scope

- AGENTS.md: adds concise hard rules for runtime implementation requirements and artifact limits
- docs/AGENT_WORKFLOW.md: adds detailed PR type, implementation, governance, artifact, testing, and stopping rules
- .github/pull_request_template.md: requires PR type, runtime behavior, artifact size, business progress, safety, and tests
- docs/_manifests/README.md: adds manifest bloat guardrail and current-state guidance
- no large artifact
- no phase snapshot
- no historical artifact cleanup

## Tests Run

```text
docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown AGENTS.md docs/AGENT_WORKFLOW.md .github/pull_request_template.md docs/_manifests/README.md
docker compose -f docker-compose.dev.yml exec -T dev npm run lint
docker compose -f docker-compose.dev.yml exec -T dev npm test
docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage
git diff --cached --check
hidden/bidi scan on changed files and cached diff
full payload marker scan on cached diff
docs/_staging_preview absence check
l1-config residue check
pre-commit Gatekeeper
pre-push Gatekeeper
```

Additional note: `npm run lint:md` was attempted and failed on pre-existing repository-wide markdownlint violations in AGENTS/archive/root docs; this PR does not attempt a broad markdown cleanup.
