### PR TITLE
data(source): block Ligue 1 inverted source inventory candidates

### DIFF
--- a/docs/_reports/FOTMOB_LIGUE1_SOURCE_INVENTORY_INVERSION_CORRECTION_IMPLEMENTATION_ADG14.md
+++ b/docs/_reports/FOTMOB_LIGUE1_SOURCE_INVENTORY_INVERSION_CORRECTION_IMPLEMENTATION_ADG14.md
@@ -1,0 +1,26 @@
+# Ligue 1 Source Inventory Inversion Correction Implementation ADG14
+
+- Phase: Phase 5.21-ADG14
+- Status: completed_runtime_correction_implementation
+- runtime_code_changed=true
+
+## Runtime Changes
+
+### 1. FotMobRouteIdentityReconciler.js
+Added `classifyDetailCandidateIdentity()` — classifies detail identity candidates at generation time using source-controlled evidence. Returns `detail_identity_candidate_status` (accepted_validated/rejected_home_away_inversion/rejected_reverse_fixture_mapping/requires_new_source_inventory_record/unknown_insufficient_evidence).
+
+### 2. FotMobSourceInventoryAdapter.js
+Updated `buildDetailIdentityFields()` and `buildSourceEvidenceFields()` to call `classifyDetailCandidateIdentity()` during candidate generation. Adds `detail_identity_candidate_status`, `fixture_identity_guard_status`, `correction_needed` fields to manifest candidate seeds. Source inventory candidates are now classified at generation time, not just at validation time.
+
+## Behavior
+
+- Positive control #4813735: accepted_validated / guard passed
+- Seven reverse samples (4830458-4830471): rejected_reverse_fixture_mapping / guard blocked / correction_needed=true
+- URL hash alone: unknown_insufficient_evidence / not accepted
+- Same team pair wrong date: blocked
+- All: raw_write_execution_ready=false
+
+## Validation
+
+- 55/55 regression tests pass (ADG14 9 + Adapter 14 + Reconciler 12 + ADG9 11 + ADG12 9)
+- No DB write, no raw write, no live fetch, no network

--- a/src/infrastructure/services/FotMobRouteIdentityReconciler.js
+++ b/src/infrastructure/services/FotMobRouteIdentityReconciler.js
@@ -1018,6 +1018,110 @@ function dateDeltaDays(expected, observed) {
     return Math.round(Math.abs(observed.ms - expected.ms) / 86400000);
 }
 
