### PR TITLE
feat(data): add training eligibility after score dry-run

### DIFF
--- a/docs/_reports/training_eligibility_after_score_dry_run_20260619.md
+++ b/docs/_reports/training_eligibility_after_score_dry_run_20260619.md
@@ -1,0 +1,103 @@
+# Training Eligibility After Score Backfill Dry-Run
+- lifecycle: phase-artifact
+- scope: read-only training eligibility preflight after score backfill
+- date: 2026-06-19
+- branch: `data/training-eligibility-after-score-dry-run`
+
+## 结论
+
+这是 **dry-run，不是真实写库**。本次新增 `scripts/ops/training_eligibility_after_score_dry_run.js` 和对应单测，对 score backfill 写入完成后的 `matches` 表做只读扫描，预演哪些 Ligue 1 / 2025/2026 行满足训练准入条件。
+
+结论是：**58 条法甲目标行全部满足训练准入条件**（`would_set_true_count=58`），2 条 no-raw non-target rows 继续 keep false。无 migration、无 schema change、无 DB write、无 backfill、无 live fetch、无 raw payload 输出。
+
+## Score Backfill 后当前状态
+
+| 指标 | 数值 |
+| --- | ---: |
+| `matches` 总行数 | 60 |
+| `Ligue 1 / 2025/2026` 目标行 | 58 |
+| 目标行 `home_score` 非空 | 58 |
+| 目标行 `away_score` 非空 | 58 |
+| 目标行 `actual_result` 合法 | 58 |
+| 当前 `is_training_eligible=true` | 0 |
+| 当前 `is_training_eligible=false` | 60 |
+
+## 训练准入条件
+
+本次 dry-run 使用 11 条条件逐行评估：
+
+| # | 条件 | 目标行通过 |
+| --- | --- | ---: |
+| 1 | `status=finished` | 58 |
+| 2 | `pipeline_status=harvested` | 58 |
+| 3 | `source_type=fotmob_live_fetch` | 58 |
+| 4 | `evidence_level=strong` | 58 |
+| 5 | `is_production_scope=true` | 58 |
+| 6 | `is_reconciliation_eligible=true` | 58 |
+| 7 | `home_score IS NOT NULL` | 58 |
+| 8 | `away_score IS NOT NULL` | 58 |
+| 9 | `actual_result IN (home_win, draw, away_win)` | 58 |
+| 10 | `pipeline_status_reason IS NULL` | 58 |
+| 11 | `is_training_eligible=false` | 58 |
+
+**58/58 目标行全部通过。**
+
+## Dry-Run 结果
+
+| 指标 | 数值 |
+| --- | ---: |
+| `total_matches_scanned` | 60 |
+| `target_ligue1_count` | 58 |
+| `would_set_true_count` | **58** |
+| `would_keep_false_count` | 2 |
+| `current_training_eligible_true` | 0 |
+| `current_training_eligible_false` | 60 |
+
+### actual_result 分布
+
+| 编码 | 数量 |
+| --- | ---: |
+| `home_win` | 23 |
+| `draw` | 17 |
+| `away_win` | 18 |
+
+### 2 条 no-raw excluded keep false
+
+| `match_id` | `league_name` | `season` | 原因摘要 |
+| --- | --- | --- | --- |
+| `47_20242025_900002` | Segunda | 2024/2025 | 非目标 scope, pipeline_status=pending, source_type=synthetic, evidence_level=synthetic_invalid, not production scope, not reconciliation eligible, pipeline_status_reason=no_raw |
+| `140_20252026_4837496` | Segunda División | 2025/2026 | 非目标 scope, status=scheduled, pipeline_status=pending, source_type=synthetic, evidence_level=synthetic_invalid, not production scope, not reconciliation eligible, scores null, no actual_result, pipeline_status_reason=no_raw |
+
+### by_reason 分布
+
+| 原因 | 行数 |
+| --- | ---: |
+| `excluded_non_target_scope` | 2 |
+| `pipeline_status_not_harvested` | 2 |
+| `source_type_not_fotmob_live_fetch` | 2 |
+| `evidence_level_not_strong` | 2 |
+| `not_production_scope` | 2 |
+| `not_reconciliation_eligible` | 2 |
+| `pipeline_status_reason_not_null` | 2 |
+| `status_not_finished` | 1 |
+| `home_score_null` | 1 |
+| `away_score_null` | 1 |
+| `actual_result_invalid_or_null` | 1 |
+
+## 风险点
+
+1. `dry_run_only_no_db_write` — 本次不做任何写库
+2. `real_training_eligibility_write_requires_explicit_user_authorization` — 真实写库需要用户再次明确授权
+3. 所有 58 条 `would_set_true` 行都依赖于特征泄漏策略和预测截止时间的最终定义
+
+## 是否可进入真实 Training Eligibility Write
+
+从只读 preflight 结果看，**可以进入单独的真实 training eligibility write 授权阶段**。
+
+前提仍然成立：
+1. 本次只是 dry-run，不是真实写库
+2. 真实 write 必须由用户再次明确授权
+3. 后续 write 仍需保持 no migration / no schema change / no live fetch / no raw payload output
+4. 仅修改 `matches.is_training_eligible` 列，使用与 score backfill write 同等的单事务 + 严格 WHERE 安全措施
+
+下一步必须用户明确确认；本报告不构成真实 backfill 执行授权。

