### PR TITLE
docs(data): audit first guarded FotMob reconciliation execution

### DIFF
--- a/docs/_reports/fotmob_l2_first_guarded_reconciliation_post_execution_audit_20260615.md
+++ b/docs/_reports/fotmob_l2_first_guarded_reconciliation_post_execution_audit_20260615.md
@@ -1,0 +1,88 @@
+# FotMob L2 First Guarded Reconciliation Post-Execution Audit - 2026-06-15
+
+- lifecycle: phase-artifact
+- scope: read-only post-execution audit
+- related execution PR: #1514
+- no real write executed in this audit: yes
+- no `--allow-write` executed in this audit: yes
+- no FotMob live fetch: yes
+- no raw_match_data write: yes
+- no raw payload output: yes
+
+## 1. Purpose / 目的
+
+本报告只读审计 #1514 首批 3 条 guarded reconciliation 真实执行后的状态稳定性。
+本次仅运行 post-execution dry-run 和 SELECT-only 核查，不执行任何写库。
+
+## 2. Safety Boundary / 安全边界
+
+- no `--allow-write`
+- no DB write
+- no UPDATE / INSERT / DELETE
+- no FotMob live fetch
+- no scraper/browser
+- no raw_match_data write
+- no raw payload output
+- no parser/model/feature/schema change
+- no second batch
+
+## 3. Dry-run After Execution / 执行后 dry-run
+
+- candidate_total: `55`
+- selected_count: `3`
+- would_update_count: `3`
+- actual_update_executed: `false`
+- candidate_total confirmation: `55` as expected
+
+## 4. Executed Batch Stability / 已执行 3 条稳定性
+
+| match_id | external_id | league_name | season | home_team | away_team | match_date | status | pipeline_status | raw_data_version | raw_row_count | raw_exists | has_data_hash |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- |
+| `53_20252026_4830466` | `4830466` | `Ligue 1` | `2025/2026` | `Rennes` | `Marseille` | `2025-08-15T18:45:00.000Z` | `finished` | `harvested` | `fotmob_live_v1` | 1 | yes | yes |
+| `53_20252026_4830461` | `4830461` | `Ligue 1` | `2025/2026` | `Lens` | `Lyon` | `2025-08-16T15:00:00.000Z` | `finished` | `harvested` | `fotmob_live_v1` | 1 | yes | yes |
+| `53_20252026_4830463` | `4830463` | `Ligue 1` | `2025/2026` | `Monaco` | `Le Havre` | `2025-08-16T17:00:00.000Z` | `finished` | `harvested` | `fotmob_live_v1` | 1 | yes | yes |
+
+## 5. Raw Integrity / raw 完整性
+
+- `raw_match_data` 仍存在，3 条目标当前都是 `raw_row_count = 1`
+- `data_version = fotmob_live_v1`
+- `raw_data` 与 `data_hash` 信号仍存在，且未输出任何 raw payload
+- `raw_collected_at` 仍与 `2026-06-14` anomaly audit 一致：
+  `4830466=2026-06-10T08:14:17.296Z`、`4830461=2026-06-10T08:14:24.149Z`、`4830463=2026-06-12T18:11:11.250Z`
+- `data_hash12` 仍与历史只读基线一致：
+  `4830466=3ecf1c7dd8bb`、`4830461=1f9dcc93dec6`、`4830463=57e986606a68`
+
+## 6. No Extra Update Check / 无额外误更新检查
+
+- `updated_at = 2026-06-15 14:59:01.658922+00` 仅命中这次执行的 3 条目标，无其他 `match_id`
+- `later_or_equal_non_target_with_v1_raw = 0`，未发现这 3 条之外的可疑同批次/后续更新时间
+- 当前 `harvested + single_complete_raw_v1` 总数是 `3`；结合 #1514 执行前这 3 条均为 `pending`，本次执行后的净变化为 `+3`
+- 当前 dry-run 仍然只挑出下一批 3 条 `would_update` 候选，说明没有第二批被执行
+
+## 7. Remaining Candidate Pool / 剩余候选池
+
+- expected remaining: `55`
+- actual remaining: `55`
+- by_league: `Ligue 1 = 55`
+- by_season: `2025/2026 = 55`
+- by_match_status: `finished = 55`
+
+## 8. Risk / 风险
+
+- 首批 3 条已经真实改变 `matches.pipeline_status: pending -> harvested`
+- 本次只读审计通过后，也不能直接全量推进剩余 `55` 条
+- 后续第二批仍应最多 `3` 条
+- 每批都要遵循 `plan -> execute -> verify -> audit`
+
+## 9. Conclusion / 结论
+
+- first batch stable: yes
+- remaining candidates stable: yes
+- extra update detected: no
+- safe to consider second batch planning: yes
+
+## 10. Next Recommended Task / 下一步建议
+
+- 用户确认后，可以计划第二批 `<=3` 条 guarded reconciliation
+- 不要自动开始
+- Recommended next task only after user confirmation


### PR DESCRIPTION
## Summary
- Adds a read-only post-execution audit for the first guarded FotMob L2 reconciliation execution.
- Confirms whether the 3 executed rows remain `harvested`.
- Confirms remaining candidate count and raw integrity.
- No `--allow-write`, no DB write, no FotMob live fetch.
- Do not start the next task automatically.

## Scope
- Documentation-only read-only audit.
- No second batch execution.
- No write operation.

## Documentation Impact
- Adds one report under `docs/_reports/`.

## Safety Impact
- no `--allow-write`: yes
- no DB writes: yes
- no FotMob live fetch: yes
- no scraper/browser: yes
- no raw_match_data writes: yes
- no raw payload output: yes
- no parser/model/feature/schema changes: yes
- no second batch executed: yes

## Validation
- post-execution dry-run
- read-only snapshot for the first 3 executed rows
- read-only raw integrity check
- read-only remaining candidate pool check
- `git diff --check`

## CI Gate Scope
- Documentation-only PR after read-only audit.
- No runtime code change expected.

## No deletion / no move / no rename confirmation
- No files deleted.
- No files moved.
- No files renamed.
- Only one audit report is added.

## Rollback Plan
- Revert this PR only removes the audit report.
- No database rollback required because this PR performs no write.

## Next Recommended Task
- Recommended next task: after user confirmation, plan a second guarded reconciliation batch of <=3 rows.
- Do not start automatically.
- Recommended next task only after user confirmation.
