### PR TITLE
docs(data): verify seventh guarded FotMob reconciliation execution

### DIFF
--- a/docs/_reports/fotmob_l2_seventh_guarded_reconciliation_execution_verification_20260617.md
+++ b/docs/_reports/fotmob_l2_seventh_guarded_reconciliation_execution_verification_20260617.md
@@ -1,0 +1,84 @@
+# FotMob L2 Seventh Guarded Reconciliation Execution Verification
+
+**Date:** 2026-06-17
+**Branch:** data/fotmob-l2-seventh-guarded-reconciliation-execution
+**Base:** main @ 3866075279809ddb077f0c892269fd58fd7b6461
+
+## Status: SEVENTH BATCH EXECUTED — VERIFIED
+
+User explicitly authorized `--allow-write` execution for exactly these 10 planned match IDs. Execution completed successfully.
+
+## Pre-Execution Dry-Run Verification
+
+| Metric | Value |
+|--------|-------|
+| candidate_total (before) | 33 |
+| selected_count | 10 |
+| would_update_count | 10 |
+| actual_update_executed | false |
+| safety.max_batch_size | 10 |
+| Selected match_ids match planned 10 | ✅ |
+
+## Execution Summary
+
+| Metric | Value |
+|--------|-------|
+| mode | write_executed |
+| updated_count | **10** |
+| actual_update_executed | **true** |
+| --allow-write used | Yes (user authorized) |
+| db_write_allowed | true |
+| pipeline_status_update_allowed | true |
+| live_fetch_allowed | false |
+| raw_match_data_write_allowed | false |
+| raw_payload_output_allowed | false |
+
+## Executed 10 Match IDs — All pending → harvested
+
+| # | match_id | Home | Away | Old | New | Decision |
+|---|----------|------|------|-----|-----|----------|
+| 1 | 53_20252026_4830483 | Paris FC | Metz | pending | harvested | updated |
+| 2 | 53_20252026_4830480 | Lyon | Marseille | pending | harvested | updated |
+| 3 | 53_20252026_4830488 | Marseille | Lorient | pending | harvested | updated |
+| 4 | 53_20252026_4830490 | Nice | Nantes | pending | harvested | updated |
+| 5 | 53_20252026_4830485 | Auxerre | Monaco | pending | harvested | updated |
+| 6 | 53_20252026_4830487 | Lille | Toulouse | pending | harvested | updated |
+| 7 | 53_20252026_4830486 | Brest | Paris FC | pending | harvested | updated |
+| 8 | 53_20252026_4830489 | Metz | Angers | pending | harvested | updated |
+| 9 | 53_20252026_4830491 | Paris Saint-Germain | Lens | pending | harvested | updated |
+| 10 | 53_20252026_4830493 | Strasbourg | Le Havre | pending | harvested | updated |
+
+All 10 are Ligue 1 2025/2026, status `finished`.
+
+## Post-Execution Dry-Run Verification
+
+| Metric | Value |
+|--------|-------|
+| candidate_total (after) | **23** |
+| actual_update_executed | false (dry-run) |
+| candidate_total delta | 33 → 23 (−10) |
+| Seventh batch absent from new candidates | ✅ |
+
+## Guard Verification
+
+- [x] candidate_total before: 33
+- [x] candidate_total after: 23
+- [x] updated_count: 10
+- [x] All 10: pending → harvested
+- [x] All 10 after_rows decision: "updated"
+- [x] raw_match_data_total unchanged (raw_match_data_write_allowed: false)
+- [x] No raw_match_data writes or deletes
+- [x] No extra updates beyond the 10
+- [x] No FotMob live fetch (live_fetch_allowed: false)
+- [x] No raw payload output (raw_payload_output_allowed: false)
+- [x] No eighth batch execution
+- [x] No eighth batch planning
+- [x] No next task started
+- [x] No script changes
+- [x] No test changes
+- [x] No schema changes
+- [x] No migration changes
+
+## Next Step
+
+Next recommended action is a **read-only audit** of the seventh batch execution. Do not start automatically. Recommended next task only after user confirmation. The remaining 23 pending candidates must not be processed without separate explicit authorization.


### PR DESCRIPTION
## Summary

Seventh guarded FotMob L2 reconciliation execution verification. User authorized `--allow-write` for exactly 10 planned Ligue 1 2025/2026 match IDs. All 10 rows transitioned `pending → harvested` successfully. No raw_match_data writes/deletes, no FotMob live fetch, no raw payload output.

## Scope

- Single verification report file: `docs/_reports/fotmob_l2_seventh_guarded_reconciliation_execution_verification_20260617.md`
- 10 match_ids executed, 33 → 23 candidate_total
- No script, test, schema, or migration changes

## Documentation Impact

Adds post-execution verification report documenting the seventh guarded reconciliation batch execution with pre/post dry-run confirmation, per-row verification, and guard checklist.

## Safety Impact

- `--allow-write` executed only for exactly 10 planned rows
- raw_match_data unchanged (76 rows, no writes/deletes)
- No FotMob live fetch
- No raw payload output
- No eighth batch execution or planning
- No database schema changes

## Validation

- Pre-execution dry-run: candidate_total=33, selected_count=10, actual_update_executed=false
- Execution write: updated_count=10, actual_update_executed=true, all 10 decision="updated"
- Post-execution dry-run: candidate_total=23, seventh batch absent from remaining candidates
- Database query: all 10 match_ids confirmed `harvested` in matches table
- All safety flags confirmed: live_fetch_allowed=false, raw_match_data_write_allowed=false, raw_payload_output_allowed=false

## CI Gate Scope

Productions Gate (Environment / Proxy / Static / Unit Gate) must pass. Single verification report file — expected to pass all lint, test, and gate checks.

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed. One new verification report file created.

## Rollback Plan

No rollback needed. This is a documentation-only PR recording a verified database state transition. The 10 pipeline_status updates are intentional and authorized. If rollback were needed, it would require manual SQL UPDATE to set pipeline_status back to `pending` for the 10 specific match_ids (documented in the verification report).

## Next Recommended Task

Read-only audit of the seventh batch execution. Do not start automatically. Recommended next task only after user confirmation. The remaining 23 pending candidates must not be processed without separate explicit user authorization.