### PR TITLE
data(source): diagnose FotMob identity hash routing without writes

### DIFF
--- a/docs/_manifests/fotmob_identity_anti_bot_differential_diagnosis_result.adg2.json
+++ b/docs/_manifests/fotmob_identity_anti_bot_differential_diagnosis_result.adg2.json
@@ -1,0 +1,222 @@
+{
+    "schema_version": "fotmob_identity_differential_diagnosis_result_v1",
+    "phase": "Phase 5.21-ADG2",
+    "adg2_execution_status": "completed_bounded_fotmob_identity_anti_bot_differential_diagnosis_execution",
+    "adg2_execution_performed": true,
+    "generated_at": "2026-05-27T14:45:00Z",
+    "source_prerequisites": {
+        "adg1_pr": 1335,
+        "adg1_merge_commit": "fbdf5d4f8e95866df047fd30efb5e4112018dab7",
+        "main_production_gate_green_before_adg2": true
+    },
+    "execution_scope": {
+        "positive_sample_count": 1,
+        "suspended_sample_diagnosis_count": 3,
+        "needs_new_evidence_sample_diagnosis_count": 3,
+        "uncontrolled_retry_performed": false,
+        "bulk_fetch_performed": false,
+        "captcha_bypass_performed": false,
+        "proxy_bypass_performed": false,
+        "login_or_access_control_bypass_performed": false
+    },
+    "safety_status": {
+        "live_fetch_performed": true,
+        "network_request_performed": true,
+        "browser_automation_performed": false,
+        "db_write_performed": false,
+        "raw_write_execution_performed": false,
+        "raw_match_data_insert_performed": false,
+        "matches_write_performed": false,
+        "matches_external_id_modified": false,
+        "re_acceptance_execution_performed": false,
+        "suspension_reversal_performed": false,
+        "rollback_execution_performed": false,
+        "parser_features_training_prediction_performed": false,
+        "full_payload_saved": false,
+        "full_payload_printed": false,
+        "raw_write_execution_ready": false
+    },
+    "positive_sample_url_parsing": {
+        "source_page_url": "https://www.fotmob.com/zh-Hans/matches/manchester-city-vs-afc-bournemouth/2feiv3#4813735",
+        "parsed_url_path_slug": "2feiv3",
+        "parsed_url_hash_id": "4813735",
+        "positive_sample_url_hash_id": "4813735",
+        "positive_sample_url_path_slug": "2feiv3",
+        "hash_id_numeric": true,
+        "hash_id_available_before_http_request": true,
+        "fragment_sent_to_server_by_http": false,
+        "note": "URL fragment is not sent to the server by normal HTTP requests; it must be parsed from the href/string before request."
+    },
+    "hash_id_extraction_diagnosis": {
+        "discovery_extracts_hash_id": true,
+        "discovery_persists_hash_id": true,
+        "source_url_fragment_external_id_supported": true,
+        "source_inventory_all_50_records_have_fragment_id": true,
+        "active_proposal_candidate_targets_have_fragment_id": false,
+        "diagnosis": "source inventory code and artifact support URL hash id extraction, but current active proposal candidate_targets do not carry source_page_url/source_url_fragment_external_id fields for the sampled targets."
+    },
+    "discovery_chain_diagnosis": {
+        "evidence_file_paths": [
+            "src/infrastructure/services/FotMobSourceInventoryAdapter.js",
+            "scripts/ops/pageprops_v2_source_inventory_enrichment_apply.js",
+            "scripts/ops/pageprops_v2_controlled_source_inventory_acquisition_execute.js",
+            "docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.controlled_source_inventory_acquisition_result.phase521l2v3y.json",
+            "docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.proposal.json"
+        ],
+        "code_paths_inspected": [
+            "FotMobSourceInventoryAdapter.parseSourcePageUrl",
+            "FotMobSourceInventoryAdapter.deriveSourceInventoryIdentityEvidence",
+            "pageprops_v2_source_inventory_enrichment_apply.parseSourcePageUrl",
+            "pageprops_v2_controlled_source_inventory_acquisition_execute.safeSourceRecord"
+        ],
+        "source_inventory_counts": {
+            "candidate_scope_count": 50,
+            "candidate_targets_with_source_page_url": 50,
+            "candidate_targets_with_source_page_url_base": 50,
+            "candidate_targets_with_source_url_fragment_external_id": 50,
+            "candidate_targets_with_source_inventory_record_key": 50,
+            "identity_evidence_complete_count": 50,
+            "identity_evidence_missing_count": 0
+        },
+        "active_proposal_sample_gap": {
+            "sampled_target_count": 6,
+            "sampled_targets_with_source_page_url": 0,
+            "sampled_targets_with_source_url_fragment_external_id": 0
+        }
+    },
+    "recapture_identity_usage_diagnosis": {
+        "recapture_uses_detail_identity_candidate": true,
+        "recapture_falls_back_to_schedule_external_id": false,
+        "fallback_blocked_when_not_reaccepted": true,
+        "blind_schedule_route_blocked": true,
+        "current_guard": "resolveRecaptureIdentityContract allows recapture only when a re-accepted accepted_detail_external_id exists; otherwise recapture_request_identity is null.",
+        "legacy_issue_observed_in_prior_artifact": {
+            "artifact": "docs/_manifests/fotmob_pageprops_v2_ligue1_2025_2026_profile_001.no_write_payload_recapture_blocker_investigation.phase521l2v3ap.json",
+            "ao_runner_uses_schedule_match_route": true,
+            "runner_input_contract_issue": true,
+            "raw_write_execution_ready": false
+        }
+    },
+    "positive_sample_network_diagnosis": {
+        "page_route_test_performed": true,
+        "page_request_url_without_hash": "https://www.fotmob.com/zh-Hans/matches/manchester-city-vs-afc-bournemouth/2feiv3",
+        "page_http_status": 200,
+        "page_content_type": "text/html; charset=utf-8",
+        "page_redirect_summary": [],
+        "page_body_sha256": "1d65dd396c47e9528f1e474d0c884cfa069ede9384c25e59b3759d93d57c7984",
+        "page_body_byte_length": 1005956,
+        "hydration_marker_present": true,
+        "next_data_marker_present": true,
+        "expected_hash_id_occurrences": 21,
+        "expected_team_marker_presence": {
+            "bournemouth": true,
+            "manchester_city": true
+        },
+        "page_anti_bot_signs": [],
+        "direct_api_test_performed": true,
+        "direct_api_request_url": "https://www.fotmob.com/api/data/matchDetails?matchId=4813735",
+        "direct_api_http_status": 403,
+        "direct_api_content_type": "application/json",
+        "direct_api_redirect_summary": [],
+        "direct_api_body_sha256": "9f36e31930368263ca03ccd40f8ad36ddc178b25211d7b4bf0cbc2c1f6fa7558",
+        "direct_api_body_byte_length": 61,
+        "direct_api_parse_ok": true,
+        "direct_api_observed_payload_match_id": null,
+        "direct_api_observed_detail_external_id": null,
+        "direct_api_anti_bot_signs": ["403", "block_or_captcha_marker"],
+        "browser_page_route_vs_direct_api_identity_status": "page_route_available_but_direct_api_blocked_identity_not_comparable"
+    },
+    "sample_diagnoses": {
+        "suspended_targets": [
+            {
+                "schedule_external_id": "4830461",
+                "observed_detail_external_id": "4830758",
+                "source_page_url": "/matches/lens-vs-lyon/2s3gtg#4830461",
+                "source_url_fragment_external_id": "4830461",
+                "source_route_code": "2s3gtg",
+                "page_url_base_match_status": "match",
+                "date_rule_status": "reverse_fixture_detected",
+                "classification": [
+                    "url_hash_id_persisted_but_not_used",
+                    "reverse_fixture_or_home_away_inversion",
+                    "source_inventory_candidate_generation_defect"
+                ]
+            },
+            {
+                "schedule_external_id": "4830463",
+                "observed_detail_external_id": "4830622",
+                "source_page_url": "/matches/le-havre-vs-monaco/362v61#4830463",
+                "source_url_fragment_external_id": "4830463",
+                "source_route_code": "362v61",
+                "page_url_base_match_status": "match",
+                "date_rule_status": "reverse_fixture_detected",
+                "classification": [
+                    "url_hash_id_persisted_but_not_used",
+                    "reverse_fixture_or_home_away_inversion",
+                    "source_inventory_candidate_generation_defect"
+                ]
+            },
+            {
+                "schedule_external_id": "4830465",
+                "observed_detail_external_id": "4830619",
+                "source_page_url": "/matches/nice-vs-toulouse/38dxtn#4830465",
+                "source_url_fragment_external_id": "4830465",
+                "source_route_code": "38dxtn",
+                "page_url_base_match_status": "match",
+                "date_rule_status": "reverse_fixture_detected",
+                "classification": [
+                    "url_hash_id_persisted_but_not_used",
+                    "reverse_fixture_or_home_away_inversion",
+                    "source_inventory_candidate_generation_defect"
+                ]
+            }
+        ],
+        "needs_new_evidence_targets": [
+            {
+                "schedule_external_id": "4830460",
+                "source_page_url": "/matches/brest-vs-lille/2fo2ub#4830460",
+                "source_url_fragment_external_id": "4830460",
+                "source_route_code": "2fo2ub",
+                "observed_detail_external_id": null,
+                "classification": ["url_hash_id_persisted_but_not_used", "unknown_insufficient_evidence"]
+            },
+            {
+                "schedule_external_id": "4830458",
+                "source_page_url": "/matches/paris-fc-vs-angers/1qlitv#4830458",
+                "source_url_fragment_external_id": "4830458",
+                "source_route_code": "1qlitv",
+                "observed_detail_external_id": null,
+                "classification": ["url_hash_id_persisted_but_not_used", "unknown_insufficient_evidence"]
+            },
+            {
+                "schedule_external_id": "4830459",
+                "source_page_url": "/matches/auxerre-vs-lorient/2gteq5#4830459",
+                "source_url_fragment_external_id": "4830459",
+                "source_route_code": "2gteq5",
+                "observed_detail_external_id": null,
+                "classification": ["url_hash_id_persisted_but_not_used", "unknown_insufficient_evidence"]
+            }
+        ]
+    },
+    "diagnosis_classification_summary": {
+        "url_hash_id_not_extracted": 0,
+        "url_hash_id_extracted_but_not_persisted": 0,
+        "url_hash_id_persisted_but_not_used": 6,
+        "schedule_external_id_incorrectly_used_as_detail_id": 0,
+        "direct_api_identity_differs_from_browser_route": 0,
+        "missing_request_contract_headers_session_locale_region": 1,
+        "anti_bot_or_access_block": 1,
+        "reverse_fixture_or_home_away_inversion": 3,
+        "source_inventory_candidate_generation_defect": 3,
+        "second_source_required": 0,
+        "unknown_insufficient_evidence": 3
+    },
+    "likely_root_cause": [
+        "source_inventory_hash_identity_exists_but_is_not_propagated_to_active_candidate_manifest",
+        "current_raw_write_route_was_paused_correctly_because accepted detail identity is not established for mismatched targets",
+        "public_page_route_can_return hydration for positive sample while direct matchDetails API returns 403 without a usable request contract",
+        "suspended samples show reverse fixture evidence, so schedule-side hash/slug alone is not sufficient for raw write or re-acceptance"
+    ],
+    "recommended_next_step": "Plan runtime implementation for a URL-hash/detail-external-id identity pipeline: propagate source_url_fragment_external_id from source inventory into active candidates, treat it as detail identity evidence requiring validation, and keep raw write blocked until a future implementation and review establish canonical detail identity. Also perform request-contract review for matchDetails API 403 without bypass. Do not raw write.",
+    "raw_write_execution_ready": false
+}

