### PR TITLE
fix(data): handle FotMob events without native ids

### DIFF
--- a/src/parsers/fotmob/FotMobRawParser.js
+++ b/src/parsers/fotmob/FotMobRawParser.js
@@ -268,7 +268,9 @@ function extractLineup(payload) {
  * 从 content.matchFacts.events.events[] 读取。
  * 与 header.events（score summary）明确区分。
  */
-function extractEvents(payload) {
+const MARKER_EVENT_TYPES = new Set(['AddedTime', 'Half']);
+
+function extractEvents(payload, externalId = null) {
   const eventsContainer = safeGet(payload, 'content', 'matchFacts', 'events');
   if (!eventsContainer || typeof eventsContainer !== 'object') {
     return [];
@@ -280,13 +282,22 @@ function extractEvents(payload) {
     .filter((e) => e && typeof e === 'object')
     .map((e) => {
       const player = ensureObject(e.player);
+      const nativeId = firstValue([e.eventId, e.id], null);
+      const type = firstValue([e.type], null);
       const teamSide = typeof e.isHome === 'boolean'
         ? (e.isHome ? 'home' : 'away')
         : null;
+      const sourceHasNativeId = nativeId !== null;
+      const eventKind = MARKER_EVENT_TYPES.has(type) ? 'marker_event' : 'real_event';
+      const syntheticEventKey = !sourceHasNativeId
+        && type === 'Substitution'
+        && firstValue([e.reactKey], null) !== null
+        ? `fotmob:${String(externalId ?? '')}:event:${type}:${String(e.reactKey)}`
+        : null;
 
       return {
-        id: firstValue([e.eventId, e.id], null),
-        type: firstValue([e.type], null),
+        id: sourceHasNativeId ? nativeId : syntheticEventKey,
+        type,
         minute: firstValue([e.time, e.timeStr, e.minute], null),
         teamSide,
         teamId: firstValue([e.teamId, e.team_id], null),
@@ -297,6 +308,9 @@ function extractEvents(payload) {
         awayScore: firstValue([e.awayScore], null),
         assistPlayerId: firstValue([e.assistPlayerId, e.assist_player_id], null),
         outcome: firstValue([e.outcome], null),
+        source_has_native_id: sourceHasNativeId,
+        synthetic_event_key: syntheticEventKey,
+        event_kind: eventKind,
       };
     });
 }
@@ -376,7 +390,7 @@ function parseFotMobRaw(payload, externalId) {
   const { homeTeam, awayTeam } = extractTeams(payload);
   const stats = extractStats(payload);
   const lineup = extractLineup(payload);
-  const events = extractEvents(payload);
+  const events = extractEvents(payload, matchResult.data.externalId);
   const shotmap = extractShotmap(payload);
   const playerStats = extractPlayerStats(payload);
 

--- a/tests/unit/fotmob_raw_parser.test.js
+++ b/tests/unit/fotmob_raw_parser.test.js
@@ -335,6 +335,9 @@ test('events 应从 content.matchFacts.events.events[] 读取事件时间线', (
   assert.equal(goal.homeScore, 1);
   assert.equal(goal.awayScore, 0);
   assert.equal(goal.assistPlayerId, 1002);
+  assert.equal(goal.source_has_native_id, true);
+  assert.equal(goal.synthetic_event_key, null);
+  assert.equal(goal.event_kind, 'real_event');
 
   // 第二个事件：minute 走 timeStr fallback，playerName 走 fullName，teamSide 由 isHome=false 推导
   const awayGoal = result.data.events[1];
@@ -344,6 +347,9 @@ test('events 应从 content.matchFacts.events.events[] 读取事件时间线', (
   assert.equal(awayGoal.teamId, 96);
   assert.equal(awayGoal.playerId, 2001);
   assert.equal(awayGoal.playerName, 'Himad Abdelli');
+  assert.equal(awayGoal.source_has_native_id, true);
+  assert.equal(awayGoal.synthetic_event_key, null);
+  assert.equal(awayGoal.event_kind, 'real_event');
 
   // 第三个事件：id/minute 回退到旧键，playerName 走 shortName，缺失 teamId 时不应乱造
   const card = result.data.events[2];
@@ -354,6 +360,9 @@ test('events 应从 content.matchFacts.events.events[] 读取事件时间线', (
   assert.equal(card.playerId, 1002);
   assert.equal(card.playerName, 'O. Dembélé');
   assert.equal(card.card, 'yellow');
+  assert.equal(card.source_has_native_id, true);
+  assert.equal(card.synthetic_event_key, null);
+  assert.equal(card.event_kind, 'real_event');
 });
 
 test('extractEvents 应按真实 FotMob 键顺序回退 playerName', () => {
@@ -405,6 +414,70 @@ test('extractEvents 应按真实 FotMob 键顺序回退 playerName', () => {
     events.map((event) => event.playerName),
     ['nameStr wins', 'fullName wins', 'shortName wins', 'player.name wins']
   );
+});
+
+test('extractEvents 应为无 native id 的 Substitution 生成 synthetic key，并允许 marker event 保持 id=null', () => {
+  const { extractEvents } = _internals;
+  const payload = {
+    content: {
+      matchFacts: {
+        events: {
+          events: [
+            {
+              type: 'Substitution',
+              time: 46,
+              timeStr: '46',
+              isHome: true,
+              reactKey: 'sub-46-home-1',
+              swap: 'player-swap',
+              homeScore: 1,
+              awayScore: 0,
+            },
+            {
+              type: 'AddedTime',
+              time: 45,
+              timeStr: '45+2',
+              reactKey: 'added-time-1h',
+              minutesAddedKey: '2',
+              homeScore: 1,
+              awayScore: 0,
+            },
+            {
+              type: 'Half',
+              time: 45,
+              timeStr: 'HT',
+              reactKey: 'half-time',
+              halfStrKey: 'halftime',
+              homeScore: 1,
+              awayScore: 0,
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const events = extractEvents(payload, '4830507');
+  assert.equal(events.length, 3);
+
+  const substitution = events[0];
+  assert.equal(substitution.id, 'fotmob:4830507:event:Substitution:sub-46-home-1');
+  assert.equal(substitution.source_has_native_id, false);
+  assert.equal(substitution.synthetic_event_key, 'fotmob:4830507:event:Substitution:sub-46-home-1');
+  assert.equal(substitution.event_kind, 'real_event');
+  assert.equal(substitution.teamSide, 'home');
+
+  const addedTime = events[1];
+  assert.equal(addedTime.id, null);
+  assert.equal(addedTime.source_has_native_id, false);
+  assert.equal(addedTime.synthetic_event_key, null);
+  assert.equal(addedTime.event_kind, 'marker_event');
+
+  const half = events[2];
+  assert.equal(half.id, null);
+  assert.equal(half.source_has_native_id, false);
+  assert.equal(half.synthetic_event_key, null);
+  assert.equal(half.event_kind, 'marker_event');
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/test_fotmob_raw_parser_contract.py
+++ b/tests/unit/test_fotmob_raw_parser_contract.py
@@ -208,6 +208,9 @@ def test_parser_successful_parse():
     assert data["events"][0]["minute"] == _EXPECTED_EVENT_MINUTE
     assert data["events"][0]["teamSide"] == "home"
     assert data["events"][0]["playerName"] == "Player 1"
+    assert data["events"][0]["source_has_native_id"] is True
+    assert data["events"][0]["synthetic_event_key"] is None
+    assert data["events"][0]["event_kind"] == "real_event"
 
     # lineup
     assert isinstance(data["lineup"]["home"]["starters"], list)
@@ -273,6 +276,61 @@ def test_parser_missing_events_returns_empty():
     result = _run_parser(payload, "4830507")
     assert result["ok"] is True
     assert result["data"]["events"] == []
+
+
+def test_parser_event_id_policy_for_substitution_and_marker_events():
+    """无 native id 的 substitution 生成 synthetic key；marker event 允许 id=null."""
+    payload = _build_minimal_valid_payload()
+    payload["content"]["matchFacts"]["events"]["events"] = [
+        {
+            "type": "Substitution",
+            "time": 46,
+            "timeStr": "46",
+            "isHome": True,
+            "reactKey": "sub-46-home-1",
+            "swap": "player-swap",
+            "homeScore": 1,
+            "awayScore": 0,
+        },
+        {
+            "type": "AddedTime",
+            "time": 45,
+            "timeStr": "45+2",
+            "reactKey": "added-time-1h",
+            "minutesAddedKey": "2",
+            "homeScore": 1,
+            "awayScore": 0,
+        },
+        {
+            "type": "Half",
+            "time": 45,
+            "timeStr": "HT",
+            "reactKey": "half-time",
+            "halfStrKey": "halftime",
+            "homeScore": 1,
+            "awayScore": 0,
+        },
+    ]
+
+    result = _run_parser(payload, "4830507")
+    assert result["ok"] is True
+
+    substitution, added_time, half = result["data"]["events"]
+
+    assert substitution["id"] == "fotmob:4830507:event:Substitution:sub-46-home-1"
+    assert substitution["source_has_native_id"] is False
+    assert substitution["synthetic_event_key"] == substitution["id"]
+    assert substitution["event_kind"] == "real_event"
+
+    assert added_time["id"] is None
+    assert added_time["source_has_native_id"] is False
+    assert added_time["synthetic_event_key"] is None
+    assert added_time["event_kind"] == "marker_event"
+
+    assert half["id"] is None
+    assert half["source_has_native_id"] is False
+    assert half["synthetic_event_key"] is None
+    assert half["event_kind"] == "marker_event"
 
 
 def test_parser_missing_lineup_returns_empty_containers():


### PR DESCRIPTION
## Summary

- Solidify the null-id event policy from `#1495` into `FotMobRawParser`.
- Keep native `eventId` / `id` when present.
- Generate a stable synthetic event key for `Substitution` events without native ids using `externalId + reactKey`.
- Classify `AddedTime` and `Half` as marker events that may legitimately keep `id=null`.
- Expose explicit audit fields on parsed events: `source_has_native_id`, `synthetic_event_key`, and `event_kind`.

## Scope

| Item | Value |
|---|---|
| Task type | parser implementation fix |
| One task / one branch / one PR | yes |
| Combines feature + cleanup, audit + repair, merge + new work, or docs governance + business code | no |
| Merge-only zero-change task | no |
| Business code changed | yes |
| FotMob code changed | yes |

## Files Changed

| Path | Purpose |
|---|---|
| `src/parsers/fotmob/FotMobRawParser.js` | implement native-id / synthetic-id / marker-event output policy in `extractEvents()` |
| `tests/unit/fotmob_raw_parser.test.js` | verify JS parser behavior for native ids, substitution synthetic ids, and marker events |
| `tests/unit/test_fotmob_raw_parser_contract.py` | verify Python-side contract for the new event id policy fields |

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | 0 |
| Reports added | 0 |
| Manifests added | 0 |
| Review reports added | 0 |
| Decision reports added | 0 |
| Next plans added | 0 |
| Exact allowed report paths, if any | none |

This PR intentionally keeps the change in runtime parser code and behavior tests only. It does not add reports, manifests, or governance artifacts.

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| Business code changed | yes |
| FotMob code changed | yes |
| DB used | no |
| Browser automation used | no |
| Scraper run | no |
| New manifest created | no |
| New next-plan created | no |
| New review report created | no |
| New decision report created | no |

The runtime change is bounded to `extractEvents()` output semantics. No raw rows, match rows, features, training, or prediction paths are touched.

## Validation

| Validation | Result |
|---|---|
| Host validation | `git diff --check` passed |
| Container validation | targeted JS, Python contract, related parser unit tests, and Ruff checks passed |
| GitHub Production Gate | to run after PR creation |

## CI Gate Scope

- What the validation proves:
  the parser now preserves native ids, emits a stable substitution synthetic key when native ids are absent, keeps marker events nullable for `id`, and surfaces explicit audit fields without regressing the targeted FotMob parser contract.
- What the validation does not prove:
  it does not re-run retained-row dry-run, does not validate downstream consumers beyond unit-contract scope, and does not authorize any DB/raw write path.
- Host unavailable results, if any:
  none.
- Container validation results, if any:
  all targeted parser validations passed inside the `dev` container.

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Rollback Plan

- Revert the single parser/test commit on this branch if review rejects the synthetic-id policy.
- Re-run the same targeted parser unit and contract validations to confirm the previous event output shape is restored.
- No DB rollback, raw rollback, or match rollback is required because this PR performs no write operations.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- Review downstream acceptance rules for `marker_event` rows with `id=null` and decide whether consumers should accept nullable ids or require a separate non-id key.

## PR Type

选择一个主类型：

- [x] runtime-code-change
- [ ] governance-only
- [ ] docs-only
- [ ] test-only
- [ ] ci-fix
- [ ] data-artifact

## Runtime Behavior

- Runtime code change included: yes
- Runtime code paths changed: `src/parsers/fotmob/FotMobRawParser.js -> extractEvents()`
- Runtime behavior changed: parsed FotMob events now distinguish native ids from synthetic substitution keys and marker events

如果这是 implementation phase 但没有 runtime code change，默认 No-Go。请说明原因、blocker 和人工确认：

- Explanation: not applicable; this PR contains runtime parser behavior change.
- Human confirmation: not needed beyond the explicit user task authorization.

## Artifact Scope

- Docs/report/manifest changes included: no
- Added/modified report lines: 0
- Added/modified manifest lines: 0
- Copies full historical state: no
- Includes large artifact: no
- Large artifact justification, if any: none

## Business Progress

- Business progress: codifies the `#1495` audit conclusion into parser output behavior for null-id FotMob events.
- Blocker removed: substitution events without native ids now have a stable parser-level key instead of remaining unidentifiable.
- Blocker remaining: marker-event acceptance and any broader downstream id policy still require user decision.
- Next step: wait for review and user decision on downstream nullable-id handling.

## Ingestion Convergence Gate

Fill this section for any data ingestion, source inventory, target identity, raw write readiness,
accepted mapping, baseline, suspended target, or blocked target PR. Use `n/a` only when the PR is
not part of ingestion.

- Ingestion blocker removed: n/a
- Target state delta: n/a
- Count moved to clean_candidate: n/a
- Count moved to rejected/superseded: n/a
- Count moved to eligible_for_re_acceptance_review: n/a
- Count moved to needs_new_evidence: n/a
- Count remain_suspended: n/a
- Count still blocked: n/a
- No-progress justification: n/a
- Does this PR trigger architecture decision gate? n/a
- Is next step bounded? n/a
- Is this the second consecutive no-progress ingestion PR? n/a

## Safety Status

- no live fetch: yes
- no detail fetch: yes
- no network request: yes
- no DB writes: yes
- no raw_match_data inserts: yes
- no matches writes: yes
- no matches.external_id changes: yes
- no raw write execution: yes
- no re-acceptance execution: yes
- no suspension reversal: yes
- no rollback execution: yes
- no parser/features/training/prediction: no
- no full body/raw_data/pageProps saved or printed: yes

If any answer is `no`, list the explicit authorization, scope, command, and verification:

- Authorization details:
  user explicitly authorized a parser-only implementation task on branch `fix/fotmob-event-synthetic-id-policy`, limited to `FotMobRawParser` and related unit tests, with no data fetch and no DB/raw writes.

## Tests Run

- [x] lint
- [x] unit tests
- [ ] coverage
- [x] formatter
- [x] git diff --check
- [ ] hidden/bidi scan
- [ ] full payload marker scan
- [ ] DB SELECT-only safety check, if applicable
- [x] other:

Commands and results:

```text
git diff --check
PASS

docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/fotmob_raw_parser.test.js
PASS (34/34)

docker compose -f docker-compose.dev.yml exec -T dev python3 -m pytest tests/unit/test_fotmob_raw_parser_contract.py -q
PASS (11/11)

docker compose -f docker-compose.dev.yml exec -T dev python3 -m pytest -q tests/unit -k "fotmob and parser"
PASS (37 passed, 976 deselected)

docker compose -f docker-compose.dev.yml exec -T dev python3 -m ruff check tests/unit/test_fotmob_raw_parser_contract.py
PASS

docker compose -f docker-compose.dev.yml exec -T dev python3 -m ruff format --check tests/unit/test_fotmob_raw_parser_contract.py
PASS
```

## Repository Hygiene / Debt Impact

- New files added: 0
- File lifecycle for each new file:
  none
- Permanent files:
  none
- Phase-only artifacts:
  none
- One-shot helpers (describe cleanup condition):
  none
- Test fixtures:
  none
- Files superseded:
  none
- Files deleted or archived:
  none
- Cleanup required later:
  none from this PR; unrelated untracked local helper remains intentionally untouched and uncommitted.
- Current-state doc updated? yes / no / not needed:
  not needed
- Report line count:
  0
- Manifest size (lines / fields):
  0 / 0
- Does this PR increase repository noise? yes / no:
  no
- If yes, why is it justified:
  n/a
- Next cleanup trigger:
  if downstream consumers require a unified event-id abstraction, handle that in a follow-up runtime PR rather than adding reports.

## Artifact limits checklist

- [x] No full HTML/pageProps/raw_data/source body saved
- [x] No large report unless justified in comments above
- [x] No full historical recap copied
- [x] No orphan helper/script without lifecycle
- [x] Tests protect runtime behavior where applicable

## Review Notes

- Reviewer focus:
  confirm the synthetic-key scope remains limited to `Substitution`, marker events keep `id=null`, and no unrelated FotMob parser sections changed.
- Residual risk:
  downstream consumers that assume every `real_event` has non-null `id` may still need follow-up adjustment if other null-id real-event types appear in future raw payloads.
- Follow-up PR, if any:
  only after user confirmation on downstream nullable-id policy.
