### PR TITLE
test(fotmob): add PlayerParser bench extraction coverage

### DIFF
--- a/tests/unit/collectors/fotmob/FotMobThinParsers.test.js
+++ b/tests/unit/collectors/fotmob/FotMobThinParsers.test.js
@@ -100,6 +100,52 @@ test('PlayerParser 在空 lineup 时应安全返回空数组', () => {
   assert.equal(players.length, 0);
 });
 
+test('PlayerParser bench/substitutes extraction — 应从 lineup 中提取替补球员并分配正确的 side', () => {
+  const raw = {
+    matchId: '4506745',
+    content: {
+      lineup: {
+        home: {
+          starters: [{ id: 10, name: 'Home Starter', rating: 7.1 }],
+          substitutes: [
+            { id: 11, name: 'Home Substitute', rating: 6.0 },
+            { id: 12, name: 'Home Unrated Sub' }
+          ]
+        },
+        away: {
+          starters: [{ id: 20, name: 'Away Starter', rating: 6.8 }],
+          substitutes: [
+            { id: 21, name: 'Away Substitute', rating: 5.5 }
+          ]
+        }
+      }
+    }
+  };
+
+  const players = new PlayerParser().parsePlayers(raw);
+
+  // 2 starters + 3 substitutes = 5 total
+  assert.equal(players.length, 5);
+
+  // All substitutes present with correct side
+  const subs = players.filter(p => p.name && p.name.toLowerCase().includes('sub'));
+  assert.equal(subs.length, 3);
+
+  const homeSub = players.find(p => p.name === 'Home Substitute');
+  assert.equal(homeSub.side, 'home');
+  assert.equal(homeSub.id, 11);
+  assert.equal(homeSub.rating, 6.0);
+
+  const awaySub = players.find(p => p.name === 'Away Substitute');
+  assert.equal(awaySub.side, 'away');
+  assert.equal(awaySub.id, 21);
+  assert.equal(awaySub.rating, 5.5);
+
+  // Unrated substitute should have null rating, not NaN
+  const unrated = players.find(p => p.name === 'Home Unrated Sub');
+  assert.equal(unrated.rating, null);
+});
+
 test('MatchStatsParser 在缺少 xG 数据时应安全返回 null 不抛异常', () => {
   // Extremely minimal input — no content.stats at all
   const raw = { matchId: '4506745' };


### PR DESCRIPTION
## Summary

Add 1 PlayerParser parser-only test covering bench/substitutes extraction from the FotMob lineup structure.

The test verifies that `PlayerParser.parsePlayers()` correctly reads the `substitutes` array from each side's lineup, merges subs with starters, and assigns the correct `side` value. An unrated substitute (missing `rating` field) is also covered to ensure null-rating normalization works.

## Scope

- **Changed file:** `tests/unit/collectors/fotmob/FotMobThinParsers.test.js` only.
- No src, docs, fixtures, scripts, CI changes.
- No new files.
- No network, no browser, no DB, no raw_match_data.
- Test data: in-memory object.

## Documentation Impact

None.

## Safety Impact

- no live fetch / detail fetch / network request
- no DB write / no raw_match_data insert / no matches write
- no raw write execution
- no re-acceptance / suspension reversal / rollback
- no parser / features / training / prediction
- no full body / full JSON / full raw_data / full pageProps saved or printed

## Validation

- `docker compose -f docker-compose.dev.yml exec dev node --test tests/unit/collectors/fotmob/FotMobThinParsers.test.js`: 6/6 pass.
- All existing tests continue to pass.
- No lint/format changes needed.

## CI Gate Scope

- Unit test file only; no runtime code paths changed.
- PR body gate must pass (`scripts/ops/ai_workflow_gate.py`).

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed.

## Rollback Plan

Revert the commit.

## Next Recommended Task

Do not start automatically.
Recommended next task only after user confirmation.