### PR TITLE
docs(data): plan pageProps v2 identity contract regression

### DIFF
--- a/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.identity_contract_regression_plan.phase521l2v3ax.json
+++ b/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.identity_contract_regression_plan.phase521l2v3ax.json
@@ -1,0 +1,85 @@
+{
+    "artifact_type": "identity_contract_regression_plan",
+    "artifact_status": "completed_controlled_no_write_identity_contract_regression_planning",
+    "proposal_phase": "Phase 5.21L2V3AX",
+    "phase_name": "controlled_no_write_identity_contract_regression_planning",
+    "generated_at": "2026-05-26T23:29:56Z",
+    "pr_type": "data-artifact/planning",
+    "planning_only": true,
+    "runtime_code_change": false,
+    "regression_planning_status": "completed_controlled_no_write_identity_contract_regression_planning",
+    "reviewed_input_artifact_count": 7,
+    "reviewed_input_artifact_paths": {
+        "aw_implementation_manifest": "docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.recapture_runner_identity_input_contract_fix_implementation.phase521l2v3aw.json",
+        "aw_implementation_report": "docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3AW.md",
+        "av_fix_plan_manifest": "docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.recapture_runner_identity_input_contract_fix_plan.phase521l2v3av.json",
+        "ao_no_write_recapture_result": "docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.no_write_payload_recapture_result.phase521l2v3ao.json",
+        "aw_implementation_tests": "tests/unit/pageprops_v2_recapture_runner_identity_input_contract_fix_implementation_aw.test.js",
+        "recapture_runner": "scripts/ops/pageprops_v2_no_write_payload_recapture_execute.js",
+        "route_identity_reconciler": "src/infrastructure/services/FotMobRouteIdentityReconciler.js"
+    },
+    "target_behavior_under_test_count": 7,
+    "planned_regression_case_count": 7,
+    "planned_regression_cases": [
+        {
+            "id": "schedule_external_id_is_correlation_only",
+            "expected_result": "schedule-side external_id is not blindly used as detail route identity"
+        },
+        {
+            "id": "suspended_mapping_baseline_blocks_before_fetch",
+            "expected_result": "suspended mapping or baseline blocks recapture before fetch"
+        },
+        {
+            "id": "missing_re_acceptance_blocks_before_fetch",
+            "expected_result": "missing re-acceptance blocks recapture before fetch"
+        },
+        {
+            "id": "page_url_base_slug_fragment_alone_insufficient",
+            "expected_result": "page_url_base, slug, and fragment evidence alone remain insufficient"
+        },
+        {
+            "id": "requested_4830466_observed_4830759_remains_blocked",
+            "expected_result": "requested 4830466 observed 4830759 remains blocked"
+        },
+        {
+            "id": "hash_mismatch_under_identity_mismatch_cannot_update_baseline",
+            "expected_result": "hash mismatch under identity mismatch cannot update baseline"
+        },
+        {
+            "id": "raw_write_execution_ready_remains_false",
+            "expected_result": "raw_write_execution_ready remains false"
+        }
+    ],
+    "planned_blocking_rule_count": 7,
+    "planned_blocking_rules": [
+        "schedule_external_id_default_detail_route_blocked",
+        "suspended_mapping_or_baseline_blocks_recapture",
+        "missing_re_acceptance_blocks_recapture",
+        "page_url_base_slug_fragment_alone_insufficient",
+        "identity_mismatch_blocks_recapture",
+        "hash_mismatch_secondary_to_identity_mismatch_blocks_baseline_update",
+        "raw_write_execution_ready_false_until_future_authorization"
+    ],
+    "live_fetch_performed": false,
+    "detail_fetch_performed": false,
+    "network_request_performed": false,
+    "recapture_retry_performed": false,
+    "db_write_performed": false,
+    "raw_match_data_insert_performed": false,
+    "matches_write_performed": false,
+    "matches_external_id_modified": false,
+    "raw_write_execution_performed": false,
+    "re_acceptance_execution_performed": false,
+    "suspension_reversal_performed": false,
+    "rollback_execution_performed": false,
+    "parser_features_training_prediction_performed": false,
+    "schema_migration_performed": false,
+    "full_payload_saved": false,
+    "full_payload_printed": false,
+    "raw_write_execution_ready": false,
+    "large_artifact_added": false,
+    "full_phase_snapshot_added": false,
+    "history_artifact_cleanup_performed": false,
+    "recommended_next_step": "Phase 5.21L2V3AY: controlled no-write identity contract regression execution",
+    "next_required_step": "controlled_no_write_identity_contract_regression_execution"
+}

