### PR TITLE
chore: use python3 for post-merge check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,9 +249,9 @@ pr-post-merge-check: ## Post-merge check / cleanup gate. Usage: make pr-post-mer
 		exit 1; \
 	fi
 	@if [ "$(CONFIRM_CLEANUP)" = "1" ]; then \
-		python scripts/devops/pr_post_merge_check.py --pr $(PR) --merge-commit $(MERGE_COMMIT) --branch $(BRANCH) --confirm-cleanup; \
+		python3 scripts/devops/pr_post_merge_check.py --pr $(PR) --merge-commit $(MERGE_COMMIT) --branch $(BRANCH) --confirm-cleanup; \
 	else \
-		python scripts/devops/pr_post_merge_check.py --pr $(PR) --merge-commit $(MERGE_COMMIT) --branch $(BRANCH); \
+		python3 scripts/devops/pr_post_merge_check.py --pr $(PR) --merge-commit $(MERGE_COMMIT) --branch $(BRANCH); \
 	fi
 
 # ============================================


### PR DESCRIPTION
## Summary
- PR type: governance-only.
- only Makefile changed.
- no runtime code changed.
- Head SHA: e40c234
- Changed Files: 1

## Scope
- Replace `python` with `python3` in the `pr-post-merge-check` Makefile target only.
- No script logic changes.
- No tests changed.
- No docs changed.

## Documentation Impact
- None.

## Safety Impact
- governance-only.
- no runtime code changed.
- no FotMob touched.
- no DB touched.
- no scraper touched.
- no-live-fetch: yes for product/data-source paths.
- no-DB-write: yes.
- no-raw-write: yes.

## Validation
- PASS: `rg -n "python scripts/devops/pr_post_merge_check.py|python3 scripts/devops/pr_post_merge_check.py" Makefile`
  - `pr-post-merge-check` no longer calls `python scripts/devops/pr_post_merge_check.py`.
  - It now calls `python3 scripts/devops/pr_post_merge_check.py` in both branches.
- PASS: `make workflow-pr-check FILES="scripts/devops/pr_post_merge_check.py tests/unit/test_pr_post_merge_check.py tests/unit/test_pr_post_merge_check_protected.py" TESTS="tests/unit/test_pr_post_merge_check.py tests/unit/test_pr_post_merge_check_protected.py"`
  - ruff check passed.
  - ruff format --check passed.
  - pytest passed: `41 passed in 0.19s`.
- PASS: Production Gate `27159049872` completed with conclusion `success` for head SHA `e40c23483c99b7fe42472206be73942c1a99924d`.

## CI Gate Scope
- Expected workflow: Production Gate.
- Current head SHA: `e40c23483c99b7fe42472206be73942c1a99924d`.
- Current changed files: 1.
- Production Gate run id: `27159049872`.
- Production Gate status/conclusion: `completed / success`.

## No deletion / no move / no rename confirmation
- No deletion.
- No move.
- No rename.

## Rollback Plan
- Revert this PR to restore the previous `python` command in `pr-post-merge-check`.

## Next Recommended Task
Do not start automatically.
Recommended next task only after user confirmation.

## Debt Impact
- new files added: 0.
- permanent files: 0.
- phase-only files: 0.
- temporary helpers: 0.
- files superseded: none.
- files deleted/archived: none.
- cleanup needed later: none.
- repository noise increased? no.