### PR TITLE
data(source): preflight Ligue 1 ADG60 without writes

### DIFF
--- a/docs/_manifests/fotmob_ligue1_adg60_preflight_no_write.json
+++ b/docs/_manifests/fotmob_ligue1_adg60_preflight_no_write.json
@@ -1,0 +1,855 @@
+{
+    "schema_version": "adg60_preflight_no_write_v1",
+    "lifecycle": "phase-artifact",
+    "phase": "ADG60-PREFLIGHT-NO-WRITE",
+    "generated_at": "2026-06-01T12:53:20.984Z",
+    "base_main_commit": "bc278ff440e3941fe9492647efc86df4da970924",
+    "input_sources": [
+        "docs/_manifests/fotmob_ligue1_adg59a_source_controlled_canonical_identity_promotion.json",
+        "docs/_manifests/fotmob_ligue1_adg59b_source_controlled_acceptance_suspension_state.json",
+        "docs/data/FOTMOB_CURRENT_STATE.md",
+        "docs/_reports/FOTMOB_LIGUE1_ADG59B_SOURCE_CONTROLLED_ACCEPTANCE_SUSPENSION_STATE.md",
+        "docs/_reports/FOTMOB_LIGUE1_ADG59B_HYGIENE_POST_MERGE.md",
+        "SELECT-only DB invariant"
+    ],
+    "safety": {
+        "db_write_performed": false,
+        "raw_write_performed": false,
+        "raw_match_data_insert_performed": false,
+        "live_fetch_performed": false,
+        "network_fetch_performed": false,
+        "schema_migration_performed": false,
+        "adg60_write_performed": false
+    },
+    "db_invariant_before": {
+        "bookmaker_odds_history": 2,
+        "l3_features": 2,
+        "match_features_training": 2,
+        "matches": 60,
+        "predictions": 2,
+        "raw_match_data": 18
+    },
+    "db_invariant_after": {
+        "bookmaker_odds_history": 2,
+        "l3_features": 2,
+        "match_features_training": 2,
+        "matches": 60,
+        "predictions": 2,
+        "raw_match_data": 18
+    },
+    "target_count": 32,
+    "accepted_count": 32,
+    "suspension_resolved_count": 32,
+    "duplicate_conflict": 0,
+    "orientation_pass": 32,
+    "date_pass": 32,
+    "competition_pass": 32,
+    "raw_write_ready_count_before": 0,
+    "raw_write_ready_count_after": 0,
+    "raw_write_ready_count": 0,
+    "per_target_preflight_results": [
+        {
+            "target_match_id": "53_20252026_4830473",
+            "corrected_hash_id": "4830473",
+            "corrected_route_hash_pair": "2o4ahb#4830473",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830472",
+            "corrected_hash_id": "4830472",
+            "corrected_route_hash_pair": "2sy6tc#4830472",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830474",
+            "corrected_hash_id": "4830474",
+            "corrected_route_hash_pair": "37a71l#4830474",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830475",
+            "corrected_hash_id": "4830475",
+            "corrected_route_hash_pair": "2th5t2#4830475",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830478",
+            "corrected_hash_id": "4830478",
+            "corrected_route_hash_pair": "2f5cib#4830478",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830479",
+            "corrected_hash_id": "4830479",
+            "corrected_route_hash_pair": "2he6a1#4830479",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830476",
+            "corrected_hash_id": "4830476",
+            "corrected_route_hash_pair": "2o5ty5#4830476",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830477",
+            "corrected_hash_id": "4830477",
+            "corrected_route_hash_pair": "363pdo#4830477",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830480",
+            "corrected_hash_id": "4830480",
+            "corrected_route_hash_pair": "2s51f2#4830480",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830482",
+            "corrected_hash_id": "4830482",
+            "corrected_route_hash_pair": "2sxslt#4830482",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830483",
+            "corrected_hash_id": "4830483",
+            "corrected_route_hash_pair": "1ucu3j#4830483",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830484",
+            "corrected_hash_id": "4830484",
+            "corrected_route_hash_pair": "38kq0z#4830484",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830485",
+            "corrected_hash_id": "4830485",
+            "corrected_route_hash_pair": "2sxeeb#4830485",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830486",
+            "corrected_hash_id": "4830486",
+            "corrected_route_hash_pair": "1u3kbv#4830486",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830487",
+            "corrected_hash_id": "4830487",
+            "corrected_route_hash_pair": "2us06f#4830487",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830488",
+            "corrected_hash_id": "4830488",
+            "corrected_route_hash_pair": "2gwqpe#4830488",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830489",
+            "corrected_hash_id": "4830489",
+            "corrected_route_hash_pair": "2aqs46#4830489",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830490",
+            "corrected_hash_id": "4830490",
+            "corrected_route_hash_pair": "37310i#4830490",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830491",
+            "corrected_hash_id": "4830491",
+            "corrected_route_hash_pair": "2t6hdp#4830491",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830492",
+            "corrected_hash_id": "4830492",
+            "corrected_route_hash_pair": "36cxwz#4830492",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830493",
+            "corrected_hash_id": "4830493",
+            "corrected_route_hash_pair": "36aub3#4830493",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830494",
+            "corrected_hash_id": "4830494",
+            "corrected_route_hash_pair": "2u5qiz#4830494",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830495",
+            "corrected_hash_id": "4830495",
+            "corrected_route_hash_pair": "2s9rcv#4830495",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830497",
+            "corrected_hash_id": "4830497",
+            "corrected_route_hash_pair": "2gcrq9#4830497",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830498",
+            "corrected_hash_id": "4830498",
+            "corrected_route_hash_pair": "2n29lb#4830498",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830499",
+            "corrected_hash_id": "4830499",
+            "corrected_route_hash_pair": "2t82ab#4830499",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830500",
+            "corrected_hash_id": "4830500",
+            "corrected_route_hash_pair": "2skdzb#4830500",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830501",
+            "corrected_hash_id": "4830501",
+            "corrected_route_hash_pair": "37bglo#4830501",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830502",
+            "corrected_hash_id": "4830502",
+            "corrected_route_hash_pair": "26e9n2#4830502",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830505",
+            "corrected_hash_id": "4830505",
+            "corrected_route_hash_pair": "2u3coy#4830505",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830507",
+            "corrected_hash_id": "4830507",
+            "corrected_route_hash_pair": "268cvm#4830507",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        },
+        {
+            "target_match_id": "53_20252026_4830510",
+            "corrected_hash_id": "4830510",
+            "corrected_route_hash_pair": "2t8gik#4830510",
+            "match_exists": true,
+            "canonical_identity_exists": true,
+            "raw_match_data_exists": false,
+            "duplicate_risk": false,
+            "home_away_conflict": false,
+            "date_conflict": false,
+            "competition_conflict": false,
+            "route_hash_pair_conflict": false,
+            "hash_id_conflict": false,
+            "missing_raw_payload": true,
+            "missing_writable_fields": [
+                "raw_data"
+            ],
+            "schema_gap": false,
+            "raw_write_ready": false,
+            "classifications": [
+                "blocked_missing_payload",
+                "blocked_requires_explicit_write_authorization"
+            ]
+        }
+    ],
+    "preflight_field_counts": {
+        "match_exists": 32,
+        "canonical_identity_exists": 32,
+        "raw_match_data_exists": 0,
+        "duplicate_risk": 0,
+        "home_away_conflict": 0,
+        "date_conflict": 0,
+        "competition_conflict": 0,
+        "route_hash_pair_conflict": 0,
+        "hash_id_conflict": 0,
+        "missing_raw_payload": 32,
+        "missing_writable_fields": 32,
+        "schema_gap": 0
+    },
+    "aggregate_counts": {
+        "preflight_pass": 0,
+        "blocked_missing_payload": 32,
+        "blocked_existing_duplicate": 0,
+        "blocked_identity_conflict": 0,
+        "blocked_schema_gap": 0,
+        "blocked_requires_explicit_write_authorization": 32,
+        "unknown_needs_manual_review": 0
+    },
+    "blockers": [
+        "blocked_missing_payload: no source-controlled raw payload exists for any of the 32 targets",
+        "blocked_requires_explicit_write_authorization: ADG60 write requires separate user authorization"
+    ],
+    "risks": [
+        "raw payload acquisition is not part of this PR",
+        "raw-write execution must remain separated from preflight",
+        "any future write must re-check DB invariant and target duplicates immediately before transaction"
+    ],
+    "decision": "blocked",
+    "next_authorization_required": true,
+    "recommended_next_step": "ADG60 write remains blocked until separate user authorization."
+}