--- a/scripts/ops/training_eligibility_after_score_dry_run.js
+++ b/scripts/ops/training_eligibility_after_score_dry_run.js
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+'use strict';
+
+// lifecycle: permanent
+// scope: read-only training eligibility dry-run for Ligue 1 2025/2026 after score backfill
+
+const PHASE = 'TRAINING_ELIGIBILITY_AFTER_SCORE_DRY_RUN';
+const CONTRACT_CARRIER = 'matches.is_training_eligible (read-only preflight)';
+const TARGET_LEAGUE = 'Ligue 1';
+const TARGET_SEASON = '2025/2026';
+const READ_ONLY_BEGIN_SQL = 'BEGIN READ ONLY';
+const READ_ONLY_ROLLBACK_SQL = 'ROLLBACK';
+
+const VALID_ACTUAL_RESULTS = new Set(['home_win', 'draw', 'away_win']);
+
+const SCAN_SQL = `
+SELECT
+    m.match_id,
+    m.external_id,
+    m.league_name,
+    m.season,
+    m.status,
+    m.pipeline_status,
+    m.source_type,
+    m.evidence_level,
+    m.is_production_scope,
+    m.is_reconciliation_eligible,
+    m.is_training_eligible,
+    m.pipeline_status_reason,
+    m.home_score,
+    m.away_score,
+    m.actual_result
+FROM matches m
+ORDER BY
+    CASE
+        WHEN m.league_name = $1
+         AND m.season = $2
+        THEN 0
+        ELSE 1
+    END,
+    m.league_name ASC,
+    m.season ASC,
+    m.match_id ASC
+`;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/training_eligibility_after_score_dry_run.js [--json]',
+        '',
+        'Safety:',
+        '  Dry-run only. No migration, no schema change, no DB write, no backfill,',
+        '  no live fetch, no raw payload output.',
+    ].join('\n');
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = { json: false, help: false };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (arg === '--json') {
+            options.json = true;
+        } else if (arg === '--help' || arg === '-h') {
+            options.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    return options;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+function createPool(dependencies = {}) {
+    if (dependencies.pool) {
+        return dependencies.pool;
+    }
+    const { Pool } = require('pg');
+    return new Pool(buildDbConfig());
+}
+
+async function openReadOnlyClient(dependencies = {}) {
+    if (dependencies.client) {
+        return { client: dependencies.client, close: async () => {} };
+    }
+
+    const pool = createPool(dependencies);
+    const ownsPool = !dependencies.pool;
+
+    if (typeof pool.connect === 'function') {
+        const client = await pool.connect();
+        return {
+            client,
+            close: async () => {
+                if (typeof client.release === 'function') { client.release(); }
+                if (ownsPool && typeof pool.end === 'function') { await pool.end(); }
+            },
+        };
+    }
+
+    return {
+        client: pool,
+        close: async () => {
+            if (ownsPool && typeof pool.end === 'function') { await pool.end(); }
+        },
+    };
+}
+
+function assertSelectOnlySql(sql) {
+    const normalized = String(sql || '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toUpperCase();
+
+    const allowed =
+        normalized === READ_ONLY_BEGIN_SQL ||
+        normalized === READ_ONLY_ROLLBACK_SQL ||
+        normalized.startsWith('SELECT ') ||
+        normalized.startsWith('WITH ');
+
+    if (!allowed) {
+        throw new Error(`Unsafe SQL rejected by ${PHASE}: ${normalized.slice(0, 80)}`);
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+function normalizeOptionalText(value) {
+    const normalized = String(value ?? '').trim();
+    return normalized ? normalized : null;
+}
+
+function isTargetScope(row) {
+    return row.league_name === TARGET_LEAGUE && row.season === TARGET_SEASON;
+}
+
+/**
+ * Evaluate whether a match row satisfies all training eligibility conditions.
+ * Returns the would-be eligibility and a reason string.
+ */
+function evaluateRow(row) {
+    const checks = [
+        { key: 'target_scope', fn: () => isTargetScope(row), reason: 'excluded_non_target_scope' },
+        { key: 'status_finished', fn: () => String(row.status || '').trim().toLowerCase() === 'finished', reason: 'status_not_finished' },
+        { key: 'pipeline_status_harvested', fn: () => String(row.pipeline_status || '').trim().toLowerCase() === 'harvested', reason: 'pipeline_status_not_harvested' },
+        { key: 'source_type_fotmob_live_fetch', fn: () => row.source_type === 'fotmob_live_fetch', reason: 'source_type_not_fotmob_live_fetch' },
+        { key: 'evidence_level_strong', fn: () => row.evidence_level === 'strong', reason: 'evidence_level_not_strong' },
+        { key: 'is_production_scope_true', fn: () => row.is_production_scope === true, reason: 'not_production_scope' },
+        { key: 'is_reconciliation_eligible_true', fn: () => row.is_reconciliation_eligible === true, reason: 'not_reconciliation_eligible' },
+        { key: 'home_score_not_null', fn: () => row.home_score !== null, reason: 'home_score_null' },
+        { key: 'away_score_not_null', fn: () => row.away_score !== null, reason: 'away_score_null' },
+        { key: 'actual_result_valid', fn: () => VALID_ACTUAL_RESULTS.has(normalizeOptionalText(row.actual_result)), reason: 'actual_result_invalid_or_null' },
+        { key: 'pipeline_status_reason_null', fn: () => row.pipeline_status_reason === null, reason: 'pipeline_status_reason_not_null' },
+        { key: 'currently_training_eligible_false', fn: () => row.is_training_eligible === false || row.is_training_eligible === null, reason: 'already_training_eligible_true' },
+    ];
+
+    const validations = {};
+    const failedReasons = [];
+
+    for (const check of checks) {
+        const passed = check.fn();
+        validations[check.key] = passed;
+        if (!passed) {
+            failedReasons.push(check.reason);
+        }
+    }
+
+    return {
+        would_set_true: failedReasons.length === 0,
+        validations,
+        skip_reasons: failedReasons,
+    };
+}
+
+function countDistribution(rows, keyFn) {
+    const distribution = {};
+    for (const row of rows) {
+        const key = keyFn(row);
+        if (key === null || key === undefined || key === '') { continue; }
+        distribution[key] = (distribution[key] || 0) + 1;
+    }
+    return distribution;
+}
+
+function countByReason(wouldKeepFalseRows) {
+    const reasonCounts = {};
+    for (const row of wouldKeepFalseRows) {
+        for (const reason of row.skip_reasons) {
+            reasonCounts[reason] = (reasonCounts[reason] || 0) + 1;
+        }
+    }
+    return reasonCounts;
+}
+
+function formatSampleRow(row) {
+    return {
+        match_id: row.match_id,
+        external_id: row.external_id,
+        league_name: row.league_name,
+        season: row.season,
+        status: row.status,
+        pipeline_status: row.pipeline_status,
+        source_type: row.source_type,
+        evidence_level: row.evidence_level,
+        is_production_scope: row.is_production_scope,
+        is_reconciliation_eligible: row.is_reconciliation_eligible,
+        current_training_eligible: row.is_training_eligible,
+        would_set_true: row.would_set_true,
+        skip_reasons: row.skip_reasons,
+    };
+}
+
+function buildDryRunPayload(classifiedRows) {
+    const targetRows = classifiedRows.filter(row => row.is_target_scope);
+    const wouldSetTrue = classifiedRows.filter(row => row.would_set_true);
+    const wouldKeepFalse = classifiedRows.filter(row => !row.would_set_true);
+
+    const byReason = countByReason(wouldKeepFalse);
+
+    const riskFlags = [
+        'dry_run_only_no_db_write',
+        'real_training_eligibility_write_requires_explicit_user_authorization',
+    ];
+
+    if (wouldSetTrue.length !== targetRows.length) {
+        riskFlags.push(`target_gap_detected:target=${targetRows.length}_would_set_true=${wouldSetTrue.length}`);
+    }
+
+    const excludedNoRawRows = wouldKeepFalse.filter(
+        row => row.skip_reasons.includes('source_type_not_fotmob_live_fetch') &&
+               row.skip_reasons.includes('evidence_level_not_strong')
+    );
+    if (excludedNoRawRows.length !== 2) {
+        riskFlags.push(`unexpected_excluded_count:${excludedNoRawRows.length}`);
+    }
+
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        contract_carrier: CONTRACT_CARRIER,
+        script: 'scripts/ops/training_eligibility_after_score_dry_run.js',
+        generated_at: new Date().toISOString(),
+        target_scope: {
+            league_name: TARGET_LEAGUE,
+            season: TARGET_SEASON,
+            description: 'Evaluate training eligibility after score backfill write',
+        },
+        total_matches_scanned: classifiedRows.length,
+        target_ligue1_count: targetRows.length,
+        would_set_true_count: wouldSetTrue.length,
+        would_keep_false_count: wouldKeepFalse.length,
+        current_training_eligible_true: classifiedRows.filter(r => r.is_training_eligible === true).length,
+        current_training_eligible_false: classifiedRows.filter(r => r.is_training_eligible === false || r.is_training_eligible === null).length,
+        actual_result_distribution: countDistribution(
+            wouldSetTrue,
+            row => normalizeOptionalText(row.actual_result)
+        ),
+        eligibility_conditions: [
+            'status=finished',
+            'pipeline_status=harvested',
+            'source_type=fotmob_live_fetch',
+            'evidence_level=strong',
+            'is_production_scope=true',
+            'is_reconciliation_eligible=true',
+            'home_score IS NOT NULL',
+            'away_score IS NOT NULL',
+            'actual_result IN (home_win, draw, away_win)',
+            'pipeline_status_reason IS NULL',
+            'is_training_eligible=false',
+        ],
+        by_reason: byReason,
+        sample_true: wouldSetTrue.slice(0, 5).map(formatSampleRow),
+        sample_false: wouldKeepFalse.map(formatSampleRow),
+        risk_flags: riskFlags,
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            backfill_executed: false,
+            live_fetch_allowed: false,
+            raw_payload_output_allowed: false,
+            parser_change_in_scope: false,
+            training_change_in_scope: false,
+            prediction_change_in_scope: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function scanMatches(dependencies = {}) {
+    const connection = await openReadOnlyClient(dependencies);
+    let rolledBack = false;
+
+    try {
+        await querySelectOnly(connection.client, READ_ONLY_BEGIN_SQL);
+        const result = await querySelectOnly(connection.client, SCAN_SQL, [TARGET_LEAGUE, TARGET_SEASON]);
+        await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL);
+        rolledBack = true;
+        return result.rows || [];
+    } finally {
+        if (!rolledBack) {
+            try { await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL); } catch { /* preserve original */ }
+        }
+        await connection.close();
+    }
+}
+
+async function runDryRun(options = {}, dependencies = {}) {
+    const scannedRows = await scanMatches(dependencies);
+    const classifiedRows = scannedRows.map(row => ({
+        ...evaluateRow(row),
+        match_id: row.match_id,
+        external_id: row.external_id,
+        league_name: row.league_name,
+        season: row.season,
+        status: row.status,
+        pipeline_status: row.pipeline_status,
+        source_type: row.source_type,
+        evidence_level: row.evidence_level,
+        is_production_scope: row.is_production_scope,
+        is_reconciliation_eligible: row.is_reconciliation_eligible,
+        is_training_eligible: row.is_training_eligible,
+        pipeline_status_reason: row.pipeline_status_reason,
+        is_target_scope: isTargetScope(row),
+        home_score: row.home_score,
+        away_score: row.away_score,
+        actual_result: normalizeOptionalText(row.actual_result),
+    }));
+    return buildDryRunPayload(classifiedRows);
+}
+
+function payloadToText(payload) {
+    const actualResultDistribution = Object.entries(payload.actual_result_distribution || {})
+        .map(([key, value]) => `  ${key}: ${value}`)
+        .join('\n') || '  none';
+    const byReason = Object.entries(payload.by_reason || {})
+        .map(([key, value]) => `  ${key}: ${value}`)
+        .join('\n') || '  none';
+    const riskFlags = (payload.risk_flags || []).map(flag => `  - ${flag}`).join('\n') || '  - none';
+
+    return [
+        '[DRY-RUN] Training eligibility after score backfill preflight',
+        `Phase: ${payload.phase}`,
+        `Mode: ${payload.mode}`,
+        `Actual update executed: ${payload.actual_update_executed}`,
+        `Target scope: ${payload.target_scope.league_name} / ${payload.target_scope.season}`,
+        `Total matches scanned: ${payload.total_matches_scanned}`,
+        `Target Ligue 1 count: ${payload.target_ligue1_count}`,
+        `Would set true count: ${payload.would_set_true_count}`,
+        `Would keep false count: ${payload.would_keep_false_count}`,
+        `Current training_eligible=true: ${payload.current_training_eligible_true}`,
+        `Current training_eligible=false: ${payload.current_training_eligible_false}`,
+        'Actual result distribution:',
+        actualResultDistribution,
+        'By reason:',
+        byReason,
+        'Risk flags:',
+        riskFlags,
+    ].join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json
+        ? `${JSON.stringify(payload, null, 2)}\n`
+        : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function buildFailurePayload(error, options = {}) {
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        contract_carrier: CONTRACT_CARRIER,
+        script: 'scripts/ops/training_eligibility_after_score_dry_run.js',
+        target_scope: { league_name: TARGET_LEAGUE, season: TARGET_SEASON },
+        errors: [error.message],
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            backfill_executed: false,
+            live_fetch_allowed: false,
+            raw_payload_output_allowed: false,
+            parser_change_in_scope: false,
+            training_change_in_scope: false,
+            prediction_change_in_scope: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    let options = { json: false, help: false };
+
+    try {
+        options = parseArgs(argv);
+        if (options.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+
+        const payload = await runDryRun(options);
+        writePayload(payload, options.json, output);
+        return 0;
+    } catch (error) {
+        const payload = buildFailurePayload(error, options);
+        writePayload(payload, options.json === true, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => { process.exitCode = status; });
+}
+
+module.exports = {
+    PHASE,
+    CONTRACT_CARRIER,
+    TARGET_LEAGUE,
+    TARGET_SEASON,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    SCAN_SQL,
+    parseArgs,
+    buildDbConfig,
+    openReadOnlyClient,
+    assertSelectOnlySql,
+    querySelectOnly,
+    normalizeOptionalText,
+    isTargetScope,
+    evaluateRow,
+    countDistribution,
+    countByReason,
+    formatSampleRow,
+    buildDryRunPayload,
+    scanMatches,
+    runDryRun,
+    payloadToText,
+    buildFailurePayload,
+    main,
+};

--- a/tests/unit/training_eligibility_after_score_dry_run.test.js
+++ b/tests/unit/training_eligibility_after_score_dry_run.test.js
@@ -1,0 +1,288 @@
+'use strict';
+
+// lifecycle: permanent
+// scope: unit safety coverage for read-only training eligibility after score dry-run
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    parseArgs,
+    assertSelectOnlySql,
+    normalizeOptionalText,
+    isTargetScope,
+    evaluateRow,
+    countDistribution,
+    countByReason,
+    buildDryRunPayload,
+    runDryRun,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+} = require('../../scripts/ops/training_eligibility_after_score_dry_run');
+
+function buildTargetRow(overrides = {}) {
+    return {
+        match_id: '53_20252026_4830458',
+        external_id: '4830458',
+        league_name: 'Ligue 1',
+        season: '2025/2026',
+        status: 'finished',
+        pipeline_status: 'harvested',
+        source_type: 'fotmob_live_fetch',
+        evidence_level: 'strong',
+        is_production_scope: true,
+        is_reconciliation_eligible: true,
+        is_training_eligible: false,
+        pipeline_status_reason: null,
+        home_score: 2,
+        away_score: 1,
+        actual_result: 'home_win',
+        ...overrides,
+    };
+}
+
+function buildExcludedRows() {
+    return [
+        {
+            match_id: '47_20242025_900002',
+            external_id: '900002',
+            league_name: 'Segunda',
+            season: '2024/2025',
+            status: 'finished',
+            pipeline_status: 'pending',
+            source_type: 'synthetic',
+            evidence_level: 'synthetic_invalid',
+            is_production_scope: false,
+            is_reconciliation_eligible: false,
+            is_training_eligible: false,
+            pipeline_status_reason: 'no_raw',
+            home_score: 1,
+            away_score: 0,
+            actual_result: 'home_win',
+        },
+        {
+            match_id: '140_20252026_4837496',
+            external_id: '4837496',
+            league_name: 'Segunda División',
+            season: '2025/2026',
+            status: 'scheduled',
+            pipeline_status: 'pending',
+            source_type: 'synthetic',
+            evidence_level: 'synthetic_invalid',
+            is_production_scope: false,
+            is_reconciliation_eligible: false,
+            is_training_eligible: false,
+            pipeline_status_reason: 'no_raw',
+            home_score: null,
+            away_score: null,
+            actual_result: null,
+        },
+    ];
+}
+
+function createMockClient(rows) {
+    const calls = [];
+
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+
+            const normalized = String(sql).replace(/\s+/g, ' ').trim();
+            if (normalized === READ_ONLY_BEGIN_SQL || normalized === READ_ONLY_ROLLBACK_SQL) {
+                return { rows: [] };
+            }
+
+            if (normalized.startsWith('SELECT')) {
+                return { rows };
+            }
+
+            throw new Error(`Unexpected SQL in test mock: ${normalized.slice(0, 80)}`);
+        },
+    };
+}
+
+test('parseArgs supports --json and --help', () => {
+    const jsonOpts = parseArgs(['--json']);
+    assert.equal(jsonOpts.json, true);
+
+    const helpOpts = parseArgs(['--help']);
+    assert.equal(helpOpts.help, true);
+
+    const defaultOpts = parseArgs([]);
+    assert.equal(defaultOpts.json, false);
+    assert.equal(defaultOpts.help, false);
+});
+
+test('assertSelectOnlySql rejects non-select and allows WITH/ROLLBACK', () => {
+    assert.doesNotThrow(() => assertSelectOnlySql('SELECT 1'));
+    assert.doesNotThrow(() => assertSelectOnlySql('ROLLBACK'));
+    assert.throws(() => assertSelectOnlySql('COMMIT'));
+    assert.throws(() => assertSelectOnlySql('DROP TABLE x'));
+});
+
+test('isTargetScope identifies Ligue 1 2025/2026', () => {
+    assert.equal(isTargetScope({ league_name: 'Ligue 1', season: '2025/2026' }), true);
+    assert.equal(isTargetScope({ league_name: 'Premier League', season: '2025/2026' }), false);
+    assert.equal(isTargetScope({ league_name: 'Ligue 1', season: '2024/2025' }), false);
+});
+
+test('evaluateRow marks a fully qualified Ligue 1 row as would_set_true', () => {
+    const result = evaluateRow(buildTargetRow());
+
+    assert.equal(result.would_set_true, true);
+    assert.deepEqual(result.skip_reasons, []);
+    assert.equal(result.validations.status_finished, true);
+    assert.equal(result.validations.pipeline_status_harvested, true);
+    assert.equal(result.validations.source_type_fotmob_live_fetch, true);
+    assert.equal(result.validations.evidence_level_strong, true);
+    assert.equal(result.validations.is_production_scope_true, true);
+    assert.equal(result.validations.is_reconciliation_eligible_true, true);
+    assert.equal(result.validations.home_score_not_null, true);
+    assert.equal(result.validations.away_score_not_null, true);
+    assert.equal(result.validations.actual_result_valid, true);
+    assert.equal(result.validations.pipeline_status_reason_null, true);
+    assert.equal(result.validations.currently_training_eligible_false, true);
+});
+
+test('evaluateRow returns would_set_true=false with reasons for excluded rows', () => {
+    const excluded = buildExcludedRows();
+
+    const result0 = evaluateRow(excluded[0]);
+    assert.equal(result0.would_set_true, false);
+    assert.ok(result0.skip_reasons.includes('excluded_non_target_scope'));
+    assert.ok(result0.skip_reasons.includes('pipeline_status_not_harvested'));
+    assert.ok(result0.skip_reasons.includes('source_type_not_fotmob_live_fetch'));
+    assert.ok(result0.skip_reasons.includes('evidence_level_not_strong'));
+
+    const result1 = evaluateRow(excluded[1]);
+    assert.equal(result1.would_set_true, false);
+    assert.ok(result1.skip_reasons.includes('status_not_finished'));
+    assert.ok(result1.skip_reasons.includes('home_score_null'));
+    assert.ok(result1.skip_reasons.includes('actual_result_invalid_or_null'));
+});
+
+test('evaluateRow catches null home_score even when other fields pass', () => {
+    const result = evaluateRow(buildTargetRow({ home_score: null }));
+
+    assert.equal(result.would_set_true, false);
+    assert.ok(result.skip_reasons.includes('home_score_null'));
+    assert.equal(result.validations.home_score_not_null, false);
+});
+
+test('evaluateRow catches null away_score even when other fields pass', () => {
+    const result = evaluateRow(buildTargetRow({ away_score: null }));
+
+    assert.equal(result.would_set_true, false);
+    assert.ok(result.skip_reasons.includes('away_score_null'));
+});
+
+test('evaluateRow catches invalid actual_result', () => {
+    const result = evaluateRow(buildTargetRow({ actual_result: null }));
+
+    assert.equal(result.would_set_true, false);
+    assert.ok(result.skip_reasons.includes('actual_result_invalid_or_null'));
+});
+
+test('evaluateRow catches non-null pipeline_status_reason', () => {
+    const result = evaluateRow(buildTargetRow({ pipeline_status_reason: 'blocked' }));
+
+    assert.equal(result.would_set_true, false);
+    assert.ok(result.skip_reasons.includes('pipeline_status_reason_not_null'));
+});
+
+test('evaluateRow handles already-eligible row correctly', () => {
+    const result = evaluateRow(buildTargetRow({ is_training_eligible: true }));
+
+    assert.equal(result.would_set_true, false);
+    assert.ok(result.skip_reasons.includes('already_training_eligible_true'));
+});
+
+test('buildDryRunPayload summarizes target scope, eligibility, and false reasons', () => {
+    const classifiedRows = [
+        { ...buildTargetRow(), ...evaluateRow(buildTargetRow()), is_target_scope: true, actual_result: 'home_win' },
+        { ...buildTargetRow({
+            match_id: '53_20252026_4830459',
+            external_id: '4830459',
+            home_score: 1,
+            away_score: 1,
+            actual_result: 'draw',
+        }), ...evaluateRow(buildTargetRow({
+            match_id: '53_20252026_4830459',
+            external_id: '4830459',
+            home_score: 1,
+            away_score: 1,
+            actual_result: 'draw',
+        })), is_target_scope: true, actual_result: 'draw' },
+        { ...buildTargetRow({
+            match_id: '53_20252026_4830460',
+            external_id: '4830460',
+            home_score: 0,
+            away_score: 2,
+            actual_result: 'away_win',
+        }), ...evaluateRow(buildTargetRow({
+            match_id: '53_20252026_4830460',
+            external_id: '4830460',
+            home_score: 0,
+            away_score: 2,
+            actual_result: 'away_win',
+        })), is_target_scope: true, actual_result: 'away_win' },
+        ...buildExcludedRows().map(row => ({
+            ...row,
+            ...evaluateRow(row),
+            is_target_scope: false,
+            actual_result: row.actual_result,
+        })),
+    ];
+
+    const payload = buildDryRunPayload(classifiedRows);
+
+    assert.equal(payload.total_matches_scanned, 5);
+    assert.equal(payload.target_ligue1_count, 3);
+    assert.equal(payload.would_set_true_count, 3);
+    assert.equal(payload.would_keep_false_count, 2);
+    assert.deepEqual(payload.actual_result_distribution, {
+        home_win: 1,
+        draw: 1,
+        away_win: 1,
+    });
+    assert.ok(Object.keys(payload.by_reason).length > 0);
+    assert.equal(payload.sample_true.length, 3);
+    assert.equal(payload.sample_false.length, 2);
+    assert.equal(payload.safety.db_write_allowed, false);
+    assert.equal(payload.safety.read_only_transaction_used, true);
+});
+
+test('runDryRun uses read-only SQL and returns the expected dry-run safety shape', async () => {
+    const rows = [
+        buildTargetRow(),
+        buildTargetRow({
+            match_id: '53_20252026_4830459',
+            external_id: '4830459',
+            home_score: 1,
+            away_score: 1,
+            actual_result: 'draw',
+        }),
+        ...buildExcludedRows(),
+    ];
+    const mockClient = createMockClient(rows);
+
+    const payload = await runDryRun(
+        {},
+        { client: mockClient }
+    );
+
+    assert.equal(payload.mode, 'dry_run');
+    assert.equal(payload.actual_update_executed, false);
+    assert.equal(payload.total_matches_scanned, 4);
+    assert.equal(payload.target_ligue1_count, 2);
+    assert.equal(payload.would_set_true_count, 2);
+    assert.equal(payload.would_keep_false_count, 2);
+    assert.equal(payload.current_training_eligible_true, 0);
+    assert.equal(payload.safety.db_write_allowed, false);
+    assert.equal(payload.safety.read_only_transaction_used, true);
+    assert.equal(mockClient.calls.length, 3);
+    assert.equal(mockClient.calls[0].sql.trim(), READ_ONLY_BEGIN_SQL);
+    assert.match(mockClient.calls[1].sql.trim(), /^SELECT/);
+    assert.equal(mockClient.calls[2].sql.trim(), READ_ONLY_ROLLBACK_SQL);
+});


### PR DESCRIPTION
## Summary

- Read-only dry-run after score backfill to evaluate future `is_training_eligible=true` candidates.
- Adds `scripts/ops/training_eligibility_after_score_dry_run.js` — focused preflight for Ligue 1 2025/2026 post-score-backfill state.
- Result: 58/58 target rows pass all 11 training eligibility conditions; 2 no-raw excluded rows keep false.
- No migration, no schema change, no DB write, no backfill, no live fetch, no raw payload output.

## Scope

| Item | Value |
|---|---|
| Task type | data dry-run / preflight |
| One task / one branch / one PR | yes |
| Combines feature + cleanup, audit + repair, merge + new work, or docs governance + business code | no |
| Merge-only zero-change task | no |
| Business code changed | no |
| FotMob code changed | no |

## Files Changed

| Path | Purpose |
|---|---|
| `scripts/ops/training_eligibility_after_score_dry_run.js` | New read-only dry-run script: scans matches, evaluates 11 training eligibility conditions per row, produces preflight report |
| `tests/unit/training_eligibility_after_score_dry_run.test.js` | Unit tests: arg parsing, SQL safety, evaluation per-condition, payload shape, read-only transaction verification |
| `docs/_reports/training_eligibility_after_score_dry_run_20260619.md` | Dry-run report with full results, conditions table, distribution, risk flags |

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | 1 |
| Reports added | `docs/_reports/training_eligibility_after_score_dry_run_20260619.md` |
| Manifests added | 0 |
| Review reports added | 0 |
| Decision reports added | 0 |
| Next plans added | 0 |

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| Business code changed | no |
| FotMob code changed | no |
| DB used | yes (read-only SELECT) |
| Browser automation used | no |
| Scraper run | no |

## Validation

| Validation | Result |
|---|---|
| Host validation | N/A |
| Container validation | 12/12 unit tests pass, eslint clean, git diff --check clean, dry-run outputs match expected values |
| GitHub Production Gate | Pending CI |

## CI Gate Scope

- What the validation proves: 58/58 Ligue 1 target rows satisfy all 11 training eligibility conditions. 2 no-raw excluded rows correctly identified as keep-false. Read-only transaction used — no writes.
- What the validation does not prove: Feature leakage policy correctness (conditional). Cutoff time definition.
- Host unavailable results, if any: N/A
- Container validation results, if any: 12/12 tests pass, eslint 0 errors

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Rollback Plan

- N/A — dry-run only, no writes performed.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- Authorized `is_training_eligible=true` write for 58 Ligue 1 matches (requires explicit user authorization)

## PR Type

- [x] governance-only
- [ ] docs-only
- [ ] test-only
- [ ] ci-fix
- [ ] data-artifact
- [ ] runtime-code-change

## Runtime Behavior

- Runtime code change included: yes (new script)
- Runtime code paths changed: new `scripts/ops/training_eligibility_after_score_dry_run.js`
- Runtime behavior changed: no (read-only, no DB writes)

## Artifact Scope

- Docs/report/manifest changes included: yes
- Added/modified report lines: 1 new report, ~130 lines
- Added/modified manifest lines: 0
- Copies full historical state: no
- Includes large artifact: no

## Business Progress

- Business progress: Preflight confirms 58 Ligue 1 matches are training-eligible after score backfill
- Blocker removed: Score backfill data availability verified — all 58 have valid scores/results
- Blocker remaining: is_training_eligible still false (requires authorized write)

## Ingestion Convergence Gate

n/a — this PR is training eligibility dry-run, not ingestion pipeline work.

## Safety Status

- no live fetch: yes
- no detail fetch: yes
- no network request: yes
- no DB writes: yes
- no raw_match_data inserts: yes
- no matches writes: yes
- no matches.external_id changes: yes
- no raw write execution: yes
- no re-acceptance execution: yes
- no suspension reversal: yes
- no rollback execution: yes
- no parser/features/training/prediction: yes
- no full body/raw_data/pageProps saved or printed: yes

## Tests Run

- [x] lint (eslint clean)
- [x] unit tests (12/12 pass)
- [ ] coverage
- [ ] formatter
- [x] git diff --check (clean)
- [ ] hidden/bidi scan
- [ ] full payload marker scan
- [x] DB SELECT-only safety check
- [ ] other:

Commands and results:

```
# Unit tests
docker compose -f docker-compose.dev.yml exec dev node --test tests/unit/training_eligibility_after_score_dry_run.test.js
# Result: 12/12 pass, 0 fail

# ESLint
docker compose -f docker-compose.dev.yml exec dev npx eslint scripts/ops/training_eligibility_after_score_dry_run.js tests/unit/training_eligibility_after_score_dry_run.test.js
# Result: clean, 0 errors

# Dry-run execution
docker compose -f docker-compose.dev.yml exec dev node scripts/ops/training_eligibility_after_score_dry_run.js --json
# Result: total=60, target=58, would_set_true=58, would_keep_false=2, distribution H=23/D=17/A=18
```

## Repository Hygiene / Debt Impact

- New files added: 3
- File lifecycle: `scripts/ops/training_eligibility_after_score_dry_run.js` (permanent), `tests/unit/training_eligibility_after_score_dry_run.test.js` (permanent), `docs/_reports/training_eligibility_after_score_dry_run_20260619.md` (phase-artifact)
- Permanent files: 2
- Phase-only artifacts: 1
- Report line count: ~130 lines
- Does this PR increase repository noise? no

## Artifact limits checklist

- [x] No full HTML/pageProps/raw_data/source body saved
- [x] No large report unless justified
- [x] No full historical recap copied
- [x] No orphan helper/script without lifecycle
- [x] Tests protect runtime behavior where applicable

## Review Notes

- Reviewer focus: Verify 11 eligibility conditions are correct and complete. Verify read-only safety.
- Residual risk: Feature leakage policy not yet formalized — noted in risk flags.
- Follow-up PR, if any: Authorized `is_training_eligible=true` write (requires separate authorization)