### PR TITLE
feat(data): add training eligibility dry-run

### DIFF
--- a/docs/_reports/training_eligibility_dry_run_20260619.md
+++ b/docs/_reports/training_eligibility_dry_run_20260619.md
@@ -1,0 +1,96 @@
+# Training Eligibility Dry-Run Report
+
+- lifecycle: phase-artifact
+- generated: 2026-06-19
+- branch: data/training-eligibility-dry-run
+- script: scripts/ops/training_eligibility_dry_run.js
+- test: tests/unit/training_eligibility_dry_run.test.js
+- policy: docs/_reports/training_eligibility_policy_design_20260619.md
+
+## Nature
+
+Read-only dry-run for future `is_training_eligible` backfill. Evaluates all 60
+matches against the 6-rule training eligibility policy. No DB write.
+
+## Execution Command
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T dev \
+  node scripts/ops/training_eligibility_dry_run.js --json
+```
+
+## Current State
+
+| Metric | Count |
+|--------|-------|
+| total matches | 60 |
+| is_training_eligible=true | 0 |
+| is_training_eligible=false | 60 |
+
+## Dry-Run Summary
+
+| Metric | Count |
+|--------|-------|
+| would_set_true_count | **0** |
+| would_keep_false_count | **60** |
+
+## by_reason
+
+| Reason | Count | Description |
+|--------|-------|-------------|
+| no_valid_scores: home_score or away_score is null | **58** | Ligue 1 2025/2026 matches have no scores |
+| forbidden_evidence: synthetic_invalid | **2** | Synthetic data permanently excluded |
+
+## 58 Ligue 1 2025/2026 Analysis
+
+All 58 matches pass most training eligibility gates:
+- ✅ source_type=fotmob_live_fetch (valid)
+- ✅ evidence_level=strong
+- ✅ status=finished
+- ✅ is_production_scope=true
+- ✅ is_reconciliation_eligible=true
+- ✅ pipeline_status=harvested
+- ✅ pipeline_status_reason=NULL
+
+**Blocker**: All 58 matches have `home_score=NULL` and `away_score=NULL`.
+Training requires known outcomes (labels). Scores must be backfilled before
+these matches can be `is_training_eligible=true`.
+
+Additional conditional blocker: Feature leakage policy and prediction cutoff
+time are not yet defined. Even after scores are backfilled, training eligibility
+remains conditional on these policies.
+
+## 2 No-Raw Excluded Analysis
+
+| match_id | Reason |
+|----------|--------|
+| 140_20252026_4837496 | forbidden_evidence: synthetic_invalid |
+| 47_20242025_900002 | forbidden_evidence: synthetic_invalid |
+
+Both matches are permanently excluded from training.
+
+## Risk Flags
+
+1. All would_set_true rows are conditional on feature leakage policy and cutoff
+   time definition
+2. WARNING: feature leakage policy and prediction cutoff time are NOT yet
+   defined — training eligibility remains conditional
+3. 58 Ligue 1 matches lack scores — score backfill is a prerequisite
+
+## Safety
+
+- No migration
+- No schema change
+- No DB write
+- No backfill
+- No live fetch
+- No raw payload output
+- No parser/training/prediction changes
+
+## Next Step
+
+Do not start automatically.
+Two prerequisites before training eligibility can be set to true:
+1. Score backfill for the 58 Ligue 1 matches
+2. Feature leakage policy and cutoff time definition
+Recommended next task only after user confirmation.

--- a/scripts/ops/training_eligibility_dry_run.js
+++ b/scripts/ops/training_eligibility_dry_run.js
@@ -1,0 +1,334 @@
+/**
+ * training_eligibility_dry_run.js — 训练准入只读预演
+ * ====================================================
+ *
+ * 基于 training_eligibility_policy_design_20260619.md 的 6 条准入规则，
+ * 对当前 matches 表做只读扫描，预演哪些行未来可以设 is_training_eligible=true，
+ * 哪些必须保持 false，以及每条 false 的原因。
+ *
+ * 只输出 dry-run 结果，不写库。
+ *
+ * 使用方式:
+ *   node scripts/ops/training_eligibility_dry_run.js --json
+ *   node scripts/ops/training_eligibility_dry_run.js --json --match-id "53_20252026_4830458"
+ *
+ * lifecycle: one-shot-helper
+ *
+ * @module scripts/ops/training_eligibility_dry_run
+ */
+
+'use strict';
+
+const { getPool } = require('../../config/database');
+
+// ---------------------------------------------------------------------------
+// 常量：训练准入规则定义
+// ---------------------------------------------------------------------------
+
+/** 允许进入训练的 source_type 集合。 */
+const TRAINING_VALID_SOURCE_TYPES = new Set([
+  'fotmob_live_fetch',
+  'fotmob_html_hydration',
+  'fotmob_pageprops',
+]);
+
+/** 允许进入训练的 pipeline_status 集合。 */
+const TRAINING_VALID_PIPELINE_STATUSES = new Set([
+  'harvested',
+  'recon_linked',
+]);
+
+/** 永远禁止进入训练的证据级别。 */
+const TRAINING_FORBIDDEN_EVIDENCE = new Set([
+  'synthetic_invalid',
+  'missing',
+]);
+
+// ---------------------------------------------------------------------------
+// CLI 参数解析
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { json: false, matchId: null };
+  for (let i = 2; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--json':
+        args.json = true;
+        break;
+      case '--match-id':
+        args.matchId = argv[++i];
+        if (!args.matchId) throw new Error('--match-id requires a value');
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// 只读扫描
+// ---------------------------------------------------------------------------
+
+async function scanMatches(pool, args) {
+  const conditions = [];
+  const params = [];
+  let i = 1;
+
+  if (args.matchId) {
+    conditions.push(`match_id = $${i++}`);
+    params.push(args.matchId);
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const sql = `
+    SELECT match_id, league_name, season, status, pipeline_status,
+           home_score, away_score, data_source, external_id,
+           source_type, evidence_level,
+           is_production_scope, is_reconciliation_eligible,
+           is_training_eligible, pipeline_status_reason
+    FROM matches
+    ${where}
+    ORDER BY league_name, season, match_id
+  `;
+
+  const client = await pool.connect();
+  try {
+    return (await client.query(sql, params)).rows;
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 规则评估
+// ---------------------------------------------------------------------------
+
+/**
+ * 评估单场比赛的训练准入资格。
+ *
+ * 按优先级依次检查 6 条规则，返回第一个失败原因。
+ * 全部通过则 eligible=true。
+ *
+ * @param {object} row - matches 行
+ * @returns {{ eligible: boolean, reason: string|null }}
+ */
+function evaluateTrainingEligibility(row) {
+  // Rule 1: Evidence Quality Gate
+  if (!TRAINING_VALID_SOURCE_TYPES.has(row.source_type)) {
+    if (TRAINING_FORBIDDEN_EVIDENCE.has(row.evidence_level)) {
+      return {
+        eligible: false,
+        reason: `forbidden_evidence: ${row.evidence_level || 'missing'}`,
+      };
+    }
+    return {
+      eligible: false,
+      reason: `invalid_source_type: ${row.source_type || 'null'}`,
+    };
+  }
+
+  // Rule 2: Match Completion Gate
+  if (row.status !== 'finished') {
+    return {
+      eligible: false,
+      reason: `match_not_finished: status=${row.status}`,
+    };
+  }
+
+  // Rule 2b: Valid scores required
+  if (row.home_score === null || row.away_score === null) {
+    return {
+      eligible: false,
+      reason: 'no_valid_scores: home_score or away_score is null',
+    };
+  }
+
+  // Rule 3: Feature Leakage — cannot check from DB, noted in summary
+  // (passed if we reach here, but noted as conditional)
+
+  // Rule 4: Production Scope Alignment
+  if (row.is_production_scope !== true) {
+    return {
+      eligible: false,
+      reason: 'non_production_scope',
+    };
+  }
+
+  // Rule 5: Pipeline Completion
+  if (!TRAINING_VALID_PIPELINE_STATUSES.has(
+    (row.pipeline_status || '').toLowerCase()
+  )) {
+    return {
+      eligible: false,
+      reason: `pipeline_not_complete: pipeline_status=${row.pipeline_status}`,
+    };
+  }
+
+  if (row.pipeline_status_reason !== null) {
+    return {
+      eligible: false,
+      reason: `pipeline_blocked: ${row.pipeline_status_reason}`,
+    };
+  }
+
+  // Rule 6: Reconciliation Gate (should be covered by rules 1+2+4+5)
+  if (row.is_reconciliation_eligible !== true) {
+    return {
+      eligible: false,
+      reason: 'not_reconciliation_eligible',
+    };
+  }
+
+  // All rules passed — conditional on leakage policy
+  return {
+    eligible: true,
+    reason: 'all_rules_passed_conditional_on_leakage_policy',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 汇总构建
+// ---------------------------------------------------------------------------
+
+function countDistribution(rows, keyFn) {
+  const dist = {};
+  for (const r of rows) {
+    const k = keyFn(r);
+    dist[k] = (dist[k] || 0) + 1;
+  }
+  return dist;
+}
+
+function buildSummary(rows) {
+  const evaluated = rows.map((row) => ({
+    match_id: row.match_id,
+    league_name: row.league_name,
+    season: row.season,
+    status: row.status,
+    pipeline_status: row.pipeline_status,
+    source_type: row.source_type,
+    evidence_level: row.evidence_level,
+    is_production_scope: row.is_production_scope,
+    is_reconciliation_eligible: row.is_reconciliation_eligible,
+    current_training_eligible: row.is_training_eligible,
+    ...evaluateTrainingEligibility(row),
+  }));
+
+  const wouldSetTrue = evaluated.filter((r) => r.eligible);
+  const wouldKeepFalse = evaluated.filter((r) => !r.eligible);
+  const byReason = countDistribution(wouldKeepFalse, (r) => r.reason);
+
+  // Sample rows
+  const sampleTrue = wouldSetTrue.slice(0, 5).map(formatSampleRow);
+  const sampleFalse = wouldKeepFalse.map(formatSampleRow);
+
+  // Risk flags
+  const riskFlags = [];
+  const syntheticInTraining = wouldSetTrue.filter(
+    (r) => r.source_type === 'synthetic'
+  );
+  if (syntheticInTraining.length > 0) {
+    riskFlags.push(
+      `CRITICAL: ${syntheticInTraining.length} synthetic rows would be training-eligible`
+    );
+  }
+  const notFinishedInTraining = wouldSetTrue.filter(
+    (r) => r.status !== 'finished'
+  );
+  if (notFinishedInTraining.length > 0) {
+    riskFlags.push(
+      `WARNING: ${notFinishedInTraining.length} non-finished rows would be training-eligible`
+    );
+  }
+  riskFlags.push(
+    'NOTE: all would_set_true rows are conditional on feature leakage policy and cutoff time definition'
+  );
+  if (rowHasAnyMissingLeakageSignal(evaluated)) {
+    riskFlags.push(
+      'WARNING: feature leakage policy and prediction cutoff time are NOT yet defined — training eligibility remains conditional'
+    );
+  }
+
+  return {
+    mode: 'dry_run',
+    actual_update_executed: false,
+    script: 'scripts/ops/training_eligibility_dry_run.js',
+    policy_ref: 'docs/_reports/training_eligibility_policy_design_20260619.md',
+    generated_at: new Date().toISOString(),
+    total_matches_scanned: rows.length,
+    current_training_eligible_true: rows.filter((r) => r.is_training_eligible === true).length,
+    current_training_eligible_false: rows.filter((r) => r.is_training_eligible === false).length,
+    would_set_true_count: wouldSetTrue.length,
+    would_keep_false_count: wouldKeepFalse.length,
+    by_reason: byReason,
+    sample_true: sampleTrue,
+    sample_false: sampleFalse,
+    risk_flags: riskFlags,
+    ligue1_candidates: wouldSetTrue.filter(
+      (r) => r.league_name === 'Ligue 1' && r.season === '2025/2026'
+    ).length,
+    no_raw_excluded_false: wouldKeepFalse
+      .filter((r) => r.source_type === 'synthetic')
+      .map((r) => ({
+        match_id: r.match_id,
+        league_name: r.league_name,
+        season: r.season,
+        reason: r.reason,
+      })),
+  };
+}
+
+function rowHasAnyMissingLeakageSignal(evaluated) {
+  // If any row would be set true, leakage policy is needed
+  return evaluated.some((r) => r.eligible);
+}
+
+function formatSampleRow(r) {
+  return {
+    match_id: r.match_id,
+    league_name: r.league_name,
+    season: r.season,
+    status: r.status,
+    source_type: r.source_type,
+    evidence_level: r.evidence_level,
+    is_production_scope: r.is_production_scope,
+    is_reconciliation_eligible: r.is_reconciliation_eligible,
+    current_training_eligible: r.current_training_eligible,
+    would_set_true: r.eligible,
+    reason: r.reason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 主流程
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const pool = getPool();
+
+  const rows = await scanMatches(pool, args);
+  const summary = buildSummary(rows);
+
+  console.log(JSON.stringify(summary, null, 2));
+  await pool.end();
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Training eligibility dry-run failed:', err.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  parseArgs,
+  scanMatches,
+  evaluateTrainingEligibility,
+  buildSummary,
+  TRAINING_VALID_SOURCE_TYPES,
+  TRAINING_VALID_PIPELINE_STATUSES,
+  TRAINING_FORBIDDEN_EVIDENCE,
+};

--- a/tests/unit/training_eligibility_dry_run.test.js
+++ b/tests/unit/training_eligibility_dry_run.test.js
@@ -1,0 +1,339 @@
+/**
+ * training_eligibility_dry_run.test.js — 训练准入 dry-run 单元测试
+ * ================================================================
+ *
+ * 验证：
+ *   1. evaluateTrainingEligibility 各规则路径
+ *   2. buildSummary 正确统计
+ *   3. 禁止进训练的类型
+ *   4. 输出不包含 raw payload
+ *   5. actual_update_executed=false
+ */
+
+'use strict';
+
+const assert = require('assert');
+const {
+  parseArgs,
+  evaluateTrainingEligibility,
+  buildSummary,
+  TRAINING_VALID_SOURCE_TYPES,
+  TRAINING_VALID_PIPELINE_STATUSES,
+  TRAINING_FORBIDDEN_EVIDENCE,
+} = require('../../scripts/ops/training_eligibility_dry_run');
+
+let testsRun = 0;
+let testsPassed = 0;
+
+function test(name, fn) {
+  testsRun++;
+  try {
+    fn();
+    testsPassed++;
+  } catch (e) {
+    console.error(`\n  FAIL [${name}]: ${e.message}`);
+    throw e;
+  }
+}
+
+// =========================================================================
+// 1. parseArgs
+// =========================================================================
+
+test('parseArgs --json', () => {
+  const args = parseArgs(['node', 'script.js', '--json']);
+  assert.strictEqual(args.json, true);
+  assert.strictEqual(args.matchId, null);
+});
+
+test('parseArgs --match-id', () => {
+  const args = parseArgs(['node', 'script.js', '--json', '--match-id', '53_20252026_4830458']);
+  assert.strictEqual(args.matchId, '53_20252026_4830458');
+});
+
+test('parseArgs defaults', () => {
+  const args = parseArgs(['node', 'script.js']);
+  assert.strictEqual(args.json, false);
+  assert.strictEqual(args.matchId, null);
+});
+
+// =========================================================================
+// 2. Constants
+// =========================================================================
+
+test('TRAINING_VALID_SOURCE_TYPES includes fotmob sources', () => {
+  assert.ok(TRAINING_VALID_SOURCE_TYPES.has('fotmob_live_fetch'));
+  assert.ok(TRAINING_VALID_SOURCE_TYPES.has('fotmob_html_hydration'));
+  assert.ok(TRAINING_VALID_SOURCE_TYPES.has('fotmob_pageprops'));
+});
+
+test('TRAINING_VALID_SOURCE_TYPES excludes synthetic', () => {
+  assert.ok(!TRAINING_VALID_SOURCE_TYPES.has('synthetic'));
+  assert.ok(!TRAINING_VALID_SOURCE_TYPES.has('manual_seed'));
+  assert.ok(!TRAINING_VALID_SOURCE_TYPES.has('local_csv'));
+  assert.ok(!TRAINING_VALID_SOURCE_TYPES.has('unknown'));
+});
+
+test('TRAINING_FORBIDDEN_EVIDENCE includes synthetic_invalid and missing', () => {
+  assert.ok(TRAINING_FORBIDDEN_EVIDENCE.has('synthetic_invalid'));
+  assert.ok(TRAINING_FORBIDDEN_EVIDENCE.has('missing'));
+});
+
+// =========================================================================
+// 3. evaluateTrainingEligibility — PASS cases
+// =========================================================================
+
+const LIGUE1_ROW = {
+  match_id: '53_20252026_4830458',
+  league_name: 'Ligue 1',
+  season: '2025/2026',
+  status: 'finished',
+  pipeline_status: 'harvested',
+  home_score: 2,
+  away_score: 1,
+  source_type: 'fotmob_live_fetch',
+  evidence_level: 'strong',
+  is_production_scope: true,
+  is_reconciliation_eligible: true,
+  pipeline_status_reason: null,
+};
+
+test('Ligue 1 finished + fotmob_live_fetch → eligible (conditional)', () => {
+  const result = evaluateTrainingEligibility(LIGUE1_ROW);
+  assert.strictEqual(result.eligible, true);
+  assert.ok(result.reason.includes('all_rules_passed'));
+});
+
+// =========================================================================
+// 4. evaluateTrainingEligibility — FAIL cases by rule
+// =========================================================================
+
+test('Rule 1: synthetic source_type → forbidden_evidence', () => {
+  const row = { ...LIGUE1_ROW, source_type: 'synthetic', evidence_level: 'synthetic_invalid' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('forbidden_evidence'));
+});
+
+test('Rule 1: unknown source_type → invalid_source_type', () => {
+  const row = { ...LIGUE1_ROW, source_type: 'unknown', evidence_level: 'missing' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('forbidden_evidence'));
+});
+
+test('Rule 1: manual_seed source_type → invalid_source_type', () => {
+  const row = { ...LIGUE1_ROW, source_type: 'manual_seed', evidence_level: 'weak' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('invalid_source_type'));
+});
+
+test('Rule 1: local_csv source_type → invalid_source_type', () => {
+  const row = { ...LIGUE1_ROW, source_type: 'local_csv', evidence_level: 'weak' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('invalid_source_type'));
+});
+
+test('Rule 2: scheduled match → match_not_finished', () => {
+  const row = { ...LIGUE1_ROW, status: 'scheduled' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('match_not_finished'));
+});
+
+test('Rule 2b: finished but no scores → no_valid_scores', () => {
+  const row = { ...LIGUE1_ROW, home_score: null, away_score: null };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('no_valid_scores'));
+});
+
+test('Rule 2b: finished but only home_score missing → no_valid_scores', () => {
+  const row = { ...LIGUE1_ROW, home_score: null, away_score: 2 };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('no_valid_scores'));
+});
+
+test('Rule 4: non-production scope → non_production_scope', () => {
+  const row = { ...LIGUE1_ROW, is_production_scope: false };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('non_production_scope'));
+});
+
+test('Rule 5: pipeline_status=failed → pipeline_not_complete', () => {
+  const row = { ...LIGUE1_ROW, pipeline_status: 'failed' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('pipeline_not_complete'));
+});
+
+test('Rule 5: pipeline_status=pending → pipeline_not_complete', () => {
+  const row = { ...LIGUE1_ROW, pipeline_status: 'pending' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('pipeline_not_complete'));
+});
+
+test('Rule 5: pipeline_status_reason not null → pipeline_blocked', () => {
+  const row = { ...LIGUE1_ROW, pipeline_status_reason: 'synthetic_raw_not_valid' };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('pipeline_blocked'));
+});
+
+test('Rule 6: not reconciliation_eligible → not_reconciliation_eligible', () => {
+  const row = { ...LIGUE1_ROW, is_reconciliation_eligible: false };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('not_reconciliation_eligible'));
+});
+
+// =========================================================================
+// 5. evaluateTrainingEligibility — Priority order
+// =========================================================================
+
+test('Priority: evidence gate checked before match completion', () => {
+  // synthetic + scheduled → should report forbidden_evidence, not match_not_finished
+  const row = {
+    ...LIGUE1_ROW,
+    source_type: 'synthetic',
+    evidence_level: 'synthetic_invalid',
+    status: 'scheduled',
+  };
+  const result = evaluateTrainingEligibility(row);
+  assert.strictEqual(result.eligible, false);
+  assert.ok(result.reason.includes('forbidden_evidence'));
+});
+
+// =========================================================================
+// 6. buildSummary
+// =========================================================================
+
+function makeRow(overrides = {}) {
+  return {
+    match_id: 'test_001',
+    league_name: 'Ligue 1',
+    season: '2025/2026',
+    status: 'finished',
+    pipeline_status: 'harvested',
+    home_score: 2,
+    away_score: 1,
+    source_type: 'fotmob_live_fetch',
+    evidence_level: 'strong',
+    is_production_scope: true,
+    is_reconciliation_eligible: true,
+    is_training_eligible: false,
+    pipeline_status_reason: null,
+    ...overrides,
+  };
+}
+
+test('buildSummary — correct totals for all-eligible set', () => {
+  const rows = [
+    makeRow({ match_id: 'm1' }),
+    makeRow({ match_id: 'm2' }),
+    makeRow({ match_id: 'm3' }),
+  ];
+  const summary = buildSummary(rows);
+  assert.strictEqual(summary.total_matches_scanned, 3);
+  assert.strictEqual(summary.would_set_true_count, 3);
+  assert.strictEqual(summary.would_keep_false_count, 0);
+  assert.strictEqual(summary.current_training_eligible_true, 0);
+  assert.strictEqual(summary.current_training_eligible_false, 3);
+});
+
+test('buildSummary — mixed eligible and ineligible', () => {
+  const rows = [
+    makeRow({ match_id: 'm1' }),
+    makeRow({ match_id: 'm2', source_type: 'synthetic', evidence_level: 'synthetic_invalid' }),
+    makeRow({ match_id: 'm3', status: 'scheduled' }),
+  ];
+  const summary = buildSummary(rows);
+  assert.strictEqual(summary.would_set_true_count, 1);
+  assert.strictEqual(summary.would_keep_false_count, 2);
+  assert.ok(summary.by_reason['forbidden_evidence: synthetic_invalid']);
+  assert.ok(summary.by_reason['match_not_finished: status=scheduled']);
+});
+
+test('buildSummary — by_reason aggregation', () => {
+  const rows = [
+    makeRow({ match_id: 'm1' }),
+    makeRow({ match_id: 'm2', source_type: 'synthetic', evidence_level: 'synthetic_invalid' }),
+    makeRow({ match_id: 'm3', source_type: 'synthetic', evidence_level: 'synthetic_invalid' }),
+    makeRow({ match_id: 'm4', status: 'scheduled' }),
+  ];
+  const summary = buildSummary(rows);
+  assert.strictEqual(summary.by_reason['forbidden_evidence: synthetic_invalid'], 2);
+  assert.strictEqual(summary.by_reason['match_not_finished: status=scheduled'], 1);
+});
+
+test('buildSummary — mode and actual_update_executed', () => {
+  const summary = buildSummary([makeRow()]);
+  assert.strictEqual(summary.mode, 'dry_run');
+  assert.strictEqual(summary.actual_update_executed, false);
+});
+
+test('buildSummary — risk flags include leakage policy note', () => {
+  const summary = buildSummary([makeRow()]);
+  const leakageNote = summary.risk_flags.find((f) => f.includes('leakage policy'));
+  assert.ok(leakageNote, 'should note leakage policy is conditional');
+});
+
+test('buildSummary — no_raw_excluded_false captures synthetic rows', () => {
+  const rows = [
+    makeRow({ match_id: '53_xxx' }),
+    makeRow({
+      match_id: '140_20252026_4837496',
+      league_name: 'Segunda División',
+      season: '2025/2026',
+      status: 'scheduled',
+      source_type: 'synthetic',
+      evidence_level: 'synthetic_invalid',
+      is_production_scope: false,
+      is_reconciliation_eligible: false,
+      home_score: null,
+      away_score: null,
+    }),
+    makeRow({
+      match_id: '47_20242025_900002',
+      league_name: 'Segunda',
+      season: '2024/2025',
+      status: 'finished',
+      source_type: 'synthetic',
+      evidence_level: 'synthetic_invalid',
+      is_production_scope: false,
+      is_reconciliation_eligible: false,
+      pipeline_status_reason: 'synthetic_raw_not_valid',
+    }),
+  ];
+  const summary = buildSummary(rows);
+  assert.strictEqual(summary.no_raw_excluded_false.length, 2);
+  assert.strictEqual(summary.would_keep_false_count, 2);
+});
+
+// =========================================================================
+// 7. Output safety
+// =========================================================================
+
+test('buildSummary output contains no raw_data or raw payload', () => {
+  const summary = buildSummary([makeRow()]);
+  const str = JSON.stringify(summary);
+  assert.ok(!str.includes('raw_data'));
+  assert.ok(!str.includes('raw_payload'));
+  assert.ok(!str.includes('pageProps'));
+  assert.ok(!str.includes('__NEXT_DATA__'));
+});
+
+// =========================================================================
+// 报告
+// =========================================================================
+
+console.log(`\n=== Training Eligibility Dry-Run Unit Tests: ${testsPassed}/${testsRun} passed ===`);
+if (testsPassed < testsRun) {
+  console.error(`FAILED: ${testsRun - testsPassed} test(s) failed`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Read-only training eligibility dry-run that evaluates all 60 matches against the
6-rule training eligibility policy from docs/_reports/training_eligibility_policy_design_20260619.md.
Computes would_set_true_count and would_keep_false_count with per-row reasons.
No DB write, no backfill, no code changes beyond the dry-run script and tests.

## Scope

- New script: scripts/ops/training_eligibility_dry_run.js (one-shot-helper)
- New test: tests/unit/training_eligibility_dry_run.test.js (27 tests)
- New report: docs/_reports/training_eligibility_dry_run_20260619.md
- SELECT-only queries on matches table
- No migration, no schema change, no DB write
- No backfill, no live fetch, no raw payload output

## Documentation Impact

One phase-artifact report added (81 lines) documenting the dry-run results.
Key finding: 58 Ligue 1 matches have no scores and 2 synthetic matches are
permanently excluded, resulting in would_set_true_count=0.

## Safety Impact

Zero. Read-only dry-run with SELECT-only queries. No DB writes, no network
access, no schema changes. actual_update_executed=false is hardcoded.

## Validation

- tests/unit/MatchLabelingGovernance.test.js: 53/53 passed
- tests/unit/matches_labeling_backfill_dry_run.test.js: 37/37 passed
- tests/unit/training_eligibility_dry_run.test.js: 27/27 passed
- git diff --check: clean
- Dry-run executed and verified:
  - total_matches_scanned=60
  - would_set_true_count=0 (58 no scores, 2 synthetic_invalid)
  - would_keep_false_count=60
  - 2 no-raw excluded correctly flagged as forbidden_evidence
  - actual_update_executed=false

## CI Gate Scope

Standard Production Gate: AI Workflow Gate (P0), Run Gatekeeper, Docker Build
Validation.

## No deletion / no move / no rename confirmation

This PR creates 3 new files. No existing files are deleted, moved, or renamed.

## Rollback Plan

This is a read-only dry-run that adds a script, tests, and report. No data was
written. Rollback consists of reverting the merge commit.

## Next Recommended Task

Do not start automatically.
Recommended next task only after user confirmation.