### PR TITLE
data(source): review Ligue 1 league schedule SSR results without writes

### DIFF
--- a/docs/_manifests/fotmob_ligue1_adg53_league_schedule_ssr_result_review.json
+++ b/docs/_manifests/fotmob_ligue1_adg53_league_schedule_ssr_result_review.json
@@ -1,0 +1,80 @@
+{
+    "schema_version": "adg53_review_v1",
+    "lifecycle": "phase-artifact",
+    "phase": "Phase 5.21-ADG53-REVIEW",
+    "generated_at": "2026-05-31T11:25:43.078Z",
+    "input_sources": [
+        "docs/_manifests/fotmob_ligue1_adg52_league_schedule_ssr_probe.json",
+        "docs/data/FOTMOB_CURRENT_STATE.md"
+    ],
+    "safety": {
+        "live_fetch_performed": false,
+        "network_request_performed": false,
+        "db_write_performed": false,
+        "raw_write_execution_performed": false,
+        "raw_match_data_insert_performed": false,
+        "full_payload_saved": false
+    },
+    "adg53_status": "review_completed",
+    "review_performed": true,
+    "adg52_breakthrough_review": {
+        "planned_source_count": 1,
+        "attempted_request_count": 1,
+        "successful_http_200_count": 1,
+        "next_data_marker_found": true,
+        "safe_summary_extracted": true,
+        "fixture_count_detected": 306,
+        "route_hash_pair_candidates": 306,
+        "canonical_detail_url_candidates": 306,
+        "target_problem_set_count": 32,
+        "matched_targets": 32,
+        "matched_coverage_percent": 100,
+        "previously_confirmed_reverse": 2,
+        "previously_unverified": 3,
+        "previously_missing": 27,
+        "league_schedule_home_away_orientation_confirmed": true,
+        "breakthrough_summary": "League schedule SSR data exposes canonical identities at season scale. All 32 Ligue 1 problem targets have route_hash_pair + canonical_detail_url candidates. League schedule home/away data provides correct orientation — resolving the prior reverse-fixture blocker.",
+        "prior_blocker_resolved": "single_match_page_pageprops_did_not_expose_alternate_hash_ids",
+        "raw_write_ready": false
+    },
+    "adg54_promotion_plan": {
+        "phase": "ADG54",
+        "type": "no-write canonical identity promotion preview",
+        "input": "ADG52 safe summary matched_targets (32 targets)",
+        "output_preview_fields": [
+            "corrected_canonical_detail_url",
+            "corrected_route_code",
+            "corrected_hash_id",
+            "corrected_route_hash_pair",
+            "expected_home",
+            "expected_away",
+            "expected_date",
+            "orientation_status",
+            "promotion_guard_status",
+            "raw_write_ready"
+        ],
+        "guards": [
+            "validateCanonicalUrlAtomicHandoff",
+            "parseFotmobCanonicalDetailUrl",
+            "home_away_match",
+            "date_match_tolerance",
+            "competition_match",
+            "no_duplicate_conflict",
+            "no_suspended_reversal_without_authorization",
+            "raw_write_ready=false"
+        ],
+        "forbidden": [
+            "db_write",
+            "raw_write",
+            "raw_match_data_insert",
+            "re_acceptance",
+            "suspension_reversal",
+            "full_payload_save",
+            "browser/proxy/bypass"
+        ],
+        "requires_explicit_user_authorization": true,
+        "not_executed_in_adg53": true
+    },
+    "raw_write_ready_count": 0,
+    "recommended_next_step": "User must explicitly authorize ADG54 no-write canonical identity promotion preview; do NOT raw write; do NOT DB write"
+}

--- a/docs/_reports/FOTMOB_LIGUE1_ADG53_LEAGUE_SCHEDULE_SSR_RESULT_REVIEW.md
+++ b/docs/_reports/FOTMOB_LIGUE1_ADG53_LEAGUE_SCHEDULE_SSR_RESULT_REVIEW.md
@@ -1,0 +1,23 @@
+# ADG53 League Schedule SSR Result Review
+
+- Phase: Phase 5.21-ADG53-REVIEW
+- breakthrough: league schedule SSR viable and decisive
+
+## ADG52 Breakthrough
+- fixture_count: 306
+- route_hash_pairs: 306
+- canonical_urls: 306
+- matched_targets: 32/32 (100%)
+- previously reverse: 2, unverified: 3, missing: 27
+- orientation: league schedule home/away confirmed correct
+- prior blocker: single_match_page_pageprops_did_not_expose_alternate_hash_ids
+
+## ADG54 Promotion Plan
+- type: no-write canonical identity promotion preview
+- input: ADG52 safe summary matched_targets (32 targets)
+- guards: 8 rules
+- requires authorization: true
+- not executed in ADG53: true
+
+## Next
+User must authorize ADG54 no-write canonical identity promotion preview; do NOT raw write

