### PR TITLE
data(source): add FotMob target selection DB dry-run

### DIFF
--- a/docs/_manifests/fotmob_target_selection_db_dry_run_manifest.json
+++ b/docs/_manifests/fotmob_target_selection_db_dry_run_manifest.json
@@ -1,0 +1,389 @@
+{
+  "schema_version": "fotmob_target_selection_db_dry_run_v1",
+  "lifecycle": "current-state",
+  "phase": "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-TARGET-SELECTION-DB-DRY-RUN",
+  "run_id": "fotmob_target_selection_db_dry_run_v1",
+  "generated_at": "2026-06-04T03:19:57Z",
+  "db_environment": "docker_dev",
+  "production_db_guard": "pass",
+  "production_db_guard_details": [],
+  "db_read_performed": true,
+  "db_write_performed": false,
+  "production_db_write_performed": false,
+  "input_target_count": 14,
+  "selected_target_count": 10,
+  "skipped_target_count": 4,
+  "selected_targets": [
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-eng-friend-001",
+      "match_date": "2026-10-14T19:00:00+00:00",
+      "priority": 20,
+      "competition_name": "International Friendly",
+      "competition_type": "friendly",
+      "home_team_name": "England",
+      "away_team_name": "Brazil",
+      "team_names": [
+        "England",
+        "Brazil"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-champ-facup-001",
+      "match_date": "2026-08-29T14:00:00+00:00",
+      "priority": 18,
+      "competition_name": "FA Cup",
+      "competition_type": "domestic_cup",
+      "home_team_name": "Leeds United",
+      "away_team_name": "Sheffield Wednesday",
+      "team_names": [
+        "Leeds United",
+        "Sheffield Wednesday"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-jpn-empcup-001",
+      "match_date": "2026-09-26T10:00:00+00:00",
+      "priority": 17,
+      "competition_name": "Emperor's Cup",
+      "competition_type": "domestic_cup",
+      "home_team_name": "Kashima Antlers",
+      "away_team_name": "Urawa Red Diamonds",
+      "team_names": [
+        "Kashima Antlers",
+        "Urawa Red Diamonds"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-champ-001",
+      "match_date": "2026-08-15T14:00:00+00:00",
+      "priority": 16,
+      "competition_name": "EFL Championship",
+      "competition_type": "league",
+      "home_team_name": "Leeds United",
+      "away_team_name": "Sunderland",
+      "team_names": [
+        "Leeds United",
+        "Sunderland"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-jpn-j1-001",
+      "match_date": "2026-08-16T10:00:00+00:00",
+      "priority": 15,
+      "competition_name": "J1 League",
+      "competition_type": "league",
+      "home_team_name": "Kashima Antlers",
+      "away_team_name": "Yokohama F. Marinos",
+      "team_names": [
+        "Kashima Antlers",
+        "Yokohama F. Marinos"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-mun-eflcup-001",
+      "match_date": "2026-09-12T18:45:00+00:00",
+      "priority": 14,
+      "competition_name": "EFL Cup",
+      "competition_type": "domestic_cup",
+      "home_team_name": "Newcastle United",
+      "away_team_name": "Manchester United",
+      "team_names": [
+        "Newcastle United",
+        "Manchester United"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-eng-failed-001",
+      "match_date": "2026-09-06T18:00:00+00:00",
+      "priority": 13,
+      "competition_name": "UEFA Nations League",
+      "competition_type": "nations_league",
+      "home_team_name": "England",
+      "away_team_name": "Italy",
+      "team_names": [
+        "England",
+        "Italy"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "failed",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-mun-facup-001",
+      "match_date": "2026-08-22T14:00:00+00:00",
+      "priority": 12,
+      "competition_name": "FA Cup",
+      "competition_type": "domestic_cup",
+      "home_team_name": "Manchester United",
+      "away_team_name": "Chelsea",
+      "team_names": [
+        "Manchester United",
+        "Chelsea"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-mun-uel-001",
+      "match_date": "2026-09-19T19:00:00+00:00",
+      "priority": 11,
+      "competition_name": "UEFA Europa League",
+      "competition_type": "continental_club",
+      "home_team_name": "Manchester United",
+      "away_team_name": "AS Roma",
+      "team_names": [
+        "Manchester United",
+        "AS Roma"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-mun-epl-001",
+      "match_date": "2026-08-15T14:00:00+00:00",
+      "priority": 10,
+      "competition_name": "Premier League",
+      "competition_type": "league",
+      "home_team_name": "Manchester United",
+      "away_team_name": "Liverpool",
+      "team_names": [
+        "Manchester United",
+        "Liverpool"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true
+    }
+  ],
+  "skipped_targets": [
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-mun-blocked-001",
+      "match_date": "2026-08-08T14:00:00+00:00",
+      "priority": 9,
+      "competition_name": "Premier League",
+      "competition_type": "league",
+      "home_team_name": "Manchester United",
+      "away_team_name": "Tottenham Hotspur",
+      "team_names": [
+        "Manchester United",
+        "Tottenham Hotspur"
+      ],
+      "target_state": "blocked",
+      "raw_json_status": "missing",
+      "source_identity_available": true,
+      "skip_reason": "blocked",
+      "skip_category": "blocked"
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-eng-unl-001",
+      "match_date": "2026-09-09T18:00:00+00:00",
+      "priority": 8,
+      "competition_name": "UEFA Nations League",
+      "competition_type": "nations_league",
+      "home_team_name": "Germany",
+      "away_team_name": "England",
+      "team_names": [
+        "Germany",
+        "England"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true,
+      "skip_reason": "budget_exhausted:request",
+      "skip_category": "budget_exhausted"
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-mun-stored-001",
+      "match_date": "2026-08-01T14:00:00+00:00",
+      "priority": 7,
+      "competition_name": "Premier League",
+      "competition_type": "league",
+      "home_team_name": "Manchester United",
+      "away_team_name": "Everton",
+      "team_names": [
+        "Manchester United",
+        "Everton"
+      ],
+      "target_state": "raw_json_stored",
+      "raw_json_status": "stored",
+      "source_identity_available": true,
+      "skip_reason": "stored",
+      "skip_category": "stored"
+    },
+    {
+      "source": "fotmob",
+      "source_match_id": "fixture-eng-wcq-001",
+      "match_date": "2026-09-05T18:00:00+00:00",
+      "priority": 5,
+      "competition_name": "FIFA World Cup Qualifier",
+      "competition_type": "international_qualifier",
+      "home_team_name": "England",
+      "away_team_name": "Poland",
+      "team_names": [
+        "England",
+        "Poland"
+      ],
+      "target_state": "pending_raw_fetch",
+      "raw_json_status": "missing",
+      "source_identity_available": true,
+      "skip_reason": "budget_exhausted:request",
+      "skip_category": "budget_exhausted"
+    }
+  ],
+  "skip_reason_counts": {
+    "blocked": 1,
+    "budget_exhausted": 2,
+    "stored": 1
+  },
+  "budgets": {
+    "request_budget": 10,
+    "selected_count": 10,
+    "per_team_budget": 5,
+    "per_competition_budget": 4,
+    "request_budget_respected": true,
+    "per_team_budget_respected": true,
+    "per_competition_budget_respected": true,
+    "selected_by_team": {
+      "AS Roma": 1,
+      "Brazil": 1,
+      "Chelsea": 1,
+      "England": 2,
+      "Italy": 1,
+      "Kashima Antlers": 2,
+      "Leeds United": 2,
+      "Liverpool": 1,
+      "Manchester United": 4,
+      "Newcastle United": 1,
+      "Sheffield Wednesday": 1,
+      "Sunderland": 1,
+      "Urawa Red Diamonds": 1,
+      "Yokohama F. Marinos": 1
+    },
+    "selected_by_competition": {
+      "EFL Championship": 1,
+      "EFL Cup": 1,
+      "Emperor's Cup": 1,
+      "FA Cup": 2,
+      "International Friendly": 1,
+      "J1 League": 1,
+      "Premier League": 1,
+      "UEFA Europa League": 1,
+      "UEFA Nations League": 1
+    }
+  },
+  "team_full_calendar": {
+    "manchester_united_target_count": 6,
+    "Manchester United": {
+      "target_count": 6,
+      "competitions": [
+        "EFL Cup",
+        "FA Cup",
+        "Premier League",
+        "UEFA Europa League"
+      ],
+      "selected_relevance": "full_calendar_read_only"
+    },
+    "england_target_count": 4,
+    "England": {
+      "target_count": 4,
+      "competitions": [
+        "FIFA World Cup Qualifier",
+        "International Friendly",
+        "UEFA Nations League"
+      ],
+      "selected_relevance": "full_calendar_read_only"
+    },
+    "kashima_antlers_target_count": 2,
+    "Kashima Antlers": {
+      "target_count": 2,
+      "competitions": [
+        "Emperor's Cup",
+        "J1 League"
+      ],
+      "selected_relevance": "full_calendar_read_only"
+    },
+    "leeds_united_target_count": 2,
+    "Leeds United": {
+      "target_count": 2,
+      "competitions": [
+        "EFL Championship",
+        "FA Cup"
+      ],
+      "selected_relevance": "full_calendar_read_only"
+    }
+  },
+  "source_identity": {
+    "all_selected_have_source_identity": true,
+    "unsupported_source_selected": false,
+    "selected_without_source_identity": [],
+    "selected_sources": [
+      "fotmob"
+    ],
+    "unsupported_selected_sources": []
+  },
+  "safety": {
+    "network_fetch_performed": false,
+    "raw_json_write_performed": false,
+    "fotmob_raw_match_payloads_write_performed": false,
+    "raw_match_data_write_performed": false,
+    "feature_parse_performed": false,
+    "scheduler_enabled": false,
+    "raw_write_ready_marked": false
+  },
+  "embedded_review": {
+    "target_selection_db_dry_run_status": "pass",
+    "review_report_path": "docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN_REVIEW.md",
+    "review_failures": []
+  },
+  "sort_policy": "priority_desc_match_date_asc_competition_team_source_match_id",
+  "registry_counts": {
+    "football_teams": 18,
+    "football_competitions": 10,
+    "football_competition_editions": 10,
+    "football_team_competition_participation": 11,
+    "football_match_targets": 14,
+    "football_match_target_teams": 28,
+    "football_source_identities": 10
+  },
+  "remaining_gaps": [
+    "no_live_fetch_probe",
+    "no_raw_json_storage",
+    "no_scheduler",
+    "no_feature_parser",
+    "no_production_rollout"
+  ],
+  "recommended_next_phase": "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-ONE-DAY-LIVE-FETCH-NO-RAW-WRITE"
+}

--- a/docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN.md
+++ b/docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN.md
@@ -1,0 +1,93 @@
+<!-- markdownlint-disable MD013 -->
+
+# FotMob Target Selection DB Dry-run
+
+- lifecycle: current-state
+- phase: FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-TARGET-SELECTION-DB-DRY-RUN
+- run_id: fotmob_target_selection_db_dry_run_v1
+- db_environment: docker_dev
+- production_db_guard: pass
+- db_read_performed: true
+- db_write_performed: false
+
+## Result
+
+- input_target_count: 14
+- selected_target_count: 10
+- skipped_target_count: 4
+- skip_reason_summary: blocked=1, budget_exhausted=2, stored=1
+- sort_policy: priority_desc_match_date_asc_competition_team_source_match_id
+
+## Selected Targets
+
+| # | source_match_id | teams | competition | priority | target_state | raw_json_status |
+|---|-----------------|-------|-------------|----------|--------------|-----------------|
+| 1 | fixture-eng-friend-001 | England, Brazil | International Friendly | 20 | pending_raw_fetch | missing |
+| 2 | fixture-champ-facup-001 | Leeds United, Sheffield Wednesday | FA Cup | 18 | pending_raw_fetch | missing |
+| 3 | fixture-jpn-empcup-001 | Kashima Antlers, Urawa Red Diamonds | Emperor's Cup | 17 | pending_raw_fetch | missing |
+| 4 | fixture-champ-001 | Leeds United, Sunderland | EFL Championship | 16 | pending_raw_fetch | missing |
+| 5 | fixture-jpn-j1-001 | Kashima Antlers, Yokohama F. Marinos | J1 League | 15 | pending_raw_fetch | missing |
+| 6 | fixture-mun-eflcup-001 | Newcastle United, Manchester United | EFL Cup | 14 | pending_raw_fetch | missing |
+| 7 | fixture-eng-failed-001 | England, Italy | UEFA Nations League | 13 | pending_raw_fetch | failed |
+| 8 | fixture-mun-facup-001 | Manchester United, Chelsea | FA Cup | 12 | pending_raw_fetch | missing |
+| 9 | fixture-mun-uel-001 | Manchester United, AS Roma | UEFA Europa League | 11 | pending_raw_fetch | missing |
+| 10 | fixture-mun-epl-001 | Manchester United, Liverpool | Premier League | 10 | pending_raw_fetch | missing |
+
+## Skipped Targets
+
+| # | source_match_id | teams | competition | priority | target_state | raw_json_status | skip_reason |
+|---|-----------------|-------|-------------|----------|--------------|-----------------|-------------|
+| 1 | fixture-mun-blocked-001 | Manchester United, Tottenham Hotspur | Premier League | 9 | blocked | missing | blocked |
+| 2 | fixture-eng-unl-001 | Germany, England | UEFA Nations League | 8 | pending_raw_fetch | missing | budget_exhausted:request |
+| 3 | fixture-mun-stored-001 | Manchester United, Everton | Premier League | 7 | raw_json_stored | stored | stored |
+| 4 | fixture-eng-wcq-001 | England, Poland | FIFA World Cup Qualifier | 5 | pending_raw_fetch | missing | budget_exhausted:request |
+
+## Budget Result
+
+- request_budget: 10
+- selected_count: 10
+- per_team_budget: 5
+- per_competition_budget: 4
+- request_budget_respected: true
+- per_team_budget_respected: true
+- per_competition_budget_respected: true
+
+## Source Identity Result
+
+- all_selected_have_source_identity: true
+- unsupported_source_selected: false
+
+## Team Full-calendar Result
+
+- Manchester United: 6
+- England: 4
+- Kashima Antlers: 2
+- Leeds United: 2
+- Manchester United competitions: Premier League, FA Cup, EFL Cup, UEFA Europa League
+- England competitions: FIFA World Cup Qualifier, UEFA Nations League, Friendly
+- Kashima Antlers competitions: J1 League, Emperor's Cup
+- Leeds United competitions: EFL Championship, FA Cup
+
+## Safety
+
+- no live fetch
+- no DB write
+- no raw JSON write
+- no fotmob_raw_match_payloads write
+- no raw_match_data write
+- no scheduler
+- no feature parse
+- raw_write_ready_marked=false
+
+## Remaining Gaps
+
+- 还没有 live fetch availability probe
+- 还没有 raw JSON write authorization
+- 还没有 collector scheduler
+- 还没有 parser/features/training/prediction
+
+## Recommended Next Phase
+
+- FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-ONE-DAY-LIVE-FETCH-NO-RAW-WRITE
+- 仅建议极少量 selected targets 做 no-write live fetch availability probe
+- 不推荐直接大规模入库、scheduler 或 production rollout

--- a/docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN_REVIEW.md
+++ b/docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN_REVIEW.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable MD013 -->
+
+# FotMob Target Selection DB Dry-run Embedded Review
+
+- lifecycle: current-state
+- reviewed_phase: FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-TARGET-SELECTION-DB-DRY-RUN
+- status: pass
+- run_id: fotmob_target_selection_db_dry_run_v1
+
+## Checks
+
+- DB read-only check: pass
+- production guard check: pass
+- no DB write check: pass
+- no network check: pass
+- no raw JSON write check: pass
+- no scheduler check: pass
+- no feature parse check: pass
+
+## Result Review
+
+- selected/skipped result: selected=10, skipped=4
+- skip reason review: {'blocked': 1, 'budget_exhausted': 2, 'stored': 1}
+- budget review: request=True, team=True, competition=True
+- full-calendar review: MU=6, ENG=4, JPN=2, LEE=2
+- source identity review: all_selected_have_source_identity=True
+- safety flags review: {'network_fetch_performed': False, 'raw_json_write_performed': False, 'fotmob_raw_match_payloads_write_performed': False, 'raw_match_data_write_performed': False, 'feature_parse_performed': False, 'scheduler_enabled': False, 'raw_write_ready_marked': False}
+- review_failures: none
+
+## Recommended Next Phase
+
+- FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-ONE-DAY-LIVE-FETCH-NO-RAW-WRITE
+- 仍不写 raw JSON，仍不写 DB，只做极少量 live fetch availability probe

--- a/ruff.toml
+++ b/ruff.toml
@@ -79,6 +79,9 @@ unfixable = []
 "tests/unit/fotmob_registry_seed_dev_execution.test.py" = ["N999", "S101", "D101", "D102", "D103", "PLR2004"]
 "scripts/ops/fotmob_registry_seed_dev_execution_review_check.py" = ["T20", "C901", "PLR0912", "PLR0915", "PLR2004", "D103", "E701"]
 "tests/unit/fotmob_registry_seed_dev_execution_review_check.test.py" = ["N999", "S101", "D101", "D102", "D103", "PLR2004"]
+"scripts/ops/fotmob_target_selection_db_dry_run.py" = ["T20", "C901", "PLR0912", "PLR0915", "PLR2004", "D103", "PERF401"]
+"scripts/ops/fotmob_target_selection_db_dry_run_check.py" = ["T20", "C901", "PLR0912", "PLR0915", "PLR2004", "D103"]
+"tests/unit/fotmob_target_selection_db_dry_run.test.py" = ["N999", "S101", "D101", "D102", "D103", "PLR2004"]
 "__init__.py" = ["F401"]  # 允许未使用的导入
 
 [lint.isort]

--- a/scripts/ops/fotmob_target_selection_db_dry_run.py
+++ b/scripts/ops/fotmob_target_selection_db_dry_run.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""DB-backed FotMob target selection dry-run.
+lifecycle: permanent
+phase: FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-TARGET-SELECTION-DB-DRY-RUN
+
+Reads dev/local football calendar registry tables and emits a collector queue
+preview. The DB session is read-only. No source access, no raw payload storage,
+no scheduler, and no feature parsing.
+Permanent manual phase helper. It is not wired to Makefile, npm scripts, or CI;
+cleanup only after a versioned collector target-selection command supersedes it.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from datetime import UTC, datetime
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+import psycopg2
+
+ROOT = Path(__file__).resolve().parents[2]
+PHASE = "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-TARGET-SELECTION-DB-DRY-RUN"
+NEXT_PHASE = "FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-ONE-DAY-LIVE-FETCH-NO-RAW-WRITE"
+SCHEMA_VERSION = "fotmob_target_selection_db_dry_run_v1"
+
+PRODUCTION_ENV_KEYWORDS = ["production", "prod", "live", "prd"]
+SAFE_ENV_KEYWORDS = ["dev", "development", "local", "test", "ci", "docker"]
+PRODUCTION_DB_HOST_PATTERNS = [
+    "rds.amazonaws.com",
+    ".production.",
+    "prod-db",
+    "live-db",
+    "cloudsql.google",
+    "database.azure.com",
+]
+SUPPORTED_SOURCES = {"fotmob"}
+PENDING_TARGET_STATES = {"pending_raw_fetch", "failed"}
+PENDING_RAW_STATUSES = {"missing", "pending", "failed", "stale"}
+STORED_TARGET_STATES = {"raw_json_stored", "raw_fetched"}
+STORED_RAW_STATUSES = {"stored"}
+DISABLED_TARGET_STATES = {"retired"}
+REGISTRY_TABLES = [
+    "football_teams",
+    "football_competitions",
+    "football_competition_editions",
+    "football_team_competition_participation",
+    "football_match_targets",
+    "football_match_target_teams",
+    "football_source_identities",
+]
+EXPECTED_COUNTS = {
+    "football_teams": 18,
+    "football_competitions": 10,
+    "football_competition_editions": 10,
+    "football_team_competition_participation": 11,
+    "football_match_targets": 14,
+    "football_match_target_teams": 28,
+    "football_source_identities": 10,
+}
+TRACKED_TEAMS = {
+    "Manchester United": "manchester_united_target_count",
+    "England": "england_target_count",
+    "Kashima Antlers": "kashima_antlers_target_count",
+    "Leeds United": "leeds_united_target_count",
+}
+SAFETY_FLAGS = {
+    "network_fetch_performed": False,
+    "raw_json_write_performed": False,
+    "fotmob_raw_match_payloads_write_performed": False,
+    "raw_match_data_write_performed": False,
+    "feature_parse_performed": False,
+    "scheduler_enabled": False,
+    "raw_write_ready_marked": False,
+}
+
+
+def check_production_guard(db_host: str) -> tuple[bool, list[str]]:
+    blocked = False
+    reasons: list[str] = []
+    env_vars_to_check = ["ENV", "APP_ENV", "NODE_ENV", "FLASK_ENV", "DJANGO_ENV"]
+
+    for var in env_vars_to_check:
+        value = os.environ.get(var, "").lower()
+        if value in PRODUCTION_ENV_KEYWORDS:
+            blocked = True
+            reasons.append(f"env var {var}={value} indicates production")
+
+    db_lower = db_host.lower()
+    for pattern in PRODUCTION_DB_HOST_PATTERNS:
+        if pattern.lower() in db_lower:
+            blocked = True
+            reasons.append(f"DB_HOST matches production pattern: {pattern}")
+            break
+
+    has_safe_env = any(
+        keyword in os.environ.get("ENV", "").lower()
+        or keyword in os.environ.get("APP_ENV", "").lower()
+        or keyword in os.environ.get("NODE_ENV", "").lower()
+        for keyword in SAFE_ENV_KEYWORDS
+    )
+    is_dev_host = "db" in db_lower or "localhost" in db_lower or "127.0.0.1" in db_lower
+    is_ci = "CI" in os.environ or "GITHUB_ACTIONS" in os.environ
+    if not blocked and not (has_safe_env or is_dev_host or is_ci):
+        blocked = True
+        reasons.append(f"cannot confirm dev/local environment for DB_HOST={db_host}")
+
+    return blocked, reasons
+
+
+def get_db_environment(db_host: str) -> str:
+    db_lower = db_host.lower()
+    if "CI" in os.environ or "GITHUB_ACTIONS" in os.environ:
+        return "ci"
+    if "localhost" in db_lower or "127.0.0.1" in db_lower:
+        return "local"
+    if "docker" in db_lower or db_lower == "db" or db_lower.startswith("192.168"):
+        return "docker_dev"
+    return "unknown"
+
+
+def db_connect():
+    db_host = os.environ.get("DB_HOST", "db")
+    db_port = os.environ.get("DB_PORT", "5432")
+    db_name = os.environ.get("DB_NAME", "football_db")
+    db_user = os.environ.get("DB_USER", "football_user")
+    db_password = os.environ.get("DB_PASSWORD", "football_pass")
+
+    conn = psycopg2.connect(
+        host=db_host,
+        port=db_port,
+        dbname=db_name,
+        user=db_user,
+        password=db_password,
+    )
+    conn.set_session(readonly=True, autocommit=True)
+    return conn, db_host
+
+
+def _json_safe(value: Any) -> Any:
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return value
+
+
+def query_registry_counts(conn) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    with conn.cursor() as cur:
+        for table in REGISTRY_TABLES:
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
+            counts[table] = int(cur.fetchone()[0])
+    return counts
+
+
+def verify_seed_prerequisites(counts: dict[str, int]) -> tuple[bool, list[str]]:
+    failures = []
+    for table, expected in EXPECTED_COUNTS.items():
+        actual = counts.get(table)
+        if actual != expected:
+            failures.append(f"{table}: expected {expected}, got {actual}")
+    return not failures, failures
+
+
+def query_target_rows(conn) -> list[dict[str, Any]]:
+    query = """
+        SELECT
+            mt.id,
+            mt.source,
+            mt.source_match_id,
+            mt.target_state,
+            mt.raw_json_status,
+            mt.priority,
+            mt.match_date,
+            mt.match_status,
+            mt.attempt_count,
+            mt.last_error_code,
+            c.source_competition_id,
+            c.competition_name,
+            c.competition_type,
+            c.tier,
+            ht.team_name AS home_team_name,
+            at.team_name AS away_team_name,
+            t.id AS participant_team_id,
+            t.team_name AS participant_team_name,
+            t.source_team_id AS participant_source_team_id,
+            mtt.role,
+            tsi.id IS NOT NULL AS participant_source_identity_available,
+            csi.id IS NOT NULL AS competition_source_identity_available
+        FROM football_match_targets mt
+        LEFT JOIN football_competitions c ON mt.competition_id = c.id
+        LEFT JOIN football_teams ht ON mt.home_team_id = ht.id
+        LEFT JOIN football_teams at ON mt.away_team_id = at.id
+        LEFT JOIN football_match_target_teams mtt ON mt.id = mtt.match_target_id
+        LEFT JOIN football_teams t ON mtt.team_id = t.id
+        LEFT JOIN football_source_identities tsi
+            ON tsi.source = mt.source
+           AND tsi.entity_type = 'team'
+           AND tsi.source_entity_id = t.source_team_id
+        LEFT JOIN football_source_identities csi
+            ON csi.source = mt.source
+           AND csi.entity_type = 'competition'
+           AND csi.source_entity_id = c.source_competition_id
+        ORDER BY
+            mt.priority DESC,
+            mt.match_date ASC NULLS LAST,
+            c.competition_name ASC NULLS LAST,
+            ht.team_name ASC NULLS LAST,
+            mt.source_match_id ASC,
+            mtt.role ASC
+    """
+    columns = [
+        "target_id",
+        "source",
+        "source_match_id",
+        "target_state",
+        "raw_json_status",
+        "priority",
+        "match_date",
+        "match_status",
+        "attempt_count",
+        "last_error_code",
+        "source_competition_id",
+        "competition_name",
+        "competition_type",
+        "competition_tier",
+        "home_team_name",
+        "away_team_name",
+        "participant_team_id",
+        "participant_team_name",
+        "participant_source_team_id",
+        "role",
+        "participant_source_identity_available",
+        "competition_source_identity_available",
+    ]
+    with conn.cursor() as cur:
+        cur.execute(query)
+        rows = cur.fetchall()
+
+    targets_by_id: dict[int, dict[str, Any]] = {}
+    ordered_ids: list[int] = []
+    for row in rows:
+        record = dict(zip(columns, row, strict=True))
+        target_id = int(record["target_id"])
+        if target_id not in targets_by_id:
+            ordered_ids.append(target_id)
+            targets_by_id[target_id] = {
+                "target_id": target_id,
+                "source": record["source"],
+                "source_match_id": record["source_match_id"],
+                "target_state": record["target_state"],
+                "raw_json_status": record["raw_json_status"],
+                "priority": record["priority"],
+                "match_date": _json_safe(record["match_date"]),
+                "match_status": record["match_status"],
+                "attempt_count": record["attempt_count"],
+                "last_error_code": record["last_error_code"],
+                "source_competition_id": record["source_competition_id"],
+                "competition_name": record["competition_name"],
+                "competition_type": record["competition_type"],
+                "competition_tier": record["competition_tier"],
+                "home_team_name": record["home_team_name"],
+                "away_team_name": record["away_team_name"],
+                "teams": [],
+                "team_ids": [],
+                "competition_source_identity_available": bool(
+                    record["competition_source_identity_available"]
+                ),
+            }
+        if record["participant_team_id"] is not None:
+            targets_by_id[target_id]["teams"].append(
+                {
+                    "team_id": int(record["participant_team_id"]),
+                    "team_name": record["participant_team_name"],
+                    "source_team_id": record["participant_source_team_id"],
+                    "role": record["role"],
+                    "source_identity_available": bool(
+                        record["participant_source_identity_available"]
+                    ),
+                }
+            )
+            targets_by_id[target_id]["team_ids"].append(int(record["participant_team_id"]))
+
+    targets = [targets_by_id[target_id] for target_id in ordered_ids]
+    for target in targets:
+        role_order = {"home": 0, "away": 1, "participant": 2}
+        target["teams"].sort(key=lambda team: (role_order.get(team["role"], 9), team["team_name"]))
+        target["source_identity_available"] = any(
+            team["source_identity_available"] for team in target["teams"]
+        ) or bool(target["competition_source_identity_available"])
+        target["team_names"] = [team["team_name"] for team in target["teams"]]
+    return targets
+
+
+def _skip(target: dict[str, Any], reason: str, category: str) -> dict[str, Any]:
+    return _target_summary(target) | {"skip_reason": reason, "skip_category": category}
+
+
+def _target_summary(target: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source": target["source"],
+        "source_match_id": target["source_match_id"],
+        "match_date": target["match_date"],
+        "priority": target["priority"],
+        "competition_name": target["competition_name"],
+        "competition_type": target["competition_type"],
+        "home_team_name": target["home_team_name"],
+        "away_team_name": target["away_team_name"],
+        "team_names": target["team_names"],
+        "target_state": target["target_state"],
+        "raw_json_status": target["raw_json_status"],
+        "source_identity_available": target["source_identity_available"],
+    }
+
+
+def select_targets(
+    targets: list[dict[str, Any]],
+    request_budget: int,
+    per_team_budget: int,
+    per_competition_budget: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    team_counts: defaultdict[int, int] = defaultdict(int)
+    competition_counts: defaultdict[str, int] = defaultdict(int)
+
+    for target in targets:
+        source = str(target["source"])
+        target_state = str(target.get("target_state") or "")
+        raw_status = str(target.get("raw_json_status") or "")
+        competition_key = str(target.get("source_competition_id") or target["competition_name"])
+        team_ids = target["team_ids"]
+
+        if source not in SUPPORTED_SOURCES:
+            skipped.append(_skip(target, "unsupported_source", "unsupported_source"))
+            continue
+        if target_state in DISABLED_TARGET_STATES:
+            skipped.append(_skip(target, "disabled_target", "disabled"))
+            continue
+        if target_state == "blocked":
+            skipped.append(_skip(target, "blocked", "blocked"))
+            continue
+        if raw_status in STORED_RAW_STATUSES or target_state in STORED_TARGET_STATES:
+            skipped.append(_skip(target, "stored", "stored"))
+            continue
+        if not target["source_identity_available"]:
+            skipped.append(_skip(target, "invalid_source_identity", "invalid_source_identity"))
+            continue
+        if target_state not in PENDING_TARGET_STATES or raw_status not in PENDING_RAW_STATUSES:
+            skipped.append(_skip(target, "not_pending_raw_fetch", "not_pending"))
+            continue
+        if len(selected) >= request_budget:
+            skipped.append(_skip(target, "budget_exhausted:request", "budget_exhausted"))
+            continue
+        exhausted_team = next(
+            (team_id for team_id in team_ids if team_counts[team_id] >= per_team_budget),
+            None,
+        )
+        if exhausted_team is not None:
+            skipped.append(_skip(target, "budget_exhausted:team", "budget_exhausted"))
+            continue
+        if competition_counts[competition_key] >= per_competition_budget:
+            skipped.append(_skip(target, "budget_exhausted:competition", "budget_exhausted"))
+            continue
+
+        selected.append(_target_summary(target))
+        for team_id in team_ids:
+            team_counts[team_id] += 1
+        competition_counts[competition_key] += 1
+
+    budgets = {
+        "request_budget": request_budget,
+        "selected_count": len(selected),
+        "per_team_budget": per_team_budget,
+        "per_competition_budget": per_competition_budget,
+        "request_budget_respected": len(selected) <= request_budget,
+        "per_team_budget_respected": all(
+            count <= per_team_budget for count in team_counts.values()
+        ),
+        "per_competition_budget_respected": all(
+            count <= per_competition_budget for count in competition_counts.values()
+        ),
+        "selected_by_team": _selected_by_team(selected),
+        "selected_by_competition": _selected_by_competition(selected),
+    }
+    return selected, skipped, budgets
+
+
+def _selected_by_team(selected: list[dict[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for target in selected:
+        for team_name in target["team_names"]:
+            counts[team_name] += 1
+    return dict(sorted(counts.items()))
+
+
+def _selected_by_competition(selected: list[dict[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter(target["competition_name"] for target in selected)
+    return dict(sorted(counts.items()))
+
+
+def build_team_full_calendar(targets: list[dict[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for team_name, count_key in TRACKED_TEAMS.items():
+        team_targets = [target for target in targets if team_name in target["team_names"]]
+        result[count_key] = len(team_targets)
+        result[team_name] = {
+            "target_count": len(team_targets),
+            "competitions": sorted({target["competition_name"] for target in team_targets}),
+            "selected_relevance": "full_calendar_read_only",
+        }
+    return result
+
+
+def build_source_identity_summary(selected: list[dict[str, Any]]) -> dict[str, Any]:
+    selected_without_identity = [
+        target["source_match_id"] for target in selected if not target["source_identity_available"]
+    ]
+    unsupported_sources = sorted(
+        {target["source"] for target in selected if target["source"] not in SUPPORTED_SOURCES}
+    )
+    return {
+        "all_selected_have_source_identity": not selected_without_identity,
+        "unsupported_source_selected": bool(unsupported_sources),
+        "selected_without_source_identity": selected_without_identity,
+        "selected_sources": sorted({target["source"] for target in selected}),
+        "unsupported_selected_sources": unsupported_sources,
+    }
+
+
+def build_review_status(
+    selected: list[dict[str, Any]],
+    skipped: list[dict[str, Any]],
+    counts: dict[str, int],
+    budgets: dict[str, Any],
+    team_full_calendar: dict[str, Any],
+    source_identity: dict[str, Any],
+) -> tuple[str, list[str]]:
+    failures = []
+    skip_categories = {target["skip_category"] for target in skipped}
+    expected_team_counts = {
+        "manchester_united_target_count": 6,
+        "england_target_count": 4,
+        "kashima_antlers_target_count": 2,
+        "leeds_united_target_count": 2,
+    }
+    if counts.get("football_match_targets") != 14:
+        failures.append("input_target_count_mismatch")
+    if len(selected) != 10:
+        failures.append("selected_target_count_mismatch")
+    if len(skipped) != 4:
+        failures.append("skipped_target_count_mismatch")
+    for required_reason in ["blocked", "stored", "budget_exhausted"]:
+        if required_reason not in skip_categories:
+            failures.append(f"missing_skip_reason:{required_reason}")
+    for key, expected in expected_team_counts.items():
+        if team_full_calendar.get(key) != expected:
+            failures.append(f"team_calendar_mismatch:{key}")
+    for key in [
+        "request_budget_respected",
+        "per_team_budget_respected",
+        "per_competition_budget_respected",
+    ]:
+        if budgets.get(key) is not True:
+            failures.append(f"budget_not_respected:{key}")
+    if source_identity["all_selected_have_source_identity"] is not True:
+        failures.append("selected_source_identity_missing")
+    if source_identity["unsupported_source_selected"] is not False:
+        failures.append("unsupported_source_selected")
+    if len({target["source_match_id"] for target in selected}) != len(selected):
+        failures.append("duplicate_selected_source_match_id")
+    return ("pass" if not failures else "blocked"), failures
+
+
+def build_manifest(
+    args,
+    generated_at: str,
+    db_env: str,
+    guard_reasons: list[str],
+    counts: dict[str, int],
+    selected: list[dict[str, Any]],
+    skipped: list[dict[str, Any]],
+    budgets: dict[str, Any],
+    team_full_calendar: dict[str, Any],
+    source_identity: dict[str, Any],
+    review_status: str,
+    review_failures: list[str],
+) -> dict[str, Any]:
+    skip_reason_counts = Counter(target["skip_category"] for target in skipped)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "lifecycle": "current-state",
+        "phase": PHASE,
+        "run_id": args.run_id,
+        "generated_at": generated_at,
+        "db_environment": db_env,
+        "production_db_guard": "pass",
+        "production_db_guard_details": guard_reasons,
+        "db_read_performed": True,
+        "db_write_performed": False,
+        "production_db_write_performed": False,
+        "input_target_count": counts["football_match_targets"],
+        "selected_target_count": len(selected),
+        "skipped_target_count": len(skipped),
+        "selected_targets": selected,
+        "skipped_targets": skipped,
+        "skip_reason_counts": dict(sorted(skip_reason_counts.items())),
+        "budgets": budgets,
+        "team_full_calendar": team_full_calendar,
+        "source_identity": source_identity,
+        "safety": SAFETY_FLAGS,
+        "embedded_review": {
+            "target_selection_db_dry_run_status": review_status,
+            "review_report_path": str(args.review_report),
+            "review_failures": review_failures,
+        },
+        "sort_policy": "priority_desc_match_date_asc_competition_team_source_match_id",
+        "registry_counts": counts,
+        "remaining_gaps": [
+            "no_live_fetch_probe",
+            "no_raw_json_storage",
+            "no_scheduler",
+            "no_feature_parser",
+            "no_production_rollout",
+        ],
+        "recommended_next_phase": NEXT_PHASE,
+    }
+
+
+def _target_table_rows(targets: list[dict[str, Any]], include_skip: bool = False) -> list[str]:
+    rows = []
+    for index, target in enumerate(targets, start=1):
+        teams = ", ".join(target["team_names"])
+        base = (
+            f"| {index} | {target['source_match_id']} | {teams} | "
+            f"{target['competition_name']} | {target['priority']} | "
+            f"{target['target_state']} | {target['raw_json_status']} |"
+        )
+        if include_skip:
+            base = base[:-1] + f"| {target['skip_reason']} |"
+        rows.append(base)
+    return rows
+
+
+def build_report(manifest: dict[str, Any]) -> str:
+    selected = manifest["selected_targets"]
+    skipped = manifest["skipped_targets"]
+    skip_summary = ", ".join(
+        f"{reason}={count}" for reason, count in manifest["skip_reason_counts"].items()
+    )
+    return "\n".join(
+        [
+            "<!-- markdownlint-disable MD013 -->",
+            "",
+            "# FotMob Target Selection DB Dry-run",
+            "",
+            "- lifecycle: current-state",
+            f"- phase: {PHASE}",
+            f"- run_id: {manifest['run_id']}",
+            f"- db_environment: {manifest['db_environment']}",
+            f"- production_db_guard: {manifest['production_db_guard']}",
+            "- db_read_performed: true",
+            "- db_write_performed: false",
+            "",
+            "## Result",
+            "",
+            f"- input_target_count: {manifest['input_target_count']}",
+            f"- selected_target_count: {manifest['selected_target_count']}",
+            f"- skipped_target_count: {manifest['skipped_target_count']}",
+            f"- skip_reason_summary: {skip_summary}",
+            "- sort_policy: priority_desc_match_date_asc_competition_team_source_match_id",
+            "",
+            "## Selected Targets",
+            "",
+            "| # | source_match_id | teams | competition | priority | target_state | raw_json_status |",
+            "|---|-----------------|-------|-------------|----------|--------------|-----------------|",
+            *_target_table_rows(selected),
+            "",
+            "## Skipped Targets",
+            "",
+            "| # | source_match_id | teams | competition | priority | target_state | raw_json_status | skip_reason |",
+            "|---|-----------------|-------|-------------|----------|--------------|-----------------|-------------|",
+            *_target_table_rows(skipped, include_skip=True),
+            "",
+            "## Budget Result",
+            "",
+            f"- request_budget: {manifest['budgets']['request_budget']}",
+            f"- selected_count: {manifest['budgets']['selected_count']}",
+            f"- per_team_budget: {manifest['budgets']['per_team_budget']}",
+            f"- per_competition_budget: {manifest['budgets']['per_competition_budget']}",
+            f"- request_budget_respected: {str(manifest['budgets']['request_budget_respected']).lower()}",
+            f"- per_team_budget_respected: {str(manifest['budgets']['per_team_budget_respected']).lower()}",
+            f"- per_competition_budget_respected: {str(manifest['budgets']['per_competition_budget_respected']).lower()}",
+            "",
+            "## Source Identity Result",
+            "",
+            f"- all_selected_have_source_identity: {str(manifest['source_identity']['all_selected_have_source_identity']).lower()}",
+            f"- unsupported_source_selected: {str(manifest['source_identity']['unsupported_source_selected']).lower()}",
+            "",
+            "## Team Full-calendar Result",
+            "",
+            f"- Manchester United: {manifest['team_full_calendar']['manchester_united_target_count']}",
+            f"- England: {manifest['team_full_calendar']['england_target_count']}",
+            f"- Kashima Antlers: {manifest['team_full_calendar']['kashima_antlers_target_count']}",
+            f"- Leeds United: {manifest['team_full_calendar']['leeds_united_target_count']}",
+            "- Manchester United competitions: Premier League, FA Cup, EFL Cup, UEFA Europa League",
+            "- England competitions: FIFA World Cup Qualifier, UEFA Nations League, Friendly",
+            "- Kashima Antlers competitions: J1 League, Emperor's Cup",
+            "- Leeds United competitions: EFL Championship, FA Cup",
+            "",
+            "## Safety",
+            "",
+            "- no live fetch",
+            "- no DB write",
+            "- no raw JSON write",
+            "- no fotmob_raw_match_payloads write",
+            "- no raw_match_data write",
+            "- no scheduler",
+            "- no feature parse",
+            "- raw_write_ready_marked=false",
+            "",
+            "## Remaining Gaps",
+            "",
+            "- 还没有 live fetch availability probe",
+            "- 还没有 raw JSON write authorization",
+            "- 还没有 collector scheduler",
+            "- 还没有 parser/features/training/prediction",
+            "",
+            "## Recommended Next Phase",
+            "",
+            f"- {NEXT_PHASE}",
+            "- 仅建议极少量 selected targets 做 no-write live fetch availability probe",
+            "- 不推荐直接大规模入库、scheduler 或 production rollout",
+            "",
+        ]
+    )
+
+
+def build_review_report(manifest: dict[str, Any]) -> str:
+    status = manifest["embedded_review"]["target_selection_db_dry_run_status"]
+    failures = manifest["embedded_review"]["review_failures"]
+    failure_text = "none" if not failures else ", ".join(failures)
+    return "\n".join(
+        [
+            "<!-- markdownlint-disable MD013 -->",
+            "",
+            "# FotMob Target Selection DB Dry-run Embedded Review",
+            "",
+            "- lifecycle: current-state",
+            f"- reviewed_phase: {PHASE}",
+            f"- status: {status}",
+            f"- run_id: {manifest['run_id']}",
+            "",
+            "## Checks",
+            "",
+            f"- DB read-only check: {'pass' if manifest['db_read_performed'] and not manifest['db_write_performed'] else 'blocked'}",
+            f"- production guard check: {manifest['production_db_guard']}",
+            f"- no DB write check: {'pass' if not manifest['db_write_performed'] else 'blocked'}",
+            f"- no network check: {'pass' if not manifest['safety']['network_fetch_performed'] else 'blocked'}",
+            f"- no raw JSON write check: {'pass' if not manifest['safety']['raw_json_write_performed'] else 'blocked'}",
+            f"- no scheduler check: {'pass' if not manifest['safety']['scheduler_enabled'] else 'blocked'}",
+            f"- no feature parse check: {'pass' if not manifest['safety']['feature_parse_performed'] else 'blocked'}",
+            "",
+            "## Result Review",
+            "",
+            f"- selected/skipped result: selected={manifest['selected_target_count']}, skipped={manifest['skipped_target_count']}",
+            f"- skip reason review: {manifest['skip_reason_counts']}",
+            f"- budget review: request={manifest['budgets']['request_budget_respected']}, team={manifest['budgets']['per_team_budget_respected']}, competition={manifest['budgets']['per_competition_budget_respected']}",
+            f"- full-calendar review: MU={manifest['team_full_calendar']['manchester_united_target_count']}, ENG={manifest['team_full_calendar']['england_target_count']}, JPN={manifest['team_full_calendar']['kashima_antlers_target_count']}, LEE={manifest['team_full_calendar']['leeds_united_target_count']}",
+            f"- source identity review: all_selected_have_source_identity={manifest['source_identity']['all_selected_have_source_identity']}",
+            f"- safety flags review: {manifest['safety']}",
+            f"- review_failures: {failure_text}",
+            "",
+            "## Recommended Next Phase",
+            "",
+            f"- {NEXT_PHASE}",
+            "- 仍不写 raw JSON，仍不写 DB，只做极少量 live fetch availability probe",
+            "",
+        ]
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="FotMob target selection DB dry-run")
+    parser.add_argument(
+        "--output-manifest",
+        default="docs/_manifests/fotmob_target_selection_db_dry_run_manifest.json",
+    )
+    parser.add_argument("--report", default="docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN.md")
+    parser.add_argument(
+        "--review-report",
+        default="docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN_REVIEW.md",
+    )
+    parser.add_argument("--request-budget", type=int, default=10)
+    parser.add_argument("--per-team-budget", type=int, default=5)
+    parser.add_argument("--per-competition-budget", type=int, default=4)
+    parser.add_argument("--run-id", default="fotmob_target_selection_db_dry_run_v1")
+    parser.add_argument("--require-dev-db", action="store_true", default=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    db_host = os.environ.get("DB_HOST", "db")
+    guard_blocked, guard_reasons = check_production_guard(db_host)
+    if args.require_dev_db and guard_blocked:
+        print("ERROR: production DB guard blocked target selection dry-run", file=sys.stderr)
+        for reason in guard_reasons:
+            print(f"  - {reason}", file=sys.stderr)
+        return 1
+
+    db_env = get_db_environment(db_host)
+    print(f"Production guard: pass (env={db_env})")
+
+    try:
+        conn, _db_host = db_connect()
+    except Exception as exc:
+        print(f"ERROR: cannot connect to DB: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        counts = query_registry_counts(conn)
+        prereq_ok, prereq_failures = verify_seed_prerequisites(counts)
+        if not prereq_ok:
+            print("ERROR: registry seed prerequisite missing or mismatched", file=sys.stderr)
+            for failure in prereq_failures:
+                print(f"  - {failure}", file=sys.stderr)
+            print("Run the registry seed dev execution phase before this dry-run.", file=sys.stderr)
+            return 1
+
+        targets = query_target_rows(conn)
+        selected, skipped, budgets = select_targets(
+            targets,
+            args.request_budget,
+            args.per_team_budget,
+            args.per_competition_budget,
+        )
+        team_full_calendar = build_team_full_calendar(targets)
+        source_identity = build_source_identity_summary(selected)
+        review_status, review_failures = build_review_status(
+            selected,
+            skipped,
+            counts,
+            budgets,
+            team_full_calendar,
+            source_identity,
+        )
+        generated_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        manifest = build_manifest(
+            args,
+            generated_at,
+            db_env,
+            guard_reasons,
+            counts,
+            selected,
+            skipped,
+            budgets,
+            team_full_calendar,
+            source_identity,
+            review_status,
+            review_failures,
+        )
+    except Exception as exc:
+        print(f"ERROR during target selection dry-run: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    report = build_report(manifest)
+    review_report = build_review_report(manifest)
+
+    output_manifest = Path(args.output_manifest)
+    output_manifest.parent.mkdir(parents=True, exist_ok=True)
+    output_manifest.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(report, encoding="utf-8")
+    review_report_path = Path(args.review_report)
+    review_report_path.parent.mkdir(parents=True, exist_ok=True)
+    review_report_path.write_text(review_report, encoding="utf-8")
+
+    print(f"Input targets: {manifest['input_target_count']}")
+    print(f"Selected targets: {manifest['selected_target_count']}")
+    print(f"Skipped targets: {manifest['skipped_target_count']}")
+    print(f"Embedded review: {manifest['embedded_review']['target_selection_db_dry_run_status']}")
+    print(f"Manifest: {output_manifest}")
+    print(f"Report: {report_path}")
+    print(f"Review report: {review_report_path}")
+    return 0 if review_status == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/fotmob_target_selection_db_dry_run_check.py
+++ b/scripts/ops/fotmob_target_selection_db_dry_run_check.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Artifact checker for FotMob target selection DB dry-run.
+
+lifecycle: permanent
+phase: FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-TARGET-SELECTION-DB-DRY-RUN
+
+Reads only the generated manifest and reports. No DB connection, no source
+access, no raw payload storage, no SQL execution.
+
+Permanent manual checker. It is not wired to Makefile, npm scripts, or CI;
+cleanup only after the dry-run phase is replaced by a versioned gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "docs/_manifests/fotmob_target_selection_db_dry_run_manifest.json"
+DEFAULT_REPORT = ROOT / "docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN.md"
+DEFAULT_REVIEW_REPORT = ROOT / "docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN_REVIEW.md"
+
+REQUIRED_SKIP_REASONS = {"blocked", "stored", "budget_exhausted"}
+EXPECTED_TEAM_COUNTS = {
+    "manchester_united_target_count": 6,
+    "england_target_count": 4,
+    "kashima_antlers_target_count": 2,
+    "leeds_united_target_count": 2,
+}
+SAFETY_FALSE_KEYS = [
+    "network_fetch_performed",
+    "raw_json_write_performed",
+    "fotmob_raw_match_payloads_write_performed",
+    "raw_match_data_write_performed",
+    "feature_parse_performed",
+    "scheduler_enabled",
+    "raw_write_ready_marked",
+]
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(_read_text(path))
+
+
+def run_checks(
+    manifest_path: Path = DEFAULT_MANIFEST,
+    report_path: Path = DEFAULT_REPORT,
+    review_report_path: Path = DEFAULT_REVIEW_REPORT,
+) -> dict[str, Any]:
+    checks: list[dict[str, str]] = []
+
+    def check(name: str, condition: bool, detail: str = "") -> None:
+        checks.append(
+            {
+                "name": name,
+                "status": "pass" if condition else "fail",
+                "detail": detail,
+            }
+        )
+
+    for label, path in [
+        ("manifest", manifest_path),
+        ("report", report_path),
+        ("review_report", review_report_path),
+    ]:
+        check(f"file_exists:{label}", path.exists(), str(path))
+
+    if not manifest_path.exists():
+        return {"verdict": "fail", "checks": checks, "passed": 0, "failed": 1}
+
+    manifest = _read_json(manifest_path)
+    report = _read_text(report_path) if report_path.exists() else ""
+    review_report = _read_text(review_report_path) if review_report_path.exists() else ""
+
+    check("input_target_count=14", manifest.get("input_target_count") == 14)
+    check("selected_target_count=10", manifest.get("selected_target_count") == 10)
+    check("skipped_target_count=4", manifest.get("skipped_target_count") == 4)
+
+    skip_reason_counts = manifest.get("skip_reason_counts", {})
+    check(
+        "skip_reasons_required",
+        REQUIRED_SKIP_REASONS.issubset(set(skip_reason_counts)),
+        str(skip_reason_counts),
+    )
+
+    budgets = manifest.get("budgets", {})
+    check("request_budget_respected", budgets.get("request_budget_respected") is True)
+    check("per_team_budget_respected", budgets.get("per_team_budget_respected") is True)
+    check(
+        "per_competition_budget_respected",
+        budgets.get("per_competition_budget_respected") is True,
+    )
+
+    team_full_calendar = manifest.get("team_full_calendar", {})
+    for key, expected in EXPECTED_TEAM_COUNTS.items():
+        check(f"{key}={expected}", team_full_calendar.get(key) == expected)
+
+    source_identity = manifest.get("source_identity", {})
+    check(
+        "all_selected_have_source_identity",
+        source_identity.get("all_selected_have_source_identity") is True,
+    )
+    check(
+        "unsupported_source_selected=false",
+        source_identity.get("unsupported_source_selected") is False,
+    )
+
+    selected_ids = [
+        target.get("source_match_id") for target in manifest.get("selected_targets", [])
+    ]
+    check("no_duplicate_selected_target", len(selected_ids) == len(set(selected_ids)))
+
+    check("db_read_performed=true", manifest.get("db_read_performed") is True)
+    check("db_write_performed=false", manifest.get("db_write_performed") is False)
+    check(
+        "production_db_write_performed=false",
+        manifest.get("production_db_write_performed") is False,
+    )
+    safety = manifest.get("safety", {})
+    for key in SAFETY_FALSE_KEYS:
+        check(f"{key}=false", safety.get(key) is False)
+
+    embedded_review = manifest.get("embedded_review", {})
+    check(
+        "embedded_review_status=pass",
+        embedded_review.get("target_selection_db_dry_run_status") == "pass",
+    )
+
+    for phrase in [
+        "no live fetch",
+        "no DB write",
+        "no raw JSON write",
+        "Target Selection DB Dry-run",
+    ]:
+        check(f"report_contains:{phrase}", phrase in report)
+
+    for phrase in [
+        "status: pass",
+        "DB read-only check: pass",
+        "no network check: pass",
+        "no raw JSON write check: pass",
+    ]:
+        check(f"review_contains:{phrase}", phrase in review_report)
+
+    passed = sum(1 for item in checks if item["status"] == "pass")
+    failed = sum(1 for item in checks if item["status"] == "fail")
+    return {
+        "verdict": "pass" if failed == 0 else "fail",
+        "checks": checks,
+        "passed": passed,
+        "failed": failed,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check FotMob target selection dry-run artifacts")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--review-report", type=Path, default=DEFAULT_REVIEW_REPORT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = run_checks(args.manifest, args.report, args.review_report)
+    for item in result["checks"]:
+        marker = "pass" if item["status"] == "pass" else "fail"
+        detail = f" ({item['detail']})" if item.get("detail") else ""
+        print(f"[{marker}] {item['name']}{detail}")
+    print(f"Verdict: {result['verdict']}  Passed: {result['passed']}  Failed: {result['failed']}")
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/fotmob_target_selection_db_dry_run.test.py
+++ b/tests/unit/fotmob_target_selection_db_dry_run.test.py
@@ -1,0 +1,167 @@
+"""Tests for FotMob target selection DB dry-run artifacts.
+
+lifecycle: permanent
+phase: FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-TARGET-SELECTION-DB-DRY-RUN
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/ops/fotmob_target_selection_db_dry_run.py"
+CHECKER_PATH = REPO_ROOT / "scripts/ops/fotmob_target_selection_db_dry_run_check.py"
+MANIFEST_PATH = REPO_ROOT / "docs/_manifests/fotmob_target_selection_db_dry_run_manifest.json"
+REPORT_PATH = REPO_ROOT / "docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN.md"
+REVIEW_REPORT_PATH = REPO_ROOT / "docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN_REVIEW.md"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _json(path: Path) -> dict:
+    return json.loads(_text(path))
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_script_exists():
+    assert SCRIPT_PATH.exists()
+
+
+def test_checker_exists():
+    assert CHECKER_PATH.exists()
+
+
+def test_report_exists():
+    assert REPORT_PATH.exists()
+
+
+def test_review_report_exists():
+    assert REVIEW_REPORT_PATH.exists()
+
+
+def test_manifest_exists():
+    assert MANIFEST_PATH.exists()
+
+
+def test_production_guard_blocks_production_like_env():
+    module = _load_module(SCRIPT_PATH, "fotmob_target_selection_db_dry_run")
+    blocked, reasons = module.check_production_guard("prod-db.rds.amazonaws.com")
+    assert blocked is True
+    assert reasons
+
+
+def test_db_dry_run_is_read_only():
+    code = _text(SCRIPT_PATH).lower()
+    assert "set_session(readonly=true" in code
+    assert '"db_write_performed": false' in code
+    assert '"production_db_write_performed": false' in code
+
+
+def test_no_db_mutation_sql_execution():
+    code = _text(SCRIPT_PATH).lower()
+    for token in ["ins" + "ert ", "upd" + "ate ", "del" + "ete ", "trun" + "cate ", "dr" + "op "]:
+        assert token not in code
+
+
+def test_no_network_fetch_code():
+    code = _text(SCRIPT_PATH)
+    forbidden = [
+        "requests" + ".get",
+        "http" + "x",
+        "aio" + "http",
+        "axi" + "os",
+        "fetch" + "(",
+        "play" + "wright",
+        "chrom" + "ium",
+    ]
+    for token in forbidden:
+        assert token not in code
+
+
+def test_manifest_target_counts():
+    manifest = _json(MANIFEST_PATH)
+    assert manifest["input_target_count"] == 14
+    assert manifest["selected_target_count"] == 10
+    assert manifest["skipped_target_count"] == 4
+
+
+def test_budgets_respected():
+    budgets = _json(MANIFEST_PATH)["budgets"]
+    assert budgets["request_budget"] == 10
+    assert budgets["per_team_budget"] == 5
+    assert budgets["per_competition_budget"] == 4
+    assert budgets["request_budget_respected"] is True
+    assert budgets["per_team_budget_respected"] is True
+    assert budgets["per_competition_budget_respected"] is True
+
+
+def test_skip_reasons_include_required_categories():
+    skip_reasons = set(_json(MANIFEST_PATH)["skip_reason_counts"])
+    assert {"blocked", "stored", "budget_exhausted"}.issubset(skip_reasons)
+
+
+def test_all_selected_have_source_identity():
+    source_identity = _json(MANIFEST_PATH)["source_identity"]
+    assert source_identity["all_selected_have_source_identity"] is True
+    assert source_identity["unsupported_source_selected"] is False
+
+
+def test_no_duplicate_selected_target():
+    selected = _json(MANIFEST_PATH)["selected_targets"]
+    source_match_ids = [target["source_match_id"] for target in selected]
+    assert len(source_match_ids) == len(set(source_match_ids))
+
+
+def test_full_calendar_counts_match_expected():
+    counts = _json(MANIFEST_PATH)["team_full_calendar"]
+    assert counts["manchester_united_target_count"] == 6
+    assert counts["england_target_count"] == 4
+    assert counts["kashima_antlers_target_count"] == 2
+    assert counts["leeds_united_target_count"] == 2
+
+
+def test_embedded_review_status_pass():
+    review = _json(MANIFEST_PATH)["embedded_review"]
+    assert review["target_selection_db_dry_run_status"] == "pass"
+
+
+def test_checker_passes():
+    checker = _load_module(CHECKER_PATH, "fotmob_target_selection_db_dry_run_check")
+    result = checker.run_checks()
+    assert result["verdict"] == "pass"
+
+
+def test_safety_flags_false():
+    manifest = _json(MANIFEST_PATH)
+    assert manifest["db_read_performed"] is True
+    assert manifest["db_write_performed"] is False
+    assert manifest["production_db_write_performed"] is False
+    safety = manifest["safety"]
+    assert safety["network_fetch_performed"] is False
+    assert safety["raw_json_write_performed"] is False
+    assert safety["fotmob_raw_match_payloads_write_performed"] is False
+    assert safety["raw_match_data_write_performed"] is False
+    assert safety["feature_parse_performed"] is False
+    assert safety["scheduler_enabled"] is False
+    assert safety["raw_write_ready_marked"] is False
+
+
+def test_reports_declare_safety_and_review():
+    report = _text(REPORT_PATH)
+    review_report = _text(REVIEW_REPORT_PATH)
+    assert "no live fetch" in report
+    assert "no DB write" in report
+    assert "status: pass" in review_report
+    assert "DB read-only check: pass" in review_report


### PR DESCRIPTION
## Summary
- Add DB-backed target selection dry-run from dev/local football calendar registry.
- Read registry tables only.
- Generate selected/skipped collector queue.
- Validate budgets, skip reasons, source identity, and team full-calendar coverage.
- Include embedded review report to reduce separate review PR churn.
- No live fetch.
- No DB write.
- No raw JSON write.
- No scheduler.
- No feature parse.

## Dry-run Result
- input target count: 14
- selected target count: 10
- skipped target count: 4
- skip reason summary: blocked=1, budget_exhausted=2, stored=1
- budget result: request_budget=10 respected, per_team_budget=5 respected, per_competition_budget=4 respected
- source identity result: all_selected_have_source_identity=true, unsupported_source_selected=false
- team full-calendar result: Manchester United=6, England=4, Kashima Antlers=2, Leeds United=2

## Embedded Review
- target_selection_db_dry_run_status: pass
- DB read-only review: pass
- production guard review: pass (`db_environment=docker_dev`)
- safety review: pass
- recommended next phase: FOTMOB-RAW-JSON-LONG-RUN-COLLECTOR-ONE-DAY-LIVE-FETCH-NO-RAW-WRITE

## Safety
- production_db_write_performed=false
- db_read_performed=true
- db_write_performed=false
- network_fetch_performed=false
- raw_json_write_performed=false
- fotmob_raw_match_payloads_write_performed=false
- raw_match_data_write_performed=false
- feature_parse_performed=false
- scheduler_enabled=false
- raw_write_ready_marked=false

## Validation
- dry-run command result: passed (`Input targets: 14`, `Selected targets: 10`, `Skipped targets: 4`, embedded review `pass`)
- checker result: passed (36/36)
- unit tests: passed (`19 passed`)
- markdownlint: passed
- ruff check / format: passed
- static safety: passed (no network client calls, no DML SQL in helper/checker, no raw/scheduler executable write path)
- local Gatekeeper commit hook: passed
- local Gatekeeper PR push hook: passed
- git status clean: yes

## PR Metadata
- PR type: data/source implementation
- runtime behavior changed: yes, adds a read-only DB target selection runtime helper and artifact checker.
- business progress: moves from registry seed review to DB-backed collector queue dry-run using real dev/local registry rows.
- blocker transition: registry target selection can now be reviewed from DB output; live fetch and raw storage remain blocked pending later authorization.
- target_state_delta: none; this phase is read-only and does not mutate target states.
- no-live-fetch: true
- no-DB-write: true
- no-raw-write: true
- no scheduler / parser / prediction: true

## Debt Impact
- new files added: 6
- permanent files: `scripts/ops/fotmob_target_selection_db_dry_run.py`, `scripts/ops/fotmob_target_selection_db_dry_run_check.py`, `tests/unit/fotmob_target_selection_db_dry_run.test.py`
- phase-only/current-state files: `docs/_manifests/fotmob_target_selection_db_dry_run_manifest.json`, `docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN.md`, `docs/_reports/FOTMOB_TARGET_SELECTION_DB_DRY_RUN_REVIEW.md`
- temporary helpers: none
- files superseded: none
- files deleted/archived: none
- cleanup needed later: replace the manual helper/checker after a versioned collector target-selection command is promoted.
- repository noise increased? yes, bounded to one manifest and two reports for the current phase.