--- a/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json
+++ b/docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json
@@ -5689,5 +5689,13 @@
     "page_url_base_alone_insufficient_enforced": true,
     "identity_mismatch_blocks_recapture": true,
     "hash_mismatch_under_identity_mismatch_blocks_baseline_update": true,
-    "recommended_next_step_after_l2v3aw": "Phase 5.21L2V3AX: controlled no-write identity contract regression planning"
+    "recommended_next_step_after_l2v3aw": "Phase 5.21L2V3AX: controlled no-write identity contract regression planning",
+    "phase_5_21_l2v3ax_planning_status": "completed_controlled_no_write_identity_contract_regression_planning",
+    "phase_5_21_l2v3ax_artifact_path": "docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.identity_contract_regression_plan.phase521l2v3ax.json",
+    "phase_5_21_l2v3ax_report_path": "docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3AX.md",
+    "identity_contract_regression_planning_status": "completed_controlled_no_write_identity_contract_regression_planning",
+    "target_behavior_under_test_count": 7,
+    "planned_regression_case_count": 7,
+    "planned_regression_blocking_rule_count": 7,
+    "recommended_next_step_after_l2v3ax": "Phase 5.21L2V3AY: controlled no-write identity contract regression execution"
 }

--- a/docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3AX.md
+++ b/docs/_reports/DATA_ENTRYPOINT_GOVERNANCE_PHASE5_21_L2V3AX.md
@@ -1,0 +1,89 @@
+# Data Entrypoint Governance - Phase 5.21 L2V3AX
+
+## Scope
+
+- phase=Phase 5.21L2V3AX
+- phase_name=controlled_no_write_identity_contract_regression_planning
+- pr_type=data-artifact/planning
+- planning_only=true
+- runtime_code_change=false
+- no live fetch
+- no detail fetch
+- no network request
+- no recapture retry
+- no DB writes
+- no raw_match_data inserts
+- no matches writes
+- no matches.external_id changes
+- no raw write execution
+- no re-acceptance execution
+- no suspension reversal
+- no rollback
+
+## Business Progress
+
+- regression_planning_status=completed_controlled_no_write_identity_contract_regression_planning
+- reviewed_input_artifact_count=7
+- target_behavior_under_test_count=7
+- planned_regression_case_count=7
+- planned_blocking_rule_count=7
+- This phase plans how to verify the L2V3AW runtime behavior without executing the regression.
+- It keeps the next action as a no-write regression execution, not a recapture retry or raw write.
+
+## Planned Regression Cases
+
+1. schedule_external_id_is_correlation_only
+    - verify schedule-side external_id is not blindly used as detail route identity.
+2. suspended_mapping_baseline_blocks_before_fetch
+    - verify suspended mapping or baseline blocks recapture before any fetch hook can run.
+3. missing_re_acceptance_blocks_before_fetch
+    - verify missing re-acceptance blocks recapture and does not fall back to schedule route.
+4. page_url_base_slug_fragment_alone_insufficient
+    - verify page_url_base, slug, and fragment evidence alone remain insufficient.
+5. requested_4830466_observed_4830759_remains_blocked
+    - verify requested 4830466 observed 4830759 remains blocked.
+6. hash_mismatch_under_identity_mismatch_cannot_update_baseline
+    - verify hash mismatch under identity mismatch cannot update baseline.
+7. raw_write_execution_ready_remains_false
+    - verify raw_write_execution_ready remains false through no-write regression.
+
+## Planned Blocking Rules
+
+- schedule_external_id_default_detail_route_blocked
+- suspended_mapping_or_baseline_blocks_recapture
+- missing_re_acceptance_blocks_recapture
+- page_url_base_slug_fragment_alone_insufficient
+- identity_mismatch_blocks_recapture
+- hash_mismatch_secondary_to_identity_mismatch_blocks_baseline_update
+- raw_write_execution_ready_false_until_future_authorization
+
+## Safety Result
+
+- live_fetch_performed=false
+- detail_fetch_performed=false
+- network_request_performed=false
+- recapture_retry_performed=false
+- db_write_performed=false
+- raw_match_data_insert_performed=false
+- matches_write_performed=false
+- matches_external_id_modified=false
+- raw_write_execution_performed=false
+- re_acceptance_execution_performed=false
+- suspension_reversal_performed=false
+- rollback_execution_performed=false
+- parser_features_training_prediction_performed=false
+- schema_migration_performed=false
+- full_payload_saved=false
+- full_payload_printed=false
+- raw_write_execution_ready=false
+
+## Artifact Guardrail Compliance
+
+- Added report is a small phase delta, not a full historical snapshot.
+- Added manifest records only the regression plan delta.
+- Proposal manifest update records current AX status and next required step only.
+- No large artifact, no full payload, no archive cleanup, no history deletion.
+
+## Next Step
+
+- recommended_next_step=Phase 5.21L2V3AY: controlled no-write identity contract regression execution

