### PR TITLE
fix(data): map FotMob raw event fields from real payloads

### DIFF
--- a/src/parsers/fotmob/FotMobRawParser.js
+++ b/src/parsers/fotmob/FotMobRawParser.js
@@ -278,16 +278,27 @@ function extractEvents(payload) {
 
   return eventsArray
     .filter((e) => e && typeof e === 'object')
-    .map((e) => ({
-      id: firstValue([e.id], null),
-      type: firstValue([e.type], null),
-      minute: firstValue([e.minute], null),
-      teamId: firstValue([e.teamId, e.team_id], null),
-      playerId: firstValue([e.playerId, e.player_id], null),
-      playerName: firstValue([e.playerName, e.player_name], null),
-      assistPlayerId: firstValue([e.assistPlayerId, e.assist_player_id], null),
-      outcome: firstValue([e.outcome], null),
-    }));
+    .map((e) => {
+      const player = ensureObject(e.player);
+      const teamSide = typeof e.isHome === 'boolean'
+        ? (e.isHome ? 'home' : 'away')
+        : null;
+
+      return {
+        id: firstValue([e.eventId, e.id], null),
+        type: firstValue([e.type], null),
+        minute: firstValue([e.time, e.timeStr, e.minute], null),
+        teamSide,
+        teamId: firstValue([e.teamId, e.team_id], null),
+        playerId: firstValue([e.playerId, e.player_id, player.id], null),
+        playerName: firstValue([e.nameStr, e.fullName, e.shortName, player.name], null),
+        card: firstValue([e.card], null),
+        homeScore: firstValue([e.homeScore], null),
+        awayScore: firstValue([e.awayScore], null),
+        assistPlayerId: firstValue([e.assistPlayerId, e.assist_player_id], null),
+        outcome: firstValue([e.outcome], null),
+      };
+    });
 }
 
 /**

--- a/tests/unit/fotmob_raw_parser.test.js
+++ b/tests/unit/fotmob_raw_parser.test.js
@@ -170,34 +170,43 @@ function buildMinimalPayload(overrides = {}) {
         events: {
           events: [
             {
-              id: 1,
+              eventId: 1,
               type: 'Goal',
-              minute: 23,
+              time: 23,
+              isHome: true,
               teamId: 85,
               playerId: 1001,
-              playerName: 'Kylian Mbappé',
+              nameStr: 'Kylian Mbappé',
               assistPlayerId: 1002,
               outcome: 'goal',
+              homeScore: 1,
+              awayScore: 0,
             },
             {
-              id: 2,
+              eventId: 2,
               type: 'Goal',
-              minute: 67,
+              timeStr: '67',
+              isHome: false,
               teamId: 96,
-              playerId: 2001,
-              playerName: 'Himad Abdelli',
+              player: { id: 2001, name: 'player.name fallback should lose to fullName' },
+              fullName: 'Himad Abdelli',
               assistPlayerId: null,
               outcome: 'goal',
+              homeScore: 1,
+              awayScore: 1,
             },
             {
               id: 3,
-              type: 'Goal',
+              type: 'Card',
               minute: 82,
-              teamId: 85,
-              playerId: 1002,
-              playerName: 'Ousmane Dembélé',
+              isHome: true,
+              player: { id: 1002, name: 'player.name fallback should lose to shortName' },
+              shortName: 'O. Dembélé',
               assistPlayerId: null,
-              outcome: 'goal',
+              outcome: 'booked',
+              card: 'yellow',
+              homeScore: 2,
+              awayScore: 1,
             },
           ],
           ongoing: null,
@@ -309,16 +318,93 @@ test('events 应从 content.matchFacts.events.events[] 读取事件时间线', (
   assert.ok(result.ok);
   assert.ok(Array.isArray(result.data.events));
   assert.equal(result.data.events.length, 3, '应解析 3 个事件');
+  for (const event of result.data.events) {
+    assert.notEqual(event.id, null, 'event.id 不应为 null');
+    assert.notEqual(event.minute, null, 'event.minute 不应为 null');
+  }
 
   // 第一个事件：Mbappé 进球
   const goal = result.data.events[0];
   assert.equal(goal.id, 1);
   assert.equal(goal.type, 'Goal');
   assert.equal(goal.minute, 23);
+  assert.equal(goal.teamSide, 'home');
   assert.equal(goal.teamId, 85);
   assert.equal(goal.playerId, 1001);
   assert.equal(goal.playerName, 'Kylian Mbappé');
+  assert.equal(goal.homeScore, 1);
+  assert.equal(goal.awayScore, 0);
   assert.equal(goal.assistPlayerId, 1002);
+
+  // 第二个事件：minute 走 timeStr fallback，playerName 走 fullName，teamSide 由 isHome=false 推导
+  const awayGoal = result.data.events[1];
+  assert.equal(awayGoal.id, 2);
+  assert.equal(awayGoal.minute, '67');
+  assert.equal(awayGoal.teamSide, 'away');
+  assert.equal(awayGoal.teamId, 96);
+  assert.equal(awayGoal.playerId, 2001);
+  assert.equal(awayGoal.playerName, 'Himad Abdelli');
+
+  // 第三个事件：id/minute 回退到旧键，playerName 走 shortName，缺失 teamId 时不应乱造
+  const card = result.data.events[2];
+  assert.equal(card.id, 3);
+  assert.equal(card.minute, 82);
+  assert.equal(card.teamSide, 'home');
+  assert.equal(card.teamId, null);
+  assert.equal(card.playerId, 1002);
+  assert.equal(card.playerName, 'O. Dembélé');
+  assert.equal(card.card, 'yellow');
+});
+
+test('extractEvents 应按真实 FotMob 键顺序回退 playerName', () => {
+  const { extractEvents } = _internals;
+  const payload = {
+    content: {
+      matchFacts: {
+        events: {
+          events: [
+            {
+              eventId: 11,
+              time: 10,
+              isHome: true,
+              nameStr: 'nameStr wins',
+              fullName: 'fullName loses',
+              shortName: 'shortName loses',
+              player: { name: 'player.name loses' },
+            },
+            {
+              eventId: 12,
+              time: 20,
+              isHome: false,
+              fullName: 'fullName wins',
+              shortName: 'shortName loses',
+              player: { name: 'player.name loses' },
+            },
+            {
+              eventId: 13,
+              time: 30,
+              isHome: true,
+              shortName: 'shortName wins',
+              player: { name: 'player.name loses' },
+            },
+            {
+              eventId: 14,
+              time: 40,
+              isHome: false,
+              player: { name: 'player.name wins' },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const events = extractEvents(payload);
+
+  assert.deepStrictEqual(
+    events.map((event) => event.playerName),
+    ['nameStr wins', 'fullName wins', 'shortName wins', 'player.name wins']
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -640,7 +726,7 @@ test('不应混淆 header.events（score summary）和 content.matchFacts.events
   assert.ok(result.ok);
   // events 数组来自 content.matchFacts.events.events，不是 header.events
   assert.equal(result.data.events.length, 3);
-  // 事件是 timeline 条目（Goal/Goal/Goal），不是 score summary
+  // 事件是 timeline 条目，不是 score summary
   assert.equal(result.data.events[0].type, 'Goal');
   assert.equal(result.data.events[0].minute, 23);
 });

--- a/tests/unit/test_fotmob_raw_parser_contract.py
+++ b/tests/unit/test_fotmob_raw_parser_contract.py
@@ -17,6 +17,7 @@ import subprocess
 ROOT = Path(__file__).resolve().parents[2]
 _EXPECTED_HOME_SCORE = 2
 _EXPECTED_AWAY_SCORE = 1
+_EXPECTED_EVENT_MINUTE = 23
 PARSER_PATH = ROOT / "src" / "parsers" / "fotmob" / "FotMobRawParser.js"
 
 
@@ -135,14 +136,17 @@ def _build_minimal_valid_payload() -> dict:
                 "events": {
                     "events": [
                         {
-                            "id": 1,
+                            "eventId": 1,
                             "type": "Goal",
-                            "minute": 23,
+                            "time": 23,
+                            "isHome": True,
                             "teamId": 85,
                             "playerId": 1,
-                            "playerName": "Player 1",
+                            "nameStr": "Player 1",
                             "assistPlayerId": None,
                             "outcome": "goal",
+                            "homeScore": 1,
+                            "awayScore": 0,
                         },
                     ],
                     "ongoing": None,
@@ -200,6 +204,10 @@ def test_parser_successful_parse():
     assert isinstance(data["events"], list)
     assert len(data["events"]) == 1
     assert data["events"][0]["type"] == "Goal"
+    assert data["events"][0]["id"] == 1
+    assert data["events"][0]["minute"] == _EXPECTED_EVENT_MINUTE
+    assert data["events"][0]["teamSide"] == "home"
+    assert data["events"][0]["playerName"] == "Player 1"
 
     # lineup
     assert isinstance(data["lineup"]["home"]["starters"], list)


### PR DESCRIPTION
## Summary

- 修复 `FotMobRawParser.extractEvents()` 对真实 FotMob retained raw event payload 的字段映射，问题来源于 4 retained rows parser dry-run 发现的 `events` 字段错位。
- 仅调整 `events` timeline 的 `id`、`minute`、`teamSide`、`teamId`、`playerId`、`playerName`、`card`、`homeScore`、`awayScore` 映射与 fallback；不改 `stats`、`lineup`、`shotmap`、`playerStats` 逻辑。
- 补充 JS/Python 单元测试覆盖真实键结构与 fallback 顺序；本 PR 不重新执行 retained rows dry-run。

## Scope

| Item | Value |
|---|---|
| Task type | runtime bug fix |
| One task / one branch / one PR | yes |
| Combines feature + cleanup, audit + repair, merge + new work, or docs governance + business code | no |
| Merge-only zero-change task | no |
| Business code changed | yes |
| FotMob code changed | yes |

## Files Changed

| Path | Purpose |
|---|---|
| `src/parsers/fotmob/FotMobRawParser.js` | 只修 `extractEvents()` 对真实 retained raw event 字段的映射 |
| `tests/unit/fotmob_raw_parser.test.js` | 用真实 event key 结构覆盖 JS runtime 行为与 fallback 顺序 |
| `tests/unit/test_fotmob_raw_parser_contract.py` | 同步 Python contract smoke test 的事件输入与关键断言 |

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | 0 |
| Reports added | 0 |
| Manifests added | 0 |
| Review reports added | 0 |
| Decision reports added | 0 |
| Next plans added | 0 |
| Exact allowed report paths, if any | none; 本 PR 只改 runtime parser 与 tests |

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| Business code changed | yes |
| FotMob code changed | yes |
| DB used | no |
| Browser automation used | no |
| Scraper run | no |
| New manifest created | no |
| New next-plan created | no |
| New review report created | no |
| New decision report created | no |

## Validation

| Validation | Result |
|---|---|
| Host validation | `git diff --check` passed |
| Container validation | `node --test tests/unit/fotmob_raw_parser.test.js`; `python3 -m pytest tests/unit/test_fotmob_raw_parser_contract.py -q`; `python3 -m pytest -q tests/unit -k "fotmob and parser"`; `python3 -m ruff check tests/unit/test_fotmob_raw_parser_contract.py`; `python3 -m ruff format --check tests/unit/test_fotmob_raw_parser_contract.py` all passed |
| GitHub Production Gate | latest Production Gate run `27354723778` for head `4c40986` completed/success |

## CI Gate Scope

- Evidence snapshot: Current head SHA prefix: 4c40986; Changed files: 3; Latest Production Gate run ID: 27354723778; status: completed/success.
- What the validation proves: `extractEvents()` 现在能从真实 retained raw key 结构读取 `eventId/time/timeStr/isHome/player.*`，`event.id` 与 `event.minute` 不再退化为 `null`，`playerName` fallback 顺序与 `teamSide` 推导已被单测锁定。
- What the validation does not prove: 本 PR 没有重新执行 4 retained rows parser dry-run，也没有做任何 live fetch、DB read/write、raw write，因此尚未重新验证 retained rows 端到端 dry-run 输出。
- Host unavailable results, if any: none.
- Container validation results, if any: all requested checks passed in `dev` container.

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Rollback Plan

- 若 CI 或 review 证明真实 retained raw event key 仍有未覆盖分支，可直接回滚本 PR 的三个文件恢复到合并前状态。
- 回滚不会触发 schema、DB、raw data、matches 或外部抓取副作用，因为本 PR 只修改纯函数 parser 和本地测试。
- 回滚后应保留本次失败信息，并在新的修复分支上补充最小复现用例后再重新提交。

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- 重新执行 4 retained rows parser dry-run，确认 `events` 字段在 retained rows 输出中与真实 payload 对齐。

## PR Type

选择一个主类型：

- [x] runtime-code-change
- [ ] governance-only
- [ ] docs-only
- [ ] test-only
- [ ] ci-fix
- [ ] data-artifact

## Runtime Behavior

- Runtime code change included: yes
- Runtime code paths changed: `src/parsers/fotmob/FotMobRawParser.js#extractEvents`
- Runtime behavior changed: yes; `events` 解析现在优先使用真实 retained raw 字段映射与 fallback，而不是错误依赖旧键。

如果这是 implementation phase 但没有 runtime code change，默认 No-Go。请说明原因、blocker 和人工确认：

- Explanation: n/a
- Human confirmation: n/a

## Artifact Scope

- Docs/report/manifest changes included: no
- Added/modified report lines: 0
- Added/modified manifest lines: 0
- Copies full historical state: no
- Includes large artifact: no
- Large artifact justification, if any: none

## Business Progress

- Business progress: 修复了 4 retained rows parser dry-run 暴露的单一 `events` 字段映射 bug，使 parser runtime 行为与真实 FotMob raw event payload 对齐。
- Blocker removed: `extractEvents()` 不再把真实 payload 的 `eventId/time/timeStr/isHome/nameStr/fullName/shortName/player.*` 误判为空或错位。
- Blocker remaining: 尚未重新执行 4 retained rows parser dry-run，因此 retained rows 验收仍待下一步人工确认后执行。
- Next step: 在单独授权下重新执行 4 retained rows parser dry-run；本 PR 不自动继续。

## Ingestion Convergence Gate

- Ingestion blocker removed: n/a; 本 PR 是 parser runtime bug fix，不是 ingestion target state 变更。
- Target state delta: n/a
- Count moved to clean_candidate: n/a
- Count moved to rejected/superseded: n/a
- Count moved to eligible_for_re_acceptance_review: n/a
- Count moved to needs_new_evidence: n/a
- Count remain_suspended: n/a
- Count still blocked: n/a
- No-progress justification: n/a
- Does this PR trigger architecture decision gate? n/a
- Is next step bounded? yes
- Is this the second consecutive no-progress ingestion PR? n/a

## Safety Status

- no live fetch: yes
- no detail fetch: yes
- no network request: yes
- no DB writes: yes
- no raw_match_data inserts: yes
- no matches writes: yes
- no matches.external_id changes: yes
- no raw write execution: yes
- no re-acceptance execution: yes
- no suspension reversal: yes
- no rollback execution: yes
- no parser/features/training/prediction: no; parser runtime code was intentionally changed within the authorized scope
- no full body/raw_data/pageProps saved or printed: yes

If any answer is `no`, list the explicit authorization, scope, command, and verification:

- Authorization details: 用户明确授权“单独修复 FotMobRawParser 的 events 字段映射 bug”，范围仅限 `src/parsers/fotmob/FotMobRawParser.js`、`tests/unit/fotmob_raw_parser.test.js`、`tests/unit/test_fotmob_raw_parser_contract.py`，且明确禁止 dry-run、DB/raw 写、live fetch、browser、feature extraction、training/model。

## Tests Run

- [x] lint
- [x] unit tests
- [ ] coverage
- [x] formatter
- [x] git diff --check
- [ ] hidden/bidi scan
- [ ] full payload marker scan
- [ ] DB SELECT-only safety check, if applicable
- [x] other: Python contract smoke test

Commands and results:

```text
git diff --check
node --test tests/unit/fotmob_raw_parser.test.js
python3 -m pytest tests/unit/test_fotmob_raw_parser_contract.py -q
python3 -m pytest -q tests/unit -k "fotmob and parser"
python3 -m ruff check tests/unit/test_fotmob_raw_parser_contract.py
python3 -m ruff format --check tests/unit/test_fotmob_raw_parser_contract.py
```

All listed commands passed in the dev container, and no dry-run / DB / raw operations were executed.

## Repository Hygiene / Debt Impact

- New files added: 0
- File lifecycle for each new file: none
- Permanent files: none new
- Phase-only artifacts: none
- One-shot helpers (describe cleanup condition): none
- Test fixtures: none new
- Files superseded: none
- Files deleted or archived: none
- Cleanup required later: none from this PR; existing untracked `scripts/ops/fotmob_parser_dry_run.js` was left untouched
- Current-state doc updated? yes / no / not needed: not needed
- Report line count: 0
- Manifest size (lines / fields): 0
- Does this PR increase repository noise? no
- If yes, why is it justified: n/a
- Next cleanup trigger: if later parser follow-up introduces temporary helpers or artifacts

## Artifact limits checklist

- [x] No full HTML/pageProps/raw_data/source body saved
- [x] No large report unless justified in comments above
- [x] No full historical recap copied
- [x] No orphan helper/script without lifecycle
- [x] Tests protect runtime behavior where applicable

## Review Notes

- Reviewer focus: `extractEvents()` 是否严格只修真实 retained raw event 字段映射，且未波及其他 parser 段。
- Residual risk: 仍需下一步单独 rerun 4 retained rows parser dry-run 才能完成 retained rows 验收。
- Follow-up PR, if any: rerun 4 retained rows parser dry-run after user confirmation.

