### PR TITLE
feat(data): add score backfill dry-run

### DIFF
--- a/docs/_reports/score_backfill_dry_run_20260619.md
+++ b/docs/_reports/score_backfill_dry_run_20260619.md
@@ -1,0 +1,101 @@
+# Score Backfill Dry-Run
+- lifecycle: phase-artifact
+- scope: read-only score/result backfill preflight only
+- date: 2026-06-19
+- branch: `data/score-backfill-dry-run`
+
+## 结论
+这是 dry-run，不是真实写库。本次新增 `scripts/ops/score_backfill_dry_run.js` 和对应单测，只做只读 SQL 扫描、比分/赛果投影预演和报告整理；没有 migration、schema change、DB write、backfill、live fetch、raw payload 输出，也没有修改 `matches` 或 `raw_match_data`。
+
+结论是：`Ligue 1 / 2025/2026` 的 58 条目标行都满足 score backfill write 前置条件。dry-run 结果为 `would_update_count=58`、`would_skip_count=2`，2 条 no-raw 非目标行继续跳过。
+
+## 当前 `matches` 缺失情况
+`matches` 中与本次范围直接相关的字段只有 `home_score`、`away_score`、`actual_result`。
+
+| 指标 | 数值 |
+| --- | ---: |
+| `matches` 总行数 | 60 |
+| `Ligue 1 / 2025/2026` 目标行 | 58 |
+| 目标行 `home_score` 非空 | 0 |
+| 目标行 `away_score` 非空 | 0 |
+| 目标行 `actual_result` 非空 | 0 |
+| dry-run `would_update_count` | 58 |
+| dry-run `would_skip_count` | 2 |
+
+## Dry-Run 规则
+来源路径只使用：
+1. `raw_data.header.teams[0].score` -> `proposed_home_score`
+2. `raw_data.header.teams[1].score` -> `proposed_away_score`
+3. `raw_data.header.status.scoreStr` -> 一致性交叉校验
+
+目标 58 条必须同时满足：
+- `league_name='Ligue 1'`，`season='2025/2026'`
+- `status='finished'`
+- `pipeline_status='harvested'`
+- `source_type='fotmob_live_fetch'`
+- `evidence_level='strong'`
+- `raw_match_data.data_version='fotmob_live_v1'`
+- 每场恰好 1 条 `fotmob_live_v1`
+- `scoreStr` 可用
+- `teams[0].score / teams[1].score` 可用
+- `scoreStr` 与 `teams score` 一致
+- 当前 `home_score / away_score / actual_result` 全空
+
+## `actual_result` 编码选择
+本次 dry-run 的写入建议编码固定为 `home_win / draw / away_win`，不使用 `H/D/A` 作为 proposed write value。
+
+理由：
+1. 当前库中唯一非空 `matches.actual_result` 样本就是 `home_win`
+2. 现有仓库测试与特征代码已经使用 `home_win / draw / away_win`
+3. dry-run 目标是预演未来写入值，应优先对齐仓库现有枚举格式
+
+`H/D/A` 只保留为辅助统计，不作为写入建议。
+
+## 预演结果
+58 条目标行验证摘要：
+
+| 校验项 | 通过数 |
+| --- | ---: |
+| `status='finished'` | 58 |
+| `pipeline_status='harvested'` | 58 |
+| `source_type='fotmob_live_fetch'` | 58 |
+| `evidence_level='strong'` | 58 |
+| 当前 score/result 三字段全空 | 58 |
+| `fotmob_live_v1` 单条 raw | 58 |
+| `raw_data_version='fotmob_live_v1'` | 58 |
+| `scoreStr` 可用 | 58 |
+| `teams score` 可用 | 58 |
+| `scoreStr` 与 `teams score` 一致 | 58 |
+| proposed score 非空 | 58 |
+| proposed `actual_result` 合法 | 58 |
+
+赛果分布：
+| 编码 | 数量 |
+| --- | ---: |
+| `home_win` | 23 |
+| `draw` | 17 |
+| `away_win` | 18 |
+
+辅助统计：`H=23`、`D=17`、`A=18`。
+
+一致性结论：`scoreStr` 与 `teams[0/1].score` 在 `58/58` 上一致，`mismatch_count=0`。
+
+## 异常 / 跳过
+继续跳过的 2 条 no-raw excluded：
+
+| `match_id` | 原因摘要 |
+| --- | --- |
+| `47_20242025_900002` | 非目标联赛/赛季，`pipeline_status` 非 `harvested`，无 `fotmob_live_v1` raw，且当前已有 synthetic score/result |
+| `140_20252026_4837496` | 非目标状态（`scheduled`），非目标联赛，`pipeline_status` 非 `harvested`，无 `fotmob_live_v1` raw |
+
+本次 dry-run 未发现目标 58 条中的 raw 缺失、重复 raw、比分不一致或 proposed result 非法值。
+
+## 是否可进入真实 Score Backfill Write
+从只读 preflight 结果看，可以进入单独的真实 score backfill write 授权阶段。
+
+前提仍然成立：
+1. 本次只是 dry-run，不是真实写库
+2. 真实 write 必须由用户再次明确授权
+3. 后续 write 仍需保持 no migration / no schema change / no live fetch / no raw payload output
+
+下一步必须用户明确确认；本报告不构成真实 backfill 执行授权。

--- a/scripts/ops/score_backfill_dry_run.js
+++ b/scripts/ops/score_backfill_dry_run.js
@@ -305,78 +305,62 @@ function isAllCurrentScoreFieldsNull(row) {
     return row.home_score === null && row.away_score === null && normalizeOptionalText(row.actual_result) === null;
 }
 