--- a/tests/unit/pageprops_v2_identity_contract_regression_plan_ax.test.js
+++ b/tests/unit/pageprops_v2_identity_contract_regression_plan_ax.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const MANIFEST_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.identity_contract_regression_plan.phase521l2v3ax.json'
+);
+const PROPOSAL_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json'
+);
+
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('L2V3AX records a controlled no-write regression plan without execution side effects', () => {
+    const artifact = readJson(MANIFEST_PATH);
+
+    assert.equal(artifact.proposal_phase, 'Phase 5.21L2V3AX');
+    assert.equal(
+        artifact.regression_planning_status,
+        'completed_controlled_no_write_identity_contract_regression_planning'
+    );
+    assert.equal(artifact.planning_only, true);
+    assert.equal(artifact.runtime_code_change, false);
+    assert.equal(artifact.live_fetch_performed, false);
+    assert.equal(artifact.network_request_performed, false);
+    assert.equal(artifact.recapture_retry_performed, false);
+    assert.equal(artifact.db_write_performed, false);
+    assert.equal(artifact.raw_match_data_insert_performed, false);
+    assert.equal(artifact.raw_write_execution_performed, false);
+    assert.equal(artifact.raw_write_execution_ready, false);
+});
+
+test('L2V3AX plans regression coverage for the L2V3AW identity contract behavior', () => {
+    const artifact = readJson(MANIFEST_PATH);
+    const caseIds = artifact.planned_regression_cases.map(item => item.id);
+
+    assert.equal(artifact.reviewed_input_artifact_count, 7);
+    assert.equal(artifact.target_behavior_under_test_count, 7);
+    assert.equal(artifact.planned_regression_case_count, 7);
+    assert.equal(artifact.planned_blocking_rule_count, 7);
+    assert.equal(caseIds.includes('schedule_external_id_is_correlation_only'), true);
+    assert.equal(caseIds.includes('requested_4830466_observed_4830759_remains_blocked'), true);
+    assert.equal(caseIds.includes('hash_mismatch_under_identity_mismatch_cannot_update_baseline'), true);
+    assert.equal(caseIds.includes('raw_write_execution_ready_remains_false'), true);
+});
+
+test('L2V3AX advances only to no-write regression execution in the current manifest', () => {
+    const artifact = readJson(MANIFEST_PATH);
+    const proposal = readJson(PROPOSAL_PATH);
+
+    assert.equal(
+        artifact.recommended_next_step,
+        'Phase 5.21L2V3AY: controlled no-write identity contract regression execution'
+    );
+    assert.equal(
+        proposal.phase_5_21_l2v3ax_planning_status,
+        'completed_controlled_no_write_identity_contract_regression_planning'
+    );
+    assert.equal(proposal.planned_regression_case_count, 7);
+    assert.equal(proposal.raw_write_execution_ready, false);
+    assert.equal(
+        proposal.recommended_next_step_after_l2v3ax,
+        'Phase 5.21L2V3AY: controlled no-write identity contract regression execution'
+    );
+});

--- a/tests/unit/pageprops_v2_no_write_payload_recapture_plan_an.test.js
+++ b/tests/unit/pageprops_v2_no_write_payload_recapture_plan_an.test.js
@@ -440,6 +440,8 @@ test('repository L2V3AN artifacts preserve planning-only semantics when generate
             'accepted_mapping_and_baseline_suspension_execution',
             'expanded_accepted_mapping_baseline_contradiction_review_planning',
             'recapture_runner_identity_input_contract_fix_planning',
+            'controlled_no_write_identity_contract_regression_planning',
+            'controlled_no_write_identity_contract_regression_execution',
             'continued_no_write_recapture_blocker_investigation',
         ].includes(manifestJson.next_required_step)
     );