+// ADG14: Classification of detail candidate identity during source inventory generation.
+// Uses limited source-controlled evidence (no live fetch required).
+// Returns candidate_status: accepted_validated | rejected_home_away_inversion |
+//   rejected_reverse_fixture_mapping | requires_new_source_inventory_record |
+//   unknown_insufficient_evidence
+function classifyDetailCandidateIdentity(input = {}) {
+    const expectedHome = normalizeTeam(
+        firstText(input.expected_home_team, input.schedule_home_team)
+    );
+    const expectedAway = normalizeTeam(
+        firstText(input.expected_away_team, input.schedule_away_team)
+    );
+    const sourceHome = normalizeTeam(
+        firstText(input.source_home_team, input.observed_home_team)
+    );
+    const sourceAway = normalizeTeam(
+        firstText(input.source_away_team, input.observed_away_team)
+    );
+    const expectedDate = firstText(
+        input.expected_match_date, input.schedule_match_date, input.schedule_date
+    );
+    const sourceDate = firstText(
+        input.source_match_date, input.observed_match_date
+    );
+    const detailCandidate = firstId(
+        input.detail_external_id_candidate, input.source_url_fragment_external_id
+    );
+    const expectedCompetition = normalizeLower(
+        firstText(input.expected_competition, input.league_name)
+    );
+    const sourceCompetition = normalizeLower(
+        firstText(input.source_competition, input.observed_competition)
+    );
+
+    const teamsKnown = Boolean(expectedHome && expectedAway && sourceHome && sourceAway);
+    const sameOrder = teamsKnown && expectedHome === sourceHome && expectedAway === sourceAway;
+    const isReversed = teamsKnown && expectedHome === sourceAway && expectedAway === sourceHome;
+
+    const expectedDateMs = expectedDate ? parseDateInfo(expectedDate) : null;
+    const sourceDateMs = sourceDate ? parseDateInfo(sourceDate) : null;
+    const dateDelta = dateDeltaDays(expectedDateMs, sourceDateMs);
+    const dateLargeGap = dateDelta !== null && dateDelta > STRICT_DATE_TOLERANCE_DAYS;
+
+    const competitionMismatch =
+        Boolean(expectedCompetition && sourceCompetition && expectedCompetition !== sourceCompetition);
+
+    // Classification logic
+    let candidateStatus = 'unknown_insufficient_evidence';
+    let guardStatus = FIXTURE_IDENTITY_GUARD_BLOCKED;
+    let correctionNeeded = false;
+    let correctionType = null;
+
+    if (!detailCandidate) {
+        candidateStatus = 'unknown_insufficient_evidence';
+        guardStatus = FIXTURE_IDENTITY_GUARD_BLOCKED;
+    } else if (isReversed && dateLargeGap) {
+        candidateStatus = 'rejected_reverse_fixture_mapping';
+        guardStatus = FIXTURE_IDENTITY_GUARD_BLOCKED;
+        correctionNeeded = true;
+        correctionType = 'reject_candidate';
+    } else if (isReversed) {
+        candidateStatus = 'rejected_home_away_inversion';
+        guardStatus = FIXTURE_IDENTITY_GUARD_BLOCKED;
+        correctionNeeded = true;
+        correctionType = 'reject_candidate';
+    } else if (dateLargeGap) {
+        candidateStatus = 'rejected_reverse_fixture_mapping';
+        guardStatus = FIXTURE_IDENTITY_GUARD_BLOCKED;
+        correctionNeeded = true;
+        correctionType = 'require_new_source_inventory_record';
+    } else if (competitionMismatch) {
+        candidateStatus = 'requires_new_source_inventory_record';
+        guardStatus = FIXTURE_IDENTITY_GUARD_BLOCKED;
+        correctionNeeded = true;
+        correctionType = 'require_new_source_inventory_record';
+    } else if (sameOrder && detailCandidate) {
+        candidateStatus = 'accepted_validated';
+        guardStatus = FIXTURE_IDENTITY_GUARD_PASSED;
+        correctionNeeded = false;
+    } else if (detailCandidate && !teamsKnown) {
+        candidateStatus = 'unknown_insufficient_evidence';
+        guardStatus = FIXTURE_IDENTITY_GUARD_BLOCKED;
+    }
+
+    return {
+        detail_identity_candidate_status: candidateStatus,
+        fixture_identity_guard_status: guardStatus,
+        detail_external_id_candidate: detailCandidate,
+        expected_home_team: expectedHome || null,
+        expected_away_team: expectedAway || null,
+        source_home_team: sourceHome || null,
+        source_away_team: sourceAway || null,
+        home_away_orientation: sameOrder ? 'matches' : isReversed ? 'reversed' : 'unknown',
+        date_delta_days: dateDelta,
+        correction_needed: correctionNeeded,
+        correction_type: correctionType,
+        correction_actions: correctionNeeded
+            ? ['reject_candidate', 'supersede_candidate', 'require_strict_home_away_date_guard']
+            : [],
+        raw_write_execution_ready: false,
+        url_hash_alone_insufficient: Boolean(detailCandidate && !teamsKnown && !dateDelta),
+    };
+}
+
 module.exports = {
     IDENTITY_MATCH,
     REQUESTED_OBSERVED_MISMATCH,
@@ -1047,6 +1151,7 @@ module.exports = {
     AUDIT_CLASSIFICATION_SUSPENDED_REFERENCE_STILL_BLOCKED,
     AUDIT_CLASSIFICATION_INSUFFICIENT_EVIDENCE,
     validateStrictFixtureIdentity,
+    classifyDetailCandidateIdentity,
     normalizePageUrlBase,
     normalizeDateOnly,
     normalizeSeason,

--- a/src/infrastructure/services/FotMobSourceInventoryAdapter.js
+++ b/src/infrastructure/services/FotMobSourceInventoryAdapter.js
@@ -101,17 +101,50 @@ function fallback(value, defaultValue = null) {
     return value || defaultValue;
 }
 
-function buildDetailIdentityFields(evidence = {}) {
+function buildDetailIdentityFields(evidence = {}, candidateContext = {}) {
     const detailExternalIdCandidate = isNumericExternalId(evidence.source_url_fragment_external_id)
         ? String(evidence.source_url_fragment_external_id).trim()
         : null;
-    return {
+    const base = {
         detail_external_id_candidate: detailExternalIdCandidate,
         detail_identity_source: detailExternalIdCandidate ? DETAIL_IDENTITY_SOURCE_URL_HASH_FRAGMENT : null,
     };
+
+    // ADG14: Classify detail candidate at generation time when context is available.
+    // Only home/away orientation from source inventory evidence can be used (no live fetch).
+    if (candidateContext.schedule_home_team || candidateContext.schedule_away_team) {
+        try {
+            const reconciler = require('./FotMobRouteIdentityReconciler');
+            const classification = reconciler.classifyDetailCandidateIdentity({
+                expected_home_team: candidateContext.schedule_home_team,
+                expected_away_team: candidateContext.schedule_away_team,
+                expected_match_date: candidateContext.schedule_date,
+                expected_competition: candidateContext.league_name,
+                source_home_team: evidence.source_home_team,
+                source_away_team: evidence.source_away_team,
+                source_match_date: evidence.source_match_date,
+                detail_external_id_candidate: detailExternalIdCandidate,
+            });
+            return {
+                ...base,
+                detail_identity_candidate_status: classification.detail_identity_candidate_status,
+                fixture_identity_guard_status: classification.fixture_identity_guard_status,
+                home_away_orientation: classification.home_away_orientation,
+                correction_needed: classification.correction_needed,
+                correction_type: classification.correction_type,
+                correction_actions: classification.correction_actions,
+                raw_write_execution_ready: false,
+                url_hash_alone_insufficient: classification.url_hash_alone_insufficient,
+            };
+        } catch {
+            return { ...base, detail_identity_candidate_status: 'unknown_insufficient_evidence' };
+        }
+    }
+
+    return { ...base, detail_identity_candidate_status: 'unknown_insufficient_evidence' };
 }
 
-function buildSourceEvidenceFields(evidence = {}) {
+function buildSourceEvidenceFields(evidence = {}, candidateContext = {}) {
     return {
         source_url: fallback(evidence.source_page_url),
         source_page_url: fallback(evidence.source_page_url),
@@ -120,7 +153,7 @@ function buildSourceEvidenceFields(evidence = {}) {
         source_slug: fallback(evidence.source_slug),
         source_route_code: fallback(evidence.source_route_code),
         source_url_path_slug: fallback(evidence.source_url_path_slug || evidence.source_route_code),
-        ...buildDetailIdentityFields(evidence),
+        ...buildDetailIdentityFields(evidence, candidateContext),
         source_inventory_record_key: fallback(evidence.source_inventory_record_key),
         source_inventory_generated_at: fallback(evidence.source_inventory_generated_at, 'unknown'),
         identity_evidence_status: fallback(evidence.identity_evidence_status, 'missing'),
@@ -351,6 +384,12 @@ class FotMobSourceInventoryAdapter {
     toManifestCandidateSeed(fixture, priority = null, sourceEvidence = {}) {
         const externalId = String(fixture?.external_id || '').trim();
         const evidence = sourceEvidence || {};
+        const candidateContext = {
+            schedule_home_team: fallback(fixture?.home_team),
+            schedule_away_team: fallback(fixture?.away_team),
+            schedule_date: toIsoText(fixture?.match_date),
+            league_name: fallback(fixture?.league_name),
+        };
         return {
             source: SOURCE,
             source_inventory_route: ROUTE_KIND,
@@ -366,7 +405,7 @@ class FotMobSourceInventoryAdapter {
             status: fallback(fixture?.status, 'scheduled'),
             data_source: fallback(fixture?.data_source, 'FotMob'),
             source_path: ROUTE_KIND,
-            ...buildSourceEvidenceFields(evidence),
+            ...buildSourceEvidenceFields(evidence, candidateContext),
             ...buildScheduleEvidenceFields(fixture, externalId),
             priority,
         };

--- a/tests/unit/fotmob_ligue1_source_inventory_inversion_correction_implementation_adg14.test.js
+++ b/tests/unit/fotmob_ligue1_source_inventory_inversion_correction_implementation_adg14.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    classifyDetailCandidateIdentity,
+    validateStrictFixtureIdentity,
+    FIXTURE_IDENTITY_GUARD_PASSED,
+    FIXTURE_IDENTITY_GUARD_BLOCKED,
+} = require('../../src/infrastructure/services/FotMobRouteIdentityReconciler');
+
+const { FotMobSourceInventoryAdapter } = require('../../src/infrastructure/services/FotMobSourceInventoryAdapter');
+
+// --- Test fixtures ---
+
+function positiveControlContext() {
+    return {
+        schedule_home_team: 'AFC Bournemouth',
+        schedule_away_team: 'Manchester City',
+        schedule_date: '2026-05-19T18:30:00.000Z',
+        league_name: 'Premier League',
+        source_home_team: 'AFC Bournemouth',
+        source_away_team: 'Manchester City',
+        source_match_date: 'Tue, May 19, 2026, 18:30 UTC',
+        detail_external_id_candidate: '4813735',
+    };
+}
+
+function reverseSample467() {
+    return {
+        schedule_home_team: 'Le Havre',
+        schedule_away_team: 'Lens',
+        schedule_date: '2025-08-24T15:15:00.000Z',
+        league_name: 'Ligue 1',
+        source_home_team: 'Lens',
+        source_away_team: 'Le Havre',
+        source_match_date: 'Sun, Feb 1, 2026, 16:15 UTC',
+        detail_external_id_candidate: '4830630',
+    };
+}
+
+function reverseSample468() {
+    return {
+        schedule_home_team: 'Lille',
+        schedule_away_team: 'Monaco',
+        schedule_date: '2025-08-24T18:45:00.000Z',
+        league_name: 'Ligue 1',
+        source_home_team: 'Monaco',
+        source_away_team: 'Lille',
+        source_match_date: 'Sun, May 10, 2026, 19:00 UTC',
+        detail_external_id_candidate: '4830751',
+    };
+}
+
+function unknownOnlyCandidate() {
+    return {
+        detail_external_id_candidate: '4830999',
+    };
+}
+
+function sameTeamPairWrongDate() {
+    return {
+        schedule_home_team: 'Paris FC',
+        schedule_away_team: 'Angers',
+        schedule_date: '2025-08-17T15:15:00.000Z',
+        source_home_team: 'Paris FC',
+        source_away_team: 'Angers',
+        source_match_date: 'Sun, Jan 25, 2026, 16:15 UTC',
+        detail_external_id_candidate: '4830627',
+    };
+}
+
+// --- classifyDetailCandidateIdentity tests ---
+
+test('ADG14 classifyDetailCandidateIdentity: positive control passes', () => {
+    const result = classifyDetailCandidateIdentity(positiveControlContext());
+
+    assert.equal(result.detail_identity_candidate_status, 'accepted_validated');
+    assert.equal(result.fixture_identity_guard_status, FIXTURE_IDENTITY_GUARD_PASSED);
+    assert.equal(result.correction_needed, false);
+    assert.equal(result.raw_write_execution_ready, false);
+    assert.equal(result.home_away_orientation, 'matches');
+    assert.equal(result.detail_external_id_candidate, '4813735');
+});
+
+test('ADG14 classifyDetailCandidateIdentity: reverse sample 467 blocked', () => {
+    const result = classifyDetailCandidateIdentity(reverseSample467());
+
+    assert.equal(result.detail_identity_candidate_status, 'rejected_reverse_fixture_mapping');
+    assert.equal(result.fixture_identity_guard_status, FIXTURE_IDENTITY_GUARD_BLOCKED);
+    assert.equal(result.correction_needed, true);
+    assert.equal(result.correction_type, 'reject_candidate');
+    assert.equal(result.home_away_orientation, 'reversed');
+    assert.ok(result.date_delta_days > 100, `delta=${result.date_delta_days} must be >100`);
+    assert.ok(result.correction_actions.includes('reject_candidate'));
+});
+
+test('ADG14 classifyDetailCandidateIdentity: reverse sample 468 blocked', () => {
+    const result = classifyDetailCandidateIdentity(reverseSample468());
+
+    assert.equal(result.fixture_identity_guard_status, FIXTURE_IDENTITY_GUARD_BLOCKED);
+    assert.equal(result.detail_identity_candidate_status, 'rejected_reverse_fixture_mapping');
+    assert.equal(result.home_away_orientation, 'reversed');
+});
+
+test('ADG14 classifyDetailCandidateIdentity: all seven reverse samples blocked', () => {
+    const samples = [
+        { id: '4830458', schedule_home: 'Angers', schedule_away: 'Paris FC', source_home: 'Paris FC', source_away: 'Angers', sched_date: '2025-08-17T15:15:00.000Z', src_date: 'Sun, Jan 25, 2026, 16:15 UTC' },
+        { id: '4830464', schedule_home: 'Nantes', schedule_away: 'Paris Saint-Germain', source_home: 'Paris Saint-Germain', source_away: 'Nantes', sched_date: '2025-08-17T18:45:00.000Z', src_date: 'Wed, Apr 22, 2026, 17:00 UTC' },
+        { id: '4830467', schedule_home: 'Le Havre', schedule_away: 'Lens', source_home: 'Lens', source_away: 'Le Havre', sched_date: '2025-08-24T15:15:00.000Z', src_date: 'Sun, Feb 1, 2026, 16:15 UTC' },
+        { id: '4830468', schedule_home: 'Lille', schedule_away: 'Monaco', source_home: 'Monaco', source_away: 'Lille', sched_date: '2025-08-24T18:45:00.000Z', src_date: 'Sun, May 10, 2026, 19:00 UTC' },
+        { id: '4830469', schedule_home: 'Lorient', schedule_away: 'Rennes', source_home: 'Rennes', source_away: 'Lorient', sched_date: '2025-08-24T13:00:00.000Z', src_date: 'Sun, Jan 25, 2026, 14:00 UTC' },
+        { id: '4830470', schedule_home: 'Lyon', schedule_away: 'Metz', source_home: 'Metz', source_away: 'Lyon', sched_date: '2025-08-23T19:05:00.000Z', src_date: 'Sat, Jan 24, 2026, 18:00 UTC' },
+        { id: '4830471', schedule_home: 'Marseille', schedule_away: 'Paris FC', source_home: 'Paris FC', source_away: 'Marseille', sched_date: '2025-08-23T15:00:00.000Z', src_date: 'Sat, Jan 31, 2026, 16:00 UTC' },
+    ];
+
+    for (const s of samples) {
+        const result = classifyDetailCandidateIdentity({
+            schedule_home_team: s.schedule_home,
+            schedule_away_team: s.schedule_away,
+            schedule_date: s.sched_date,
+            source_home_team: s.source_home,
+            source_away_team: s.source_away,
+            source_match_date: s.src_date,
+            detail_external_id_candidate: s.id,
+        });
+
+        assert.equal(result.fixture_identity_guard_status, FIXTURE_IDENTITY_GUARD_BLOCKED, `${s.id} must be blocked`);
+        assert.equal(result.correction_needed, true, `${s.id} must need correction`);
+        assert.equal(result.raw_write_execution_ready, false);
+        assert.ok(result.correction_actions.includes('require_strict_home_away_date_guard'));
+    }
+});
+
+test('ADG14 classifyDetailCandidateIdentity: URL hash alone insufficient', () => {
+    const result = classifyDetailCandidateIdentity(unknownOnlyCandidate());
+
+    assert.equal(result.detail_identity_candidate_status, 'unknown_insufficient_evidence');
+    assert.equal(result.fixture_identity_guard_status, FIXTURE_IDENTITY_GUARD_BLOCKED);
+    assert.equal(result.url_hash_alone_insufficient, true);
+    assert.equal(result.raw_write_execution_ready, false);
+});
+
+test('ADG14 classifyDetailCandidateIdentity: same team pair wrong date blocks', () => {
+    const result = classifyDetailCandidateIdentity(sameTeamPairWrongDate());
+
+    assert.equal(result.fixture_identity_guard_status, FIXTURE_IDENTITY_GUARD_BLOCKED);
+    assert.ok(result.date_delta_days > 100);
+    assert.ok(result.correction_actions.includes('require_strict_home_away_date_guard'));
+});
+
+test('ADG14 SourceInventoryAdapter toManifestCandidateSeed produces candidate status fields', () => {
+    const adapter = new FotMobSourceInventoryAdapter();
+
+    const seed = adapter.toManifestCandidateSeed(
+        {
+            external_id: '4813735',
+            home_team: 'AFC Bournemouth',
+            away_team: 'Manchester City',
+            match_date: '2026-05-19T18:30:00.000Z',
+            league_name: 'Premier League',
+        },
+        1,
+        {
+            source_page_url: 'https://www.fotmob.com/matches/manchester-city-vs-afc-bournemouth/2feiv3#4813735',
+            source_url_fragment_external_id: '4813735',
+            source_inventory_record_key: 'l1_api_data_leagues:test:4813735',
+        }
+    );
+
+    assert.equal(seed.external_id, '4813735');
+    assert.equal(seed.detail_external_id_candidate, '4813735',
+        'detail hash preserved as evidence');
+    assert.ok('detail_identity_candidate_status' in seed, 'must have candidate status field');
+    // Without source observed teams, classification is unknown_insufficient_evidence
+    // This is correct: URL hash is preserved but not validated without observed data
+    assert.ok('correction_needed' in seed, 'must have correction field');
+    assert.ok('raw_write_execution_ready' in seed);
+    assert.equal(seed.raw_write_execution_ready, false);
+});
+
+test('ADG14 SourceInventoryAdapter toManifestCandidateSeed sets rejected when home/away inverted', () => {
+    const adapter = new FotMobSourceInventoryAdapter();
+
+    const seed = adapter.toManifestCandidateSeed(
+        {
+            external_id: '4830458',
+            home_team: 'Angers',
+            away_team: 'Paris FC',
+            match_date: '2025-08-17T15:15:00.000Z',
+            league_name: 'Ligue 1',
+        },
+        1,
+        {
+            source_page_url: 'https://www.fotmob.com/matches/paris-fc-vs-angers/1qlitv#4830458',
+            source_url_fragment_external_id: '4830458',
+            source_inventory_record_key: 'l1_api_data_leagues:test:4830458',
+            source_home_team: 'Paris FC',
+            source_away_team: 'Angers',
+            source_match_date: 'Sun, Jan 25, 2026, 16:15 UTC',
+        }
+    );
+
+    assert.equal(seed.external_id, '4830458');
+    assert.equal(seed.detail_identity_candidate_status, 'rejected_reverse_fixture_mapping',
+        'inverted candidate must be rejected at generation time');
+    assert.equal(seed.correction_needed, true);
+    assert.equal(seed.raw_write_execution_ready, false);
+});
+
+test('ADG14 validateStrictFixtureIdentity still works for integration', () => {
+    const result = validateStrictFixtureIdentity({
+        schedule_external_id: '4813735',
+        detail_external_id_candidate: '4813735',
+        expected_home_team: 'AFC Bournemouth',
+        expected_away_team: 'Manchester City',
+        observed_detail_id: '4813735',
+        observed_home_team: 'AFC Bournemouth',
+        observed_away_team: 'Manchester City',
+        expected_match_date: '2026-05-19T18:30:00.000Z',
+        observed_match_date: 'Tue, May 19, 2026, 18:30 UTC',
+    });
+
+    assert.equal(result.fixture_identity_guard_status, FIXTURE_IDENTITY_GUARD_PASSED);
+});


### PR DESCRIPTION
## Summary

PR type: runtime-code-change

Runtime behavior changed: yes.

### Business progress
- Implements runtime correction guard for systematic Ligue 1 source inventory home/away inversion
- Adds `classifyDetailCandidateIdentity()` to `FotMobRouteIdentityReconciler`
- Updates `FotMobSourceInventoryAdapter` to classify candidates at generation time
- Blocks reverse fixture / wrong-leg candidates at generation/enrichment time
- Preserves positive control #4813735 (accepted_validated)
- Blocks seven known reverse samples (rejected_reverse_fixture_mapping)
- URL hash alone insufficient (unknown_insufficient_evidence)

### Runtime paths changed
- `FotMobRouteIdentityReconciler.js` — added `classifyDetailCandidateIdentity()`
- `FotMobSourceInventoryAdapter.js` — updated `buildDetailIdentityFields()` and `buildSourceEvidenceFields()`

### Tests
- 9 new ADG14 targeted tests
- 55/55 total regression tests pass (ADG14 + Adapter + Reconciler + ADG9 + ADG12)

### Safety
- No live fetch, network, browser automation, direct API probing
- No DB writes, raw writes, raw_match_data inserts
- No re-acceptance, suspension reversal
- No source inventory mutation, candidate mutation
- raw_write_execution_ready=false always