--- a/docs/_reports/FOTMOB_IDENTITY_ANTI_BOT_DIFFERENTIAL_DIAGNOSIS_RESULT_ADG2.md
+++ b/docs/_reports/FOTMOB_IDENTITY_ANTI_BOT_DIFFERENTIAL_DIAGNOSIS_RESULT_ADG2.md
@@ -1,0 +1,172 @@
+# FotMob Identity / Anti-Bot Differential Diagnosis Result ADG2
+
+> Date: 2026-05-27
+> Phase: Phase 5.21-ADG2
+> Scope: bounded read-only diagnosis execution
+
+## 1. Execution Boundary
+
+ADG2 executed only the bounded diagnosis authorized after PR #1335 merged and main Production Gate passed.
+
+- adg2_execution_performed=true
+- live_fetch_performed=true
+- network_request_performed=true
+- browser_automation_performed=false
+- db_write_performed=false
+- raw_write_execution_performed=false
+- raw_match_data_insert_performed=false
+- re_acceptance_execution_performed=false
+- suspension_reversal_performed=false
+- rollback_execution_performed=false
+- full_payload_saved=false
+- full_payload_printed=false
+- uncontrolled_retry_performed=false
+- captcha_bypass_performed=false
+- proxy_bypass_performed=false
+- bulk_fetch_performed=false
+- raw_write_execution_ready=false
+
+No full HTML, JSON, pageProps, raw_data, or source body was saved or printed. The network step produced only status, content-type, redirect summary, hashes, byte counts, marker booleans, and blocker tags.
+
+## 2. Positive Sample URL Parsing
+
+Positive sample:
+
+`https://www.fotmob.com/zh-Hans/matches/manchester-city-vs-afc-bournemouth/2feiv3#4813735`
+
+Parsed result:
+
+- parsed_url_path_slug=`2feiv3`
+- parsed_url_hash_id=`4813735`
+- hash_id_numeric=true
+- hash_id_available_before_http_request=true
+- URL fragment is not sent to the server by normal HTTP requests, so the hash id must be parsed from the href/string before request.
+
+## 3. Discovery Chain Diagnosis
+
+Inspected code paths:
+
+- `FotMobSourceInventoryAdapter.parseSourcePageUrl`
+- `FotMobSourceInventoryAdapter.deriveSourceInventoryIdentityEvidence`
+- `pageprops_v2_source_inventory_enrichment_apply.parseSourcePageUrl`
+- `pageprops_v2_controlled_source_inventory_acquisition_execute.safeSourceRecord`
+
+Findings:
+
+- discovery_extracts_hash_id=true
+- discovery_persists_hash_id=true
+- source_url_fragment_external_id_supported=true
+- source inventory artifact has `source_page_url`, `source_page_url_base`, `source_url_fragment_external_id`, and record keys for all 50 candidate records.
+- current active proposal candidate targets sampled in ADG2 do not carry `source_page_url` or `source_url_fragment_external_id`.
+
+This means the problem is not that the repository lacks hash parsing support. The gap is that source inventory hash evidence is not propagated into the active candidate manifest/recapture decision path as canonical detail identity evidence.
+
+## 4. Recapture Identity Usage Diagnosis
+
+Inspected code paths:
+
+- `FotMobRouteIdentityReconciler.resolveRecaptureIdentityContract`
+- `pageprops_v2_no_write_payload_recapture_execute`
+- `pageprops_v2_recapture_runner_identity_input_contract_fix_implementation_aw.test`
+- prior blocker artifact `phase521l2v3ap`
+
+Current behavior:
+
+- recapture_uses_detail_identity_candidate=true when a re-accepted `accepted_detail_external_id` exists.
+- recapture_falls_back_to_schedule_external_id=false in the current guarded path.
+- fallback_blocked_when_not_reaccepted=true.
+- blind_schedule_route_blocked=true.
+
+Prior artifact evidence still matters: the older AO runner path used a schedule match route for `4830466`, and that was correctly recorded as a runner input contract issue. The current L2V3AW guard fixes the unsafe fallback by blocking recapture until a re-accepted detail identity exists.
+
+## 5. Positive Sample Network Diagnosis
+
+Only two bounded public requests were made for the positive sample:
+
+1. Page route without URL fragment:
+   `https://www.fotmob.com/zh-Hans/matches/manchester-city-vs-afc-bournemouth/2feiv3`
+2. Known direct API route:
+   `https://www.fotmob.com/api/data/matchDetails?matchId=4813735`
+
+Safe summary:
+
+| Route      | HTTP | content-type               | redirects | marker / blocker                                 |
+| ---------- | ---: | -------------------------- | --------: | ------------------------------------------------ |
+| page route |  200 | `text/html; charset=utf-8` |         0 | hydration marker present; expected teams present |
+| direct API |  403 | `application/json`         |         0 | blocked/access marker; no observed payload id    |
+
+Additional safe page route summary:
+
+- page_body_sha256=`1d65dd396c47e9528f1e474d0c884cfa069ede9384c25e59b3759d93d57c7984`
+- page_body_byte_length=1005956
+- next_data_marker_present=true
+- hydration_marker_present=true
+- expected_hash_id_occurrences=21
+- expected team markers present=true
+- page_anti_bot_signs=[]
+
+Direct API summary:
+
+- direct_api_http_status=403
+- direct_api_body_sha256=`9f36e31930368263ca03ccd40f8ad36ddc178b25211d7b4bf0cbc2c1f6fa7558`
+- direct_api_body_byte_length=61
+- direct_api_parse_ok=true
+- observed_payload_match_id=null
+- direct_api_anti_bot_signs=`403`, `block_or_captcha_marker`
+
+Browser automation was not used. Because direct API returned 403, browser/page-route vs direct API identity could not be compared; the route-level result is `page_route_available_but_direct_api_blocked_identity_not_comparable`.
+
+## 6. Suspended Sample Diagnosis
+
+ADG2 inspected three suspended targets from source-controlled artifacts only:
+
+| schedule_external_id | observed_detail_external_id | source URL fragment | route code | classification                                                                                                           |
+| -------------------- | --------------------------- | ------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 4830461              | 4830758                     | 4830461             | 2s3gtg     | url_hash_id_persisted_but_not_used; reverse_fixture_or_home_away_inversion; source_inventory_candidate_generation_defect |
+| 4830463              | 4830622                     | 4830463             | 362v61     | url_hash_id_persisted_but_not_used; reverse_fixture_or_home_away_inversion; source_inventory_candidate_generation_defect |
+| 4830465              | 4830619                     | 4830465             | 38dxtn     | url_hash_id_persisted_but_not_used; reverse_fixture_or_home_away_inversion; source_inventory_candidate_generation_defect |
+
+All three have complete source inventory hash evidence, but prior bounded review classified them as reverse fixture / large date gap identity mismatches. The schedule-side URL hash is not enough to re-accept or raw write.
+
+## 7. Needs-New-Evidence Sample Diagnosis
+
+ADG2 inspected three `needs_new_evidence` targets from source-controlled artifacts only:
+
+| schedule_external_id | source URL fragment | route code | observed_detail_external_id | classification                                                    |
+| -------------------- | ------------------- | ---------- | --------------------------- | ----------------------------------------------------------------- |
+| 4830460              | 4830460             | 2fo2ub     | null                        | url_hash_id_persisted_but_not_used; unknown_insufficient_evidence |
+| 4830458              | 4830458             | 1qlitv     | null                        | url_hash_id_persisted_but_not_used; unknown_insufficient_evidence |
+| 4830459              | 4830459             | 2gteq5     | null                        | url_hash_id_persisted_but_not_used; unknown_insufficient_evidence |
+
+These targets have source inventory URL hash evidence, but source-controlled review artifacts do not contain observed detail identity evidence sufficient for raw write or re-acceptance.
+
+## 8. Classification Summary
+
+- url_hash_id_not_extracted=0
+- url_hash_id_extracted_but_not_persisted=0
+- url_hash_id_persisted_but_not_used=6
+- schedule_external_id_incorrectly_used_as_detail_id=0 for current guarded recapture path
+- missing_request_contract_headers_session_locale_region=1
+- anti_bot_or_access_block=1
+- reverse_fixture_or_home_away_inversion=3
+- source_inventory_candidate_generation_defect=3
+- unknown_insufficient_evidence=3
+
+## 9. Likely Root Cause
+
+Likely root causes:
+
+1. Source inventory hash identity exists, but it is not propagated into the active candidate manifest / recapture decision path as usable detail identity evidence.
+2. Current raw write route was correctly paused because accepted detail identity is not established for mismatched targets.
+3. Public page route can return hydration for the positive sample, while direct `matchDetails` API returns 403 without a usable request contract.
+4. Suspended samples show reverse fixture evidence, so schedule-side hash/slug alone is insufficient for raw write or re-acceptance.
+
+## 10. Recommended Next Step
+
+Plan runtime implementation for a URL-hash/detail-external-id identity pipeline:
+
+- propagate `source_url_fragment_external_id` from source inventory into active candidates;
+- treat URL hash id as detail identity evidence requiring validation, not as automatic acceptance;
+- keep recapture blocked unless a validated detail identity is bound by the current identity contract;
+- review the direct `matchDetails` API request contract because the positive sample returned 403;
+- do not raw write, do not re-accept, and do not bulk recapture.