### PR DESCRIPTION
## PR Type

选择一个主类型：

- [ ] runtime-code-change
- [ ] governance-only
- [ ] docs-only
- [ ] test-only
- [ ] ci-fix
- [x] data-artifact

## Runtime Behavior

- Runtime code change included: no
- Runtime code paths changed: n/a
- Runtime behavior changed: no

如果这是 implementation phase 但没有 runtime code change，默认 No-Go。请说明原因、blocker 和人工确认：

- Explanation: This is Phase 5.21L2V3AX planning-only, not an implementation phase.
- Human confirmation: user explicitly requested controlled no-write identity contract regression planning after #1326 and main CI green.

## Artifact Scope

- Docs/report/manifest changes included: yes
- Added/modified report lines: 89 added
- Added/modified manifest lines: 85 added in AX delta manifest; proposal manifest +9/-1 current-state delta
- Copies full historical state: no
- Includes large artifact: no
- Large artifact justification, if any: n/a

## Business Progress

- Business progress: plans the controlled no-write regression that will verify the L2V3AW runtime identity contract behavior before any renewed recapture or raw write step.
- Blocker removed: next regression execution now has a small explicit case list, blocking rule list, no-write flags, and artifact guardrails.
- Blocker remaining: the no-write identity contract regression has not been executed in this PR.
- Next step: Phase 5.21L2V3AY controlled no-write identity contract regression execution.

## Safety Status

- no live fetch: yes
- no detail fetch: yes
- no network request: yes
- no DB writes: yes
- no raw_match_data inserts: yes
- no matches writes: yes
- no matches.external_id changes: yes
- no raw write execution: yes
- no re-acceptance execution: yes
- no suspension reversal: yes
- no rollback execution: yes
- no parser/features/training/prediction: yes
- no full body/raw_data/pageProps saved or printed: yes

If any answer is `no`, list the explicit authorization, scope, command, and verification:

- Authorization details: n/a

## Tests Run

- [x] lint
- [x] unit tests
- [x] coverage
- [x] formatter
- [x] git diff --check
- [x] hidden/bidi scan
- [x] full payload marker scan
- [x] DB SELECT-only safety check, if applicable
- [x] other: staged diff no DB/write/migration/network code path scan; docs/_staging_preview absence; L1 config residue scan

Commands and results:

```text
docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/pageprops_v2_identity_contract_regression_plan_ax.test.js tests/unit/pageprops_v2_recapture_runner_identity_input_contract_fix_implementation_aw.test.js tests/unit/pageprops_v2_recapture_runner_identity_input_contract_fix_plan_av.test.js tests/unit/pageprops_v2_no_write_payload_recapture_execute_ao.test.js
# pass: 37/37

docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/FotMobRouteIdentityReconciler.test.js tests/unit/RawMatchDataVersionSelector.test.js tests/unit/pageprops_v2_no_write_payload_recapture_plan_an.test.js tests/unit/renewed_pageprops_v2_raw_write_execute.test.js
# pass: 67/67

docker compose -f docker-compose.dev.yml exec -T dev npm run lint
# pass

docker compose -f docker-compose.dev.yml exec -T dev npm test
# pass

docker compose -f docker-compose.dev.yml exec -T dev npm run test:coverage
# pass

docker compose -f docker-compose.dev.yml exec -T dev npx prettier --check --ignore-unknown <changed files>
# pass

git diff --cached --check
# pass

hidden/bidi scan on changed files and staged diff
# affected_files=[]; character_types_found=[]

full payload marker scan
# docs/manifest contain no full payload markers; test hits are negative assertions only

docs/_staging_preview absence check
# pass

L1 config residue scan
# pass
```

## Review Notes

- Reviewer focus: planned regression cases and blocking rules match the L2V3AW behavior under test, without expanding into execution.
- Residual risk: this PR only plans the regression; it does not prove runtime behavior beyond existing L2V3AW tests.
- Follow-up PR, if any: Phase 5.21L2V3AY controlled no-write identity contract regression execution.