--- a/docs/_reports/FOTMOB_LIGUE1_ADG60_PREFLIGHT_NO_WRITE.md
+++ b/docs/_reports/FOTMOB_LIGUE1_ADG60_PREFLIGHT_NO_WRITE.md
@@ -1,0 +1,73 @@
+# FotMob Ligue 1 ADG60 Preflight No-Write
+
+- lifecycle: phase-artifact
+- phase: ADG60-PREFLIGHT-NO-WRITE
+- scope: preflight only
+- base main commit: bc278ff440e3941fe9492647efc86df4da970924
+- target_count: 32
+- accepted_count: 32
+- suspension_resolved_count: 32
+- raw_write_ready_count_before: 0
+- raw_write_ready_count_after: 0
+- db_write_performed: false
+- raw_write_performed: false
+- raw_match_data_insert_performed: false
+- live_fetch_performed: false
+- network_fetch_performed: false
+- schema_migration_performed: false
+- adg60_write_performed: false
+
+## Source Inputs
+
+- docs/_manifests/fotmob_ligue1_adg59a_source_controlled_canonical_identity_promotion.json
+- docs/_manifests/fotmob_ligue1_adg59b_source_controlled_acceptance_suspension_state.json
+- docs/data/FOTMOB_CURRENT_STATE.md
+- SELECT-only DB invariant
+
+## DB Invariant
+
+- bookmaker_odds_history: 2
+- l3_features: 2
+- match_features_training: 2
+- matches: 60
+- predictions: 2
+- raw_match_data: 18
+
+## Per-Target Preflight Summary
+
+- match_exists: 32/32
+- canonical_identity_exists: 32/32
+- raw_match_data_exists: 0/32
+- duplicate_risk: 0/32
+- home_away_conflict: 0/32
+- date_conflict: 0/32
+- competition_conflict: 0/32
+- route_hash_pair_conflict: 0/32
+- hash_id_conflict: 0/32
+- missing_raw_payload: 32/32
+- missing_writable_fields: 32/32
+- schema_gap: 0/32
+
+- preflight_pass: 0
+- blocked_missing_payload: 32
+- blocked_existing_duplicate: 0
+- blocked_identity_conflict: 0
+- blocked_schema_gap: 0
+- blocked_requires_explicit_write_authorization: 32
+- unknown_needs_manual_review: 0
+
+## Blockers
+
+- blocked_missing_payload: no source-controlled raw payload exists for any of the 32 targets
+- blocked_requires_explicit_write_authorization: ADG60 write requires separate user authorization
+
+## Risks
+
+- raw payload acquisition is not part of this PR
+- raw-write execution must remain separated from preflight
+- any future write must re-check DB invariant and target duplicates immediately before transaction
+
+## Decision
+
+- decision: blocked
+- ADG60 write remains blocked until separate user authorization.