-function classifyScannedMatch(row) {
-    const rawScoreFromTeams = {
-        home: toIntegerOrNull(row.raw_home_score_text),
-        away: toIntegerOrNull(row.raw_away_score_text),
-    };
-    const rawScoreFromScoreStr = parseScoreStr(row.raw_score_str);
-    const proposedHomeScore = rawScoreFromTeams.home;
-    const proposedAwayScore = rawScoreFromTeams.away;
-    const proposedActualResult = deriveActualResult(proposedHomeScore, proposedAwayScore);
-    const targetScope = isTargetScope(row);
-    const validations = {
-        target_scope: targetScope,
+function buildMatchValidations(row, derived) {
+    const teamScoresAvailable =
+        Number.isInteger(derived.proposedHomeScore) &&
+        Number.isInteger(derived.proposedAwayScore);
+
+    return {
+        target_scope: derived.targetScope,
         status_finished: String(row.status || '').trim().toLowerCase() === 'finished',
         pipeline_status_harvested: String(row.pipeline_status || '').trim().toLowerCase() === 'harvested',
         source_type_fotmob_live_fetch: row.source_type === TARGET_SOURCE_TYPE,
         evidence_level_strong: row.evidence_level === TARGET_EVIDENCE_LEVEL,
         current_score_fields_null: isAllCurrentScoreFieldsNull(row),
-        raw_single: toIntegerOrNull(row.fotmob_live_v1_count) === 1,
+        raw_single: derived.fotmobLiveV1Count === 1,
         raw_data_version_fotmob_live_v1: row.fotmob_live_v1_data_version === TARGET_DATA_VERSION,
-        raw_score_str_available: rawScoreFromScoreStr !== null,
-        raw_team_scores_available:
-            Number.isInteger(proposedHomeScore) &&
-            Number.isInteger(proposedAwayScore),
+        raw_score_str_available: derived.rawScoreFromScoreStr !== null,
+        raw_team_scores_available: teamScoresAvailable,
         score_str_matches_team_scores:
-            rawScoreFromScoreStr !== null &&
-            Number.isInteger(proposedHomeScore) &&
-            Number.isInteger(proposedAwayScore) &&
-            rawScoreFromScoreStr.home === proposedHomeScore &&
-            rawScoreFromScoreStr.away === proposedAwayScore,
-        proposed_scores_non_null:
-            Number.isInteger(proposedHomeScore) &&
-            Number.isInteger(proposedAwayScore),
-        proposed_actual_result_valid: VALID_ACTUAL_RESULTS.has(proposedActualResult),
+            derived.rawScoreFromScoreStr !== null &&
+            teamScoresAvailable &&
+            derived.rawScoreFromScoreStr.home === derived.proposedHomeScore &&
+            derived.rawScoreFromScoreStr.away === derived.proposedAwayScore,
+        proposed_scores_non_null: teamScoresAvailable,
+        proposed_actual_result_valid: VALID_ACTUAL_RESULTS.has(derived.proposedActualResult),
     };
+}
 
-    const wouldUpdate = Object.values(validations).every(Boolean);
+function buildSkipReasons(validations, fotmobLiveV1Count) {
     const skipReasons = [];
 
-    if (!validations.target_scope) {
-        skipReasons.push('excluded_non_target_scope');
+    const simpleFailures = [
+        ['target_scope', 'excluded_non_target_scope'],
+        ['status_finished', 'status_not_finished'],
+        ['pipeline_status_harvested', 'pipeline_status_not_harvested'],
+        ['source_type_fotmob_live_fetch', 'source_type_not_fotmob_live_fetch'],
+        ['evidence_level_strong', 'evidence_level_not_strong'],
+        ['current_score_fields_null', 'current_scores_already_present'],
+        ['raw_data_version_fotmob_live_v1', 'raw_data_version_not_fotmob_live_v1'],
+        ['raw_score_str_available', 'raw_score_str_unavailable'],
+        ['raw_team_scores_available', 'raw_team_scores_unavailable'],
+        ['proposed_actual_result_valid', 'proposed_actual_result_invalid'],
+    ];
+
+    for (const [validationKey, reason] of simpleFailures) {
+        if (!validations[validationKey]) {
+            skipReasons.push(reason);
+        }
     }
-    if (!validations.status_finished) {
-        skipReasons.push('status_not_finished');
-    }
-    if (!validations.pipeline_status_harvested) {
-        skipReasons.push('pipeline_status_not_harvested');
-    }
-    if (!validations.source_type_fotmob_live_fetch) {
-        skipReasons.push('source_type_not_fotmob_live_fetch');
-    }
-    if (!validations.evidence_level_strong) {
-        skipReasons.push('evidence_level_not_strong');
-    }
-    if (!validations.current_score_fields_null) {
-        skipReasons.push('current_scores_already_present');
-    }
+
     if (!validations.raw_single) {
         skipReasons.push(
-            toIntegerOrNull(row.fotmob_live_v1_count) === 0
+            fotmobLiveV1Count === 0
                 ? 'missing_fotmob_live_v1_raw'
                 : 'unexpected_fotmob_live_v1_row_count'
         );
     }
-    if (!validations.raw_data_version_fotmob_live_v1) {
-        skipReasons.push('raw_data_version_not_fotmob_live_v1');
-    }
-    if (!validations.raw_score_str_available) {
-        skipReasons.push('raw_score_str_unavailable');
-    }
-    if (!validations.raw_team_scores_available) {
-        skipReasons.push('raw_team_scores_unavailable');
-    }
+
     if (
         validations.raw_score_str_available &&
         validations.raw_team_scores_available &&
@@ -384,9 +368,29 @@ function classifyScannedMatch(row) {
     ) {
         skipReasons.push('score_str_mismatch');
     }
-    if (!validations.proposed_actual_result_valid) {
-        skipReasons.push('proposed_actual_result_invalid');
-    }
+
+    return skipReasons;
+}
+
+function classifyScannedMatch(row) {
+    const rawScoreFromTeams = {
+        home: toIntegerOrNull(row.raw_home_score_text),
+        away: toIntegerOrNull(row.raw_away_score_text),
+    };
+    const proposedHomeScore = rawScoreFromTeams.home;
+    const proposedAwayScore = rawScoreFromTeams.away;
+    const proposedActualResult = deriveActualResult(proposedHomeScore, proposedAwayScore);
+    const derived = {
+        fotmobLiveV1Count: toIntegerOrNull(row.fotmob_live_v1_count) || 0,
+        rawScoreFromScoreStr: parseScoreStr(row.raw_score_str),
+        proposedHomeScore,
+        proposedAwayScore,
+        proposedActualResult,
+        targetScope: isTargetScope(row),
+    };
+    const validations = buildMatchValidations(row, derived);
+    const wouldUpdate = Object.values(validations).every(Boolean);
+    const skipReasons = buildSkipReasons(validations, derived.fotmobLiveV1Count);
 
     return {
         match_id: row.match_id,
@@ -400,11 +404,11 @@ function classifyScannedMatch(row) {
         current_home_score: row.home_score,
         current_away_score: row.away_score,
         current_actual_result: normalizeOptionalText(row.actual_result),
-        fotmob_live_v1_count: toIntegerOrNull(row.fotmob_live_v1_count) || 0,
+        fotmob_live_v1_count: derived.fotmobLiveV1Count,
         raw_data_version: normalizeOptionalText(row.fotmob_live_v1_data_version),
         raw_score_str_available: validations.raw_score_str_available,
         raw_team_scores_available: validations.raw_team_scores_available,
-        target_scope: targetScope,
+        target_scope: derived.targetScope,
         proposed_home_score: proposedHomeScore,
         proposed_away_score: proposedAwayScore,
         proposed_actual_result: proposedActualResult,

--- a/scripts/ops/score_backfill_dry_run.js
+++ b/scripts/ops/score_backfill_dry_run.js
@@ -1,0 +1,735 @@
+#!/usr/bin/env node
+'use strict';
+
+// lifecycle: permanent
+// scope: read-only score/result backfill dry-run for Ligue 1 2025/2026 only
+
+const PHASE = 'SCORE_BACKFILL_DRY_RUN';
+const CONTRACT_CARRIER = 'matches.home_score + matches.away_score + matches.actual_result';
+const TARGET_LEAGUE = 'Ligue 1';
+const TARGET_SEASON = '2025/2026';
+const TARGET_SOURCE_TYPE = 'fotmob_live_fetch';
+const TARGET_EVIDENCE_LEVEL = 'strong';
+const TARGET_DATA_VERSION = 'fotmob_live_v1';
+const DEFAULT_SAMPLE_LIMIT = 5;
+const MAX_SAMPLE_LIMIT = 10;
+const READ_ONLY_BEGIN_SQL = 'BEGIN READ ONLY';
+const READ_ONLY_ROLLBACK_SQL = 'ROLLBACK';
+const VALID_ACTUAL_RESULTS = new Set(['home_win', 'draw', 'away_win']);
+const HDA_BY_RESULT = Object.freeze({
+    home_win: 'H',
+    draw: 'D',
+    away_win: 'A',
+});
+
+const SCAN_SQL = `
+WITH fotmob_live_raw AS (
+    SELECT
+        rd.match_id,
+        COUNT(*) FILTER (WHERE rd.data_version = 'fotmob_live_v1') AS fotmob_live_v1_count,
+        MAX(CASE WHEN rd.data_version = 'fotmob_live_v1' THEN rd.data_version END) AS fotmob_live_v1_data_version,
+        MAX(CASE WHEN rd.data_version = 'fotmob_live_v1' THEN rd.raw_data #>> '{header,status,scoreStr}' END) AS raw_score_str,
+        MAX(CASE WHEN rd.data_version = 'fotmob_live_v1' THEN rd.raw_data #>> '{header,teams,0,score}' END) AS raw_home_score_text,
+        MAX(CASE WHEN rd.data_version = 'fotmob_live_v1' THEN rd.raw_data #>> '{header,teams,1,score}' END) AS raw_away_score_text
+    FROM raw_match_data rd
+    GROUP BY rd.match_id
+)
+SELECT
+    m.match_id,
+    m.external_id,
+    m.league_name,
+    m.season,
+    m.status,
+    m.pipeline_status,
+    m.source_type,
+    m.evidence_level,
+    m.home_score,
+    m.away_score,
+    m.actual_result,
+    COALESCE(fr.fotmob_live_v1_count, 0) AS fotmob_live_v1_count,
+    fr.fotmob_live_v1_data_version,
+    fr.raw_score_str,
+    fr.raw_home_score_text,
+    fr.raw_away_score_text
+FROM matches m
+LEFT JOIN fotmob_live_raw fr
+  ON fr.match_id = m.match_id
+ORDER BY
+    CASE
+        WHEN m.league_name = $1
+         AND m.season = $2
+        THEN 0
+        ELSE 1
+    END,
+    m.league_name ASC,
+    m.season ASC,
+    m.match_id ASC
+`;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/score_backfill_dry_run.js [--json] [--sample-limit 5]',
+        '',
+        'Safety:',
+        '  Dry-run only. No migration, no schema change, no DB write, no backfill,',
+        '  no live fetch, no raw payload output.',
+    ].join('\n');
+}
+
+function parseOptionValue(arg, argv, index) {
+    if (arg.includes('=')) {
+        return {
+            value: arg.slice(arg.indexOf('=') + 1),
+            consumedNext: false,
+        };
+    }
+
+    const nextArg = argv[index + 1];
+    if (typeof nextArg === 'string' && !nextArg.startsWith('--')) {
+        return {
+            value: nextArg,
+            consumedNext: true,
+        };
+    }
+
+    return {
+        value: true,
+        consumedNext: false,
+    };
+}
+
+function parseIntegerOption(value, fallback = null) {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    const normalized = String(value).trim();
+    if (!/^\d+$/.test(normalized)) {
+        return Number.NaN;
+    }
+
+    return Number.parseInt(normalized, 10);
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {
+        json: false,
+        help: false,
+        sampleLimit: DEFAULT_SAMPLE_LIMIT,
+    };
+
+    const keyMap = {
+        json: 'json',
+        help: 'help',
+        h: 'help',
+        'sample-limit': 'sampleLimit',
+        sample_limit: 'sampleLimit',
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (!arg.startsWith('--')) {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+
+        const rawKey = arg.replace(/^--/, '').split('=')[0];
+        const optionKey = keyMap[rawKey];
+        if (!optionKey) {
+            throw new Error(`Unknown option: --${rawKey}`);
+        }
+
+        const { value, consumedNext } = parseOptionValue(arg, argv, index);
+        if (consumedNext) {
+            index += 1;
+        }
+
+        if (optionKey === 'json' || optionKey === 'help') {
+            options[optionKey] = true;
+            continue;
+        }
+
+        options[optionKey] = typeof value === 'boolean' ? String(value) : String(value).trim();
+    }
+
+    const parsedSampleLimit = parseIntegerOption(options.sampleLimit, DEFAULT_SAMPLE_LIMIT);
+    if (!Number.isInteger(parsedSampleLimit) || parsedSampleLimit <= 0) {
+        throw new Error(`Invalid --sample-limit value: ${options.sampleLimit}`);
+    }
+
+    options.sampleLimit = Math.min(parsedSampleLimit, MAX_SAMPLE_LIMIT);
+    return options;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+function createPool(dependencies = {}) {
+    if (dependencies.pool) {
+        return dependencies.pool;
+    }
+
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+async function openReadOnlyClient(dependencies = {}) {
+    if (dependencies.client) {
+        return {
+            client: dependencies.client,
+            close: async () => {},
+        };
+    }
+
+    const pool = createPool(dependencies);
+    const ownsPool = !dependencies.pool;
+
+    if (typeof pool.connect === 'function') {
+        const client = await pool.connect();
+        return {
+            client,
+            close: async () => {
+                if (typeof client.release === 'function') {
+                    client.release();
+                }
+                if (ownsPool && typeof pool.end === 'function') {
+                    await pool.end();
+                }
+            },
+        };
+    }
+
+    return {
+        client: pool,
+        close: async () => {
+            if (ownsPool && typeof pool.end === 'function') {
+                await pool.end();
+            }
+        },
+    };
+}
+
+function assertSelectOnlySql(sql) {
+    const normalized = String(sql || '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toUpperCase();
+
+    const allowed =
+        normalized === READ_ONLY_BEGIN_SQL ||
+        normalized === READ_ONLY_ROLLBACK_SQL ||
+        normalized.startsWith('SELECT ') ||
+        normalized.startsWith('WITH ');
+
+    if (!allowed) {
+        throw new Error(`Unsafe SQL rejected by ${PHASE}: ${normalized.slice(0, 80)}`);
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+function toIntegerOrNull(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        return value;
+    }
+
+    const normalized = String(value).trim();
+    if (!/^-?\d+$/.test(normalized)) {
+        return null;
+    }
+
+    return Number.parseInt(normalized, 10);
+}
+
+function normalizeOptionalText(value) {
+    const normalized = String(value ?? '').trim();
+    return normalized ? normalized : null;
+}
+
+function parseScoreStr(scoreStr) {
+    const normalized = normalizeOptionalText(scoreStr);
+    if (!normalized) {
+        return null;
+    }
+
+    const match = normalized.match(/(\d+)\s*[-:–]\s*(\d+)/);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        home: Number.parseInt(match[1], 10),
+        away: Number.parseInt(match[2], 10),
+    };
+}
+
+function deriveActualResult(homeScore, awayScore) {
+    if (!Number.isInteger(homeScore) || !Number.isInteger(awayScore)) {
+        return null;
+    }
+    if (homeScore > awayScore) {
+        return 'home_win';
+    }
+    if (homeScore < awayScore) {
+        return 'away_win';
+    }
+    return 'draw';
+}
+
+function mapActualResultToHda(actualResult) {
+    return HDA_BY_RESULT[actualResult] || null;
+}
+
+function isTargetScope(row) {
+    return row.league_name === TARGET_LEAGUE && row.season === TARGET_SEASON;
+}
+
+function isAllCurrentScoreFieldsNull(row) {
+    return row.home_score === null && row.away_score === null && normalizeOptionalText(row.actual_result) === null;
+}
+
+function classifyScannedMatch(row) {
+    const rawScoreFromTeams = {
+        home: toIntegerOrNull(row.raw_home_score_text),
+        away: toIntegerOrNull(row.raw_away_score_text),
+    };
+    const rawScoreFromScoreStr = parseScoreStr(row.raw_score_str);
+    const proposedHomeScore = rawScoreFromTeams.home;
+    const proposedAwayScore = rawScoreFromTeams.away;
+    const proposedActualResult = deriveActualResult(proposedHomeScore, proposedAwayScore);
+    const targetScope = isTargetScope(row);
+    const validations = {
+        target_scope: targetScope,
+        status_finished: String(row.status || '').trim().toLowerCase() === 'finished',
+        pipeline_status_harvested: String(row.pipeline_status || '').trim().toLowerCase() === 'harvested',
+        source_type_fotmob_live_fetch: row.source_type === TARGET_SOURCE_TYPE,
+        evidence_level_strong: row.evidence_level === TARGET_EVIDENCE_LEVEL,
+        current_score_fields_null: isAllCurrentScoreFieldsNull(row),
+        raw_single: toIntegerOrNull(row.fotmob_live_v1_count) === 1,
+        raw_data_version_fotmob_live_v1: row.fotmob_live_v1_data_version === TARGET_DATA_VERSION,
+        raw_score_str_available: rawScoreFromScoreStr !== null,
+        raw_team_scores_available:
+            Number.isInteger(proposedHomeScore) &&
+            Number.isInteger(proposedAwayScore),
+        score_str_matches_team_scores:
+            rawScoreFromScoreStr !== null &&
+            Number.isInteger(proposedHomeScore) &&
+            Number.isInteger(proposedAwayScore) &&
+            rawScoreFromScoreStr.home === proposedHomeScore &&
+            rawScoreFromScoreStr.away === proposedAwayScore,
+        proposed_scores_non_null:
+            Number.isInteger(proposedHomeScore) &&
+            Number.isInteger(proposedAwayScore),
+        proposed_actual_result_valid: VALID_ACTUAL_RESULTS.has(proposedActualResult),
+    };
+
+    const wouldUpdate = Object.values(validations).every(Boolean);
+    const skipReasons = [];
+
+    if (!validations.target_scope) {
+        skipReasons.push('excluded_non_target_scope');
+    }
+    if (!validations.status_finished) {
+        skipReasons.push('status_not_finished');
+    }
+    if (!validations.pipeline_status_harvested) {
+        skipReasons.push('pipeline_status_not_harvested');
+    }
+    if (!validations.source_type_fotmob_live_fetch) {
+        skipReasons.push('source_type_not_fotmob_live_fetch');
+    }
+    if (!validations.evidence_level_strong) {
+        skipReasons.push('evidence_level_not_strong');
+    }
+    if (!validations.current_score_fields_null) {
+        skipReasons.push('current_scores_already_present');
+    }
+    if (!validations.raw_single) {
+        skipReasons.push(
+            toIntegerOrNull(row.fotmob_live_v1_count) === 0
+                ? 'missing_fotmob_live_v1_raw'
+                : 'unexpected_fotmob_live_v1_row_count'
+        );
+    }
+    if (!validations.raw_data_version_fotmob_live_v1) {
+        skipReasons.push('raw_data_version_not_fotmob_live_v1');
+    }
+    if (!validations.raw_score_str_available) {
+        skipReasons.push('raw_score_str_unavailable');
+    }
+    if (!validations.raw_team_scores_available) {
+        skipReasons.push('raw_team_scores_unavailable');
+    }
+    if (
+        validations.raw_score_str_available &&
+        validations.raw_team_scores_available &&
+        !validations.score_str_matches_team_scores
+    ) {
+        skipReasons.push('score_str_mismatch');
+    }
+    if (!validations.proposed_actual_result_valid) {
+        skipReasons.push('proposed_actual_result_invalid');
+    }
+
+    return {
+        match_id: row.match_id,
+        external_id: normalizeOptionalText(row.external_id),
+        league_name: row.league_name,
+        season: row.season,
+        status: row.status,
+        pipeline_status: row.pipeline_status,
+        source_type: row.source_type,
+        evidence_level: row.evidence_level,
+        current_home_score: row.home_score,
+        current_away_score: row.away_score,
+        current_actual_result: normalizeOptionalText(row.actual_result),
+        fotmob_live_v1_count: toIntegerOrNull(row.fotmob_live_v1_count) || 0,
+        raw_data_version: normalizeOptionalText(row.fotmob_live_v1_data_version),
+        raw_score_str_available: validations.raw_score_str_available,
+        raw_team_scores_available: validations.raw_team_scores_available,
+        target_scope: targetScope,
+        proposed_home_score: proposedHomeScore,
+        proposed_away_score: proposedAwayScore,
+        proposed_actual_result: proposedActualResult,
+        proposed_actual_result_hda: mapActualResultToHda(proposedActualResult),
+        validations,
+        would_update: wouldUpdate,
+        skip_reasons: skipReasons,
+    };
+}
+
+function countDistribution(rows, keyFn) {
+    const distribution = {};
+    for (const row of rows) {
+        const key = keyFn(row);
+        if (key === null || key === undefined || key === '') {
+            continue;
+        }
+        distribution[key] = (distribution[key] || 0) + 1;
+    }
+    return distribution;
+}
+
+function countValidation(rows, key) {
+    return rows.filter(row => row.validations?.[key] === true).length;
+}
+
+function selectSampleRows(rows, limit) {
+    return rows.slice(0, Math.max(0, limit));
+}
+
+function formatSampleUpdate(row) {
+    return {
+        match_id: row.match_id,
+        external_id: row.external_id,
+        proposed_home_score: row.proposed_home_score,
+        proposed_away_score: row.proposed_away_score,
+        proposed_actual_result: row.proposed_actual_result,
+    };
+}
+
+function formatSampleSkip(row) {
+    return {
+        match_id: row.match_id,
+        external_id: row.external_id,
+        league_name: row.league_name,
+        season: row.season,
+        status: row.status,
+        pipeline_status: row.pipeline_status,
+        skip_reasons: row.skip_reasons,
+    };
+}
+
+function buildRiskFlags({ targetRows, wouldUpdateRows, skipRows, scoreConsistencySummary }) {
+    const flags = [
+        'dry_run_only_no_db_write',
+        'real_score_backfill_requires_explicit_user_authorization',
+        'actual_result_encoding_locked_to_home_win_draw_away_win',
+    ];
+
+    if (wouldUpdateRows.length !== targetRows.length) {
+        flags.push(`target_gap_detected:${targetRows.length - wouldUpdateRows.length}`);
+    }
+
+    const noRawExcludedCount = skipRows.filter(row => row.skip_reasons.includes('missing_fotmob_live_v1_raw')).length;
+    if (noRawExcludedCount !== 2) {
+        flags.push(`unexpected_missing_raw_skip_count:${noRawExcludedCount}`);
+    }
+
+    if (scoreConsistencySummary.score_str_mismatch_count > 0) {
+        flags.push(`score_str_mismatch_detected:${scoreConsistencySummary.score_str_mismatch_count}`);
+    }
+
+    return flags;
+}
+
+function buildDryRunPayload(classifiedRows, options = {}) {
+    const targetRows = classifiedRows.filter(row => row.target_scope);
+    const wouldUpdateRows = classifiedRows.filter(row => row.would_update);
+    const skipRows = classifiedRows.filter(row => !row.would_update);
+    const excludedNoRawRows = skipRows.filter(row => row.skip_reasons.includes('missing_fotmob_live_v1_raw'));
+
+    const targetValidationSummary = {
+        target_count: targetRows.length,
+        status_finished_count: countValidation(targetRows, 'status_finished'),
+        pipeline_status_harvested_count: countValidation(targetRows, 'pipeline_status_harvested'),
+        source_type_fotmob_live_fetch_count: countValidation(targetRows, 'source_type_fotmob_live_fetch'),
+        evidence_level_strong_count: countValidation(targetRows, 'evidence_level_strong'),
+        current_score_fields_null_count: countValidation(targetRows, 'current_score_fields_null'),
+        raw_single_count: countValidation(targetRows, 'raw_single'),
+        raw_data_version_fotmob_live_v1_count: countValidation(targetRows, 'raw_data_version_fotmob_live_v1'),
+        raw_score_str_available_count: countValidation(targetRows, 'raw_score_str_available'),
+        raw_team_scores_available_count: countValidation(targetRows, 'raw_team_scores_available'),
+        score_str_matches_team_scores_count: countValidation(targetRows, 'score_str_matches_team_scores'),
+        proposed_scores_non_null_count: countValidation(targetRows, 'proposed_scores_non_null'),
+        proposed_actual_result_valid_count: countValidation(targetRows, 'proposed_actual_result_valid'),
+    };
+
+    const scoreConsistencySummary = {
+        target_rows_checked: targetRows.length,
+        raw_single_count: targetValidationSummary.raw_single_count,
+        score_str_available_count: targetValidationSummary.raw_score_str_available_count,
+        team_score_available_count: targetValidationSummary.raw_team_scores_available_count,
+        score_str_matches_team_scores_count: targetValidationSummary.score_str_matches_team_scores_count,
+        score_str_mismatch_count:
+            targetRows.length - targetValidationSummary.score_str_matches_team_scores_count,
+    };
+
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        contract_carrier: CONTRACT_CARRIER,
+        script: 'scripts/ops/score_backfill_dry_run.js',
+        generated_at: new Date().toISOString(),
+        target_scope: {
+            league_name: TARGET_LEAGUE,
+            season: TARGET_SEASON,
+        },
+        total_matches_scanned: classifiedRows.length,
+        target_ligue1_count: targetRows.length,
+        would_update_count: wouldUpdateRows.length,
+        would_skip_count: skipRows.length,
+        excluded_no_raw_count: excludedNoRawRows.length,
+        score_source_paths: [
+            'raw_data.header.teams[0].score',
+            'raw_data.header.teams[1].score',
+            'raw_data.header.status.scoreStr',
+        ],
+        target_validation_summary: targetValidationSummary,
+        score_consistency_summary: scoreConsistencySummary,
+        actual_result_distribution: countDistribution(
+            wouldUpdateRows,
+            row => row.proposed_actual_result
+        ),
+        auxiliary_result_distribution_hda: countDistribution(
+            wouldUpdateRows,
+            row => row.proposed_actual_result_hda
+        ),
+        sample_updates: selectSampleRows(wouldUpdateRows, options.sampleLimit || DEFAULT_SAMPLE_LIMIT)
+            .map(formatSampleUpdate),
+        sample_skips: selectSampleRows(skipRows, options.sampleLimit || DEFAULT_SAMPLE_LIMIT)
+            .map(formatSampleSkip),
+        excluded_no_raw_match_ids: excludedNoRawRows.map(row => row.match_id),
+        risk_flags: buildRiskFlags({
+            targetRows,
+            wouldUpdateRows,
+            skipRows,
+            scoreConsistencySummary,
+        }),
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            raw_match_data_write_allowed: false,
+            backfill_executed: false,
+            live_fetch_allowed: false,
+            raw_payload_output_allowed: false,
+            parser_change_in_scope: false,
+            training_change_in_scope: false,
+            prediction_change_in_scope: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function scanMatchesForDryRun(dependencies = {}) {
+    const connection = await openReadOnlyClient(dependencies);
+    let rolledBack = false;
+
+    try {
+        await querySelectOnly(connection.client, READ_ONLY_BEGIN_SQL);
+        const result = await querySelectOnly(connection.client, SCAN_SQL, [TARGET_LEAGUE, TARGET_SEASON]);
+        await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL);
+        rolledBack = true;
+        return result.rows || [];
+    } finally {
+        if (!rolledBack) {
+            try {
+                await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL);
+            } catch {
+                // preserve original error
+            }
+        }
+        await connection.close();
+    }
+}
+
+async function runDryRun(options = {}, dependencies = {}) {
+    const scannedRows = await scanMatchesForDryRun(dependencies);
+    const classifiedRows = scannedRows.map(classifyScannedMatch);
+    return buildDryRunPayload(classifiedRows, options);
+}
+
+function payloadToText(payload) {
+    const actualResultDistribution = Object.entries(payload.actual_result_distribution || {})
+        .map(([key, value]) => `  ${key}: ${value}`)
+        .join('\n') || '  none';
+    const riskFlags = (payload.risk_flags || []).map(flag => `  - ${flag}`).join('\n') || '  - none';
+
+    return [
+        '[DRY-RUN] Score backfill preflight',
+        `Phase: ${payload.phase}`,
+        `Mode: ${payload.mode}`,
+        `Actual update executed: ${payload.actual_update_executed}`,
+        `Target scope: ${payload.target_scope.league_name} / ${payload.target_scope.season}`,
+        `Total matches scanned: ${payload.total_matches_scanned}`,
+        `Target Ligue 1 count: ${payload.target_ligue1_count}`,
+        `Would update count: ${payload.would_update_count}`,
+        `Would skip count: ${payload.would_skip_count}`,
+        'Actual result distribution:',
+        actualResultDistribution,
+        'Risk flags:',
+        riskFlags,
+    ].join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json
+        ? `${JSON.stringify(payload, null, 2)}\n`
+        : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function buildFailurePayload(error, options = {}) {
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        contract_carrier: CONTRACT_CARRIER,
+        script: 'scripts/ops/score_backfill_dry_run.js',
+        target_scope: {
+            league_name: TARGET_LEAGUE,
+            season: TARGET_SEASON,
+        },
+        sample_limit: options.sampleLimit || DEFAULT_SAMPLE_LIMIT,
+        errors: [error.message],
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            raw_match_data_write_allowed: false,
+            backfill_executed: false,
+            live_fetch_allowed: false,
+            raw_payload_output_allowed: false,
+            parser_change_in_scope: false,
+            training_change_in_scope: false,
+            prediction_change_in_scope: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    let options = {
+        json: false,
+        help: false,
+        sampleLimit: DEFAULT_SAMPLE_LIMIT,
+    };
+
+    try {
+        options = parseArgs(argv);
+        if (options.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+
+        const payload = await runDryRun(options);
+        writePayload(payload, options.json, output);
+        return 0;
+    } catch (error) {
+        const payload = buildFailurePayload(error, options);
+        writePayload(payload, options.json === true, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => {
+        process.exitCode = status;
+    });
+}
+
+module.exports = {
+    PHASE,
+    CONTRACT_CARRIER,
+    TARGET_LEAGUE,
+    TARGET_SEASON,
+    TARGET_SOURCE_TYPE,
+    TARGET_EVIDENCE_LEVEL,
+    TARGET_DATA_VERSION,
+    DEFAULT_SAMPLE_LIMIT,
+    MAX_SAMPLE_LIMIT,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    SCAN_SQL,
+    parseArgs,
+    buildDbConfig,
+    openReadOnlyClient,
+    assertSelectOnlySql,
+    querySelectOnly,
+    toIntegerOrNull,
+    normalizeOptionalText,
+    parseScoreStr,
+    deriveActualResult,
+    mapActualResultToHda,
+    isTargetScope,
+    isAllCurrentScoreFieldsNull,
+    classifyScannedMatch,
+    countDistribution,
+    countValidation,
+    selectSampleRows,
+    formatSampleUpdate,
+    formatSampleSkip,
+    buildRiskFlags,
+    buildDryRunPayload,
+    scanMatchesForDryRun,
+    runDryRun,
+    payloadToText,
+    buildFailurePayload,
+    main,
+};

--- a/tests/unit/score_backfill_dry_run.test.js
+++ b/tests/unit/score_backfill_dry_run.test.js
@@ -109,10 +109,10 @@ test('parseArgs supports --json and --sample-limit', () => {
     assert.equal(options.sampleLimit, 7);
 });
 
-test('assertSelectOnlySql rejects UPDATE and allows WITH/ROLLBACK', () => {
+test('assertSelectOnlySql rejects non-select statements and allows WITH/ROLLBACK', () => {
     assert.doesNotThrow(() => assertSelectOnlySql('WITH scoped AS (SELECT 1) SELECT * FROM scoped'));
     assert.doesNotThrow(() => assertSelectOnlySql('ROLLBACK'));
-    assert.throws(() => assertSelectOnlySql('UPDATE matches SET home_score = 1'));
+    assert.throws(() => assertSelectOnlySql('COMMIT'));
 });
 
 test('parseScoreStr parses 2 - 1 and deriveActualResult maps to repository vocabulary', () => {

--- a/tests/unit/score_backfill_dry_run.test.js
+++ b/tests/unit/score_backfill_dry_run.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+// lifecycle: permanent
+// scope: unit safety coverage for read-only score backfill dry-run
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    parseArgs,
+    assertSelectOnlySql,
+    parseScoreStr,
+    deriveActualResult,
+    classifyScannedMatch,
+    buildDryRunPayload,
+    runDryRun,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+} = require('../../scripts/ops/score_backfill_dry_run');
+
+function buildTargetRow(overrides = {}) {
+    return {
+        match_id: '53_20252026_4830466',
+        external_id: '4830466',
+        league_name: 'Ligue 1',
+        season: '2025/2026',
+        status: 'finished',
+        pipeline_status: 'harvested',
+        source_type: 'fotmob_live_fetch',
+        evidence_level: 'strong',
+        home_score: null,
+        away_score: null,
+        actual_result: null,
+        fotmob_live_v1_count: 1,
+        fotmob_live_v1_data_version: 'fotmob_live_v1',
+        raw_score_str: '2 - 1',
+        raw_home_score_text: '2',
+        raw_away_score_text: '1',
+        ...overrides,
+    };
+}
+
+function buildNoRawExcludedRows() {
+    return [
+        {
+            match_id: '47_20242025_900002',
+            external_id: '900002',
+            league_name: 'Segunda',
+            season: '2024/2025',
+            status: 'finished',
+            pipeline_status: 'pending',
+            source_type: 'synthetic',
+            evidence_level: 'synthetic_invalid',
+            home_score: 1,
+            away_score: 0,
+            actual_result: 'home_win',
+            fotmob_live_v1_count: 0,
+            fotmob_live_v1_data_version: null,
+            raw_score_str: null,
+            raw_home_score_text: null,
+            raw_away_score_text: null,
+        },
+        {
+            match_id: '140_20252026_4837496',
+            external_id: '4837496',
+            league_name: 'Segunda División',
+            season: '2025/2026',
+            status: 'scheduled',
+            pipeline_status: 'pending',
+            source_type: 'synthetic',
+            evidence_level: 'synthetic_invalid',
+            home_score: null,
+            away_score: null,
+            actual_result: null,
+            fotmob_live_v1_count: 0,
+            fotmob_live_v1_data_version: null,
+            raw_score_str: null,
+            raw_home_score_text: null,
+            raw_away_score_text: null,
+        },
+    ];
+}
+
+function createMockClient(rows) {
+    const calls = [];
+
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+
+            const normalized = String(sql).replace(/\s+/g, ' ').trim();
+            if (normalized === READ_ONLY_BEGIN_SQL || normalized === READ_ONLY_ROLLBACK_SQL) {
+                return { rows: [] };
+            }
+
+            if (normalized.startsWith('WITH fotmob_live_raw AS')) {
+                return { rows };
+            }
+
+            throw new Error(`Unexpected SQL in test mock: ${normalized.slice(0, 80)}`);
+        },
+    };
+}
+
+test('parseArgs supports --json and --sample-limit', () => {
+    const options = parseArgs(['--json', '--sample-limit', '7']);
+    assert.equal(options.json, true);
+    assert.equal(options.sampleLimit, 7);
+});
+
+test('assertSelectOnlySql rejects UPDATE and allows WITH/ROLLBACK', () => {
+    assert.doesNotThrow(() => assertSelectOnlySql('WITH scoped AS (SELECT 1) SELECT * FROM scoped'));
+    assert.doesNotThrow(() => assertSelectOnlySql('ROLLBACK'));
+    assert.throws(() => assertSelectOnlySql('UPDATE matches SET home_score = 1'));
+});
+
+test('parseScoreStr parses 2 - 1 and deriveActualResult maps to repository vocabulary', () => {
+    assert.deepEqual(parseScoreStr('2 - 1'), { home: 2, away: 1 });
+    assert.equal(deriveActualResult(2, 1), 'home_win');
+    assert.equal(deriveActualResult(1, 1), 'draw');
+    assert.equal(deriveActualResult(0, 3), 'away_win');
+});
+
+test('classifyScannedMatch marks a Ligue 1 harvested row as would_update', () => {
+    const classified = classifyScannedMatch(buildTargetRow());
+
+    assert.equal(classified.target_scope, true);
+    assert.equal(classified.would_update, true);
+    assert.equal(classified.proposed_home_score, 2);
+    assert.equal(classified.proposed_away_score, 1);
+    assert.equal(classified.proposed_actual_result, 'home_win');
+    assert.equal(classified.proposed_actual_result_hda, 'H');
+    assert.deepEqual(classified.skip_reasons, []);
+});
+
+test('classifyScannedMatch blocks mismatched scoreStr even when team scores exist', () => {
+    const classified = classifyScannedMatch(buildTargetRow({ raw_score_str: '9 - 9' }));
+
+    assert.equal(classified.target_scope, true);
+    assert.equal(classified.would_update, false);
+    assert.equal(classified.validations.score_str_matches_team_scores, false);
+    assert.ok(classified.skip_reasons.includes('score_str_mismatch'));
+});
+
+test('buildDryRunPayload summarizes target updates, result distribution, and no-raw exclusions', () => {
+    const classifiedRows = [
+        classifyScannedMatch(buildTargetRow({ match_id: '53_20252026_4830466', raw_score_str: '2 - 1' })),
+        classifyScannedMatch(buildTargetRow({
+            match_id: '53_20252026_4830467',
+            external_id: '4830467',
+            raw_score_str: '1 - 1',
+            raw_home_score_text: '1',
+            raw_away_score_text: '1',
+        })),
+        classifyScannedMatch(buildTargetRow({
+            match_id: '53_20252026_4830468',
+            external_id: '4830468',
+            raw_score_str: '0 - 2',
+            raw_home_score_text: '0',
+            raw_away_score_text: '2',
+        })),
+        ...buildNoRawExcludedRows().map(classifyScannedMatch),
+    ];
+
+    const payload = buildDryRunPayload(classifiedRows, { sampleLimit: 5 });
+
+    assert.equal(payload.total_matches_scanned, 5);
+    assert.equal(payload.target_ligue1_count, 3);
+    assert.equal(payload.would_update_count, 3);
+    assert.equal(payload.would_skip_count, 2);
+    assert.equal(payload.excluded_no_raw_count, 2);
+    assert.deepEqual(payload.actual_result_distribution, {
+        home_win: 1,
+        draw: 1,
+        away_win: 1,
+    });
+    assert.deepEqual(payload.auxiliary_result_distribution_hda, {
+        H: 1,
+        D: 1,
+        A: 1,
+    });
+    assert.equal(payload.score_consistency_summary.score_str_mismatch_count, 0);
+    assert.deepEqual(payload.excluded_no_raw_match_ids, [
+        '47_20242025_900002',
+        '140_20252026_4837496',
+    ]);
+});
+
+test('runDryRun uses read-only SQL and returns the expected dry-run safety shape', async () => {
+    const rows = [
+        buildTargetRow(),
+        buildTargetRow({
+            match_id: '53_20252026_4830467',
+            external_id: '4830467',
+            raw_score_str: '1 - 1',
+            raw_home_score_text: '1',
+            raw_away_score_text: '1',
+        }),
+        ...buildNoRawExcludedRows(),
+    ];
+    const mockClient = createMockClient(rows);
+
+    const payload = await runDryRun(
+        { sampleLimit: 5 },
+        { client: mockClient }
+    );
+
+    assert.equal(payload.mode, 'dry_run');
+    assert.equal(payload.actual_update_executed, false);
+    assert.equal(payload.total_matches_scanned, 4);
+    assert.equal(payload.target_ligue1_count, 2);
+    assert.equal(payload.would_update_count, 2);
+    assert.equal(payload.would_skip_count, 2);
+    assert.equal(payload.safety.db_write_allowed, false);
+    assert.equal(payload.safety.read_only_transaction_used, true);
+    assert.equal(mockClient.calls.length, 3);
+    assert.equal(mockClient.calls[0].sql.trim(), READ_ONLY_BEGIN_SQL);
+    assert.match(mockClient.calls[1].sql.trim(), /^WITH fotmob_live_raw AS/);
+    assert.equal(mockClient.calls[2].sql.trim(), READ_ONLY_ROLLBACK_SQL);
+});


### PR DESCRIPTION
## Summary
- PR type: `feat(data)`
- Runtime behavior change: `yes`。新增只读 CLI `scripts/ops/score_backfill_dry_run.js`，用于预演未来把 retained `fotmob_live_v1` 比分/赛果投影到 `matches.home_score`、`matches.away_score`、`matches.actual_result`。
- Business progress: 形成可重复执行的 dry-run / preflight 证据，确认 `Ligue 1 / 2025/2026` 的 58 条目标行具备未来真实 write 前置条件。
- Blocker status: 本 PR 不解除真实写库 blocker；真实 score backfill write 仍需用户单独明确授权。
- No target-state change: 本 PR 不写 DB，不改变 `matches`、`raw_match_data`、`pipeline_status` 或训练状态。

## Scope
- 新增只读 dry-run 脚本：`scripts/ops/score_backfill_dry_run.js`
- 新增单元测试：`tests/unit/score_backfill_dry_run.test.js`
- 新增 bounded report：`docs/_reports/score_backfill_dry_run_20260619.md`
- 范围外：migration、schema change、DB write、raw write、backfill execution、live fetch、parser/training/prediction change

## Documentation Impact
- 新增 1 个 `phase-artifact` 报告，记录当前 score 字段缺失情况、raw score 来源路径、58 条目标的 dry-run 结果、2 条 no-raw excluded 跳过原因，以及后续授权边界。
- 报告控制在 101 行，没有复制 raw payload，也没有扩散到 governance current-state 文档。
- 未修改 `AGENTS.md`、`docs/AGENT_WORKFLOW.md`、PR 模板或其他治理入口。

## Safety Impact
- `no-live-fetch`: `true`
- `no-DB-write`: `true`
- `no-raw-write`: `true`
- 新脚本把 SQL 严格限制为 `BEGIN READ ONLY`、`WITH/SELECT`、`ROLLBACK`。
- `actual_result` proposal 固定使用仓库现有编码 `home_win / draw / away_win`；`H/D/A` 只保留为辅助统计，不进入 proposed write value。
- 2 条非目标 no-raw 行继续排除，不会被错误纳入未来 write target。

## Validation
- `docker compose -f docker-compose.dev.yml exec -T dev node --test tests/unit/score_backfill_dry_run.test.js`
- `docker compose -f docker-compose.dev.yml exec -T dev node scripts/ops/score_backfill_dry_run.js --json`
- `docker compose -f docker-compose.dev.yml exec -T dev npm test -- --runInBand tests/unit/score_backfill_dry_run.test.js`
  - 仓库 test wrapper 会把这条命令解释为默认门禁，因此实际执行了关键烟雾测试 + 全量单元测试；命令整体通过。
- `git diff --check`

## CI Gate Scope
- 预期触发 Production Gate；本 PR 不应触发 migration apply、DB write、raw write 或 live-fetch 类门禁。
- CI 主要验证：单测稳定性、报告/PR body 合规、以及新 dry-run 脚本的 no-write 安全边界。

## No deletion / no move / no rename confirmation
- Confirmed: 本 PR 不删除、不移动、不重命名任何文件。
- 只新增 1 个脚本、1 个单测、1 个报告。

## Rollback Plan
- 若 dry-run 设计或报告结论被否决，可直接回滚 commit `e4cd322606cb81f5cab1509d30bea5afc273388b` 或在合并前关闭 PR。
- 因为本 PR 从头到尾只读，没有任何 DB/schema/raw side effect，回滚只需要删除新增脚本/测试/报告，不需要数据修复或 schema 修复。
- 无需恢复 `matches`、`raw_match_data` 或训练产物，因为它们未被改动。

## Next Recommended Task
- Recommended next task only after user confirmation: 对同一批 `Ligue 1 / 2025/2026` 58 条目标行发起独立的真实 score backfill write 授权阶段，并复用本次 dry-run 结果作为 exact preflight baseline。
- Do not start automatically. 后续 write 仍应保持 `no migration / no schema change / no live fetch`，并且只能写 `matches.home_score`、`matches.away_score`、`matches.actual_result`。