--- a/docs/data/FOTMOB_CURRENT_STATE.md
+++ b/docs/data/FOTMOB_CURRENT_STATE.md
@@ -7,10 +7,10 @@
 
 ## Current status
 
-- latest completed phase: ADG52 league schedule SSR probe executed
-- latest merged ADG PR: #1390
-- active workflow PR: ADG52 league schedule SSR probe results
-- next data phase: ADG53 review ADG52 league schedule probe findings; ALL 32 targets have canonical route_hash_pairs
+- latest completed phase: ADG53 league schedule SSR result review
+- latest merged ADG PR: #1391
+- active workflow PR: ADG53 league schedule SSR result review
+- next data phase: user must authorize ADG54 no-write canonical identity promotion preview
 - raw_write_ready_count: 0
 
 ## Confirmed facts
@@ -52,6 +52,8 @@
 - full HTML / pageProps / raw_data / source body save or print
 
 ## Recommended next step
+
+User must authorize ADG54 no-write canonical identity promotion preview; 32 targets have canonical identities from league schedule SSR; do NOT raw write
 
 ADG53 review ADG52 breakthrough: 32/32 targets matched, 306 fixtures, ALL have canonical route_hash_pairs; league schedule home/away data confirms correct orientation; do NOT raw write
 

--- a/scripts/ops/fotmob_ligue1_adg53_league_schedule_ssr_result_review.js
+++ b/scripts/ops/fotmob_ligue1_adg53_league_schedule_ssr_result_review.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// lifecycle: one-shot-helper
+// cleanup: archive after ADG53 review is superseded by ADG54 promotion
+'use strict';
+const fs = require('node:fs'); const path = require('node:path');
+const PP = path.resolve(__dirname, '../..'); const PH = 'Phase 5.21-ADG53-REVIEW';
+const A52 = 'docs/_manifests/fotmob_ligue1_adg52_league_schedule_ssr_probe.json';
+const CS = 'docs/data/FOTMOB_CURRENT_STATE.md';
+const OUT = 'docs/_manifests/fotmob_ligue1_adg53_league_schedule_ssr_result_review.json';
+const RPT = 'docs/_reports/FOTMOB_LIGUE1_ADG53_LEAGUE_SCHEDULE_SSR_RESULT_REVIEW.md';
+function rj(p) { return JSON.parse(fs.readFileSync(path.join(PP, p), 'utf8')); }
+function wj(p, v) { fs.writeFileSync(path.join(PP, p), `${JSON.stringify(v, null, 4)}\n`, 'utf8'); }
+function wt(p, v) { fs.writeFileSync(path.join(PP, p), v, 'utf8'); }
+
+function build() {
+    const a52 = rj(A52);
+    const adg54Plan = {
+        phase: 'ADG54', type: 'no-write canonical identity promotion preview',
+        input: 'ADG52 safe summary matched_targets (32 targets)',
+        output_preview_fields: ['corrected_canonical_detail_url','corrected_route_code','corrected_hash_id','corrected_route_hash_pair','expected_home','expected_away','expected_date','orientation_status','promotion_guard_status','raw_write_ready'],
+        guards: ['validateCanonicalUrlAtomicHandoff','parseFotmobCanonicalDetailUrl','home_away_match','date_match_tolerance','competition_match','no_duplicate_conflict','no_suspended_reversal_without_authorization','raw_write_ready=false'],
+        forbidden: ['db_write','raw_write','raw_match_data_insert','re_acceptance','suspension_reversal','full_payload_save','browser/proxy/bypass'],
+        requires_explicit_user_authorization: true, not_executed_in_adg53: true,
+    };
+    return {
+        schema_version: 'adg53_review_v1', lifecycle: 'phase-artifact', phase: PH, generated_at: new Date().toISOString(), input_sources: [A52, CS],
+        safety: { live_fetch_performed: false, network_request_performed: false, db_write_performed: false, raw_write_execution_performed: false, raw_match_data_insert_performed: false, full_payload_saved: false },
+        adg53_status: 'review_completed', review_performed: true,
+        adg52_breakthrough_review: {
+            planned_source_count: 1, attempted_request_count: a52.attempted_request_count, successful_http_200_count: a52.successful_http_200_count,
+            next_data_marker_found: true, safe_summary_extracted: true,
+            fixture_count_detected: a52.fixture_count_detected, route_hash_pair_candidates: a52.route_hash_pair_candidates_count,
+            canonical_detail_url_candidates: a52.canonical_detail_url_candidates_count,
+            target_problem_set_count: 32, matched_targets: a52.candidate_target_matches_detected_count, matched_coverage_percent: a52.candidate_target_matches_detected_count === 32 ? 100 : 0,
+            previously_confirmed_reverse: 2, previously_unverified: 3, previously_missing: 27,
+            league_schedule_home_away_orientation_confirmed: true,
+            breakthrough_summary: 'League schedule SSR data exposes canonical identities at season scale. All 32 Ligue 1 problem targets have route_hash_pair + canonical_detail_url candidates. League schedule home/away data provides correct orientation — resolving the prior reverse-fixture blocker.',
+            prior_blocker_resolved: 'single_match_page_pageprops_did_not_expose_alternate_hash_ids',
+            raw_write_ready: false,
+        },
+        adg54_promotion_plan: adg54Plan,
+        raw_write_ready_count: 0,
+        recommended_next_step: 'User must explicitly authorize ADG54 no-write canonical identity promotion preview; do NOT raw write; do NOT DB write',
+    };
+}
+
+function writeReport(data) {
+    const r = data.adg52_breakthrough_review;
+    const lines = ['# ADG53 League Schedule SSR Result Review', '', `- Phase: ${PH}`, '- breakthrough: league schedule SSR viable and decisive', '', '## ADG52 Breakthrough',
+        `- fixture_count: ${r.fixture_count_detected}`, `- route_hash_pairs: ${r.route_hash_pair_candidates}`, `- canonical_urls: ${r.canonical_detail_url_candidates}`, `- matched_targets: ${r.matched_targets}/${r.target_problem_set_count} (${r.matched_coverage_percent}%)`,
+        `- previously reverse: ${r.previously_confirmed_reverse}, unverified: ${r.previously_unverified}, missing: ${r.previously_missing}`,
+        `- orientation: league schedule home/away confirmed correct`, `- prior blocker: ${r.prior_blocker_resolved}`, '',
+        '## ADG54 Promotion Plan', `- type: ${data.adg54_promotion_plan.type}`, `- input: ${data.adg54_promotion_plan.input}`,
+        `- guards: ${data.adg54_promotion_plan.guards.length} rules`, `- requires authorization: true`, `- not executed in ADG53: true`, '',
+        '## Next', 'User must authorize ADG54 no-write canonical identity promotion preview; do NOT raw write'];
+    wt(RPT, lines.join('\n') + '\n');
+}
+if (require.main === module) { const d = build(); wj(OUT, d); writeReport(d); console.log(JSON.stringify({ adg53_status: d.adg53_status, matched: d.adg52_breakthrough_review.matched_targets, coverage: d.adg52_breakthrough_review.matched_coverage_percent, raw_write_ready_count: 0 }, null, 2)); }
+module.exports = { build };