--- a/tests/unit/fotmob_identity_anti_bot_differential_diagnosis_execute_adg2.test.js
+++ b/tests/unit/fotmob_identity_anti_bot_differential_diagnosis_execute_adg2.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const RESULT_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/_manifests/fotmob_identity_anti_bot_differential_diagnosis_result.adg2.json'
+);
+const REPORT_PATH = path.join(
+    PROJECT_ROOT,
+    'docs/_reports/FOTMOB_IDENTITY_ANTI_BOT_DIFFERENTIAL_DIAGNOSIS_RESULT_ADG2.md'
+);
+
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('ADG2 records bounded execution and keeps all write paths blocked', () => {
+    const result = readJson(RESULT_PATH);
+
+    assert.equal(result.phase, 'Phase 5.21-ADG2');
+    assert.equal(result.adg2_execution_performed, true);
+    assert.equal(result.execution_scope.positive_sample_count, 1);
+    assert.equal(result.execution_scope.suspended_sample_diagnosis_count, 3);
+    assert.equal(result.execution_scope.needs_new_evidence_sample_diagnosis_count, 3);
+    assert.equal(result.execution_scope.uncontrolled_retry_performed, false);
+    assert.equal(result.execution_scope.bulk_fetch_performed, false);
+    assert.equal(result.execution_scope.captcha_bypass_performed, false);
+    assert.equal(result.execution_scope.proxy_bypass_performed, false);
+    assert.equal(result.safety_status.db_write_performed, false);
+    assert.equal(result.safety_status.raw_write_execution_performed, false);
+    assert.equal(result.safety_status.raw_match_data_insert_performed, false);
+    assert.equal(result.safety_status.re_acceptance_execution_performed, false);
+    assert.equal(result.safety_status.full_payload_saved, false);
+    assert.equal(result.safety_status.full_payload_printed, false);
+    assert.equal(result.safety_status.raw_write_execution_ready, false);
+});
+
+test('ADG2 preserves positive sample URL hash parsing facts', () => {
+    const result = readJson(RESULT_PATH);
+    const parsing = result.positive_sample_url_parsing;
+
+    assert.equal(parsing.positive_sample_url_hash_id, '4813735');
+    assert.equal(parsing.positive_sample_url_path_slug, '2feiv3');
+    assert.equal(parsing.parsed_url_hash_id, '4813735');
+    assert.equal(parsing.parsed_url_path_slug, '2feiv3');
+    assert.equal(parsing.hash_id_numeric, true);
+    assert.equal(parsing.hash_id_available_before_http_request, true);
+    assert.equal(parsing.fragment_sent_to_server_by_http, false);
+});
+
+test('ADG2 diagnoses hash extraction support and active manifest propagation gap', () => {
+    const result = readJson(RESULT_PATH);
+    const hash = result.hash_id_extraction_diagnosis;
+    const discovery = result.discovery_chain_diagnosis;
+
+    assert.equal(hash.discovery_extracts_hash_id, true);
+    assert.equal(hash.discovery_persists_hash_id, true);
+    assert.equal(hash.source_url_fragment_external_id_supported, true);
+    assert.equal(hash.source_inventory_all_50_records_have_fragment_id, true);
+    assert.equal(hash.active_proposal_candidate_targets_have_fragment_id, false);
+    assert.equal(discovery.source_inventory_counts.candidate_targets_with_source_url_fragment_external_id, 50);
+    assert.equal(discovery.active_proposal_sample_gap.sampled_targets_with_source_url_fragment_external_id, 0);
+});
+
+test('ADG2 diagnoses current recapture as guarded against blind schedule fallback', () => {
+    const result = readJson(RESULT_PATH);
+    const recapture = result.recapture_identity_usage_diagnosis;
+
+    assert.equal(recapture.recapture_uses_detail_identity_candidate, true);
+    assert.equal(recapture.recapture_falls_back_to_schedule_external_id, false);
+    assert.equal(recapture.fallback_blocked_when_not_reaccepted, true);
+    assert.equal(recapture.blind_schedule_route_blocked, true);
+    assert.equal(recapture.legacy_issue_observed_in_prior_artifact.ao_runner_uses_schedule_match_route, true);
+    assert.equal(recapture.legacy_issue_observed_in_prior_artifact.raw_write_execution_ready, false);
+});
+
+test('ADG2 records positive page route success and direct API access block without full payload', () => {
+    const result = readJson(RESULT_PATH);
+    const network = result.positive_sample_network_diagnosis;
+
+    assert.equal(network.page_route_test_performed, true);
+    assert.equal(network.page_http_status, 200);
+    assert.equal(network.hydration_marker_present, true);
+    assert.equal(network.expected_team_marker_presence.bournemouth, true);
+    assert.equal(network.expected_team_marker_presence.manchester_city, true);
+    assert.deepEqual(network.page_anti_bot_signs, []);
+    assert.equal(network.direct_api_test_performed, true);
+    assert.equal(network.direct_api_http_status, 403);
+    assert.equal(network.direct_api_observed_payload_match_id, null);
+    assert.equal(network.direct_api_anti_bot_signs.includes('403'), true);
+    assert.equal(
+        network.browser_page_route_vs_direct_api_identity_status,
+        'page_route_available_but_direct_api_blocked_identity_not_comparable'
+    );
+});
+
+test('ADG2 sample groups are bounded and classified', () => {
+    const result = readJson(RESULT_PATH);
+    const suspended = result.sample_diagnoses.suspended_targets;
+    const needsEvidence = result.sample_diagnoses.needs_new_evidence_targets;
+
+    assert.equal(suspended.length, 3);
+    assert.equal(needsEvidence.length, 3);
+    assert.deepEqual(
+        suspended.map(item => item.schedule_external_id),
+        ['4830461', '4830463', '4830465']
+    );
+    assert.deepEqual(
+        needsEvidence.map(item => item.schedule_external_id),
+        ['4830460', '4830458', '4830459']
+    );
+
+    for (const item of suspended) {
+        assert.equal(item.classification.includes('url_hash_id_persisted_but_not_used'), true);
+        assert.equal(item.classification.includes('reverse_fixture_or_home_away_inversion'), true);
+    }
+    for (const item of needsEvidence) {
+        assert.equal(item.classification.includes('url_hash_id_persisted_but_not_used'), true);
+        assert.equal(item.classification.includes('unknown_insufficient_evidence'), true);
+    }
+});
+
+test('ADG2 recommends implementation planning but not raw write or re-acceptance', () => {
+    const result = readJson(RESULT_PATH);
+
+    assert.equal(result.raw_write_execution_ready, false);
+    assert.match(result.recommended_next_step, /runtime implementation/);
+    assert.match(result.recommended_next_step, /do not raw write/i);
+    assert.equal(
+        result.likely_root_cause.includes(
+            'source_inventory_hash_identity_exists_but_is_not_propagated_to_active_candidate_manifest'
+        ),
+        true
+    );
+});
+
+test('ADG2 artifacts do not contain full payload fields or body dumps', () => {
+    const resultText = fs.readFileSync(RESULT_PATH, 'utf8');
+    const reportText = fs.readFileSync(REPORT_PATH, 'utf8');
+
+    for (const text of [resultText, reportText]) {
+        assert.equal(text.includes('"raw_data":'), false);
+        assert.equal(text.includes('"pageProps":'), false);
+        assert.equal(text.includes('__NEXT_DATA__":'), false);
+        assert.equal(text.includes('<!DOCTYPE'), false);
+        assert.equal(text.includes('<html'), false);
+        assert.equal(text.includes('"body":'), false);
+        assert.equal(text.includes('"source_body":'), false);
+    }
+});


