### PR TITLE
data(source): add football calendar target registry design and migration

### DIFF
--- a/database/migrations/V26.6__create_football_calendar_target_registry.sql
+++ b/database/migrations/V26.6__create_football_calendar_target_registry.sql
@@ -1,0 +1,258 @@
+-- V26.6: Create football calendar target registry tables for FotMob long-run collection.
+-- lifecycle: permanent
+-- Scope: target registry schema only. No source access. No seed data. No raw JSON storage.
+
+CREATE TABLE IF NOT EXISTS football_teams (
+    id BIGSERIAL PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'fotmob',
+    source_team_id TEXT NOT NULL,
+    team_name TEXT NOT NULL,
+    team_type TEXT NOT NULL,
+    country TEXT,
+    gender TEXT DEFAULT 'men',
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_football_teams_source_team UNIQUE (source, source_team_id),
+    CONSTRAINT ck_football_teams_team_type CHECK (team_type IN ('club', 'national'))
+);
+
+CREATE TABLE IF NOT EXISTS football_competitions (
+    id BIGSERIAL PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'fotmob',
+    source_competition_id TEXT NOT NULL,
+    competition_name TEXT NOT NULL,
+    competition_type TEXT NOT NULL,
+    country TEXT,
+    confederation TEXT,
+    tier INTEGER,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_football_competitions_source_competition UNIQUE (source, source_competition_id),
+    CONSTRAINT ck_football_competitions_competition_type CHECK (
+        competition_type IN (
+            'league',
+            'domestic_cup',
+            'continental_club',
+            'international_tournament',
+            'international_qualifier',
+            'nations_league',
+            'friendly',
+            'super_cup',
+            'other'
+        )
+    )
+);
+
+CREATE TABLE IF NOT EXISTS football_competition_editions (
+    id BIGSERIAL PRIMARY KEY,
+    competition_id BIGINT NOT NULL REFERENCES football_competitions(id),
+    season TEXT NOT NULL,
+    edition_name TEXT,
+    start_date DATE,
+    end_date DATE,
+    calendar_type TEXT,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_football_competition_editions_competition_season UNIQUE (competition_id, season)
+);
+
+CREATE TABLE IF NOT EXISTS football_team_competition_participation (
+    id BIGSERIAL PRIMARY KEY,
+    team_id BIGINT NOT NULL REFERENCES football_teams(id),
+    competition_id BIGINT NOT NULL REFERENCES football_competitions(id),
+    edition_id BIGINT NOT NULL REFERENCES football_competition_editions(id),
+    participation_state TEXT NOT NULL DEFAULT 'unknown',
+    qualification_source TEXT,
+    first_seen_at TIMESTAMPTZ,
+    last_seen_at TIMESTAMPTZ,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_football_team_competition_participation UNIQUE (team_id, competition_id, edition_id),
+    CONSTRAINT ck_football_team_competition_participation_state CHECK (
+        participation_state IN ('expected', 'confirmed', 'eliminated', 'completed', 'unknown')
+    )
+);
+
+CREATE TABLE IF NOT EXISTS football_match_targets (
+    id BIGSERIAL PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'fotmob',
+    source_match_id TEXT NOT NULL,
+    competition_id BIGINT REFERENCES football_competitions(id),
+    edition_id BIGINT REFERENCES football_competition_editions(id),
+    match_date TIMESTAMPTZ,
+    home_team_id BIGINT REFERENCES football_teams(id),
+    away_team_id BIGINT REFERENCES football_teams(id),
+    match_status TEXT,
+    target_state TEXT NOT NULL DEFAULT 'discovered',
+    priority INTEGER NOT NULL DEFAULT 100,
+    discovery_source TEXT,
+    source_url TEXT,
+    raw_json_status TEXT,
+    last_attempt_at TIMESTAMPTZ,
+    last_success_at TIMESTAMPTZ,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error_code TEXT,
+    last_error_message TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_football_match_targets_source_match UNIQUE (source, source_match_id),
+    CONSTRAINT ck_football_match_targets_target_state CHECK (
+        target_state IN (
+            'discovered',
+            'pending_raw_fetch',
+            'raw_fetched',
+            'raw_json_stored',
+            'blocked',
+            'failed',
+            'retired'
+        )
+    ),
+    CONSTRAINT ck_football_match_targets_attempt_count CHECK (attempt_count >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS football_match_target_teams (
+    id BIGSERIAL PRIMARY KEY,
+    match_target_id BIGINT NOT NULL REFERENCES football_match_targets(id),
+    team_id BIGINT NOT NULL REFERENCES football_teams(id),
+    role TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_football_match_target_teams_target_team_role UNIQUE (match_target_id, team_id, role),
+    CONSTRAINT ck_football_match_target_teams_role CHECK (role IN ('home', 'away', 'participant'))
+);
+
+CREATE TABLE IF NOT EXISTS football_source_identities (
+    id BIGSERIAL PRIMARY KEY,
+    source TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id BIGINT,
+    source_entity_id TEXT NOT NULL,
+    source_url TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_football_source_identities_source_entity UNIQUE (source, entity_type, source_entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_football_teams_team_type
+    ON football_teams (team_type);
+
+CREATE INDEX IF NOT EXISTS idx_football_teams_country
+    ON football_teams (country);
+
+CREATE INDEX IF NOT EXISTS idx_football_teams_active
+    ON football_teams (active);
+
+CREATE INDEX IF NOT EXISTS idx_football_competitions_type
+    ON football_competitions (competition_type);
+
+CREATE INDEX IF NOT EXISTS idx_football_competitions_country
+    ON football_competitions (country);
+
+CREATE INDEX IF NOT EXISTS idx_football_competitions_confederation
+    ON football_competitions (confederation);
+
+CREATE INDEX IF NOT EXISTS idx_football_competitions_tier
+    ON football_competitions (tier);
+
+CREATE INDEX IF NOT EXISTS idx_football_competitions_active
+    ON football_competitions (active);
+
+CREATE INDEX IF NOT EXISTS idx_football_competition_editions_competition
+    ON football_competition_editions (competition_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_competition_editions_season
+    ON football_competition_editions (season);
+
+CREATE INDEX IF NOT EXISTS idx_football_competition_editions_dates
+    ON football_competition_editions (start_date, end_date);
+
+CREATE INDEX IF NOT EXISTS idx_football_competition_editions_active
+    ON football_competition_editions (active);
+
+CREATE INDEX IF NOT EXISTS idx_football_team_competition_participation_team
+    ON football_team_competition_participation (team_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_team_competition_participation_competition
+    ON football_team_competition_participation (competition_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_team_competition_participation_edition
+    ON football_team_competition_participation (edition_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_team_competition_participation_state
+    ON football_team_competition_participation (participation_state);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_source_match
+    ON football_match_targets (source, source_match_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_competition
+    ON football_match_targets (competition_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_edition
+    ON football_match_targets (edition_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_match_date
+    ON football_match_targets (match_date);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_home_team
+    ON football_match_targets (home_team_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_away_team
+    ON football_match_targets (away_team_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_target_state
+    ON football_match_targets (target_state);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_targets_raw_json_status
+    ON football_match_targets (raw_json_status);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_target_teams_target
+    ON football_match_target_teams (match_target_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_target_teams_team
+    ON football_match_target_teams (team_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_match_target_teams_role
+    ON football_match_target_teams (role);
+
+CREATE INDEX IF NOT EXISTS idx_football_source_identities_entity
+    ON football_source_identities (entity_type, entity_id);
+
+CREATE INDEX IF NOT EXISTS idx_football_source_identities_source_entity_id
+    ON football_source_identities (source, source_entity_id);
+
+COMMENT ON TABLE football_teams IS 'Football team identity registry for club and national teams from FotMob.';
+COMMENT ON COLUMN football_teams.source_team_id IS 'FotMob team id or source-specific team identity.';
+COMMENT ON COLUMN football_teams.team_type IS 'Team type: club or national.';
+COMMENT ON COLUMN football_teams.metadata IS 'Additional source identity metadata. No raw match payload.';
+
+COMMENT ON TABLE football_competitions IS 'Football competition registry covering leagues, cups, continental club, and national team competitions.';
+COMMENT ON COLUMN football_competitions.source_competition_id IS 'FotMob competition id or source-specific competition identity.';
+COMMENT ON COLUMN football_competitions.competition_type IS 'Competition type enum used for calendar coverage and collector targeting.';
+COMMENT ON COLUMN football_competitions.tier IS 'Collection coverage tier. Smaller values indicate higher priority.';
+
+COMMENT ON TABLE football_competition_editions IS 'Competition season or tournament edition registry.';
+COMMENT ON COLUMN football_competition_editions.season IS 'Season, calendar year, or tournament edition label.';
+COMMENT ON COLUMN football_competition_editions.calendar_type IS 'Calendar shape such as season, calendar_year, or tournament_window.';
+
+COMMENT ON TABLE football_team_competition_participation IS 'Team participation registry linking teams to competition editions for full-calendar reconstruction.';
+COMMENT ON COLUMN football_team_competition_participation.participation_state IS 'Participation state: expected, confirmed, eliminated, completed, or unknown.';
+COMMENT ON COLUMN football_team_competition_participation.qualification_source IS 'How this team entered the competition edition.';
+
+COMMENT ON TABLE football_match_targets IS 'FotMob match detail collection targets. Stores target status only, not raw JSON.';
+COMMENT ON COLUMN football_match_targets.source_match_id IS 'FotMob match id used to connect targets with fotmob_raw_match_payloads.match_id.';
+COMMENT ON COLUMN football_match_targets.target_state IS 'Collection target state for raw JSON acquisition lifecycle.';
+COMMENT ON COLUMN football_match_targets.raw_json_status IS 'Local summary of raw JSON storage state. Raw payload is stored outside this table.';
+
+COMMENT ON TABLE football_match_target_teams IS 'Team-role join table for football match targets.';
+COMMENT ON COLUMN football_match_target_teams.role IS 'Team role in a match target: home, away, or participant.';
+
+COMMENT ON TABLE football_source_identities IS 'Source identity registry for teams, competitions, editions, and match targets.';
+COMMENT ON COLUMN football_source_identities.entity_type IS 'Local entity type such as team, competition, edition, or match_target.';
+COMMENT ON COLUMN football_source_identities.source_entity_id IS 'Source-specific entity id.';

--- a/docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json
+++ b/docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "fotmob_football_calendar_target_registry_design_v1",
+  "lifecycle": "permanent/governance",
+  "phase": "FOTMOB-FOOTBALL-CALENDAR-TARGET-REGISTRY-DESIGN-AND-MIGRATION",
+  "migration_path": "database/migrations/V26.6__create_football_calendar_target_registry.sql",
+  "design_doc_path": "docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md",
+  "helper_path": "scripts/ops/fotmob_football_calendar_target_registry_design_check.py",
+  "test_path": "tests/unit/fotmob_football_calendar_target_registry_design_check.test.py",
+  "tables": [
+    "football_teams",
+    "football_competitions",
+    "football_competition_editions",
+    "football_team_competition_participation",
+    "football_match_targets",
+    "football_match_target_teams",
+    "football_source_identities"
+  ],
+  "enums": {
+    "team_type": ["club", "national"],
+    "competition_type": [
+      "league",
+      "domestic_cup",
+      "continental_club",
+      "international_tournament",
+      "international_qualifier",
+      "nations_league",
+      "friendly",
+      "super_cup",
+      "other"
+    ],
+    "target_state": [
+      "discovered",
+      "pending_raw_fetch",
+      "raw_fetched",
+      "raw_json_stored",
+      "blocked",
+      "failed",
+      "retired"
+    ],
+    "participation_state": ["expected", "confirmed", "eliminated", "completed", "unknown"]
+  },
+  "supports_club_matches": true,
+  "supports_national_team_matches": true,
+  "supports_league": true,
+  "supports_domestic_cup": true,
+  "supports_continental_club": true,
+  "supports_international_tournament": true,
+  "supports_international_qualifier": true,
+  "supports_secondary_leagues": true,
+  "supports_team_full_calendar": true,
+  "non_goals": {
+    "no_network_fetch": true,
+    "no_live_fetch": true,
+    "no_db_data_write": true,
+    "no_raw_json_write": true,
+    "no_raw_match_data_write": true,
+    "no_l3_features_write": true,
+    "no_match_features_training_write": true,
+    "no_predictions_write": true,
+    "no_scheduler_enable": true,
+    "no_feature_parse": true,
+    "no_model_training": true
+  },
+  "safety": {
+    "network_fetch_performed": false,
+    "db_data_write_performed": false,
+    "raw_json_write_performed": false,
+    "feature_parse_performed": false,
+    "scheduler_enabled": false,
+    "raw_write_ready_marked": false
+  },
+  "next_phase": "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-DRY-RUN"
+}

--- a/docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md
+++ b/docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md
@@ -1,0 +1,368 @@
+<!-- markdownlint-disable MD013 -->
+
+# FotMob Football Calendar Target Registry 设计
+
+- lifecycle: permanent / governance
+- phase: FOTMOB-FOOTBALL-CALENDAR-TARGET-REGISTRY-DESIGN-AND-MIGRATION
+- version: 1.0.0
+- scope: target registry schema design and migration
+- no network fetch / no DB data write / no raw JSON write / no scheduler enable / no feature parse
+- raw_write_ready remains false
+
+## 1. 为什么不能只按联赛采集
+
+长期预测系统不能只从某一个联赛赛程里找比赛。球队基本面来自全年所有正式比赛，联赛只是其中一条赛程线。
+
+杯赛、欧战、洲际俱乐部赛事、超级杯、国家队比赛都会影响近期状态、体能、轮换、伤停和教练选择。只采联赛会漏掉赛程密度、连续客场、加时赛消耗、杯赛轮换和国际比赛日影响，最终让 Raw Layer 缺少解释基本面的关键上下文。
+
+例如 Manchester United 的全年比赛不只来自 Premier League，还会来自 FA Cup、EFL Cup、UEFA competitions、Community Shield 或其他赛事。系统必须能按球队还原跨赛事最近 N 场，而不是只看联赛内最近 N 场。
+
+国家队也是独立球队实体。国家队的状态来自世界杯、欧洲杯、美洲杯、亚洲杯、非洲杯、世界杯预选赛、洲际杯赛预选赛、欧国联和重要友谊赛。系统必须能还原国际比赛日和预选赛窗口，不能把国家队比赛排除在长期采集目标之外。
+
+## 2. 总体目标
+
+本阶段建立长期采集目标注册体系，为 future FotMob raw JSON collector 提供稳定、可审计、可扩展的目标来源。
+
+目标注册体系包含以下表：
+
+- `football_teams`
+- `football_competitions`
+- `football_competition_editions`
+- `football_team_competition_participation`
+- `football_match_targets`
+- `football_match_target_teams`
+- `football_source_identities`
+
+这些表只管理目标、身份和赛程关系，不保存 FotMob 原始 JSON，不解析业务字段，不写 features/training/predictions。
+
+## 3. 覆盖范围分层
+
+### 3.1 Tier 0
+
+Tier 0 是必须优先支持的全年采集范围：
+
+- 五大联赛
+- UEFA Champions League / Europa League / Conference League
+- 主要国内杯赛
+- FIFA World Cup / UEFA Euro / Copa America / AFC Asian Cup
+- World Cup qualifiers
+- UEFA Nations League
+- 国家队重要正式比赛
+
+### 3.2 Tier 1
+
+Tier 1 是长期系统应尽快纳入的扩展范围：
+
+- Eredivisie、Primeira Liga、Belgian Pro League、Turkish Super Lig、Scottish Premiership、EFL Championship
+- J1 League
+- K League
+- Major League Soccer
+- Brasileirao Serie A / Argentine Primera Division
+- AFC Champions League
+- Copa Libertadores
+
+### 3.3 Tier 2
+
+Tier 2 作为后续扩展范围：
+
+- 次级联赛
+- 各国杯赛早期轮次
+- 其他亚洲、欧洲、美洲联赛
+- 重要友谊赛，视 FotMob 数据质量和采集成本决定
+
+## 4. 数据模型说明
+
+### 4.1 `football_teams`
+
+用途：保存 FotMob 源上的球队身份，覆盖俱乐部和国家队。
+
+关键字段：
+
+- `source`: 数据源，默认 `fotmob`
+- `source_team_id`: FotMob team id
+- `team_name`: 球队名称
+- `team_type`: `club` 或 `national`
+- `country`: 国家或地区
+- `gender`: 默认 `men`
+- `active`: 是否仍参与采集
+- `metadata`: 额外身份信息
+
+唯一约束：`unique(source, source_team_id)`。
+
+状态枚举：`team_type in ('club', 'national')`。
+
+主要索引：`team_type`、`country`、`active`。
+
+### 4.2 `football_competitions`
+
+用途：保存 FotMob 源上的赛事身份，覆盖联赛、杯赛、洲际俱乐部赛事和国家队赛事。
+
+关键字段：
+
+- `source`: 数据源，默认 `fotmob`
+- `source_competition_id`: FotMob league/competition id
+- `competition_name`: 赛事名称
+- `competition_type`: 赛事类型
+- `country`: 国内赛事所属国家或地区
+- `confederation`: UEFA、CONMEBOL、AFC 等
+- `tier`: 采集优先级层级
+- `active`: 是否仍参与采集
+- `metadata`: 额外赛事信息
+
+唯一约束：`unique(source, source_competition_id)`。
+
+状态枚举：
+
+- `league`
+- `domestic_cup`
+- `continental_club`
+- `international_tournament`
+- `international_qualifier`
+- `nations_league`
+- `friendly`
+- `super_cup`
+- `other`
+
+主要索引：`competition_type`、`country`、`confederation`、`tier`、`active`。
+
+### 4.3 `football_competition_editions`
+
+用途：保存赛事的具体赛季或届次，例如 `Premier League 2025/2026`、`FA Cup 2025/2026`、`World Cup 2026`。
+
+关键字段：
+
+- `competition_id`: 所属赛事
+- `season`: 赛季或届次标签
+- `edition_name`: 展示名称
+- `start_date` / `end_date`: 赛程时间范围
+- `calendar_type`: season、calendar_year、tournament_window 等
+- `active`: 是否仍参与采集
+- `metadata`: 额外届次信息
+
+唯一约束：`unique(competition_id, season)`。
+
+主要索引：`competition_id`、`season`、`start_date`、`end_date`、`active`。
+
+### 4.4 `football_team_competition_participation`
+
+用途：登记某支球队参加某个赛事届次。它是球队全年日历还原的关键桥梁。
+
+关键字段：
+
+- `team_id`: 球队
+- `competition_id`: 赛事
+- `edition_id`: 赛事届次
+- `participation_state`: 参赛状态
+- `qualification_source`: 参赛来源，例如 league table、cup winner、draw、seeded
+- `first_seen_at` / `last_seen_at`: 采集系统首次和最近观察时间
+- `metadata`: 额外参赛信息
+
+唯一约束：`unique(team_id, competition_id, edition_id)`。
+
+状态枚举：
+
+- `expected`
+- `confirmed`
+- `eliminated`
+- `completed`
+- `unknown`
+
+主要索引：`team_id`、`competition_id`、`edition_id`、`participation_state`。
+
+### 4.5 `football_match_targets`
+
+用途：登记未来 raw JSON collector 应采集的 FotMob match detail 目标。它只管理目标，不保存 raw JSON。
+
+关键字段：
+
+- `source`: 数据源，默认 `fotmob`
+- `source_match_id`: FotMob match id
+- `competition_id`: 赛事
+- `edition_id`: 赛事届次
+- `match_date`: 比赛时间
+- `home_team_id` / `away_team_id`: 主客队
+- `match_status`: scheduled、live、finished、postponed、cancelled 等源状态
+- `target_state`: 采集目标状态
+- `priority`: 采集优先级，数值越小优先级越高
+- `discovery_source`: league_schedule、team_calendar、cup_draw、manual 等
+- `source_url`: FotMob detail URL
+- `raw_json_status`: raw JSON storage 状态摘要
+- `last_attempt_at` / `last_success_at`: 采集尝试和成功时间
+- `attempt_count`: 尝试次数
+- `last_error_code` / `last_error_message`: 最近失败信息
+- `metadata`: 额外目标信息
+
+唯一约束：`unique(source, source_match_id)`。
+
+状态枚举：
+
+- `discovered`
+- `pending_raw_fetch`
+- `raw_fetched`
+- `raw_json_stored`
+- `blocked`
+- `failed`
+- `retired`
+
+主要索引：`source/source_match_id`、`competition_id`、`edition_id`、`match_date`、`home_team_id`、`away_team_id`、`target_state`、`raw_json_status`。
+
+### 4.6 `football_match_target_teams`
+
+用途：保存比赛目标和球队的多角色关系。常规足球比赛通常是 home/away，未来也可支持中立场或多参与方上下文。
+
+关键字段：
+
+- `match_target_id`: 比赛目标
+- `team_id`: 球队
+- `role`: `home`、`away` 或 `participant`
+
+唯一约束：`unique(match_target_id, team_id, role)`。
+
+状态枚举：`role in ('home', 'away', 'participant')`。
+
+主要索引：`match_target_id`、`team_id`、`role`。
+
+### 4.7 `football_source_identities`
+
+用途：保存跨表源身份映射，避免未来引入新 source 或新实体类型时把源 id 写散。
+
+关键字段：
+
+- `source`: 数据源
+- `entity_type`: team、competition、edition、match_target 等
+- `entity_id`: 本地实体 id
+- `source_entity_id`: 源系统实体 id
+- `source_url`: 源系统 URL
+- `metadata`: 额外映射信息
+
+唯一约束：`unique(source, entity_type, source_entity_id)`。
+
+主要索引：`entity_type/entity_id`、`source/source_entity_id`。
+
+## 5. 球队全年赛程还原逻辑
+
+球队全年赛程必须以 team 为核心：
+
+1. 先识别 `football_teams` 中的 team。
+2. 再识别该 team 所属的全部 `football_competitions`。
+3. 再识别每个赛事的 `football_competition_editions`。
+4. 再通过 `football_team_competition_participation` 记录该队参加哪些赛事届次。
+5. 最后把该队关联到 `football_match_targets` 和 `football_match_target_teams`。
+
+这样可以查询某支球队跨赛事最近 N 场比赛。查询 Manchester United 时，结果不应只来自 Premier League，也要覆盖 FA Cup、EFL Cup、UEFA competitions、Community Shield 和未来授权的重要友谊赛。
+
+此模型避免把 `matches` 或单一联赛赛程当作 uncontrolled workflow queue。长期采集目标应由 target registry 明确登记、审计和状态推进。
+
+## 6. 国家队赛程还原逻辑
+
+国家队使用同一套 team 模型，`team_type = 'national'`。
+
+国家队赛事通过 `competition_type` 区分：
+
+- `international_tournament`
+- `international_qualifier`
+- `nations_league`
+- `friendly`
+
+系统应能登记 World Cup、continental tournaments、qualifiers、Nations League 和重要友谊赛。国家队比赛窗口会影响球员负荷和俱乐部赛前基本面，后续 feature 层必须能知道这些比赛存在；当前阶段只建立 raw target registry。
+
+## 7. 与 Raw JSON DB 的关系
+
+`football_match_targets` 只管理采集目标和状态。
+
+`fotmob_raw_match_payloads` 保存 FotMob match detail 原始 JSON，包括 `next_data_json` 和 `page_props_json`。
+
+二者通过以下身份关联：
+
+- `football_match_targets.source`
+- `football_match_targets.source_match_id`
+- `fotmob_raw_match_payloads.source`
+- `fotmob_raw_match_payloads.match_id`
+
+Target registry 不保存原始 JSON，不保存完整 pageProps，不保存 HTML body。Raw JSON DB 是 raw layer 的持久化来源；target registry 是 collector 的目标和审计控制面。
+
+## 8. 状态机
+
+### 8.1 `target_state`
+
+```text
+discovered
+  -> pending_raw_fetch
+  -> raw_fetched
+  -> raw_json_stored
+```
+
+异常分支：
+
+- `blocked`: 403、429、captcha、source policy blocker、identity blocker
+- `failed`: 单目标失败，可在后续授权下重试
+- `retired`: 比赛取消、目标废弃或源身份不再有效
+
+### 8.2 `participation_state`
+
+```text
+expected -> confirmed -> eliminated
+expected -> confirmed -> completed
+unknown  -> expected
+unknown  -> confirmed
+```
+
+解释：
+
+- `expected`: 预计参赛，但还未被可靠源确认
+- `confirmed`: 已确认参赛
+- `eliminated`: 杯赛或淘汰赛出局
+- `completed`: 该届赛事已完成
+- `unknown`: 发现早期信息不足
+
+### 8.3 `competition_type`
+
+允许值：
+
+- `league`
+- `domestic_cup`
+- `continental_club`
+- `international_tournament`
+- `international_qualifier`
+- `nations_league`
+- `friendly`
+- `super_cup`
+- `other`
+
+### 8.4 `team_type`
+
+允许值：
+
+- `club`
+- `national`
+
+## 9. 安全边界
+
+本阶段只新增设计、schema migration、manifest、只读本地 helper 和测试。
+
+本阶段不做：
+
+- no FotMob network fetch
+- no live fetch
+- no writes to `fotmob_raw_match_payloads`
+- no raw JSON payload write
+- no writes to `raw_match_data`
+- no writes to `l3_features`
+- no writes to `match_features_training`
+- no writes to `predictions`
+- no scheduler enable
+- no parser implementation
+- no feature parsing
+- no model training
+- no raw_write_ready marking
+
+## 10. 下一阶段
+
+下一阶段应是 `FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-DRY-RUN`。
+
+前提条件：
+
+- target registry migration 通过 review
+- 新表结构能支持 club 和 national team calendars
+- collector dry-run 只读取 registry，不触 FotMob live source
+- raw write 仍需单独授权，且 raw_write_ready remains false

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,15 +1,16 @@
-[tool:pytest]
+[pytest]
 # pytest配置文件
 
 # 测试发现
 testpaths = tests
-python_files = test_*.py *_test.py
+python_files = test_*.py *_test.py *.test.py
 python_classes = Test*
 python_functions = test_*
 
 # 输出配置
 addopts =
     -v
+    --import-mode=importlib
     --tb=short
     --strict-markers
     --disable-warnings

--- a/ruff.toml
+++ b/ruff.toml
@@ -65,6 +65,7 @@ unfixable = []
 "scripts/*" = ["T20"]  # 允许脚本中使用 print
 "tests/**/*.py" = ["S101", "D101", "D102", "D103"]
 "tests/*.py" = ["S101", "D101", "D102", "D103"]
+"tests/unit/fotmob_football_calendar_target_registry_design_check.test.py" = ["N999", "S101", "D101", "D102", "D103"]
 "__init__.py" = ["F401"]  # 允许未使用的导入
 
 [lint.isort]

--- a/scripts/ops/fotmob_football_calendar_target_registry_design_check.py
+++ b/scripts/ops/fotmob_football_calendar_target_registry_design_check.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Read-only checks for the FotMob football calendar target registry design.
+
+lifecycle: permanent
+
+This helper reads local design, manifest, and migration files only. It does not
+access the network, connect to a database, execute a migration, or parse match
+business fields.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+DESIGN_PATH = ROOT / "docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md"
+MANIFEST_PATH = (
+    ROOT / "docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json"
+)
+MIGRATION_PATH = ROOT / "database/migrations/V26.6__create_football_calendar_target_registry.sql"
+
+REQUIRED_TABLES = [
+    "football_teams",
+    "football_competitions",
+    "football_competition_editions",
+    "football_team_competition_participation",
+    "football_match_targets",
+    "football_match_target_teams",
+    "football_source_identities",
+]
+
+TEAM_TYPES = ["club", "national"]
+
+COMPETITION_TYPES = [
+    "league",
+    "domestic_cup",
+    "continental_club",
+    "international_tournament",
+    "international_qualifier",
+    "nations_league",
+    "friendly",
+    "super_cup",
+]
+
+TARGET_STATES = [
+    "discovered",
+    "pending_raw_fetch",
+    "raw_fetched",
+    "raw_json_stored",
+    "blocked",
+    "failed",
+    "retired",
+]
+
+FORBIDDEN_MIGRATION_SQL = ["DROP", "TRUNCATE", "DELETE", "UPDATE", "ALTER"]
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(_read_text(path))
+
+
+def _check(name: str, passed: bool, details: object | None = None) -> dict:
+    item = {"name": name, "pass": passed}
+    if details is not None:
+        item["details"] = details
+    return item
+
+
+def _has_create_table(migration_sql: str, table_name: str) -> bool:
+    pattern = rf"\bCREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+{re.escape(table_name)}\b"
+    return re.search(pattern, migration_sql, flags=re.IGNORECASE) is not None
+
+
+def _contains_all_values(text: str, values: list[str]) -> bool:
+    return all(f"'{value}'" in text or f'"{value}"' in text for value in values)
+
+
+def run_checks() -> dict:
+    """Validate local registry design artifacts without side effects."""
+    checks: list[dict] = []
+    checks.append(_check("design_doc_exists", DESIGN_PATH.exists()))
+    checks.append(_check("manifest_exists", MANIFEST_PATH.exists()))
+    checks.append(_check("migration_exists", MIGRATION_PATH.exists()))
+
+    if not DESIGN_PATH.exists() or not MANIFEST_PATH.exists() or not MIGRATION_PATH.exists():
+        return {
+            "verdict": "fail",
+            "checks": checks,
+            "network_fetch_performed": False,
+            "db_data_write_performed": False,
+        }
+
+    design_doc = _read_text(DESIGN_PATH)
+    manifest = _read_json(MANIFEST_PATH)
+    migration_sql = _read_text(MIGRATION_PATH)
+
+    for table_name in REQUIRED_TABLES:
+        checks.append(
+            _check(
+                f"migration_declares_{table_name}",
+                _has_create_table(migration_sql, table_name),
+            )
+        )
+        checks.append(
+            _check(
+                f"design_declares_{table_name}",
+                table_name in design_doc,
+            )
+        )
+
+    forbidden_hits = sorted(
+        {
+            match.group(0).upper()
+            for match in re.finditer(
+                r"\b(" + "|".join(FORBIDDEN_MIGRATION_SQL) + r")\b",
+                migration_sql,
+                flags=re.IGNORECASE,
+            )
+        }
+    )
+    checks.append(
+        _check(
+            "migration_has_no_drop_truncate_delete_update_or_alter",
+            not forbidden_hits,
+            forbidden_hits,
+        )
+    )
+
+    checks.append(
+        _check(
+            "competition_type_enum_complete", _contains_all_values(migration_sql, COMPETITION_TYPES)
+        )
+    )
+    checks.append(
+        _check("team_type_enum_complete", _contains_all_values(migration_sql, TEAM_TYPES))
+    )
+    checks.append(
+        _check("target_state_enum_complete", _contains_all_values(migration_sql, TARGET_STATES))
+    )
+
+    checks.append(
+        _check(
+            "manifest_supports_team_full_calendar",
+            manifest.get("supports_team_full_calendar") is True,
+        )
+    )
+    checks.append(
+        _check(
+            "manifest_raw_write_ready_marked_false",
+            manifest.get("safety", {}).get("raw_write_ready_marked") is False,
+        )
+    )
+
+    safety = manifest.get("safety", {})
+    checks.extend(
+        [
+            _check(f"safety_{key}_false", safety.get(key) is False)
+            for key in [
+                "network_fetch_performed",
+                "db_data_write_performed",
+                "raw_json_write_performed",
+                "feature_parse_performed",
+                "scheduler_enabled",
+                "raw_write_ready_marked",
+            ]
+        ]
+    )
+
+    passed_count = sum(1 for item in checks if item["pass"])
+    failed_count = len(checks) - passed_count
+    return {
+        "verdict": "pass" if failed_count == 0 else "fail",
+        "checks": checks,
+        "passed_count": passed_count,
+        "failed_count": failed_count,
+        "network_fetch_performed": False,
+        "db_data_write_performed": False,
+        "raw_json_write_performed": False,
+        "feature_parse_performed": False,
+        "scheduler_enabled": False,
+        "raw_write_ready_marked": False,
+    }
+
+
+def main() -> int:
+    """Run the local read-only checks and return a shell exit status."""
+    result = run_checks()
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/fotmob_football_calendar_target_registry_design_check.test.py
+++ b/tests/unit/fotmob_football_calendar_target_registry_design_check.test.py
@@ -1,0 +1,156 @@
+"""Tests for the FotMob football calendar target registry design check.
+
+lifecycle: permanent
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESIGN_PATH = REPO_ROOT / "docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md"
+MANIFEST_PATH = (
+    REPO_ROOT / "docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json"
+)
+MIGRATION_PATH = (
+    REPO_ROOT / "database/migrations/V26.6__create_football_calendar_target_registry.sql"
+)
+HELPER_PATH = REPO_ROOT / "scripts/ops/fotmob_football_calendar_target_registry_design_check.py"
+
+TABLES = [
+    "football_teams",
+    "football_competitions",
+    "football_competition_editions",
+    "football_team_competition_participation",
+    "football_match_targets",
+    "football_match_target_teams",
+    "football_source_identities",
+]
+
+COMPETITION_TYPES = [
+    "league",
+    "domestic_cup",
+    "continental_club",
+    "international_tournament",
+    "international_qualifier",
+    "nations_league",
+    "friendly",
+    "super_cup",
+]
+
+TARGET_STATES = [
+    "discovered",
+    "pending_raw_fetch",
+    "raw_fetched",
+    "raw_json_stored",
+    "blocked",
+    "failed",
+    "retired",
+]
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _manifest() -> dict:
+    return json.loads(_text(MANIFEST_PATH))
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("registry_design_check", HELPER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_design_doc_manifest_and_migration_exist():
+    assert DESIGN_PATH.exists()
+    assert MANIFEST_PATH.exists()
+    assert MIGRATION_PATH.exists()
+    assert HELPER_PATH.exists()
+
+
+def test_all_seven_tables_are_declared():
+    design_doc = _text(DESIGN_PATH)
+    migration_sql = _text(MIGRATION_PATH)
+    manifest = _manifest()
+
+    assert manifest["tables"] == TABLES
+    for table in TABLES:
+        assert table in design_doc
+        assert re.search(
+            rf"\bCREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+{re.escape(table)}\b",
+            migration_sql,
+            flags=re.IGNORECASE,
+        )
+
+
+def test_team_type_supports_club_and_national():
+    migration_sql = _text(MIGRATION_PATH)
+    manifest = _manifest()
+    assert manifest["enums"]["team_type"] == ["club", "national"]
+    assert "'club'" in migration_sql
+    assert "'national'" in migration_sql
+
+
+def test_competition_type_supports_required_calendar_scope():
+    migration_sql = _text(MIGRATION_PATH)
+    manifest = _manifest()
+    for value in COMPETITION_TYPES:
+        assert value in manifest["enums"]["competition_type"]
+        assert f"'{value}'" in migration_sql
+
+
+def test_target_state_supports_raw_collection_lifecycle():
+    migration_sql = _text(MIGRATION_PATH)
+    manifest = _manifest()
+    for value in TARGET_STATES:
+        assert value in manifest["enums"]["target_state"]
+        assert f"'{value}'" in migration_sql
+
+
+def test_migration_has_no_drop_truncate_delete_update_or_alter():
+    migration_sql = _text(MIGRATION_PATH)
+    forbidden = re.findall(
+        r"\b(DROP|TRUNCATE|DELETE|UPDATE|ALTER)\b", migration_sql, flags=re.IGNORECASE
+    )
+    assert forbidden == []
+
+
+def test_manifest_supports_full_calendar_and_required_scopes():
+    manifest = _manifest()
+    assert manifest["supports_team_full_calendar"] is True
+    assert manifest["supports_national_team_matches"] is True
+    assert manifest["supports_domestic_cup"] is True
+    assert manifest["supports_continental_club"] is True
+    assert manifest["supports_international_tournament"] is True
+    assert manifest["supports_international_qualifier"] is True
+    assert manifest["supports_secondary_leagues"] is True
+
+
+def test_safety_flags_are_false():
+    safety = _manifest()["safety"]
+    assert safety["network_fetch_performed"] is False
+    assert safety["db_data_write_performed"] is False
+    assert safety["raw_json_write_performed"] is False
+    assert safety["feature_parse_performed"] is False
+    assert safety["scheduler_enabled"] is False
+    assert safety["raw_write_ready_marked"] is False
+
+
+def test_read_only_helper_passes_all_checks():
+    helper = _load_helper()
+    result = helper.run_checks()
+    assert result["verdict"] == "pass"
+    assert result["network_fetch_performed"] is False
+    assert result["db_data_write_performed"] is False
+    assert result["raw_json_write_performed"] is False
+    assert result["feature_parse_performed"] is False
+    assert result["scheduler_enabled"] is False
+    assert result["raw_write_ready_marked"] is False


### PR DESCRIPTION
## Summary
- Add football calendar target registry design and migration.
- Support club and national team calendars.
- Support leagues, domestic cups, continental club competitions, international tournaments, qualifiers, friendlies, and secondary leagues.
- Enable future team full-calendar reconstruction.
- Add a read-only local design checker and pytest coverage for the registry artifacts.
- No network fetch.
- No DB data write.
- No raw JSON write.
- No feature parsing.
- No scheduler enabled.

## Why
- Prediction system must cover year-round matches.
- Team basic form requires league + cup + continental + national team context.
- A team-centric target registry prevents missing cup/Europe/national-team effects.

## Tables
- football_teams
- football_competitions
- football_competition_editions
- football_team_competition_participation
- football_match_targets
- football_match_target_teams
- football_source_identities

## Safety
- migration only creates tables/indexes/comments
- no data seed/write
- no network fetch
- no scheduler enable
- no feature parser
- no raw_match_data write
- raw_write_ready remains false

## Validation
- unit test: `docker compose -f docker-compose.dev.yml exec -T dev pytest tests/unit/fotmob_football_calendar_target_registry_design_check.test.py -q` => 9 passed
- markdownlint: `docker compose -f docker-compose.dev.yml exec -T dev npx markdownlint docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md` => clean
- read-only design checker: 29/29 checks passed
- migration safety check: no `DROP`, `TRUNCATE`, `DELETE`, `UPDATE`, or `ALTER` in V26.6 migration
- static safety check: no network/DB/raw-write execution patterns and no safety flags marked true
- commit/pr Gatekeeper: passed, including cold-start blueprint replay, ESLint, Ruff, formatter, ProxyProvider, incremental JS tests, and Recon coverage gate
- worktree clean before PR creation

## PR Type / Runtime Behavior
- PR type: data/source schema design + migration
- Runtime behavior change: schema migration adds target registry tables when applied; no collector/scheduler/runtime fetch behavior is enabled
- Business progress: establishes the foundation for club/national team full-calendar raw target registration
- Remaining blocker: future collector dry-run still requires separate review before any live source access or raw JSON write

## Safety Flags
- no-live-fetch: yes
- no-DB-write: yes, no DB data write executed locally; migration only defines future schema changes
- no-raw-write: yes
- raw_write_ready: false

## Debt Impact
- new files added: 5 permanent files
- permanent files: design doc, migration, manifest, read-only helper, pytest test
- phase-only files: none
- temporary helpers: none
- files superseded: none
- files deleted/archived: none
- cleanup needed later: no immediate cleanup; helper is intentionally retained for registry design guardrails
- repository noise increased: no