### PR TITLE
chore: add PR body evidence check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@
         data-synthetic-prediction-dry-run data-synthetic-prediction-commit \
         data-raw-dry-run data-raw-commit data-network-dry-run data-db-write-small data-harvest \
         data-risk-report data-schema-help data-schema-status data-schema-plan data-schema-migrate \
-        ci-local ci-local-pr pr-merge-preflight workflow-pr-check pr-post-merge-check
+        ci-local ci-local-pr pr-body-check pr-merge-preflight workflow-pr-check pr-post-merge-check
 
 # 默认目标
 .DEFAULT_GOAL := help
@@ -204,6 +204,13 @@ pr-merge-preflight: ## PR merge preflight evidence check (read-only, no merge)
 		exit 1; \
 	fi
 	@python scripts/devops/pr_merge_preflight.py --pr $(PR)
+
+pr-body-check: ## PR body + current Production Gate evidence check (read-only). Usage: make pr-body-check PR=<number>
+	@if [ -z "$(PR)" ]; then \
+		echo "ERROR: PR number required. Usage: make pr-body-check PR=<number>"; \
+		exit 1; \
+	fi
+	@python3 scripts/devops/pr_body_check.py --pr $(PR)
 
 workflow-pr-check: ## Workflow PR local validation: ruff check + format check + pytest. Usage: make workflow-pr-check FILES="<python_files>" TESTS="<test_files>"
 	@if [ -z "$(FILES)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ pr-merge-preflight: ## PR merge preflight evidence check (read-only, no merge)
 		echo "ERROR: PR number required. Usage: make pr-merge-preflight PR=<number>"; \
 		exit 1; \
 	fi
-	@python scripts/devops/pr_merge_preflight.py --pr $(PR)
+	@python3 scripts/devops/pr_merge_preflight.py --pr $(PR)
 
 pr-body-check: ## PR body + current Production Gate evidence check (read-only). Usage: make pr-body-check PR=<number>
 	@if [ -z "$(PR)" ]; then \

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -281,7 +281,22 @@ Gate must report `PASS` before `git push`.
 
 ### After creating a PR
 
-Fetch the real PR body and re-validate:
+PR body 不能靠记忆维护，也不能只看 GitHub 页面上的绿色状态。必须拉取
+GitHub 上的真实 PR body，并确认 Production Gate 对应当前 PR head SHA。
+
+Use the fixed read-only check:
+
+```bash
+make pr-body-check PR=<PR_NUMBER>
+```
+
+This check fetches the live PR body, runs `scripts/ops/ai_workflow_gate.py`
+against that body, verifies the current head SHA prefix, changed files count,
+latest Production Gate run id, and confirms Production Gate is
+`completed` + `success` for the current head SHA. If GitHub shows a green CI
+run for an older head SHA, the check must fail.
+
+Manual fallback if the Makefile target is unavailable:
 
 ```bash
 gh pr view <PR_NUMBER> --json body --jq .body > /tmp/pr_body.md

--- a/scripts/devops/pr_body_check.py
+++ b/scripts/devops/pr_body_check.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""PR body and CI evidence check - read-only, no merge, no write.
+
+lifecycle: permanent
+
+Fetches the live PR body from GitHub, validates it with the AI workflow gate,
+and verifies that the body records current-head CI evidence.
+
+Usage:
+  python3 scripts/devops/pr_body_check.py --pr 1476
+
+PASS conditions (ALL must be true):
+  - PR exists and is open
+  - PR body is fetched from GitHub
+  - AI workflow gate passes against the fetched body
+  - Body does not contain obvious stale pending/test-count evidence
+  - Body contains the current head SHA prefix
+  - Body contains the changed files count
+  - Body contains the latest Production Gate run id for the current head SHA
+  - Production Gate run is for the current head SHA
+  - Production Gate status is completed and conclusion is success
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+PRODUCTION_GATE_WORKFLOW = "Production Gate"
+TIMEOUT_SECONDS = 30
+MIN_SHA_LENGTH = 7
+
+STALE_BODY_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"GitHub\s+Production\s+Gate\s*\|\s*pending", re.IGNORECASE),
+        "PR body still says 'GitHub Production Gate | pending'",
+    ),
+    (
+        re.compile(r"(?<!GitHub\s)Production\s+Gate\s*\|\s*pending", re.IGNORECASE),
+        "PR body still says 'Production Gate | pending'",
+    ),
+    (
+        re.compile(r"pytest\s*:\s*50\s+passed", re.IGNORECASE),
+        "PR body still contains stale 'pytest: 50 passed' evidence",
+    ),
+)
+
+
+@dataclass
+class PrInfo:
+    """Normalized PR metadata extracted from ``gh pr view --json``."""
+
+    number: int
+    title: str
+    state: str
+    head_sha: str
+    changed_files: int
+    body: str | None
+
+    @property
+    def short_sha(self) -> str:
+        """Return the short SHA used in PR body evidence."""
+        return self.head_sha[:MIN_SHA_LENGTH] if self.head_sha else ""
+
+    @classmethod
+    def from_gh_json(cls, number: int, data: dict[str, Any]) -> PrInfo:
+        """Construct PrInfo from ``gh pr view --json`` output."""
+        return cls(
+            number=number,
+            title=data.get("title", ""),
+            state=data.get("state", "UNKNOWN"),
+            head_sha=data.get("headRefOid", ""),
+            changed_files=int(data.get("changedFiles", 0) or 0),
+            body=data.get("body"),
+        )
+
+    @classmethod
+    def missing(cls, number: int) -> PrInfo:
+        """Return placeholder PR info when GitHub fetch fails."""
+        return cls(
+            number=number, title="", state="UNKNOWN", head_sha="", changed_files=0, body=None
+        )
+
+
+@dataclass
+class CiInfo:
+    """Production Gate result extracted from ``gh run list --json``."""
+
+    workflow_name: str
+    run_id: str | None
+    status: str
+    conclusion: str
+    head_sha: str
+
+    @classmethod
+    def empty(cls) -> CiInfo:
+        """Return a CiInfo representing a missing CI run."""
+        return cls(
+            workflow_name=PRODUCTION_GATE_WORKFLOW,
+            run_id=None,
+            status="",
+            conclusion="",
+            head_sha="",
+        )
+
+
+@dataclass
+class AIWorkflowGateResult:
+    """Result of running scripts/ops/ai_workflow_gate.py against the PR body."""
+
+    passed: bool
+    exit_code: int | None
+    summary: str
+    stdout: str = ""
+    stderr: str = ""
+
+    @classmethod
+    def skipped(cls, reason: str) -> AIWorkflowGateResult:
+        """Return a skipped AI workflow gate result."""
+        return cls(passed=False, exit_code=None, summary=f"SKIPPED: {reason}")
+
+
+@dataclass
+class PrBodyCheckResult:
+    """Aggregate PR body check verdict and evidence."""
+
+    pr: PrInfo
+    ci: CiInfo
+    ai_gate: AIWorkflowGateResult
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+
+    def verdict(self) -> str:
+        """Return 'PASS' or 'FAIL'."""
+        return "PASS" if self.passed else "FAIL"
+
+
+def run_gh(args: list[str]) -> str:
+    """Run a read-only ``gh`` command and return stdout."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_SECONDS,
+        check=False,
+    )
+    result.check_returncode()
+    return result.stdout.strip()
+
+
+def fetch_pr(number: int) -> PrInfo:
+    """Fetch PR metadata and live body via ``gh pr view --json``."""
+    raw = run_gh(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--json",
+            "title,state,headRefOid,changedFiles,body",
+        ]
+    )
+    return PrInfo.from_gh_json(number, json.loads(raw))
+
+
+def fetch_ci(head_sha: str) -> CiInfo:
+    """Find the most recent Production Gate run for ``head_sha``."""
+    if not head_sha:
+        return CiInfo.empty()
+
+    try:
+        raw = run_gh(
+            [
+                "run",
+                "list",
+                "--workflow",
+                PRODUCTION_GATE_WORKFLOW,
+                "--commit",
+                head_sha,
+                "--limit",
+                "1",
+                "--json",
+                "name,status,conclusion,databaseId,headSha",
+            ]
+        )
+    except subprocess.CalledProcessError:
+        return CiInfo.empty()
+
+    entries: list[dict[str, Any]] = json.loads(raw)
+    if not entries:
+        return CiInfo.empty()
+
+    entry = entries[0]
+    run_id = entry.get("databaseId")
+    return CiInfo(
+        workflow_name=entry.get("name", PRODUCTION_GATE_WORKFLOW),
+        run_id=str(run_id) if run_id is not None else None,
+        status=entry.get("status", ""),
+        conclusion=entry.get("conclusion", ""),
+        head_sha=entry.get("headSha", ""),
+    )
+
+
+def _first_nonempty_line(text: str) -> str:
+    """Return the first non-empty line from text, or an empty string."""
+    return next((line.strip() for line in text.splitlines() if line.strip()), "")
+
+
+def run_ai_workflow_gate(body: str) -> AIWorkflowGateResult:
+    """Run the existing AI workflow gate against fetched PR body text."""
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, suffix=".md") as tmp:
+            tmp.write(body)
+            tmp_path = Path(tmp.name)
+
+        result = subprocess.run(
+            [
+                "python3",
+                "scripts/ops/ai_workflow_gate.py",
+                "--pr-body-file",
+                str(tmp_path),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+        )
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+    summary = _first_nonempty_line(result.stdout) or _first_nonempty_line(result.stderr)
+    if not summary:
+        summary = "PASS" if result.returncode == 0 else "FAIL"
+    return AIWorkflowGateResult(
+        passed=result.returncode == 0,
+        exit_code=result.returncode,
+        summary=summary,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def _body_contains_changed_files_count(body: str, changed_files: int) -> bool:
+    """Return true if body contains changed-files evidence for the current count."""
+    count = re.escape(str(changed_files))
+    patterns = (
+        rf"changed[\s_-]+files?\s*[:=|]\s*{count}\b",
+        rf"\b{count}\s+changed[\s_-]+files?\b",
+        rf"\b{count}\s+files?\s+changed\b",
+    )
+    return any(re.search(pattern, body, re.IGNORECASE) for pattern in patterns)
+
+
+def _check_pr(pr: PrInfo) -> list[str]:
+    failures: list[str] = []
+    if pr.body is None:
+        failures.append("PR does not exist or PR body could not be fetched from GitHub")
+    if pr.state.upper() != "OPEN":
+        failures.append(f"PR state is '{pr.state}', expected 'OPEN'")
+    if not pr.head_sha or len(pr.head_sha) < MIN_SHA_LENGTH:
+        failures.append("Head SHA is empty or too short")
+    return failures
+
+
+def _check_ci(ci: CiInfo, expected_head_sha: str) -> list[str]:
+    failures: list[str] = []
+    if ci.run_id is None:
+        failures.append(f"Production Gate run not found for head SHA {expected_head_sha or 'N/A'}")
+        return failures
+    if ci.head_sha != expected_head_sha:
+        failures.append(
+            f"Production Gate run head SHA is '{ci.head_sha or 'N/A'}', expected '{expected_head_sha}'"
+        )
+    if ci.status != "completed":
+        failures.append(f"Production Gate status is '{ci.status}', expected 'completed'")
+    if ci.conclusion != "success":
+        failures.append(f"Production Gate conclusion is '{ci.conclusion}', expected 'success'")
+    return failures
+
+
+def _check_body_evidence(pr: PrInfo, ci: CiInfo) -> list[str]:
+    failures: list[str] = []
+    body = pr.body or ""
+
+    if not body.strip():
+        failures.append("PR body is empty")
+
+    for pattern, message in STALE_BODY_PATTERNS:
+        if pattern.search(body):
+            failures.append(message)
+
+    if pr.short_sha and pr.short_sha not in body:
+        failures.append(f"PR body does not contain current head SHA prefix {pr.short_sha}")
+
+    if not _body_contains_changed_files_count(body, pr.changed_files):
+        failures.append(f"PR body does not contain changed files count {pr.changed_files}")
+
+    if ci.run_id is not None and ci.run_id not in body:
+        failures.append(f"PR body does not contain latest Production Gate run id {ci.run_id}")
+
+    return failures
+
+
+def evaluate(pr_number: int) -> PrBodyCheckResult:
+    """Fetch live PR body + CI evidence and return a verdict."""
+    failures: list[str] = []
+
+    try:
+        pr = fetch_pr(pr_number)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        pr = PrInfo.missing(pr_number)
+        ci = CiInfo.empty()
+        ai_gate = AIWorkflowGateResult.skipped("PR body unavailable")
+        failures.append(f"PR fetch failed: {exc}")
+        failures.extend(_check_pr(pr))
+        return PrBodyCheckResult(pr=pr, ci=ci, ai_gate=ai_gate, passed=False, failures=failures)
+
+    failures.extend(_check_pr(pr))
+    ci = fetch_ci(pr.head_sha)
+    failures.extend(_check_ci(ci, pr.head_sha))
+
+    if pr.body is None:
+        ai_gate = AIWorkflowGateResult.skipped("PR body unavailable")
+    else:
+        ai_gate = run_ai_workflow_gate(pr.body)
+        if not ai_gate.passed:
+            failures.append(f"AI workflow gate failed: {ai_gate.summary}")
+
+    failures.extend(_check_body_evidence(pr, ci))
+
+    return PrBodyCheckResult(
+        pr=pr,
+        ci=ci,
+        ai_gate=ai_gate,
+        passed=len(failures) == 0,
+        failures=failures,
+    )
+
+
+def format_evidence(result: PrBodyCheckResult) -> str:
+    """Render a human-readable evidence report."""
+    lines = [
+        "=" * 60,
+        "  PR Body Check Evidence",
+        "=" * 60,
+        f"  PR Number:                    {result.pr.number}",
+        f"  PR Title:                     {result.pr.title or 'N/A'}",
+        f"  PR State:                     {result.pr.state}",
+        f"  Head SHA:                     {result.pr.head_sha or 'N/A'}",
+        f"  Changed Files:                {result.pr.changed_files}",
+        "-" * 60,
+        f"  Production Gate Run ID:       {result.ci.run_id or 'NOT FOUND'}",
+        f"  Production Gate Head SHA:     {result.ci.head_sha or 'N/A'}",
+        f"  Production Gate Status:       {result.ci.status or 'N/A'}",
+        f"  Production Gate Conclusion:   {result.ci.conclusion or 'N/A'}",
+        "-" * 60,
+        f"  AI Workflow Gate Result:      {result.ai_gate.summary}",
+        "-" * 60,
+        f"  Final Verdict:                {result.verdict()}",
+    ]
+
+    if result.failures:
+        lines.append("-" * 60)
+        lines.append("  Failures:")
+        lines.extend(f"    - {failure}" for failure in result.failures)
+
+    lines.append("=" * 60)
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PR body and CI evidence check (read-only)")
+    parser.add_argument("--pr", type=int, required=True, help="PR number to evaluate")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the PR body check and exit with 0 on PASS, 1 on FAIL."""
+    args = _parse_args(argv)
+    result = evaluate(args.pr)
+    print(format_evidence(result))
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_pr_body_check.py
+++ b/tests/unit/test_pr_body_check.py
@@ -1,0 +1,201 @@
+"""Tests for the PR body and CI evidence check.
+
+lifecycle: test-fixture
+
+All tests use mocked GitHub/AI gate data unless they only exercise CLI argument parsing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/devops/pr_body_check.py"
+_PR_NUM = 1476
+_HEAD_SHA = "abc1234567890defabc1234567890defabc12345"
+_RUN_ID = "9876543210"
+
+sys.path.insert(0, str(ROOT / "scripts/devops"))
+import pr_body_check as pc  # noqa: E402
+
+
+def _valid_body() -> str:
+    return f"""## Summary
+- governance-only
+- no runtime code changed
+- Head SHA: {_HEAD_SHA[:7]}
+- Changed Files: 4
+- Production Gate run id: {_RUN_ID}
+
+## Scope
+- PR body and CI evidence check tooling only.
+
+## Documentation Impact
+- docs/AGENT_WORKFLOW.md updated.
+
+## Safety Impact
+- no FotMob touched
+- no DB touched
+- no scraper touched
+
+## Validation
+- pytest: tests/unit/test_pr_body_check.py passed
+
+## CI Gate Scope
+- Production Gate run id: {_RUN_ID}
+
+## No deletion / no move / no rename confirmation
+- No deletion, move, or rename.
+
+## Rollback Plan
+- Revert this PR.
+
+## Next Recommended Task
+Do not start automatically.
+Recommended next task only after user confirmation.
+"""
+
+
+def _pr(body: str | None = None) -> pc.PrInfo:
+    return pc.PrInfo(
+        number=_PR_NUM,
+        title="chore: add PR body check",
+        state="OPEN",
+        head_sha=_HEAD_SHA,
+        changed_files=4,
+        body=_valid_body() if body is None else body,
+    )
+
+
+def _ci(
+    *,
+    run_id: str | None = _RUN_ID,
+    status: str = "completed",
+    conclusion: str = "success",
+    head_sha: str = _HEAD_SHA,
+) -> pc.CiInfo:
+    return pc.CiInfo(
+        workflow_name="Production Gate",
+        run_id=run_id,
+        status=status,
+        conclusion=conclusion,
+        head_sha=head_sha,
+    )
+
+
+AI_PASS = pc.AIWorkflowGateResult(
+    passed=True,
+    exit_code=0,
+    summary="PASS: AI workflow gate checks passed",
+)
+
+AI_FAIL_REQUIRED_SECTION = pc.AIWorkflowGateResult(
+    passed=False,
+    exit_code=1,
+    summary="FAIL: Missing required PR body sections: ## Scope",
+)
+
+
+def _run_with(
+    pr: pc.PrInfo, ci: pc.CiInfo, ai_gate: pc.AIWorkflowGateResult = AI_PASS
+) -> pc.PrBodyCheckResult:
+    with (
+        mock.patch.object(pc, "fetch_pr", return_value=pr),
+        mock.patch.object(pc, "fetch_ci", return_value=ci),
+        mock.patch.object(pc, "run_ai_workflow_gate", return_value=ai_gate),
+    ):
+        return pc.evaluate(_PR_NUM)
+
+
+def _assert_pass(result: pc.PrBodyCheckResult) -> None:
+    assert result.passed, f"Expected PASS but got FAIL. Failures: {result.failures}"
+    assert result.verdict() == "PASS"
+
+
+def _assert_fail(result: pc.PrBodyCheckResult, reason_contains: str) -> None:
+    assert not result.passed, "Expected FAIL but got PASS"
+    assert result.verdict() == "FAIL"
+    assert any(reason_contains in failure for failure in result.failures), result.failures
+
+
+def test_pr_body_passes() -> None:
+    result = _run_with(_pr(), _ci())
+    _assert_pass(result)
+
+
+def test_pr_body_missing_required_section_fails() -> None:
+    result = _run_with(_pr(), _ci(), ai_gate=AI_FAIL_REQUIRED_SECTION)
+    _assert_fail(result, "Missing required PR body sections")
+
+
+def test_pr_body_pending_evidence_fails() -> None:
+    body = _valid_body() + "\nGitHub Production Gate | pending\n"
+    result = _run_with(_pr(body), _ci())
+    _assert_fail(result, "pending")
+
+
+def test_pr_body_missing_current_head_sha_fails() -> None:
+    body = _valid_body().replace(_HEAD_SHA[:7], "fffffff")
+    result = _run_with(_pr(body), _ci())
+    _assert_fail(result, _HEAD_SHA[:7])
+
+
+def test_ci_run_not_found_fails() -> None:
+    result = _run_with(_pr(), _ci(run_id=None, status="", conclusion="", head_sha=""))
+    _assert_fail(result, "not found")
+
+
+def test_ci_run_not_current_head_sha_fails() -> None:
+    result = _run_with(_pr(), _ci(head_sha="deadbeef"))
+    _assert_fail(result, "expected")
+
+
+def test_ci_run_failure_fails() -> None:
+    result = _run_with(_pr(), _ci(conclusion="failure"))
+    _assert_fail(result, "failure")
+
+
+def test_script_requires_pr_arg() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+
+
+def test_script_help_succeeds() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "PR body" in result.stdout
+
+
+def test_format_evidence_contains_required_output_fields() -> None:
+    result = pc.PrBodyCheckResult(
+        pr=_pr(),
+        ci=_ci(),
+        ai_gate=AI_PASS,
+        passed=True,
+        failures=[],
+    )
+    text = pc.format_evidence(result)
+    assert f"PR Number:                    {_PR_NUM}" in text
+    assert "PR Title:" in text
+    assert _HEAD_SHA in text
+    assert "Changed Files:                4" in text
+    assert f"Production Gate Run ID:       {_RUN_ID}" in text
+    assert "Production Gate Status:       completed" in text
+    assert "Production Gate Conclusion:   success" in text
+    assert "AI Workflow Gate Result:" in text
+    assert "Final Verdict:                PASS" in text


### PR DESCRIPTION
## Summary
- PR type: governance-only.
- Adds `make pr-body-check PR=<N>` as a read-only PR body and current Production Gate evidence checker.
- No runtime code changed.
- Head SHA: aadf801
- Changed Files: 4
- Production Gate run id: 27156339798

## Scope
- Added `scripts/devops/pr_body_check.py`.
- Added `tests/unit/test_pr_body_check.py`.
- Added Makefile target `pr-body-check`.
- Updated `docs/AGENT_WORKFLOW.md` to require live PR body/current-head CI evidence checking.
- File lifecycle: `scripts/devops/pr_body_check.py` is permanent; `tests/unit/test_pr_body_check.py` is test-fixture.

## Documentation Impact
- `docs/AGENT_WORKFLOW.md` now states PR body evidence must not be maintained from memory.
- It requires `make pr-body-check PR=<N>` after PR creation.
- It states GitHub page green status is insufficient unless the Production Gate run matches the current PR head SHA.

## Safety Impact
- governance-only.
- no runtime code changed.
- no FotMob touched.
- no DB touched.
- no scraper touched.
- no-live-fetch: yes for app/data-source fetches; only GitHub PR/CI metadata is used by the new devops check.
- no-DB-write: yes.
- no-raw-write: yes.
- Business progress: PR body and CI evidence checking is now tool-backed.
- Remaining blocker: none for this governance tooling.

## Validation
- PASS: `make workflow-pr-check FILES="scripts/devops/pr_body_check.py tests/unit/test_pr_body_check.py" TESTS="tests/unit/test_pr_body_check.py"`
  - ruff check passed.
  - ruff format --check passed after formatting.
  - pytest passed: `10 passed in 0.08s`.
- PASS: `make pr-body-check PR=1477`.
- PASS: `make pr-merge-preflight PR=1477`.
- PARTIAL: `make ci-local-pr`
  - Command returned 0 because the Makefile target treats local CI as partial validation.
  - Gatekeeper attempted `npm ci` and failed with `EACCES: permission denied, mkdir '/home/xupeng/FootballPrediction.clean-dev/node_modules/@acemir'`.
  - Local `node_modules` is `root:root`, so remote GitHub Actions remains the final authority.
- PASS: Production Gate `27156339798` completed with conclusion `success` for head SHA `aadf8012b479b0cab8049608048d116aef81f06b`.

## CI Gate Scope
- Expected workflow: Production Gate.
- Current head SHA: aadf8012b479b0cab8049608048d116aef81f06b.
- Current changed files: 4.
- Production Gate run id: 27156339798.
- Production Gate status/conclusion: completed / success.
- The new `make pr-body-check PR=<N>` must fail if the latest successful CI evidence is not for the current head SHA.

## No deletion / no move / no rename confirmation
- No deletion.
- No move.
- No rename.

## Rollback Plan
- Revert this PR to remove the Makefile target, devops checker, unit tests, and documentation update.
- No runtime data, DB schema, FotMob path, raw data, feature, training, or prediction rollback is required.

## Next Recommended Task
Do not start automatically.
Recommended next task only after user confirmation.

## Debt Impact
- new files added: 2.
- permanent files: `scripts/devops/pr_body_check.py`.
- phase-only files: 0.
- temporary helpers: 0.
- files superseded: none.
- files deleted/archived: none.
- cleanup needed later: none.
- repository noise increased? no.