### PR DESCRIPTION
## PR Type

- [ ] runtime-code-change
- [ ] governance-only
- [x] data-artifact
- [x] architecture-diagnosis
- [ ] test-only

## Runtime Behavior

- Runtime code change included: no
- Runtime code paths changed: n/a
- Runtime behavior changed: n/a

## Business Progress

- Business progress: bounded diagnosis of FotMob URL hash identity and schedule/detail route mismatch.
- Positive sample included: `https://www.fotmob.com/zh-Hans/matches/manchester-city-vs-afc-bournemouth/2feiv3#4813735`.
- Positive sample URL path slug: `2feiv3`.
- Positive sample URL hash id: `4813735`.
- Discovery extracts URL hash id: true, via `FotMobSourceInventoryAdapter` / source inventory enrichment parsing.
- Hash id persisted in source inventory: true for source inventory artifacts; active proposal/candidate targets still miss the propagated hash evidence.
- Recapture identity usage: current guarded path requires accepted detail identity and blocks blind schedule_external_id fallback when not re-accepted.
- Positive sample network result: public page route returned 200 with hydration markers; direct `matchDetails?matchId=4813735` request returned 403, so API/browser identity comparison remains request-contract blocked.
- Likely root cause: source inventory URL-hash evidence exists but is not propagated into the active candidate/recapture identity path; suspended samples also show reverse-fixture risk, so schedule/hash alone is not enough without validated detail identity.
- Recommended next step: plan/runtime implement URL-hash/detail_external_id identity propagation and request-contract review; not raw write.

