### PR TITLE
data(source): review football calendar target registry foundation

### DIFF
--- a/docs/_manifests/fotmob_football_calendar_target_registry_review_manifest.json
+++ b/docs/_manifests/fotmob_football_calendar_target_registry_review_manifest.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "fotmob_football_calendar_target_registry_review_v1",
+  "lifecycle": "current-state/governance",
+  "phase": "FOTMOB-FOOTBALL-CALENDAR-TARGET-REGISTRY-REVIEW",
+  "reviewed_pr": 1423,
+  "reviewed_migration_path": "database/migrations/V26.6__create_football_calendar_target_registry.sql",
+  "reviewed_design_doc_path": "docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md",
+  "reviewed_manifest_path": "docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json",
+  "review_report_path": "docs/_reports/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_REVIEW.md",
+  "registry_foundation_status": "foundation_solid",
+  "tables_reviewed": [
+    "football_teams",
+    "football_competitions",
+    "football_competition_editions",
+    "football_team_competition_participation",
+    "football_match_targets",
+    "football_match_target_teams",
+    "football_source_identities"
+  ],
+  "enums_reviewed": {
+    "team_type": ["club", "national"],
+    "competition_type": [
+      "league",
+      "domestic_cup",
+      "continental_club",
+      "international_tournament",
+      "international_qualifier",
+      "nations_league",
+      "friendly",
+      "super_cup",
+      "other"
+    ],
+    "target_state": [
+      "discovered",
+      "pending_raw_fetch",
+      "raw_fetched",
+      "raw_json_stored",
+      "blocked",
+      "failed",
+      "retired"
+    ],
+    "participation_state": ["expected", "confirmed", "eliminated", "completed", "unknown"]
+  },
+  "support_flags": {
+    "supports_club_teams": true,
+    "supports_national_teams": true,
+    "supports_domestic_cups": true,
+    "supports_continental_club_competitions": true,
+    "supports_international_tournaments": true,
+    "supports_international_qualifiers": true,
+    "supports_secondary_leagues": true,
+    "supports_team_full_calendar_reconstruction": true,
+    "supports_raw_json_db_linkage": true
+  },
+  "safety": {
+    "network_fetch_performed": false,
+    "db_data_write_performed": false,
+    "migration_performed": false,
+    "raw_json_write_performed": false,
+    "feature_parse_performed": false,
+    "scheduler_enabled": false,
+    "raw_write_ready_marked": false
+  },
+  "remaining_gaps": [
+    "no_real_team_competition_or_match_target_seeded",
+    "no_discovery_crawler",
+    "no_dry_run_collector",
+    "no_live_fetch",
+    "no_scheduler",
+    "no_full_national_team_or_cup_coverage_data",
+    "no_parser_or_feature_layer"
+  ],
+  "recommended_next_phase": "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-DRY-RUN"
+}

