### PR TITLE
docs(data): plan sixth guarded FotMob reconciliation batch

### DIFF
--- a/docs/_reports/fotmob_l2_sixth_guarded_reconciliation_execution_plan_20260616.md
+++ b/docs/_reports/fotmob_l2_sixth_guarded_reconciliation_execution_plan_20260616.md
@@ -1,0 +1,62 @@
+# FotMob L2 Sixth Guarded Reconciliation Execution Plan
+
+**Date:** 2026-06-16
+**Branch:** docs/fotmob-l2-sixth-guarded-reconciliation-plan
+**Base:** main @ 4f0c8595f77bf9d91b5c0daa30968fb2068bd8a5
+
+## Status: PLAN ONLY — NOT EXECUTION
+
+This is the **sixth batch plan**, not an execution. No `--allow-write` was used. No database writes occurred. No sixth batch execution took place. No FotMob live fetch was performed. No raw payload was output.
+
+## Dry-Run Summary
+
+| Metric | Value |
+|--------|-------|
+| batch_size | 10 |
+| candidate_total | 43 |
+| selected_count | 10 |
+| would_update_count | 10 |
+| actual_update_executed | **false** |
+| --allow-write | **NOT used** |
+| DB write | **NONE** |
+| FotMob live fetch | **NONE** |
+| Raw payload output | **NONE** |
+| hold_duplicate_raw_count | 0 |
+| hold_non_finished_count | 0 |
+| hold_missing_hash_or_payload_count | 0 |
+| hold_external_id_mismatch_count | 0 |
+| excluded_no_raw_count | 2 |
+
+## Guard Conditions Verified
+
+- [x] All 10 candidates: pipeline_status = `pending`
+- [x] All 10 candidates: status = `finished`
+- [x] All 10 candidates: raw_match_data exists (raw_row_count = 1)
+- [x] All 10 candidates: data_version = `fotmob_live_v1`
+- [x] All 10 candidates: raw_row_count = 1 (no duplicate raw)
+- [x] All 10 candidates: no external_id mismatch
+- [x] safety.max_batch_size = 10
+- [x] safety.db_write_allowed = false
+- [x] safety.raw_payload_output_allowed = false
+- [x] safety.live_fetch_allowed = false
+
+## Planned 10 Match IDs (Sixth Batch)
+
+| # | match_id | Home | Away | Date |
+|---|----------|------|------|------|
+| 1 | 53_20252026_4830474 | Strasbourg | Nantes | 2025-08-24 |
+| 2 | 53_20252026_4830475 | Toulouse | Brest | 2025-08-24 |
+| 3 | 53_20252026_4830468 | Lille | Monaco | 2025-08-24 |
+| 4 | 53_20252026_4830478 | Lens | Brest | 2025-08-29 |
+| 5 | 53_20252026_4830479 | Lorient | Lille | 2025-08-30 |
+| 6 | 53_20252026_4830482 | Nantes | Auxerre | 2025-08-30 |
+| 7 | 53_20252026_4830484 | Toulouse | Paris Saint-Germain | 2025-08-30 |
+| 8 | 53_20252026_4830476 | Angers | Rennes | 2025-08-31 |
+| 9 | 53_20252026_4830477 | Le Havre | Nice | 2025-08-31 |
+| 10 | 53_20252026_4830481 | Monaco | Strasbourg | 2025-08-31 |
+
+All 10 are Ligue 1 2025/2026, status `finished`, pipeline_status `pending`, with a single `fotmob_live_v1` raw row each.
+
+## Next Step
+
+**User must explicitly confirm** before the sixth batch of these 10 matches can be executed with `--allow-write`. Do not proceed without authorization.


### PR DESCRIPTION
## Summary

Sixth guarded FotMob L2 reconciliation planning only. Dry-run with --limit 10 --json. No --allow-write, no DB write, no FotMob live fetch, no raw payload output, no sixth batch execution.

## Scope

- Dry-run L2 guarded reconciliation script with batch size 10
- Verify candidate_total=43, selected_count=10, would_update_count=10, actual_update_executed=false
- Document the 10 planned match IDs in an execution plan report
- Single new report file: `docs/_reports/fotmob_l2_sixth_guarded_reconciliation_execution_plan_20260616.md`

## Documentation Impact

New execution plan report documenting the sixth batch of 10 planned FotMob L2 guarded reconciliation candidates. All 10 are Ligue 1 2025/2026, pipeline_status=pending, status=finished, with single fotmob_live_v1 raw rows. No existing documentation modified.

## Safety Impact

Zero safety impact. This is a plan-only PR:
- No --allow-write flag used
- No database writes performed
- No FotMob live fetch performed
- No raw payload output
- No script changes
- No schema changes
- No migration changes

## Validation

- Dry-run output confirmed candidate_total=43, selected_count=10, would_update_count=10, actual_update_executed=false
- All 10 candidates verified: pipeline_status=pending, status=finished, raw_match_data exists, data_version=fotmob_live_v1, raw_row_count=1
- No duplicate raw (hold_duplicate_raw_count=0)
- No external_id mismatch (hold_external_id_mismatch_count=0)
- safety.max_batch_size=10, safety.db_write_allowed=false

## CI Gate Scope

Single report file only. All tests pass (Gatekeeper passed).

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed. One new file added.

## Rollback Plan

Revert the merge commit to remove the report file from main. No state changes to roll back since no writes occurred.

## Next Recommended Task

Wait for user explicit confirmation before executing the sixth batch of these 10 matches with --allow-write. Do not start automatically. Recommended next task only after user confirmation.