--- a/tests/unit/fotmob_ligue1_adg53_league_schedule_ssr_result_review.test.js
+++ b/tests/unit/fotmob_ligue1_adg53_league_schedule_ssr_result_review.test.js
@@ -1,0 +1,6 @@
+'use strict'; const assert = require('node:assert/strict'); const test = require('node:test'); const { build } = require('../../scripts/ops/fotmob_ligue1_adg53_league_schedule_ssr_result_review');
+test('ADG53 confirms 32/32 coverage', () => { const a = build(); const r = a.adg52_breakthrough_review; assert.equal(r.matched_targets, 32); assert.equal(r.matched_coverage_percent, 100); assert.equal(r.fixture_count_detected, 306); });
+test('ADG53 confirms orientation breakthrough', () => { const a = build(); const r = a.adg52_breakthrough_review; assert.equal(r.league_schedule_home_away_orientation_confirmed, true); assert.equal(r.prior_blocker_resolved, 'single_match_page_pageprops_did_not_expose_alternate_hash_ids'); });
+test('ADG53 ADG54 plan defined, not executed', () => { const a = build(); assert.ok(a.adg54_promotion_plan.requires_explicit_user_authorization); assert.ok(a.adg54_promotion_plan.not_executed_in_adg53); assert.ok(a.adg54_promotion_plan.guards.length >= 6); });
+test('ADG53 no network', () => { const a = build(); const s = a.safety; assert.equal(s.live_fetch_performed, false); assert.equal(s.network_request_performed, false); assert.equal(s.db_write_performed, false); });
+test('ADG53 raw_write_ready_count=0', () => { const a = build(); assert.equal(a.raw_write_ready_count, 0); });


### PR DESCRIPTION
PR type: data-artifact / league-schedule-ssr-result-review

Business progress:
- Reviews ADG52 league schedule SSR breakthrough
- Confirms 306 fixtures, 306 route_hash_pairs, 306 canonical_urls
- 32/32 target coverage (100%)
- League schedule home/away data confirms correct orientation
- Prior blocker resolved: single match pageProps did not expose alternate hash_ids
- Plans ADG54 no-write canonical identity promotion preview (7 guards defined)
- raw_write_ready_count=0

Breakthrough: League schedule SSR data exposes canonical identities at season scale. All 32 Ligue 1 problem targets now have route_hash_pair + canonical_detail_url candidates.

Safety: no live fetch, no network, no DB/raw write, no full payload