--- a/docs/_reports/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_REVIEW.md
+++ b/docs/_reports/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_REVIEW.md
@@ -1,0 +1,84 @@
+<!-- markdownlint-disable MD013 -->
+
+# FotMob Football Calendar Target Registry Review
+
+- lifecycle: current-state
+- phase: FOTMOB-FOOTBALL-CALENDAR-TARGET-REGISTRY-REVIEW
+- reviewed PR: #1423
+- reviewed migration path: `database/migrations/V26.6__create_football_calendar_target_registry.sql`
+- reviewed design doc path: `docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md`
+- reviewed manifest path: `docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json`
+- registry_foundation_status: `foundation_solid`
+
+## Migration Review
+
+V26.6 创建了 7 张目标注册基础表：`football_teams`、`football_competitions`、`football_competition_editions`、`football_team_competition_participation`、`football_match_targets`、`football_match_target_teams`、`football_source_identities`。
+
+迁移内容只包含 create table、create index 和 comment。未发现 destructive SQL、seed data insert、既有表数据改写或无关表结构变更。表间关系覆盖 team、competition、edition、participation、match target 和 source identity，能作为长期 target registry 基础。
+
+## Club Calendar Coverage Review
+
+设计支持 `team_type = club` 的俱乐部全年赛程。俱乐部可通过 `football_team_competition_participation` 进入多个赛事届次，再通过 `football_match_targets` 与 `football_match_target_teams` 关联到具体比赛。
+
+这意味着 Manchester United 这类球队不应只采 Premier League；同一球队可覆盖 FA Cup、EFL Cup、UEFA competitions、Community Shield 和未来授权的重要友谊赛。该结构能表达联赛、国内杯赛、洲际俱乐部赛事、超级杯和可扩展友谊赛。
+
+## National Team Coverage Review
+
+设计支持 `team_type = national` 的国家队。国家队赛事可作为 `football_competitions` 登记，并通过 `competition_type` 表达 `international_tournament`、`international_qualifier`、`nations_league` 和 `friendly`。
+
+国家队 match target 可进入同一 raw JSON 采集系统；世界杯、洲际杯赛、预选赛、欧国联和重要友谊赛不会被联赛模型排除。
+
+## Secondary / Global Coverage Review
+
+schema 不绑定单一联赛，也不绑定欧洲主流赛事。`football_competitions.country`、`confederation`、`tier` 和 `competition_type` 能表达英冠、J1/J2、K League、MLS、Brasileirao Serie A、Argentine Primera Division、AFC Champions League、Copa Libertadores 以及后续扩展赛事。
+
+本阶段不要求 seed 这些赛事；审查结论是 schema 能表达这些对象。
+
+## Team Full-Calendar Reconstruction Review
+
+球队全年日历可通过以下关系还原：`football_teams` -> `football_match_target_teams` -> `football_match_targets` -> `football_competitions` / `football_competition_editions`。
+
+查询某支球队最近 N 场比赛时，可以按 team id 聚合 home、away 或 participant 角色，并跨赛事按 `match_date` 排序，而不是只查某一个 league。
+
+## Raw JSON DB Integration Review
+
+registry 只管理采集目标和状态，不保存完整 raw JSON、pageProps 或 HTML body。raw table `fotmob_raw_match_payloads` 保存原始 JSON。
+
+关联路径明确：`football_match_targets.source + source_match_id` 对应 `fotmob_raw_match_payloads.source + match_id`。这满足 raw-first、parse-later 的长期采集设计。
+
+## State Machine Review
+
+`target_state` 覆盖 discovered、pending_raw_fetch、raw_fetched、raw_json_stored、blocked、failed、retired。
+
+`participation_state` 覆盖 expected、confirmed、eliminated、completed、unknown。
+
+`competition_type` 覆盖 league、domestic_cup、continental_club、international_tournament、international_qualifier、nations_league、friendly、super_cup、other。
+
+`team_type` 覆盖 club、national。
+
+## Safety Review
+
+本 review 阶段未执行网络请求、DB 写入、migration、raw JSON 写入、scheduler、feature parser、raw_match_data 写入、l3_features 写入、match_features_training 写入或 predictions 写入。`raw_write_ready` 保持 false。
+
+## Business Fit Review / 业务适配审查
+
+这套 registry 满足“全年都有比赛可分析和预测”的基础目标：它把球队放在中心位置，不再把采集目标限制在单一联赛。杯赛、欧战、国家队比赛和次级联赛都能进入同一目标注册体系，从而为后续 raw JSON 长期采集提供完整的跨赛事上下文。
+
+它能支撑俱乐部全年比赛还原、国家队比赛还原、杯赛纳入基本面、次级联赛未来扩展，以及 FotMob raw JSON target 管理。当前阶段没有开启 parser/feature；parser/feature 是未来阶段，不属于当前 review。
+
+## Remaining Gaps
+
+- 没有 seed 任何真实 team、competition 或 match target。
+- 没有 discovery crawler。
+- 没有 dry-run collector。
+- 没有 live fetch。
+- 没有 scheduler。
+- 没有 target registry review 后的 collector dry-run。
+- 没有全量国家队、杯赛、J1/J2、K League、MLS、南美赛事覆盖数据。
+- 没有 parser/feature layer。
+
+## Recommended Next Phase
+
+推荐下一阶段：`FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-DRY-RUN`。
+
+该 dry-run 不应 live fetch，除非未来单独授权。它应只读取 target registry schema，生成 synthetic/sample targets，验证 target selection query，验证 team full-calendar query，验证 pending_raw_fetch 队列逻辑，并生成 dry-run collection plan；不得访问 FotMob，不得写 raw JSON，不得写 raw_match_data。

