### PR TITLE
chore(docs): review archive move plan without moving files

### DIFF
--- a/docs/_reports/DOCUMENTATION_CLEANUP_PHASE3A_ARCHIVE_MOVE_PLAN_NO_DELETION_NO_MOVE.md
+++ b/docs/_reports/DOCUMENTATION_CLEANUP_PHASE3A_ARCHIVE_MOVE_PLAN_NO_DELETION_NO_MOVE.md
@@ -21,6 +21,25 @@ All destinations below are proposed paths for future review, not executed moves.
 | `docs/_reports/FOTMOB_ENDPOINT_RUNTIME_CANDIDATE_PROBE_NEXT_PLAN.md` | archive_candidate | `docs/_archive/_reports/FOTMOB_ENDPOINT_RUNTIME_CANDIDATE_PROBE_NEXT_PLAN.md` | Superseded by active workflow ordering. | `docs/CODEX_WORKFLOW.md` | medium | Verify no blocker is missing from active docs. | Move back to original path. | Required before any move. |
 | `docs/_reports/FOTMOB_CONTROLLED_JSON_PROBE_NO_WRITE_ENDPOINT_DECISION.md` | archive_candidate | `docs/_archive/_reports/FOTMOB_CONTROLLED_JSON_PROBE_NO_WRITE_ENDPOINT_DECISION.md` | Historical decision should be evidence only. | `docs/data/FOTMOB_CURRENT_STATE.md` | high | Confirm decision is summarized before move. | Move back to original path. | Required before any move. |
 
+## Phase3B Review
+
+Phase3B reviews the Phase3A mapping only. It does not delete, move, rename, or
+archive files. Filename pattern alone is not enough to approve a future move.
+
+| Candidate | Current proposed action | Phase3B classification | Reason | Evidence replacement | Risk | Future action |
+|---|---|---|---|---|---|---|
+| `docs/_reports/FOTMOB_*` old probe chains | Move to `docs/_archive/_reports/FOTMOB_*` | evidence_keep_in_place_for_now | FotMob reports may contain historical success, endpoint failure, raw payload, or anti-bot boundary evidence. | `docs/data/FOTMOB_CURRENT_STATE.md` only partially preserves this history. | high | Keep in place until owner confirms specific files are summarized. |
+| `docs/_reports/*_REVIEW*.md` | Move to `docs/_archive/_reports/*_REVIEW*.md` | needs_owner_review | Some review reports may contain unique validation or safety notes. | Active docs and PR bodies may not preserve all detail. | medium | Review specific files before any move. |
+| `docs/_reports/*_NEXT_PLAN*.md` | Move to `docs/_archive/_reports/*_NEXT_PLAN*.md` | needs_owner_review | Next-plan files may include unresolved blockers. | `docs/CODEX_WORKFLOW.md` preserves workflow rules, not every blocker. | medium | Move only after blocker content is copied or closed. |
+| `docs/_reports/*_DECISION*.md` | Move to `docs/_archive/_reports/*_DECISION*.md` | evidence_keep_in_place_for_now | Decisions may be current architecture evidence until ADR/source summary exists. | `docs/DOCUMENTATION_GOVERNANCE.md` defines policy but not every decision. | high | Keep in place until replacement summary or ADR is reviewed. |
+| `docs/_manifests/*.json` | Move to `docs/_archive/_manifests/*.json` | blocked_do_not_move | Manifest references and automation consumers are not audited. | Matching report/source summary is not verified per file. | high | Do not move until dependency scan and owner review complete. |
+| `docs/_reports/FOTMOB_CONTROLLED_JSON_PROBE_NO_WRITE_REVIEW.md` | Move to `docs/_archive/_reports/FOTMOB_CONTROLLED_JSON_PROBE_NO_WRITE_REVIEW.md` | evidence_keep_in_place_for_now | Specific FotMob endpoint review may preserve no-write and failure-boundary evidence. | `docs/data/FOTMOB_CURRENT_STATE.md` summarizes but may not include probe detail. | medium | Keep in place until endpoint findings are summarized. |
+| `docs/_reports/FOTMOB_ENDPOINT_RUNTIME_CANDIDATE_PROBE_NEXT_PLAN.md` | Move to `docs/_archive/_reports/FOTMOB_ENDPOINT_RUNTIME_CANDIDATE_PROBE_NEXT_PLAN.md` | needs_owner_review | Could contain unresolved endpoint discovery blocker details. | `docs/CODEX_WORKFLOW.md` preserves workflow order only. | medium | Owner must confirm blockers are obsolete or summarized. |
+| `docs/_reports/FOTMOB_CONTROLLED_JSON_PROBE_NO_WRITE_ENDPOINT_DECISION.md` | Move to `docs/_archive/_reports/FOTMOB_CONTROLLED_JSON_PROBE_NO_WRITE_ENDPOINT_DECISION.md` | evidence_keep_in_place_for_now | Endpoint decision may preserve historical route and no-write rationale. | `docs/data/FOTMOB_CURRENT_STATE.md` only summarizes current boundary. | high | Keep until decision content is summarized or owner approves. |
+
+Phase3B result: no candidate is safe for automatic future move. A future move
+task must use a smaller, owner-approved candidate list.
+
 ## Do Not Move Yet
 
 | Candidate | Reason |