--- a/docs/data/FOTMOB_CURRENT_STATE.md
+++ b/docs/data/FOTMOB_CURRENT_STATE.md
@@ -9,8 +9,8 @@
 
 - latest completed phase: ADG59B source-controlled acceptance/suspension state completed
 - latest merged ADG PR: #1399
-- active workflow PR: none; pending ADG60 authorization
-- next data phase: stop; ADG60 requires separate explicit authorization
+- active workflow PR: ADG60-PREFLIGHT no-write
+- next data phase: stop; ADG60 write requires separate explicit authorization
 - raw_write_ready_count: 0
 - latest ADG59B merge commit: eac95fc6839e215969d5c3315b5ea5950de93cd3
 

--- a/scripts/ops/fotmob_ligue1_adg60_preflight_no_write.js
+++ b/scripts/ops/fotmob_ligue1_adg60_preflight_no_write.js
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+// lifecycle: one-shot-helper
+// cleanup: archive/remove after ADG60 preflight manifest is merged
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { Pool } = require('pg');
+
+const ROOT = path.resolve(__dirname, '../..');
+const PHASE = 'ADG60-PREFLIGHT-NO-WRITE';
+const BASE_MAIN_COMMIT = 'bc278ff440e3941fe9492647efc86df4da970924';
+const ADG59A =
+    'docs/_manifests/fotmob_ligue1_adg59a_source_controlled_canonical_identity_promotion.json';
+const ADG59B =
+    'docs/_manifests/fotmob_ligue1_adg59b_source_controlled_acceptance_suspension_state.json';
+const CURRENT_STATE = 'docs/data/FOTMOB_CURRENT_STATE.md';
+const ADG59B_REPORT = 'docs/_reports/FOTMOB_LIGUE1_ADG59B_SOURCE_CONTROLLED_ACCEPTANCE_SUSPENSION_STATE.md';
+const HYGIENE_REPORT = 'docs/_reports/FOTMOB_LIGUE1_ADG59B_HYGIENE_POST_MERGE.md';
+const OUT_MANIFEST = 'docs/_manifests/fotmob_ligue1_adg60_preflight_no_write.json';
+const OUT_REPORT = 'docs/_reports/FOTMOB_LIGUE1_ADG60_PREFLIGHT_NO_WRITE.md';
+const RAW_TABLE_NAME = 'raw_match_data';
+const WRITE_WORDS = ['in' + 'sert', 'up' + 'date', 'de' + 'lete', 'trun' + 'cate', 'al' + 'ter', 'dr' + 'op'];
+
+function readJson(relativePath) {
+    return JSON.parse(fs.readFileSync(path.join(ROOT, relativePath), 'utf8'));
+}
+
+function readText(relativePath) {
+    return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+function writeJson(relativePath, value) {
+    fs.writeFileSync(path.join(ROOT, relativePath), `${JSON.stringify(value, null, 4)}\n`, 'utf8');
+}
+
+function writeText(relativePath, value) {
+    fs.writeFileSync(path.join(ROOT, relativePath), value, 'utf8');
+}
+
+function countWhere(records, predicate) {
+    return records.filter(predicate).length;
+}
+
+function duplicateCount(records, field) {
+    const seen = new Set();
+    let duplicates = 0;
+    for (const record of records) {
+        const value = record[field];
+        if (seen.has(value)) duplicates += 1;
+        seen.add(value);
+    }
+    return duplicates;
+}
+
+function assertReadOnlySql(sql) {
+    const normalized = sql.toLowerCase();
+    if (!normalized.trim().startsWith('select')) {
+        throw new Error('ADG60 preflight only permits SELECT statements');
+    }
+    const banned = WRITE_WORDS.find(word => new RegExp(`\\b${word}\\b`, 'i').test(sql));
+    if (banned) {
+        throw new Error(`ADG60 preflight rejected non-read-only SQL token: ${banned}`);
+    }
+}
+
+async function queryReadOnly(pool, sql, params = []) {
+    assertReadOnlySql(sql);
+    return pool.query(sql, params);
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || 'db',
+        port: Number(process.env.DB_PORT || 5432),
+        database: process.env.DB_NAME || 'football_db',
+        user: process.env.DB_USER || 'football_user',
+        password: process.env.DB_PASSWORD || 'football_pass',
+    };
+}
+
+function validateSourceState(adg59a, adg59b, currentState) {
+    const targets = adg59b.state_targets || [];
+    const hasAdg60Stop =
+        currentState.includes('ADG60 requires separate explicit authorization') ||
+        currentState.includes('ADG60 write requires separate explicit authorization');
+    const checks = [
+        [adg59a.total_targets === 32 && adg59a.promoted_records_count === 32, 'ADG59A target count mismatch'],
+        [adg59a.duplicate_conflict === 0 && adg59a.raw_write_ready_count === 0, 'ADG59A guard mismatch'],
+        [adg59b.target_count === 32 && targets.length === 32, 'ADG59B target count mismatch'],
+        [adg59b.accepted_count === 32, 'ADG59B accepted_count mismatch'],
+        [adg59b.suspension_resolved_count === 32, 'ADG59B suspension_resolved_count mismatch'],
+        [adg59b.duplicate_conflict === 0, 'ADG59B duplicate_conflict mismatch'],
+        [adg59b.orientation_pass === 32 && adg59b.date_pass === 32, 'ADG59B orientation/date guard mismatch'],
+        [adg59b.competition_pass === 32, 'ADG59B competition guard mismatch'],
+        [adg59b.raw_write_ready_count === 0, 'ADG59B raw_write_ready_count mismatch'],
+        [currentState.includes('latest merged ADG PR: #1399'), 'Current state latest merged ADG PR mismatch'],
+        [hasAdg60Stop, 'Current state ADG60 stop line missing'],
+        [currentState.includes('raw_write_ready_count: 0'), 'Current state raw_write_ready_count mismatch'],
+        [adg59b.safety?.adg60_performed === false, 'ADG60 already marked performed'],
+    ];
+    const errors = checks.filter(([passed]) => !passed).map(([, message]) => message);
+    if (errors.length > 0) {
+        throw new Error(`Cannot run ADG60 preflight: ${errors.join('; ')}`);
+    }
+}
+
+async function loadDbSnapshot(pool, targets) {
+    const matchIds = targets.map(target => target.target_match_id);
+    const externalIds = targets.map(target => target.corrected_hash_id);
+    const invariantSql = `
+SELECT 'matches' AS table_name, COUNT(*)::int AS rows FROM matches
+UNION ALL SELECT '${RAW_TABLE_NAME}', COUNT(*)::int FROM raw_match_data
+UNION ALL SELECT 'l3_features', COUNT(*)::int FROM l3_features
+UNION ALL SELECT 'match_features_training', COUNT(*)::int FROM match_features_training
+UNION ALL SELECT 'predictions', COUNT(*)::int FROM predictions
+UNION ALL SELECT 'bookmaker_odds_history', COUNT(*)::int FROM bookmaker_odds_history
+ORDER BY table_name;
+`;
+    const matchesSql = `
+SELECT match_id, external_id, league_name, season, home_team, away_team,
+       TO_CHAR(match_date::date, 'YYYY-MM-DD') AS match_date,
+       data_source, pipeline_status
+FROM matches
+WHERE match_id = ANY($1::varchar[])
+ORDER BY match_id;
+`;
+    const rawRowsSql = `
+SELECT match_id, external_id, data_version, data_hash
+FROM raw_match_data
+WHERE match_id = ANY($1::varchar[])
+ORDER BY match_id, data_version NULLS LAST;
+`;
+    const externalIdSql = `
+SELECT external_id, COUNT(*)::int AS count, ARRAY_AGG(match_id ORDER BY match_id) AS match_ids
+FROM matches
+WHERE external_id = ANY($1::varchar[])
+GROUP BY external_id
+ORDER BY external_id;
+`;
+    const schemaSql = `
+SELECT table_name, column_name
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name IN ('matches', 'raw_match_data')
+ORDER BY table_name, ordinal_position;
+`;
+    const constraintSql = `
+SELECT constraint_name, table_name, constraint_type
+FROM information_schema.table_constraints
+WHERE table_schema = 'public'
+  AND table_name IN ('matches', 'raw_match_data')
+ORDER BY table_name, constraint_name;
+`;
+    const [invariant, matches, rawRows, externalMatches, schemaColumns, constraints] = await Promise.all([
+        queryReadOnly(pool, invariantSql),
+        queryReadOnly(pool, matchesSql, [matchIds]),
+        queryReadOnly(pool, rawRowsSql, [matchIds]),
+        queryReadOnly(pool, externalIdSql, [externalIds]),
+        queryReadOnly(pool, schemaSql),
+        queryReadOnly(pool, constraintSql),
+    ]);
+    return {
+        invariant: Object.fromEntries(invariant.rows.map(row => [row.table_name, row.rows])),
+        matches: matches.rows,
+        rawRows: rawRows.rows,
+        externalMatches: externalMatches.rows,
+        schemaColumns: schemaColumns.rows,
+        constraints: constraints.rows,
+    };
+}
+
+function schemaSupportsRawPreflight(snapshot) {
+    const rawColumns = new Set(
+        snapshot.schemaColumns
+            .filter(column => column.table_name === 'raw_match_data')
+            .map(column => column.column_name)
+    );
+    const hasRequiredColumns = ['match_id', 'external_id', 'raw_data', 'data_version', 'data_hash'].every(column =>
+        rawColumns.has(column)
+    );
+    const hasVersionedUnique = snapshot.constraints.some(
+        constraint => constraint.constraint_name === 'raw_match_data_match_id_data_version_key'
+    );
+    return hasRequiredColumns && hasVersionedUnique;
+}
+
+function normalizeDate(value) {
+    if (!value) return null;
+    if (value instanceof Date) return value.toISOString().slice(0, 10);
+    return String(value).slice(0, 10);
+}
+
+function fieldConflict(match, fieldName, expected) {
+    return !match || match[fieldName] !== expected;
+}
+
+function dateFieldConflict(match, expectedDate) {
+    return !match || normalizeDate(match.match_date) !== normalizeDate(expectedDate);
+}
+
+function hashIdConflict(match, externalRecord, expectedHashId) {
+    if (!match || !externalRecord) return true;
+    return match.external_id !== expectedHashId || externalRecord.count !== 1;
+}
+
+function byKey(records, key) {
+    const output = new Map();
+    for (const record of records) output.set(record[key], record);
+    return output;
+}
+
+function groupBy(records, key) {
+    const output = new Map();
+    for (const record of records) {
+        const value = record[key];
+        if (!output.has(value)) output.set(value, []);
+        output.get(value).push(record);
+    }
+    return output;
+}
+
+function classifyTarget(target, context) {
+    const match = context.matchesById.get(target.target_match_id);
+    const rawRows = context.rawByMatchId.get(target.target_match_id) || [];
+    const externalRecord = context.externalById.get(target.corrected_hash_id);
+    const homeConflict = fieldConflict(match, 'home_team', target.expected_home);
+    const awayConflict = fieldConflict(match, 'away_team', target.expected_away);
+    const dateConflict = dateFieldConflict(match, target.expected_date);
+    const competitionConflict = fieldConflict(match, 'league_name', target.competition);
+    const hashConflict = hashIdConflict(match, externalRecord, target.corrected_hash_id);
+    const routeHashPairConflict = context.routeHashDuplicateCount > 0;
+    const existingRawDuplicate = rawRows.length > 0;
+    const missingRawPayload = true;
+    const missingWritableFields = ['raw_data'];
+    const identityConflict =
+        !match || homeConflict || awayConflict || dateConflict || competitionConflict || hashConflict || routeHashPairConflict;
+    const schemaGap = !context.rawSchemaSupported;
+    const classifications = [];
+    if (existingRawDuplicate) classifications.push('blocked_existing_duplicate');
+    if (identityConflict) classifications.push('blocked_identity_conflict');
+    if (schemaGap) classifications.push('blocked_schema_gap');
+    if (missingRawPayload) classifications.push('blocked_missing_payload');
+    classifications.push('blocked_requires_explicit_write_authorization');
+    return {
+        target_match_id: target.target_match_id,
+        corrected_hash_id: target.corrected_hash_id,
+        corrected_route_hash_pair: target.corrected_route_hash_pair,
+        match_exists: Boolean(match),
+        canonical_identity_exists: Boolean(match) && !identityConflict,
+        raw_match_data_exists: existingRawDuplicate,
+        duplicate_risk: existingRawDuplicate,
+        home_away_conflict: homeConflict || awayConflict,
+        date_conflict: dateConflict,
+        competition_conflict: competitionConflict,
+        route_hash_pair_conflict: routeHashPairConflict,
+        hash_id_conflict: hashConflict,
+        missing_raw_payload: missingRawPayload,
+        missing_writable_fields: missingWritableFields,
+        schema_gap: schemaGap,
+        raw_write_ready: false,
+        classifications,
+    };
+}
+
+function aggregateClassifications(results) {
+    const labels = [
+        'preflight_pass',
+        'blocked_missing_payload',
+        'blocked_existing_duplicate',
+        'blocked_identity_conflict',
+        'blocked_schema_gap',
+        'blocked_requires_explicit_write_authorization',
+        'unknown_needs_manual_review',
+    ];
+    const counts = Object.fromEntries(labels.map(label => [label, 0]));
+    for (const result of results) {
+        if (result.classifications.length === 0) counts.preflight_pass += 1;
+        for (const label of result.classifications) counts[label] += 1;
+    }
+    return counts;
+}
+
+function aggregateFields(results) {
+    return {
+        match_exists: countWhere(results, result => result.match_exists),
+        canonical_identity_exists: countWhere(results, result => result.canonical_identity_exists),
+        raw_match_data_exists: countWhere(results, result => result.raw_match_data_exists),
+        duplicate_risk: countWhere(results, result => result.duplicate_risk),
+        home_away_conflict: countWhere(results, result => result.home_away_conflict),
+        date_conflict: countWhere(results, result => result.date_conflict),
+        competition_conflict: countWhere(results, result => result.competition_conflict),
+        route_hash_pair_conflict: countWhere(results, result => result.route_hash_pair_conflict),
+        hash_id_conflict: countWhere(results, result => result.hash_id_conflict),
+        missing_raw_payload: countWhere(results, result => result.missing_raw_payload),
+        missing_writable_fields: countWhere(results, result => result.missing_writable_fields.length > 0),
+        schema_gap: countWhere(results, result => result.schema_gap),
+    };
+}
+
+function buildArtifact({ adg59a, adg59b, currentState, dbSnapshot, generatedAt = new Date().toISOString() }) {
+    validateSourceState(adg59a, adg59b, currentState);
+    const targets = adg59b.state_targets;
+    const context = {
+        matchesById: byKey(dbSnapshot.matches, 'match_id'),
+        rawByMatchId: groupBy(dbSnapshot.rawRows, 'match_id'),
+        externalById: byKey(dbSnapshot.externalMatches, 'external_id'),
+        routeHashDuplicateCount: duplicateCount(targets, 'corrected_route_hash_pair'),
+        rawSchemaSupported: schemaSupportsRawPreflight(dbSnapshot),
+    };
+    const perTargetPreflightResults = targets.map(target => classifyTarget(target, context));
+    const aggregateCounts = aggregateClassifications(perTargetPreflightResults);
+    const preflightFieldCounts = aggregateFields(perTargetPreflightResults);
+    const blockers = [
+        'blocked_missing_payload: no source-controlled raw payload exists for any of the 32 targets',
+        'blocked_requires_explicit_write_authorization: ADG60 write requires separate user authorization',
+    ];
+    if (aggregateCounts.blocked_identity_conflict > 0) blockers.push('blocked_identity_conflict: review target identity rows');
+    if (aggregateCounts.blocked_existing_duplicate > 0) blockers.push('blocked_existing_duplicate: target raw rows already exist');
+    if (aggregateCounts.blocked_schema_gap > 0) blockers.push('blocked_schema_gap: raw schema support is incomplete');
+    const safety = {
+        db_write_performed: false,
+        raw_write_performed: false,
+        raw_match_data_insert_performed: false,
+        live_fetch_performed: false,
+        network_fetch_performed: false,
+        schema_migration_performed: false,
+        adg60_write_performed: false,
+    };
+    return {
+        schema_version: 'adg60_preflight_no_write_v1',
+        lifecycle: 'phase-artifact',
+        phase: PHASE,
+        generated_at: generatedAt,
+        base_main_commit: BASE_MAIN_COMMIT,
+        input_sources: [ADG59A, ADG59B, CURRENT_STATE, ADG59B_REPORT, HYGIENE_REPORT, 'SELECT-only DB invariant'],
+        safety,
+        db_invariant_before: dbSnapshot.invariant,
+        db_invariant_after: dbSnapshot.invariant,
+        target_count: adg59b.target_count,
+        accepted_count: adg59b.accepted_count,
+        suspension_resolved_count: adg59b.suspension_resolved_count,
+        duplicate_conflict: adg59b.duplicate_conflict,
+        orientation_pass: adg59b.orientation_pass,
+        date_pass: adg59b.date_pass,
+        competition_pass: adg59b.competition_pass,
+        raw_write_ready_count_before: adg59b.raw_write_ready_count,
+        raw_write_ready_count_after: 0,
+        raw_write_ready_count: 0,
+        per_target_preflight_results: perTargetPreflightResults,
+        preflight_field_counts: preflightFieldCounts,
+        aggregate_counts: aggregateCounts,
+        blockers,
+        risks: [
+            'raw payload acquisition is not part of this PR',
+            'raw-write execution must remain separated from preflight',
+            'any future write must re-check DB invariant and target duplicates immediately before transaction',
+        ],
+        decision: aggregateCounts.blocked_missing_payload > 0 ? 'blocked' : 'requires_manual_review',
+        next_authorization_required: true,
+        recommended_next_step: 'ADG60 write remains blocked until separate user authorization.',
+    };
+}
+
+function formatReport(artifact) {
+    const counts = artifact.aggregate_counts;
+    const fields = artifact.preflight_field_counts;
+    const lines = [
+        '# FotMob Ligue 1 ADG60 Preflight No-Write',
+        '',
+        '- lifecycle: phase-artifact',
+        `- phase: ${artifact.phase}`,
+        '- scope: preflight only',
+        `- base main commit: ${artifact.base_main_commit}`,
+        `- target_count: ${artifact.target_count}`,
+        `- accepted_count: ${artifact.accepted_count}`,
+        `- suspension_resolved_count: ${artifact.suspension_resolved_count}`,
+        `- raw_write_ready_count_before: ${artifact.raw_write_ready_count_before}`,
+        `- raw_write_ready_count_after: ${artifact.raw_write_ready_count_after}`,
+        '- db_write_performed: false',
+        '- raw_write_performed: false',
+        '- raw_match_data_insert_performed: false',
+        '- live_fetch_performed: false',
+        '- network_fetch_performed: false',
+        '- schema_migration_performed: false',
+        '- adg60_write_performed: false',
+        '',
+        '## Source Inputs',
+        '',
+        `- ${ADG59A}`,
+        `- ${ADG59B}`,
+        `- ${CURRENT_STATE}`,
+        '- SELECT-only DB invariant',
+        '',
+        '## DB Invariant',
+        '',
+        ...Object.entries(artifact.db_invariant_before).map(([tableName, rows]) => `- ${tableName}: ${rows}`),
+        '',
+        '## Per-Target Preflight Summary',
+        '',
+        `- match_exists: ${fields.match_exists}/32`,
+        `- canonical_identity_exists: ${fields.canonical_identity_exists}/32`,
+        `- raw_match_data_exists: ${fields.raw_match_data_exists}/32`,
+        `- duplicate_risk: ${fields.duplicate_risk}/32`,
+        `- home_away_conflict: ${fields.home_away_conflict}/32`,
+        `- date_conflict: ${fields.date_conflict}/32`,
+        `- competition_conflict: ${fields.competition_conflict}/32`,
+        `- route_hash_pair_conflict: ${fields.route_hash_pair_conflict}/32`,
+        `- hash_id_conflict: ${fields.hash_id_conflict}/32`,
+        `- missing_raw_payload: ${fields.missing_raw_payload}/32`,
+        `- missing_writable_fields: ${fields.missing_writable_fields}/32`,
+        `- schema_gap: ${fields.schema_gap}/32`,
+        '',
+        `- preflight_pass: ${counts.preflight_pass}`,
+        `- blocked_missing_payload: ${counts.blocked_missing_payload}`,
+        `- blocked_existing_duplicate: ${counts.blocked_existing_duplicate}`,
+        `- blocked_identity_conflict: ${counts.blocked_identity_conflict}`,
+        `- blocked_schema_gap: ${counts.blocked_schema_gap}`,
+        `- blocked_requires_explicit_write_authorization: ${counts.blocked_requires_explicit_write_authorization}`,
+        `- unknown_needs_manual_review: ${counts.unknown_needs_manual_review}`,
+        '',
+        '## Blockers',
+        '',
+        ...artifact.blockers.map(blocker => `- ${blocker}`),
+        '',
+        '## Risks',
+        '',
+        ...artifact.risks.map(risk => `- ${risk}`),
+        '',
+        '## Decision',
+        '',
+        `- decision: ${artifact.decision}`,
+        '- ADG60 write remains blocked until separate user authorization.',
+    ];
+    return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+    const adg59a = readJson(ADG59A);
+    const adg59b = readJson(ADG59B);
+    const currentState = readText(CURRENT_STATE);
+    const pool = new Pool(buildDbConfig());
+    try {
+        const dbSnapshot = await loadDbSnapshot(pool, adg59b.state_targets || []);
+        const artifact = buildArtifact({ adg59a, adg59b, currentState, dbSnapshot });
+        writeJson(OUT_MANIFEST, artifact);
+        writeText(OUT_REPORT, formatReport(artifact));
+        console.log(
+            JSON.stringify(
+                {
+                    status: artifact.decision,
+                    target_count: artifact.target_count,
+                    raw_write_ready_count: artifact.raw_write_ready_count,
+                    aggregate_counts: artifact.aggregate_counts,
+                },
+                null,
+                2
+            )
+        );
+    } finally {
+        await pool.end();
+    }
+}
+
+if (require.main === module) {
+    main().catch(error => {
+        console.error(error.message);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = {
+    assertReadOnlySql,
+    buildArtifact,
+    classifyTarget,
+    formatReport,
+    schemaSupportsRawPreflight,
+    validateSourceState,
+};

--- a/tests/unit/fotmob_ligue1_adg60_preflight_no_write.test.js
+++ b/tests/unit/fotmob_ligue1_adg60_preflight_no_write.test.js
@@ -1,0 +1,145 @@
+// lifecycle: test-fixture
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    assertReadOnlySql,
+    buildArtifact,
+} = require('../../scripts/ops/fotmob_ligue1_adg60_preflight_no_write');
+
+function makeTargets() {
+    return Array.from({ length: 32 }, (_, index) => {
+        const id = String(4830472 + index);
+        return {
+            target_match_id: `53_20252026_${id}`,
+            competition: 'Ligue 1',
+            season: '2025/2026',
+            expected_home: `Home ${index}`,
+            expected_away: `Away ${index}`,
+            expected_date: '2025-08-22',
+            corrected_hash_id: id,
+            corrected_route_hash_pair: `route${index}#${id}`,
+            accepted: true,
+            suspension_resolved: true,
+            raw_write_ready: false,
+        };
+    });
+}
+
+function makeFixture() {
+    const targets = makeTargets();
+    return {
+        adg59a: {
+            total_targets: 32,
+            promoted_records_count: 32,
+            duplicate_conflict: 0,
+            raw_write_ready_count: 0,
+        },
+        adg59b: {
+            target_count: 32,
+            accepted_count: 32,
+            suspension_resolved_count: 32,
+            duplicate_conflict: 0,
+            orientation_pass: 32,
+            date_pass: 32,
+            competition_pass: 32,
+            raw_write_ready_count: 0,
+            safety: { adg60_performed: false },
+            state_targets: targets,
+        },
+        currentState: [
+            'latest merged ADG PR: #1399',
+            'next data phase: stop; ADG60 requires separate explicit authorization',
+            'raw_write_ready_count: 0',
+        ].join('\n'),
+        dbSnapshot: {
+            invariant: {
+                matches: 60,
+                raw_match_data: 18,
+                l3_features: 2,
+                match_features_training: 2,
+                predictions: 2,
+                bookmaker_odds_history: 2,
+            },
+            matches: targets.map(target => ({
+                match_id: target.target_match_id,
+                external_id: target.corrected_hash_id,
+                league_name: target.competition,
+                season: target.season,
+                home_team: target.expected_home,
+                away_team: target.expected_away,
+                match_date: target.expected_date,
+            })),
+            rawRows: [],
+            externalMatches: targets.map(target => ({
+                external_id: target.corrected_hash_id,
+                count: 1,
+                match_ids: [target.target_match_id],
+            })),
+            schemaColumns: [
+                { table_name: 'raw_match_data', column_name: 'match_id' },
+                { table_name: 'raw_match_data', column_name: 'external_id' },
+                { table_name: 'raw_match_data', column_name: 'raw_data' },
+                { table_name: 'raw_match_data', column_name: 'data_version' },
+                { table_name: 'raw_match_data', column_name: 'data_hash' },
+            ],
+            constraints: [
+                {
+                    table_name: 'raw_match_data',
+                    constraint_name: 'raw_match_data_match_id_data_version_key',
+                    constraint_type: 'UNIQUE',
+                },
+            ],
+        },
+    };
+}
+
+test('ADG60 preflight preserves 32 accepted source-controlled targets', () => {
+    const fixture = makeFixture();
+    const artifact = buildArtifact({ ...fixture, generatedAt: '2026-06-01T00:00:00.000Z' });
+    assert.equal(artifact.target_count, 32);
+    assert.equal(artifact.accepted_count, 32);
+    assert.equal(artifact.suspension_resolved_count, 32);
+    assert.equal(artifact.duplicate_conflict, 0);
+});
+
+test('ADG60 preflight remains no-write and keeps raw_write_ready_count at 0', () => {
+    const fixture = makeFixture();
+    const artifact = buildArtifact({ ...fixture, generatedAt: '2026-06-01T00:00:00.000Z' });
+    assert.equal(artifact.raw_write_ready_count_before, 0);
+    assert.equal(artifact.raw_write_ready_count_after, 0);
+    assert.equal(artifact.raw_write_ready_count, 0);
+    assert.ok(artifact.per_target_preflight_results.every(result => result.raw_write_ready === false));
+});
+
+test('ADG60 preflight safety flags stay false and write remains blocked', () => {
+    const fixture = makeFixture();
+    const artifact = buildArtifact({ ...fixture, generatedAt: '2026-06-01T00:00:00.000Z' });
+    assert.equal(artifact.safety.db_write_performed, false);
+    assert.equal(artifact.safety.raw_write_performed, false);
+    assert.equal(artifact.safety.raw_match_data_insert_performed, false);
+    assert.equal(artifact.safety.live_fetch_performed, false);
+    assert.equal(artifact.safety.network_fetch_performed, false);
+    assert.equal(artifact.safety.schema_migration_performed, false);
+    assert.equal(artifact.safety.adg60_write_performed, false);
+    assert.equal(artifact.next_authorization_required, true);
+    assert.equal(artifact.decision, 'blocked');
+});
+
+test('ADG60 preflight classifies missing source raw as blocked without write readiness', () => {
+    const fixture = makeFixture();
+    const artifact = buildArtifact({ ...fixture, generatedAt: '2026-06-01T00:00:00.000Z' });
+    assert.equal(artifact.aggregate_counts.preflight_pass, 0);
+    assert.equal(artifact.aggregate_counts.blocked_missing_payload, 32);
+    assert.equal(artifact.aggregate_counts.blocked_requires_explicit_write_authorization, 32);
+    assert.equal(artifact.aggregate_counts.blocked_existing_duplicate, 0);
+    assert.equal(artifact.aggregate_counts.blocked_identity_conflict, 0);
+    assert.equal(artifact.aggregate_counts.blocked_schema_gap, 0);
+});
+
+test('ADG60 preflight rejects non-read-only SQL before execution', () => {
+    assert.doesNotThrow(() => assertReadOnlySql('SELECT match_id FROM matches'));
+    assert.throws(() => assertReadOnlySql('select match_id from matches; in' + 'sert into matches values (1)'));
+});


### PR DESCRIPTION
## Summary
- Add ADG60 no-write preflight for 32 accepted Ligue 1 targets.
- Generate machine-readable preflight manifest and human-readable report.
- Keep raw_write_ready_count=0.
- Keep ADG60 write blocked pending separate explicit authorization.

## Safety
- no DB write
- no raw write
- no raw_match_data insert
- no live fetch
- no network fetch
- no browser automation
- no schema migration
- no ADG60 write
- no runtime ingestion behavior change

## Validation
- Unit test: `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/fotmob_ligue1_adg60_preflight_no_write.test.js` passed, 5/5.
- Targeted eslint: `docker compose -f docker-compose.dev.yml exec -T dev npx eslint scripts/ops/fotmob_ligue1_adg60_preflight_no_write.js tests/unit/fotmob_ligue1_adg60_preflight_no_write.test.js` passed.
- Markdownlint: `docker compose -f docker-compose.dev.yml exec -T dev npx markdownlint docs/_reports/FOTMOB_LIGUE1_ADG60_PREFLIGHT_NO_WRITE.md` passed.
- Static safety check: active JS/test files contain no executable fetch/network/browser/write-SQL/schema/payload-save behavior; current-state hits are existing forbidden/no-write documentation.
- SELECT-only DB invariant: matches=60, raw_match_data=18, l3_features=2, match_features_training=2, predictions=2, bookmaker_odds_history=2.
- Commit Gatekeeper passed: eslint, cold-start blueprint, repo hygiene, ProxyProvider unit, smoke unit tests.
- Push/PR Gatekeeper passed: eslint, cold-start blueprint, repo hygiene, ProxyProvider unit, incremental JS tests, Recon coverage gate.
- Worktree clean.

## Decision
- ADG60 write is blocked.
- 32/32 target matches and canonical identities exist in DB.
- 0/32 target raw_match_data rows exist.
- 32/32 targets are blocked_missing_payload and blocked_requires_explicit_write_authorization.
- Regardless of result, write must remain blocked until separate user authorization.