## Safety Boundaries

- no DB writes
- no raw writes
- no raw_match_data inserts
- no matches writes
- no matches.external_id changes
- no re-acceptance
- no suspension reversal
- no rollback
- no full raw_data/pageProps/source body saved
- no full raw_data/pageProps/source body printed
- no browser automation
- no proxy bypass
- no captcha bypass
- no uncontrolled retry
- no bulk fetch
- raw_write_execution_ready=false

## Network / Fetch Scope

- ADG2 used the explicitly authorized bounded public positive sample only.
- Page route request was one read-only HTTP request without fragment.
- Direct API request was one read-only HTTP request to the repo-known `matchDetails` endpoint with `matchId=4813735`.
- No suspended or needs_new_evidence sample network expansion was performed.
- Full bodies were processed only in memory for safe marker/count/hash summaries and were not saved or printed.

## Validation

- ADG2 targeted tests passed.
- ADG1 targeted tests passed.
- `pageprops_v2_recapture_runner_identity_input_contract_fix_implementation_aw` tests passed.
- `npm run lint` passed in dev container.
- `npm test` passed in dev container.
- Prettier check passed for changed files.
- `git diff --check` passed.
- hidden/bidi Unicode scan passed: no suspicious codepoints found.
- full payload marker scan passed.
- `docs/_staging_preview` absence check passed.
- L1 config residue scan passed.
- DB SELECT-only preflight used `BEGIN READ ONLY` and `ROLLBACK`; row counts remained matches=60, raw_match_data=18, fotmob_pageprops_v2=8.
