### PR TITLE
feat(data): raise FotMob L2 guarded reconciliation limit to 10

### DIFF
--- a/docs/_reports/fotmob_l2_guarded_reconciliation_limit10_change_20260616.md
+++ b/docs/_reports/fotmob_l2_guarded_reconciliation_limit10_change_20260616.md
@@ -1,0 +1,47 @@
+# FotMob L2 Guarded Reconciliation Limit 10 Change - 2026-06-16
+- lifecycle: phase-artifact
+- scope: raise guarded reconciliation batch cap from 3 to 10
+- no `--allow-write` executed: yes
+- no real DB write: yes
+- no sixth batch execution: yes
+- no sixth batch planning: yes
+- no FotMob live fetch: yes
+- no raw payload output: yes
+- no schema or migration change: yes
+- no next task started: yes
+
+## Change Summary / 变更摘要
+- 本 PR 只提高 guarded reconciliation 批量上限。
+- `MAX_LIMIT`: `3 -> 10`
+- 默认仍是 dry-run / no-op。
+- 真实写库仍必须显式传入 `--allow-write`。
+
+## Test Result / 测试结果
+- command:
+  `docker compose -f docker-compose.dev.yml exec dev npm test -- --runTestsByPath tests/unit/scripts/ops/l2_guarded_reconciliation_write.test.js`
+- result: `pass`
+- coverage intent:
+  - 参数上限裁剪从 `3` 调整为 `10`
+  - dry-run `safety.max_batch_size = 10`
+  - 超过 10 个 eligible rows 时只选择前 10 条
+
+## Dry-run Result / dry-run 结果
+- command:
+  `docker compose -f docker-compose.dev.yml exec dev node scripts/ops/l2_guarded_reconciliation_write.js --limit 10 --json`
+- `candidate_total = 43`
+- `selected_count = 10`
+- `would_update_count = 10`
+- `actual_update_executed = false`
+- `safety.max_batch_size = 10`
+
+## Safety Boundary / 安全边界
+- 没有运行 `--allow-write`
+- 没有真实写库
+- 没有执行第六批
+- 没有计划第六批
+- 没有 FotMob live fetch
+- 没有 raw payload output
+
+## Next Step / 下一步
+- 下一步仍需用户确认后，才能做第六批 `10` 条 planning。
+- 不要自动开始。

--- a/scripts/ops/l2_guarded_reconciliation_write.js
+++ b/scripts/ops/l2_guarded_reconciliation_write.js
@@ -9,7 +9,7 @@ const CONTRACT_CARRIER = 'matches + pipeline_status';
 const DATA_VERSION = 'fotmob_live_v1';
 const GUARDED_TRANSITION = 'pending -> harvested';
 const DEFAULT_LIMIT = 3;
-const MAX_LIMIT = 3;
+const MAX_LIMIT = 10;
 const READ_ONLY_BEGIN_SQL = 'BEGIN READ ONLY';
 const WRITE_BEGIN_SQL = 'BEGIN';
 const COMMIT_SQL = 'COMMIT';