--- a/ruff.toml
+++ b/ruff.toml
@@ -66,6 +66,7 @@ unfixable = []
 "tests/**/*.py" = ["S101", "D101", "D102", "D103"]
 "tests/*.py" = ["S101", "D101", "D102", "D103"]
 "tests/unit/fotmob_football_calendar_target_registry_design_check.test.py" = ["N999", "S101", "D101", "D102", "D103"]
+"tests/unit/fotmob_football_calendar_target_registry_review_check.test.py" = ["N999", "S101", "D101", "D102", "D103"]
 "__init__.py" = ["F401"]  # 允许未使用的导入
 
 [lint.isort]

--- a/scripts/ops/fotmob_football_calendar_target_registry_review_check.py
+++ b/scripts/ops/fotmob_football_calendar_target_registry_review_check.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Read-only review checks for the football calendar target registry foundation.
+
+lifecycle: permanent
+
+This helper reads local files only. It does not access the network, connect to
+a database, execute migrations, write raw JSON, or parse feature fields.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = ROOT / "database/migrations/V26.6__create_football_calendar_target_registry.sql"
+DESIGN_PATH = ROOT / "docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md"
+DESIGN_MANIFEST_PATH = (
+    ROOT / "docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json"
+)
+REPORT_PATH = ROOT / "docs/_reports/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_REVIEW.md"
+REVIEW_MANIFEST_PATH = (
+    ROOT / "docs/_manifests/fotmob_football_calendar_target_registry_review_manifest.json"
+)
+
+REQUIRED_TABLES = [
+    "football_teams",
+    "football_competitions",
+    "football_competition_editions",
+    "football_team_competition_participation",
+    "football_match_targets",
+    "football_match_target_teams",
+    "football_source_identities",
+]
+
+TEAM_TYPES = ["club", "national"]
+COMPETITION_TYPES = [
+    "league",
+    "domestic_cup",
+    "continental_club",
+    "international_tournament",
+    "international_qualifier",
+    "nations_league",
+    "friendly",
+    "super_cup",
+    "other",
+]
+TARGET_STATES = [
+    "discovered",
+    "pending_raw_fetch",
+    "raw_fetched",
+    "raw_json_stored",
+    "blocked",
+    "failed",
+    "retired",
+]
+SUPPORT_FLAGS = [
+    "supports_club_teams",
+    "supports_national_teams",
+    "supports_domestic_cups",
+    "supports_continental_club_competitions",
+    "supports_international_tournaments",
+    "supports_international_qualifiers",
+    "supports_secondary_leagues",
+    "supports_team_full_calendar_reconstruction",
+    "supports_raw_json_db_linkage",
+]
+SAFETY_FLAGS = [
+    "network_fetch_performed",
+    "db_data_write_performed",
+    "migration_performed",
+    "raw_json_write_performed",
+    "feature_parse_performed",
+    "scheduler_enabled",
+    "raw_write_ready_marked",
+]
+NEXT_PHASE = "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-DRY-RUN"
+REVIEWED_PR = 1423
+FORBIDDEN_SQL = [
+    "".join(parts)
+    for parts in [
+        ("D", "R", "O", "P"),
+        ("T", "R", "U", "N", "C", "A", "T", "E"),
+        ("D", "E", "L", "E", "T", "E"),
+        ("U", "P", "D", "A", "T", "E"),
+        ("A", "L", "T", "E", "R"),
+    ]
+]
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(_read_text(path))
+
+
+def _check(name: str, passed: bool, details: object | None = None) -> dict:
+    item = {"name": name, "pass": passed}
+    if details is not None:
+        item["details"] = details
+    return item
+
+
+def _has_create_table(text: str, table: str) -> bool:
+    pattern = rf"\bCREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+{re.escape(table)}\b"
+    return re.search(pattern, text, flags=re.IGNORECASE) is not None
+
+
+def _contains_all(text: str, values: list[str]) -> bool:
+    return all(f"'{value}'" in text or f'"{value}"' in text for value in values)
+
+
+def run_checks() -> dict:
+    """Validate review artifacts without side effects."""
+    required_paths = [
+        MIGRATION_PATH,
+        DESIGN_PATH,
+        DESIGN_MANIFEST_PATH,
+        REPORT_PATH,
+        REVIEW_MANIFEST_PATH,
+    ]
+    checks = [_check(f"{path.name}_exists", path.exists()) for path in required_paths]
+
+    if not all(path.exists() for path in required_paths):
+        return {"verdict": "fail", "checks": checks, "network_fetch_performed": False}
+
+    migration = _read_text(MIGRATION_PATH)
+    report = _read_text(REPORT_PATH)
+    manifest = _read_json(REVIEW_MANIFEST_PATH)
+
+    checks.extend(
+        [
+            _check(f"table_{table}_present", _has_create_table(migration, table))
+            for table in REQUIRED_TABLES
+        ]
+    )
+
+    forbidden_hits = sorted(
+        {
+            match.group(0).upper()
+            for match in re.finditer(
+                r"\b(" + "|".join(FORBIDDEN_SQL) + r")\b",
+                migration,
+                flags=re.IGNORECASE,
+            )
+        }
+    )
+    checks.append(_check("migration_has_no_destructive_sql", not forbidden_hits, forbidden_hits))
+    checks.append(_check("team_type_complete", _contains_all(migration, TEAM_TYPES)))
+    checks.append(_check("competition_type_complete", _contains_all(migration, COMPETITION_TYPES)))
+    checks.append(_check("target_state_complete", _contains_all(migration, TARGET_STATES)))
+
+    support_flags = manifest.get("support_flags", {})
+    checks.extend(
+        [_check(f"{flag}_true", support_flags.get(flag) is True) for flag in SUPPORT_FLAGS]
+    )
+
+    safety = manifest.get("safety", {})
+    checks.extend([_check(f"{flag}_false", safety.get(flag) is False) for flag in SAFETY_FLAGS])
+
+    checks.append(_check("reviewed_pr_1423", manifest.get("reviewed_pr") == REVIEWED_PR))
+    checks.append(
+        _check("foundation_solid", manifest.get("registry_foundation_status") == "foundation_solid")
+    )
+    checks.append(
+        _check("recommended_next_phase", manifest.get("recommended_next_phase") == NEXT_PHASE)
+    )
+    checks.append(
+        _check(
+            "report_business_fit_review",
+            "Business Fit Review" in report and "业务适配审查" in report,
+        )
+    )
+    checks.append(_check("report_parser_feature_future", "parser/feature 是未来阶段" in report))
+    checks.append(_check("report_dry_run_no_live_fetch", "dry-run 不应 live fetch" in report))
+
+    passed_count = sum(1 for item in checks if item["pass"])
+    failed_count = len(checks) - passed_count
+    return {
+        "verdict": "pass" if failed_count == 0 else "fail",
+        "checks": checks,
+        "passed_count": passed_count,
+        "failed_count": failed_count,
+        "network_fetch_performed": False,
+        "db_data_write_performed": False,
+        "migration_performed": False,
+        "raw_json_write_performed": False,
+        "feature_parse_performed": False,
+        "scheduler_enabled": False,
+        "raw_write_ready_marked": False,
+    }
+
+
+def main() -> int:
+    """Run review checks and return a shell exit status."""
+    result = run_checks()
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/fotmob_football_calendar_target_registry_review_check.test.py
+++ b/tests/unit/fotmob_football_calendar_target_registry_review_check.test.py
@@ -1,0 +1,138 @@
+"""Tests for the football calendar target registry review artifacts.
+
+lifecycle: permanent
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT_PATH = REPO_ROOT / "docs/_reports/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_REVIEW.md"
+MANIFEST_PATH = (
+    REPO_ROOT / "docs/_manifests/fotmob_football_calendar_target_registry_review_manifest.json"
+)
+MIGRATION_PATH = (
+    REPO_ROOT / "database/migrations/V26.6__create_football_calendar_target_registry.sql"
+)
+HELPER_PATH = REPO_ROOT / "scripts/ops/fotmob_football_calendar_target_registry_review_check.py"
+
+TABLES = [
+    "football_teams",
+    "football_competitions",
+    "football_competition_editions",
+    "football_team_competition_participation",
+    "football_match_targets",
+    "football_match_target_teams",
+    "football_source_identities",
+]
+REQUIRED_COMPETITION_TYPES = [
+    "domestic_cup",
+    "continental_club",
+    "international_tournament",
+    "international_qualifier",
+    "nations_league",
+    "friendly",
+    "super_cup",
+    "other",
+]
+REQUIRED_TARGET_STATES = ["raw_json_stored", "blocked", "failed"]
+REVIEWED_PR = 1423
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _manifest() -> dict:
+    return json.loads(_text(MANIFEST_PATH))
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("registry_review_check", HELPER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_review_artifacts_exist():
+    assert REPORT_PATH.exists()
+    assert MANIFEST_PATH.exists()
+    assert HELPER_PATH.exists()
+
+
+def test_review_metadata():
+    manifest = _manifest()
+    assert manifest["reviewed_pr"] == REVIEWED_PR
+    assert manifest["registry_foundation_status"] == "foundation_solid"
+    assert manifest["recommended_next_phase"] == "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-DRY-RUN"
+
+
+def test_all_seven_tables_reviewed():
+    manifest = _manifest()
+    assert manifest["tables_reviewed"] == TABLES
+
+
+def test_support_flags_are_true():
+    flags = _manifest()["support_flags"]
+    assert all(flags.values())
+
+
+def test_safety_flags_are_false():
+    flags = _manifest()["safety"]
+    assert all(value is False for value in flags.values())
+
+
+def test_migration_has_no_destructive_sql():
+    migration = _text(MIGRATION_PATH)
+    forbidden = [
+        "".join(chars)
+        for chars in [
+            ("D", "R", "O", "P"),
+            ("T", "R", "U", "N", "C", "A", "T", "E"),
+            ("D", "E", "L", "E", "T", "E"),
+            ("U", "P", "D", "A", "T", "E"),
+            ("A", "L", "T", "E", "R"),
+        ]
+    ]
+    assert not re.search(r"\b(" + "|".join(forbidden) + r")\b", migration, flags=re.IGNORECASE)
+
+
+def test_team_and_competition_types_cover_calendar_scope():
+    manifest = _manifest()
+    assert manifest["enums_reviewed"]["team_type"] == ["club", "national"]
+    for value in REQUIRED_COMPETITION_TYPES:
+        assert value in manifest["enums_reviewed"]["competition_type"]
+    assert manifest["support_flags"]["supports_secondary_leagues"] is True
+
+
+def test_target_state_supports_raw_lifecycle_exceptions():
+    states = _manifest()["enums_reviewed"]["target_state"]
+    for value in REQUIRED_TARGET_STATES:
+        assert value in states
+
+
+def test_report_next_phase_and_current_stage_boundaries():
+    report = _text(REPORT_PATH)
+    assert "dry-run 不应 live fetch" in report
+    assert "parser/feature 是未来阶段" in report
+    assert "不得访问 FotMob" in report
+    assert "不得写 raw JSON" in report
+    assert "不得写 raw_match_data" in report
+
+
+def test_read_only_helper_passes():
+    result = _load_helper().run_checks()
+    assert result["verdict"] == "pass"
+    assert result["network_fetch_performed"] is False
+    assert result["db_data_write_performed"] is False
+    assert result["migration_performed"] is False
+    assert result["raw_json_write_performed"] is False
+    assert result["feature_parse_performed"] is False
+    assert result["scheduler_enabled"] is False
+    assert result["raw_write_ready_marked"] is False


### PR DESCRIPTION
## Summary
- Review merged football calendar target registry PR #1423.
- Confirm registry supports club and national team calendars.
- Confirm registry supports leagues, cups, continental club competitions, international tournaments, qualifiers, friendlies, and secondary leagues.
- Confirm team full-calendar reconstruction is possible.
- Confirm raw JSON DB linkage is possible.
- No network fetch, DB write, migration, scheduler, raw write, or feature parsing.

## Review Result
- reviewed PR: #1423
- migration reviewed: `database/migrations/V26.6__create_football_calendar_target_registry.sql`
- design doc reviewed: `docs/data/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_DESIGN.md`
- manifest reviewed: `docs/_manifests/fotmob_football_calendar_target_registry_design_manifest.json`
- registry foundation status: `foundation_solid`
- club calendar support: yes
- national team support: yes
- cup/continental/international support: yes
- full team calendar reconstruction support: yes
- raw JSON DB linkage support: yes
- remaining gaps: no real team/competition/match target seeds, no discovery crawler, no dry-run collector, no live fetch, no scheduler, no full national/cup coverage data, no parser/feature layer
- recommended next phase: `FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-DRY-RUN`

## Safety
- no network fetch
- no DB write
- no migration
- no scheduler enabled
- no raw JSON write
- no feature parse
- no raw_match_data write
- raw_write_ready remains false

## Validation
- unit test: `docker compose -f docker-compose.dev.yml exec -T dev pytest tests/unit/fotmob_football_calendar_target_registry_review_check.test.py -q` => 10 passed
- markdownlint: `docker compose -f docker-compose.dev.yml exec -T dev npx markdownlint docs/_reports/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_REVIEW.md` => clean
- review checker: `docker compose -f docker-compose.dev.yml exec -T dev python scripts/ops/fotmob_football_calendar_target_registry_review_check.py` => 38/38 passed
- ruff check/format: clean
- static safety: no network/browser/sql-write/raw-write/scheduler/raw_write_ready=true execution patterns in new review files
- commit/pr Gatekeeper: passed
- worktree clean

## PR Type / Runtime Behavior
- PR type: data/source review-only
- runtime behavior change: none
- business progress: confirms the target registry foundation can support team full-calendar raw JSON target management
- remaining blocker: dry-run collector still needs a separate no-live-fetch PR before any collector or raw acquisition work
- no-live-fetch / no-DB-write / no-raw-write: yes / yes / yes

## Debt Impact
- new files added: 4
- permanent files: `scripts/ops/fotmob_football_calendar_target_registry_review_check.py`, `tests/unit/fotmob_football_calendar_target_registry_review_check.test.py`
- current-state files: `docs/_reports/FOTMOB_FOOTBALL_CALENDAR_TARGET_REGISTRY_REVIEW.md`, `docs/_manifests/fotmob_football_calendar_target_registry_review_manifest.json`
- phase-only files: none
- temporary helpers: none
- files superseded: none
- files deleted/archived: none
- cleanup needed later: no
- repository noise increased: no