### PR DESCRIPTION
## Summary

- Review the Phase3A archive move plan without moving files.
- Classify each proposed candidate conservatively.
- Add no new report, manifest, next-plan, review-report, or decision-report.
- Do not delete, move, rename, archive, or create `docs/_archive` content.

## Scope

| Item | Value |
|---|---|
| Task type | documentation cleanup phase3b review |
| Destructive cleanup | false |
| Files deleted | 0 |
| Files moved | 0 |
| Files renamed | 0 |
| Archive operation | false |
| New files added | 0 |
| New reports added | 0 |
| New manifests added | 0 |
| New next plans added | 0 |

## Files Changed

| Path | Purpose |
|---|---|
| docs/_reports/DOCUMENTATION_CLEANUP_PHASE3A_ARCHIVE_MOVE_PLAN_NO_DELETION_NO_MOVE.md | Add Phase3B conservative review classifications |

## Documentation Impact

| Item | Value |
|---|---|
| Existing reports updated | 1 |
| New files added | 0 |
| New reports added | 0 |
| New manifests added | 0 |
| Review reports added | 0 |
| Decision reports added | 0 |
| Next plans added | 0 |
| Candidates reviewed | 8 |

## Safety Impact

| Item | Value |
| --------------------------- | ----------------------------- |
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| New files added | 0 |
| Business code changed | no |
| FotMob code changed | no |
| DB used | no |
| Browser automation used | no |
| Scraper run | no |
| New manifest created | no |
| New next-plan created | no |
| New review report created | no |
| New decision report created | no |

## Phase3B Review Summary

| Classification | Count |
|---|---:|
| safe_for_future_move | 0 |
| needs_owner_review | 3 |
| blocked_do_not_move | 1 |
| evidence_keep_in_place_for_now | 4 |

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Validation

| Validation | Result |
|---|---|
| git status --short | clean after commit |
| python scripts/ops/documentation_governance_check.py | not available on host: python command missing |
| pytest tests/unit/test_documentation_governance_check.py -q | host failed: pandas dependency missing |
| markdownlint | not available on host: markdownlint command missing |
| container documentation governance check | pass |
| container governance checker unit tests | 14/14 passed |
| container markdownlint | pass |
| container ruff | pass |

## Rollback Plan

Revert this documentation-only commit. No files were moved, deleted, renamed, archived, or written outside the allowed documentation scope.

## Next Recommended Task

DOCUMENTATION-CLEANUP-PHASE3C-OWNER-APPROVED-SMALL-ARCHIVE-MOVE-NO-DELETION