@@ -112,7 +112,7 @@ RETURNING
 function usage() {
     return [
         'Usage:',
-        '  node scripts/ops/l2_guarded_reconciliation_write.js [--limit 3] [--json] [--league "Premier League"] [--season "2025/2026"] [--status finished] [--expected-count 3] [--allow-write]',
+        '  node scripts/ops/l2_guarded_reconciliation_write.js [--limit 10] [--json] [--league "Premier League"] [--season "2025/2026"] [--status finished] [--expected-count 10] [--allow-write]',
         '',
         'Safety:',
         '  Default mode is DRY-RUN / no-op.',

--- a/tests/unit/scripts/ops/l2_guarded_reconciliation_write.test.js
+++ b/tests/unit/scripts/ops/l2_guarded_reconciliation_write.test.js
@@ -147,7 +147,28 @@ function buildReadRows() {
     ];
 }
 
-function createMockClient() {
+function buildCleanCandidateRows(count = 12) {
+    return Array.from({ length: count }, (_, index) => ({
+        match_id: `53_20252026_4900${String(index + 1).padStart(2, '0')}`,
+        external_id: `4900${String(index + 1).padStart(2, '0')}`,
+        league_name: 'Ligue 1',
+        season: '2025/2026',
+        home_team: `Home ${index + 1}`,
+        away_team: `Away ${index + 1}`,
+        match_date: `2025-10-${String(index + 1).padStart(2, '0')}T18:00:00.000Z`,
+        match_status: 'finished',
+        normalized_match_status: 'finished',
+        pipeline_status: 'pending',
+        raw_data_version: 'fotmob_live_v1',
+        raw_row_count: 1,
+        raw_external_id: `4900${String(index + 1).padStart(2, '0')}`,
+        raw_external_id_distinct_count: 1,
+        has_raw_data: true,
+        has_data_hash: true,
+    }));
+}
+
+function createMockClient(rows = buildReadRows()) {
     const calls = [];
     const guardedUpdatePrefix = ['UP', 'DATE'].join('') + " matches " + ['SE', 'T'].join('') + " pipeline_status = 'harvested'";
 
@@ -188,7 +209,7 @@ function createMockClient() {
             }
 
             if (normalized.startsWith('WITH raw_version_scope AS')) {
-                return { rows: buildReadRows() };
+                return { rows };
             }
 
             if (normalized.startsWith(guardedUpdatePrefix)) {
@@ -209,7 +230,7 @@ function createMockClient() {
     };
 }
 
-test('parseArgs defaults to dry_run limit=3 and clamps larger values to 3', () => {
+test('parseArgs defaults to dry_run limit=3 and clamps larger values to 10', () => {
     const gate = loadGateFresh();
 
     const defaults = gate.parseArgs([]);
@@ -218,7 +239,7 @@ test('parseArgs defaults to dry_run limit=3 and clamps larger values to 3', () =
     assert.equal(defaults.expectedCount, null);
 
     const limited = gate.parseArgs(['--limit', '99', '--json']);
-    assert.equal(limited.limit, 3);
+    assert.equal(limited.limit, 10);
     assert.equal(limited.json, true);
 });
 
@@ -341,10 +362,23 @@ test('default dry_run mode uses BEGIN READ ONLY and ROLLBACK and does not execut
     assert.equal(payload.safety.db_write_allowed, false);
     assert.equal(payload.safety.pipeline_status_update_allowed, false);
     assert.equal(payload.safety.requires_allow_write, true);
-    assert.equal(payload.safety.max_batch_size, 3);
+    assert.equal(payload.safety.max_batch_size, 10);
     assert.equal(Object.prototype.hasOwnProperty.call(payload.selected_candidates[0], 'raw_data'), false);
     assert.equal(Object.prototype.hasOwnProperty.call(payload.selected_candidates[0], 'raw_payload'), false);
     assert.equal(Object.prototype.hasOwnProperty.call(payload.selected_candidates[0], 'body'), false);
+});
+
+test('dry_run caps selected candidates at 10 when more than ten eligible rows exist', async () => {
+    const gate = loadGateFresh();
+    const client = createMockClient(buildCleanCandidateRows(12));
+    const payload = await gate.runGuardedReconciliationWrite(gate.parseArgs(['--limit', '99']), { client });
+
+    assert.equal(payload.summary.candidate_total, 12);
+    assert.equal(payload.summary.selected_count, 10);
+    assert.equal(payload.summary.would_update_count, 10);
+    assert.equal(payload.summary.actual_update_executed, false);
+    assert.equal(payload.safety.max_batch_size, 10);
+    assert.equal(payload.selected_candidates.length, 10);
 });
 
 test('allow-write path fails closed and rolls back when expected-count mismatches', async () => {


### PR DESCRIPTION
## Summary
This PR raises the FotMob L2 guarded reconciliation batch cap from 3 to 10.
PR type: implementation.
Runtime behavior change: yes.
Business progress: the guarded reconciliation dry-run path can now preview 10 eligible rows instead of being hard-capped at 3, which unblocks future user-authorized sixth-batch planning at size 10.
Remaining blocker: any actual sixth-batch planning or execution still requires separate user confirmation; this PR does not perform either.
no-live-fetch: yes.
no-DB-write: yes.
no-raw-write: yes.

## Scope
Changed files:
- `scripts/ops/l2_guarded_reconciliation_write.js`
- `tests/unit/scripts/ops/l2_guarded_reconciliation_write.test.js`
- `docs/_reports/fotmob_l2_guarded_reconciliation_limit10_change_20260616.md`

In scope:
- raise `MAX_LIMIT` from 3 to 10 in the guarded reconciliation script
- keep default mode as dry-run / no-op
- keep DB mutation behind explicit `--allow-write`
- update unit coverage for the raised cap
- add one bounded report that records the validation outcome

Out of scope:
- no sixth-batch execution
- no sixth-batch planning
- no FotMob fetch
- no schema or migration change

## Documentation Impact
Adds one report under `docs/_reports/` that records the exact scope of this implementation change, the test command used, and the verified dry-run result.
The report documents the new current truth for this entrypoint: `MAX_LIMIT = 10`, `candidate_total = 43`, `selected_count = 10`, and `actual_update_executed = false` when run without `--allow-write`.

## Safety Impact
- default execution remains dry-run / no-op
- explicit `--allow-write` is still required before any write path can execute
- no `--allow-write` used in this PR validation
- no real DB write
- no sixth-batch execution
- no sixth-batch planning
- no FotMob live fetch
- no raw payload output

## Validation
Validation performed:
- ran `docker compose -f docker-compose.dev.yml exec dev npm test -- --runTestsByPath tests/unit/scripts/ops/l2_guarded_reconciliation_write.test.js`
- result: pass
- ran `docker compose -f docker-compose.dev.yml exec dev node scripts/ops/l2_guarded_reconciliation_write.js --limit 10 --json`
- verified `candidate_total = 43`
- verified `selected_count = 10`
- verified `would_update_count = 10`
- verified `actual_update_executed = false`
- verified `safety.max_batch_size = 10`
- verified no `--allow-write` usage and no real DB write in this PR flow

## CI Gate Scope
Expected CI scope for this PR:
- Production Gate
- AI Workflow Gate PR-body compliance
- relevant unit-test and build validations triggered by the repository workflow

This PR changes one script, one related unit test file, and one report file only.

## No deletion / no move / no rename confirmation
Confirmed:
- no file deletion
- no file move
- no file rename
- only the scoped implementation/test/report files listed above are part of this PR

## Rollback Plan
If this change needs rollback, revert commit `477fffb` or revert the merged PR.
Rollback impact is limited to restoring the guarded reconciliation batch cap from 10 back to 3 and removing the accompanying unit-test/report updates; no database rollback or raw-data restoration is required because this PR performs no writes.

## Next Recommended Task
If the user still wants the sixth guarded reconciliation planning step, use this raised cap to run a separate explicitly confirmed planning-only dry-run for 10 rows.
Do not start automatically.
Recommended next task only after user confirmation.
