### PR TITLE
feat(data): add training dataset leakage dry-run

### DIFF
--- a/docs/_reports/training_dataset_leakage_dry_run_20260619.md
+++ b/docs/_reports/training_dataset_leakage_dry_run_20260619.md
@@ -1,0 +1,110 @@
+# Training Dataset Construction & Feature Leakage Dry-Run
+- lifecycle: phase-artifact
+- scope: read-only training dataset construction & feature leakage policy audit
+- date: 2026-06-19
+- branch: `data/training-dataset-leakage-dry-run`
+
+## 结论
+
+这是 **dry-run，不是真实训练**。没有 DB write / migration / schema change / live fetch / raw payload output / model training / model output。本次只做只读审计，分析 58 条已 `is_training_eligible=true` 的 Ligue 1 样本，确认标签完整性，区分安全特征与泄漏特征。
+
+## 训练样本状态
+
+| 指标 | 数值 |
+| --- | ---: |
+| `is_training_eligible=true` | 58 |
+| `actual_result` 非空 | 58 |
+| `actual_result` 合法值 | 58/58 |
+| 2 条 no-raw excluded 进入训练 | 0（不在此范围） |
+
+### Label 分布
+
+| 编码 | 数量 |
+| --- | ---: |
+| `home_win` | 23 |
+| `draw` | 17 |
+| `away_win` | 18 |
+
+58/58 标签完整，全部在 `{home_win, draw, away_win}` 集合内。
+
+## 字段分类（32 个 matches 列全覆盖）
+
+### Label（1 个）
+
+| 字段 | 说明 |
+| --- | --- |
+| `actual_result` | 预测目标。编码：home_win / draw / away_win |
+
+### 赛前安全特征（7 个）— 可用于训练
+
+| 字段 | 说明 | 编码注意事项 |
+| --- | --- | --- |
+| `league_name` | 联赛标识 | One-hot 或 label encode |
+| `season` | 赛季标识 | 可衍生赛季阶段/轮次 |
+| `home_team` | 主队 | 球队强度特征必须时间门控 |
+| `away_team` | 客队 | 同主队要求 |
+| `match_date` | 比赛日期 | 可衍生：周几、月份、时间、赛季天数 |
+| `venue` | 比赛场地 | 主场优势特征 |
+| `referee` | 裁判 | 裁判严格度指标须时间门控。边际特征 |
+
+### 赛后泄漏字段（10 个）— 严禁作为特征
+
+| 字段 | 原因 |
+| --- | --- |
+| `home_score` | 终场比分 — 直接泄漏标签 |
+| `away_score` | 终场比分 — 直接泄漏标签 |
+| `home_corners` | 赛后统计 |
+| `away_corners` | 赛后统计 |
+| `home_yellow_cards` | 赛后纪律记录 |
+| `away_yellow_cards` | 赛后纪律记录 |
+| `home_red_cards` | 赛后纪律记录 |
+| `away_red_cards` | 赛后纪律记录 |
+| `status` | 赛后状态（finished） |
+| `is_finished` | 赛后布尔标记 |
+
+### 管理/治理字段（14 个）— 不作为特征
+
+`external_id`, `match_id`, `collection_date`, `created_at`, `updated_at`, `data_version`, `data_source`, `pipeline_status`, `source_type`, `evidence_level`, `is_production_scope`, `is_reconciliation_eligible`, `is_training_eligible`, `pipeline_status_reason`
+
+### 不确定字段（0 个）
+
+所有 32 列全部分类完毕，无待确认。
+
+## 重要风险点
+
+1. **样本量不足**：58 条只适合 smoke/integration dataset，不适合正式模型训练。需要扩展到 500+ 条多联赛多赛季数据。
+2. **时间门控未实施**：当前 repo 没有时间门控基础设施。所有从历史数据派生的球队特征（ELO、近期状态、历史交锋等）必须保证特征数据时间 < 当前比赛 `match_date`。
+3. **raw_match_data 泄漏风险**：FotMob raw 数据包含 xG、射门、控球、传球等 100+ 字段，全部是赛后泄漏。如果未来从 raw 数据提取特征，每个字段都必须审计。
+4. **collection_date 解释**：这是数据采集时间戳，不是比赛时间。如果误用会导致跨时间泄漏。
+5. **跨联赛泛化未测试**：58 条仅来自 Ligue 1。扩展到其他联赛前需要验证联赛特定特征。
+
+## 建议
+
+1. 58 条当前样本定位为 smoke/integration dataset
+2. 赛前特征仅限 7 个已确认安全字段
+3. 严禁将任何 match statistics（score/corners/cards）作为特征
+4. 从 raw_match_data 提取的任何特征必须先通过泄漏审计
+5. 在扩展到正式训练前，实施显式的时间截止策略
+6. 定义特征时间点 T：特征必须仅使用 `match_date[T]` 之前可用的数据
+
+## 安全确认
+
+| 项目 | 状态 |
+| --- | --- |
+| 无 migration | ✅ |
+| 无 schema change | ✅ |
+| 无 DB write | ✅ |
+| 无 live fetch | ✅ |
+| 无 raw payload 输出 | ✅ |
+| 无 model training | ✅ |
+| 无 model output | ✅ |
+| 只读事务 | ✅ |
+
+## 下一步
+
+必须用户确认后才能进入正式训练 pipeline 构建：
+1. 确认 58 条 smoke dataset 用途
+2. 确认 7 个安全特征列表
+3. 确认时间门控策略
+4. 确认是否需要扩展到多联赛多赛季训练数据
+5. 确认正式模型训练目标和评估标准

--- a/scripts/ops/training_dataset_leakage_dry_run.js
+++ b/scripts/ops/training_dataset_leakage_dry_run.js
@@ -1,0 +1,546 @@
+#!/usr/bin/env node
+'use strict';
+
+// lifecycle: permanent
+// scope: read-only training dataset construction & feature leakage policy dry-run
+
+const PHASE = 'TRAINING_DATASET_LEAKAGE_DRY_RUN';
+const TARGET_LEAGUE = 'Ligue 1';
+const TARGET_SEASON = '2025/2026';
+const READ_ONLY_BEGIN_SQL = 'BEGIN READ ONLY';
+const READ_ONLY_ROLLBACK_SQL = 'ROLLBACK';
+
+const VALID_LABELS = new Set(['home_win', 'draw', 'away_win']);
+
+// Feature classification taxonomy
+// label — prediction target
+// safe_pre_match — known before kickoff, safe for training
+// leakage_post_match — only known after the match, must NOT be used as feature
+// administrative — metadata / governance, not a feature
+// uncertain — needs human review before classification
+
+const FIELD_CLASSIFICATION = Object.freeze({
+    // === Label ===
+    actual_result: {
+        category: 'label',
+        reason: 'Prediction target. Encoded as home_win / draw / away_win.',
+        usable_as_feature: false,
+    },
+
+    // === Safe pre-match features ===
+    league_name: {
+        category: 'safe_pre_match',
+        reason: 'League identifier. Known before season starts.',
+        usable_as_feature: true,
+        encoding_note: 'One-hot or label encode',
+    },
+    season: {
+        category: 'safe_pre_match',
+        reason: 'Season identifier. Known before any match.',
+        usable_as_feature: true,
+        encoding_note: 'Can derive season phase / round number',
+    },
+    home_team: {
+        category: 'safe_pre_match',
+        reason: 'Home team identity. Known when fixture is published.',
+        usable_as_feature: true,
+        encoding_note: 'Team strength features (historical form, ELO, etc.) must be time-gated',
+    },
+    away_team: {
+        category: 'safe_pre_match',
+        reason: 'Away team identity. Known when fixture is published.',
+        usable_as_feature: true,
+        encoding_note: 'Same time-gating requirement as home_team',
+    },
+    match_date: {
+        category: 'safe_pre_match',
+        reason: 'Scheduled match datetime. Known before kickoff.',
+        usable_as_feature: true,
+        encoding_note: 'Can derive: day of week, month, time of day, days since season start',
+    },
+    venue: {
+        category: 'safe_pre_match',
+        reason: 'Match venue. Known when fixture is published.',
+        usable_as_feature: true,
+        encoding_note: 'Home/away/neutral indicator. Home advantage feature.',
+    },
+    referee: {
+        category: 'safe_pre_match',
+        reason: 'Match referee appointment. Typically published days before match.',
+        usable_as_feature: true,
+        encoding_note: 'Referee strictness metrics must be time-gated. Marginal feature.',
+    },
+    external_id: {
+        category: 'administrative',
+        reason: 'FotMob match identifier. Not a feature.',
+        usable_as_feature: false,
+    },
+
+    // === Leakage (post-match — MUST NOT be features) ===
+    home_score: {
+        category: 'leakage_post_match',
+        reason: 'Final home score. Known only after match ends. DIRECT LEAKAGE of label.',
+        usable_as_feature: false,
+    },
+    away_score: {
+        category: 'leakage_post_match',
+        reason: 'Final away score. Known only after match ends. DIRECT LEAKAGE of label.',
+        usable_as_feature: false,
+    },
+    home_corners: {
+        category: 'leakage_post_match',
+        reason: 'Home corner count. Match statistic known only after match.',
+        usable_as_feature: false,
+    },
+    away_corners: {
+        category: 'leakage_post_match',
+        reason: 'Away corner count. Match statistic known only after match.',
+        usable_as_feature: false,
+    },
+    home_yellow_cards: {
+        category: 'leakage_post_match',
+        reason: 'Home yellow cards. Match discipline record known only after match.',
+        usable_as_feature: false,
+    },
+    away_yellow_cards: {
+        category: 'leakage_post_match',
+        reason: 'Away yellow cards. Match discipline record known only after match.',
+        usable_as_feature: false,
+    },
+    home_red_cards: {
+        category: 'leakage_post_match',
+        reason: 'Home red cards. Match discipline record known only after match.',
+        usable_as_feature: false,
+    },
+    away_red_cards: {
+        category: 'leakage_post_match',
+        reason: 'Away red cards. Match discipline record known only after match.',
+        usable_as_feature: false,
+    },
+    status: {
+        category: 'leakage_post_match',
+        reason: 'Match status (finished). Knowing match is finished leaks that the game occurred.',
+        usable_as_feature: false,
+    },
+    is_finished: {
+        category: 'leakage_post_match',
+        reason: 'Boolean match completion flag. Same as status.',
+        usable_as_feature: false,
+    },
+
+    // === Administrative / governance (not features) ===
+    match_id: {
+        category: 'administrative',
+        reason: 'Primary key. Not a feature.',
+        usable_as_feature: false,
+    },
+    collection_date: {
+        category: 'administrative',
+        reason: 'Data collection timestamp. Indicates when raw data was fetched, not match time.',
+        usable_as_feature: false,
+        note: 'Could leak data pipeline timing if used naively',
+    },
+    created_at: {
+        category: 'administrative',
+        reason: 'Database record creation timestamp. Not a feature.',
+        usable_as_feature: false,
+    },
+    updated_at: {
+        category: 'administrative',
+        reason: 'Database record update timestamp. Not a feature.',
+        usable_as_feature: false,
+    },
+    data_version: {
+        category: 'administrative',
+        reason: 'Data version tag. Governance metadata.',
+        usable_as_feature: false,
+    },
+    data_source: {
+        category: 'administrative',
+        reason: 'Data provenance tag. Governance metadata.',
+        usable_as_feature: false,
+    },
+    pipeline_status: {
+        category: 'administrative',
+        reason: 'Pipeline processing state. Governance metadata.',
+        usable_as_feature: false,
+    },
+    source_type: {
+        category: 'administrative',
+        reason: 'Provenance class. Governance metadata.',
+        usable_as_feature: false,
+    },
+    evidence_level: {
+        category: 'administrative',
+        reason: 'Evidence strength. Governance metadata.',
+        usable_as_feature: false,
+    },
+    is_production_scope: {
+        category: 'administrative',
+        reason: 'Production scope flag. Governance metadata.',
+        usable_as_feature: false,
+    },
+    is_reconciliation_eligible: {
+        category: 'administrative',
+        reason: 'Reconciliation eligibility flag. Governance metadata.',
+        usable_as_feature: false,
+    },
+    is_training_eligible: {
+        category: 'administrative',
+        reason: 'Training eligibility flag. Governance metadata.',
+        usable_as_feature: false,
+    },
+    pipeline_status_reason: {
+        category: 'administrative',
+        reason: 'Pipeline status reason code. Governance metadata.',
+        usable_as_feature: false,
+    },
+});
+
+const SCAN_SQL = `
+SELECT
+    m.match_id, m.external_id, m.league_name, m.season,
+    m.home_team, m.away_team,
+    m.home_score, m.away_score, m.actual_result,
+    m.match_date, m.venue, m.status, m.is_finished,
+    m.home_corners, m.away_corners,
+    m.home_yellow_cards, m.away_yellow_cards,
+    m.home_red_cards, m.away_red_cards,
+    m.referee,
+    m.is_training_eligible,
+    m.collection_date, m.created_at, m.updated_at
+FROM matches m
+WHERE m.is_training_eligible = true
+  AND m.league_name = $1
+  AND m.season = $2
+ORDER BY m.match_id
+`;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/training_dataset_leakage_dry_run.js [--json]',
+        '',
+        'Safety:',
+        '  Dry-run only. No migration, no schema change, no DB write, no model training,',
+        '  no live fetch, no raw payload output.',
+    ].join('\n');
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = { json: false, help: false };
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (arg === '--json') { options.json = true; }
+        else if (arg === '--help' || arg === '-h') { options.help = true; }
+        else { throw new Error(`Unknown argument: ${arg}`); }
+    }
+    return options;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+async function openReadOnlyClient(dependencies = {}) {
+    if (dependencies.client) {
+        return { client: dependencies.client, close: async () => {} };
+    }
+    const { Pool } = require('pg');
+    const pool = new Pool(buildDbConfig());
+    const client = await pool.connect();
+    return {
+        client,
+        close: async () => {
+            if (typeof client.release === 'function') { client.release(); }
+            await pool.end();
+        },
+    };
+}
+
+function assertSelectOnlySql(sql) {
+    const normalized = String(sql || '').replace(/\s+/g, ' ').trim().toUpperCase();
+    const allowed =
+        normalized === READ_ONLY_BEGIN_SQL ||
+        normalized === READ_ONLY_ROLLBACK_SQL ||
+        normalized.startsWith('SELECT ') ||
+        normalized.startsWith('WITH ');
+    if (!allowed) {
+        throw new Error(`Unsafe SQL rejected by ${PHASE}: ${normalized.slice(0, 80)}`);
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+async function scanTrainingEligibleMatches(dependencies = {}) {
+    const connection = await openReadOnlyClient(dependencies);
+    let rolledBack = false;
+    try {
+        await querySelectOnly(connection.client, READ_ONLY_BEGIN_SQL);
+        const result = await querySelectOnly(connection.client, SCAN_SQL, [TARGET_LEAGUE, TARGET_SEASON]);
+        await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL);
+        rolledBack = true;
+        return result.rows || [];
+    } finally {
+        if (!rolledBack) {
+            try { await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL); } catch { /* preserve */ }
+        }
+        await connection.close();
+    }
+}
+
+function countDistribution(rows, keyFn) {
+    const dist = {};
+    for (const row of rows) {
+        const key = keyFn(row);
+        if (key === null || key === undefined || key === '') { continue; }
+        dist[key] = (dist[key] || 0) + 1;
+    }
+    return dist;
+}
+
+function buildFieldSummary() {
+    const byCategory = {
+        label: [],
+        safe_pre_match: [],
+        leakage_post_match: [],
+        administrative: [],
+        uncertain: [],
+    };
+
+    for (const [fieldName, classification] of Object.entries(FIELD_CLASSIFICATION)) {
+        byCategory[classification.category].push({
+            field: fieldName,
+            reason: classification.reason,
+            usable_as_feature: classification.usable_as_feature,
+            encoding_note: classification.encoding_note || null,
+            note: classification.note || null,
+        });
+    }
+
+    return byCategory;
+}
+
+function buildDryRunPayload(rows) {
+    const labelDistribution = countDistribution(rows, r => r.actual_result);
+    const labelValidCount = rows.filter(r => VALID_LABELS.has(r.actual_result || '')).length;
+    const labelNonNullCount = rows.filter(r => r.actual_result !== null).length;
+
+    const fieldSummary = buildFieldSummary();
+
+    const safeFeatureCount = fieldSummary.safe_pre_match.length;
+    const leakageFeatureCount = fieldSummary.leakage_post_match.length;
+    const uncertainCount = fieldSummary.uncertain.length;
+
+    const riskFlags = [
+        'dry_run_only_no_model_training',
+        'real_training_pipeline_requires_explicit_user_authorization',
+        `sample_size=${rows.length}: suitable only for smoke/integration dataset, NOT for production model training`,
+        'all_safe_pre_match_features_require_time_gating: team form/ELO/historical stats must use only data before match_date',
+        'potential_raw_match_data_features_not_audited: xG, shots, possession, other FotMob stats are in raw_match_data.raw_data JSONB and are ALL post-match leakage',
+        'collection_date IS post-creation timestamp — safe features like team form must be derived from historical matches with match_date < current match_date',
+        'cross-league generalization not tested',
+    ];
+
+    const recommendations = [
+        'This 58-sample dataset is a SMOKE / INTEGRATION dataset only.',
+        'Do NOT train a production model on 58 samples.',
+        'Safe features (7): league_name, season, home_team, away_team, match_date, venue, referee.',
+        'ALL match statistics (corners, cards, scores) are post-match leakage — NEVER use as features.',
+        'Team strength features (ELO, form, etc.) must be computed from historical data with strict time-gating: only use matches with match_date < current match_date.',
+        'raw_match_data.raw_data contains FotMob JSONB with xG, shots, possession, etc. ALL of these are post-match leakage.',
+        'For production: expand dataset to 500+ matches across multiple leagues and seasons.',
+        'Define an explicit temporal cutoff: features at time T must only use data available before match_date[T].',
+    ];
+
+    // Sample rows for illustration (anonymized for safety)
+    const sampleRows = rows.slice(0, 3).map(r => ({
+        match_id: r.match_id,
+        league_name: r.league_name,
+        season: r.season,
+        home_team: r.home_team,
+        away_team: r.away_team,
+        actual_result: r.actual_result,
+        match_date: r.match_date,
+        venue: r.venue,
+    }));
+
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        script: 'scripts/ops/training_dataset_leakage_dry_run.js',
+        generated_at: new Date().toISOString(),
+        target_scope: {
+            league_name: TARGET_LEAGUE,
+            season: TARGET_SEASON,
+            description: 'Training dataset construction & feature leakage audit',
+        },
+        training_eligible_count: rows.length,
+        label_distribution: labelDistribution,
+        label_validation: {
+            non_null_count: labelNonNullCount,
+            valid_count: labelValidCount,
+            total_count: rows.length,
+            all_label_valid: labelValidCount === rows.length,
+        },
+        field_classification_summary: {
+            total_fields_classified: Object.keys(FIELD_CLASSIFICATION).length,
+            label_count: fieldSummary.label.length,
+            safe_pre_match_count: safeFeatureCount,
+            leakage_post_match_count: leakageFeatureCount,
+            administrative_count: fieldSummary.administrative.length,
+            uncertain_count: uncertainCount,
+        },
+        safe_feature_candidates: fieldSummary.safe_pre_match,
+        leakage_feature_candidates: fieldSummary.leakage_post_match,
+        uncertain_feature_candidates: fieldSummary.uncertain,
+        label_field: fieldSummary.label,
+        administrative_fields_summary: `${
+            fieldSummary.administrative.length} fields: ${
+            fieldSummary.administrative.map(f => f.field).join(', ')}`,
+        sample_rows: sampleRows,
+        sample_rows_count: rows.length,
+        risk_flags: riskFlags,
+        recommendations,
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            model_training_performed: false,
+            model_output_generated: false,
+            live_fetch_allowed: false,
+            raw_payload_output_allowed: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function runDryRun(options = {}, dependencies = {}) {
+    const rows = await scanTrainingEligibleMatches(dependencies);
+    return buildDryRunPayload(rows);
+}
+
+function payloadToText(payload) {
+    const labelDist = Object.entries(payload.label_distribution || {})
+        .map(([k, v]) => `  ${k}: ${v}`).join('\n') || '  none';
+    const safeFeatures = payload.safe_feature_candidates
+        .map(f => `  - ${f.field}: ${f.reason}`).join('\n') || '  - none';
+    const leakageFeatures = payload.leakage_feature_candidates
+        .map(f => `  - ${f.field}: ${f.reason}`).join('\n') || '  - none';
+    const riskFlags = (payload.risk_flags || []).map(f => `  - ${f}`).join('\n') || '  - none';
+    const recs = (payload.recommendations || []).map(r => `  - ${r}`).join('\n') || '  - none';
+
+    return [
+        '[DRY-RUN] Training dataset construction & feature leakage audit',
+        `Phase: ${payload.phase}`,
+        `Mode: ${payload.mode}`,
+        `Training eligible count: ${payload.training_eligible_count}`,
+        'Label distribution:',
+        labelDist,
+        `Label valid: ${payload.label_validation.all_label_valid} (${payload.label_validation.valid_count}/${payload.label_validation.total_count})`,
+        '',
+        `Safe pre-match features (${payload.field_classification_summary.safe_pre_match_count}):`,
+        safeFeatures,
+        '',
+        `Leakage post-match fields (${payload.field_classification_summary.leakage_post_match_count}) — MUST NOT be features:`,
+        leakageFeatures,
+        '',
+        `Uncertain fields (${payload.field_classification_summary.uncertain_count}):`,
+        (payload.uncertain_feature_candidates || []).map(f => `  - ${f.field}: ${f.reason}`).join('\n') || '  - none',
+        '',
+        'Risk flags:',
+        riskFlags,
+        '',
+        'Recommendations:',
+        recs,
+    ].join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json
+        ? `${JSON.stringify(payload, null, 2)}\n`
+        : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function buildFailurePayload(error, options = {}) {
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        script: 'scripts/ops/training_dataset_leakage_dry_run.js',
+        target_scope: { league_name: TARGET_LEAGUE, season: TARGET_SEASON },
+        errors: [error.message],
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            model_training_performed: false,
+            model_output_generated: false,
+            live_fetch_allowed: false,
+            raw_payload_output_allowed: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+    let options = { json: false, help: false };
+    try {
+        options = parseArgs(argv);
+        if (options.help) { output.stdout(`${usage()}\n`); return 0; }
+        const payload = await runDryRun(options);
+        writePayload(payload, options.json, output);
+        return 0;
+    } catch (error) {
+        const payload = buildFailurePayload(error, options);
+        writePayload(payload, options.json === true, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(status => { process.exitCode = status; });
+}
+
+module.exports = {
+    PHASE,
+    TARGET_LEAGUE,
+    TARGET_SEASON,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    FIELD_CLASSIFICATION,
+    SCAN_SQL,
+    parseArgs,
+    buildDbConfig,
+    openReadOnlyClient,
+    assertSelectOnlySql,
+    querySelectOnly,
+    scanTrainingEligibleMatches,
+    countDistribution,
+    buildFieldSummary,
+    buildDryRunPayload,
+    runDryRun,
+    payloadToText,
+    buildFailurePayload,
+    main,
+};

--- a/tests/unit/training_dataset_leakage_dry_run.test.js
+++ b/tests/unit/training_dataset_leakage_dry_run.test.js
@@ -1,0 +1,202 @@
+'use strict';
+
+// lifecycle: permanent
+// scope: unit safety coverage for read-only training dataset leakage dry-run
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    parseArgs,
+    assertSelectOnlySql,
+    countDistribution,
+    buildFieldSummary,
+    buildDryRunPayload,
+    runDryRun,
+    FIELD_CLASSIFICATION,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+} = require('../../scripts/ops/training_dataset_leakage_dry_run');
+
+function buildEligibleRow(overrides = {}) {
+    return {
+        match_id: '53_20252026_4830458',
+        external_id: '4830458',
+        league_name: 'Ligue 1',
+        season: '2025/2026',
+        home_team: 'Team A',
+        away_team: 'Team B',
+        home_score: 2,
+        away_score: 1,
+        actual_result: 'home_win',
+        match_date: '2025-08-16T19:00:00Z',
+        venue: 'Stadium A',
+        status: 'finished',
+        is_finished: true,
+        home_corners: 5,
+        away_corners: 3,
+        home_yellow_cards: 2,
+        away_yellow_cards: 1,
+        home_red_cards: 0,
+        away_red_cards: 0,
+        referee: 'Ref X',
+        is_training_eligible: true,
+        collection_date: '2025-08-17T01:00:00Z',
+        created_at: '2025-08-17T01:00:00Z',
+        updated_at: '2025-08-17T01:00:00Z',
+        ...overrides,
+    };
+}
+
+function createMockClient(rows) {
+    const calls = [];
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+            const normalized = String(sql).replace(/\s+/g, ' ').trim();
+            if (normalized === READ_ONLY_BEGIN_SQL || normalized === READ_ONLY_ROLLBACK_SQL) {
+                return { rows: [] };
+            }
+            if (normalized.startsWith('SELECT')) {
+                return { rows };
+            }
+            throw new Error(`Unexpected SQL in test mock: ${normalized.slice(0, 80)}`);
+        },
+    };
+}
+
+test('parseArgs supports --json and --help', () => {
+    assert.equal(parseArgs(['--json']).json, true);
+    assert.equal(parseArgs(['--help']).help, true);
+    assert.equal(parseArgs([]).json, false);
+});
+
+test('assertSelectOnlySql rejects non-select', () => {
+    assert.doesNotThrow(() => assertSelectOnlySql('SELECT 1'));
+    assert.doesNotThrow(() => assertSelectOnlySql('ROLLBACK'));
+    assert.throws(() => assertSelectOnlySql('DROP TABLE x'));
+    assert.throws(() => assertSelectOnlySql('COMMIT'));
+});
+
+test('FIELD_CLASSIFICATION covers all 32 matches columns', () => {
+    const expectedFields = [
+        'match_id', 'external_id', 'league_name', 'season',
+        'home_team', 'away_team', 'home_score', 'away_score', 'actual_result',
+        'match_date', 'venue', 'status', 'is_finished',
+        'collection_date', 'created_at', 'updated_at',
+        'data_version', 'data_source', 'pipeline_status',
+        'home_corners', 'away_corners',
+        'home_yellow_cards', 'away_yellow_cards',
+        'home_red_cards', 'away_red_cards',
+        'referee', 'source_type', 'evidence_level',
+        'is_production_scope', 'is_reconciliation_eligible',
+        'is_training_eligible', 'pipeline_status_reason',
+    ];
+
+    for (const field of expectedFields) {
+        assert.ok(FIELD_CLASSIFICATION[field], `Field ${field} must be classified`);
+    }
+
+    assert.equal(Object.keys(FIELD_CLASSIFICATION).length, 32);
+});
+
+test('FIELD_CLASSIFICATION has exactly one label field', () => {
+    const labels = Object.entries(FIELD_CLASSIFICATION).filter(([, c]) => c.category === 'label');
+    assert.equal(labels.length, 1);
+    assert.equal(labels[0][0], 'actual_result');
+});
+
+test('FIELD_CLASSIFICATION safe_pre_match fields are usable as features', () => {
+    const safe = Object.entries(FIELD_CLASSIFICATION).filter(([, c]) => c.category === 'safe_pre_match');
+    assert.ok(safe.length >= 6);
+    for (const [, c] of safe) {
+        assert.equal(c.usable_as_feature, true);
+    }
+});
+
+test('FIELD_CLASSIFICATION leakage fields are NOT usable as features', () => {
+    const leakage = Object.entries(FIELD_CLASSIFICATION).filter(([, c]) => c.category === 'leakage_post_match');
+    assert.ok(leakage.length >= 8);
+    for (const [, c] of leakage) {
+        assert.equal(c.usable_as_feature, false);
+    }
+});
+
+test('FIELD_CLASSIFICATION administrative fields are NOT usable as features', () => {
+    const admin = Object.entries(FIELD_CLASSIFICATION).filter(([, c]) => c.category === 'administrative');
+    assert.ok(admin.length >= 10);
+    for (const [, c] of admin) {
+        assert.equal(c.usable_as_feature, false);
+    }
+});
+
+test('buildFieldSummary returns correct category counts', () => {
+    const summary = buildFieldSummary();
+    assert.equal(summary.label.length, 1);
+    assert.ok(summary.safe_pre_match.length >= 6);
+    assert.ok(summary.leakage_post_match.length >= 8);
+    assert.ok(summary.administrative.length >= 10);
+    assert.equal(summary.uncertain.length, 0);
+});
+
+test('buildDryRunPayload computes label distribution correctly', () => {
+    const rows = [
+        buildEligibleRow({ match_id: 'A', actual_result: 'home_win' }),
+        buildEligibleRow({ match_id: 'B', actual_result: 'home_win' }),
+        buildEligibleRow({ match_id: 'C', actual_result: 'draw' }),
+        buildEligibleRow({ match_id: 'D', actual_result: 'away_win' }),
+    ];
+
+    const payload = buildDryRunPayload(rows);
+
+    assert.equal(payload.training_eligible_count, 4);
+    assert.deepEqual(payload.label_distribution, { home_win: 2, draw: 1, away_win: 1 });
+    assert.equal(payload.label_validation.all_label_valid, true);
+    assert.equal(payload.label_validation.valid_count, 4);
+});
+
+test('buildDryRunPayload includes required safety and recommendation fields', () => {
+    const rows = [buildEligibleRow()];
+    const payload = buildDryRunPayload(rows);
+
+    assert.equal(payload.mode, 'dry_run');
+    assert.equal(payload.actual_update_executed, false);
+    assert.equal(payload.safety.db_write_allowed, false);
+    assert.equal(payload.safety.model_training_performed, false);
+    assert.equal(payload.safety.read_only_transaction_used, true);
+    assert.ok(payload.risk_flags.length >= 3);
+    assert.ok(payload.recommendations.length >= 4);
+    assert.ok(payload.safe_feature_candidates.length >= 6);
+    assert.ok(payload.leakage_feature_candidates.length >= 8);
+    assert.equal(payload.field_classification_summary.uncertain_count, 0);
+    assert.equal(payload.sample_rows_count, 1);
+});
+
+test('runDryRun uses read-only SQL and returns expected shape', async () => {
+    const rows = [
+        buildEligibleRow(),
+        buildEligibleRow({
+            match_id: '53_20252026_4830459',
+            external_id: '4830459',
+            actual_result: 'draw',
+            home_score: 1,
+            away_score: 1,
+        }),
+    ];
+    const mockClient = createMockClient(rows);
+
+    const payload = await runDryRun({}, { client: mockClient });
+
+    assert.equal(payload.mode, 'dry_run');
+    assert.equal(payload.actual_update_executed, false);
+    assert.equal(payload.training_eligible_count, 2);
+    assert.deepEqual(payload.label_distribution, { home_win: 1, draw: 1 });
+    assert.equal(payload.safety.db_write_allowed, false);
+    assert.equal(payload.safety.read_only_transaction_used, true);
+    assert.equal(mockClient.calls.length, 3);
+    assert.equal(mockClient.calls[0].sql.trim(), READ_ONLY_BEGIN_SQL);
+    assert.match(mockClient.calls[1].sql.trim(), /^SELECT/);
+    assert.match(mockClient.calls[1].sql.trim(), /is_training_eligible = true/);
+    assert.equal(mockClient.calls[2].sql.trim(), READ_ONLY_ROLLBACK_SQL);
+});


### PR DESCRIPTION
## Summary

- Read-only dry-run auditing training dataset construction and feature leakage policy for 58 Ligue 1 is_training_eligible=true samples.
- Classifies all 32 matches columns: 1 label, 7 safe pre-match features, 10 leakage post-match fields, 14 administrative.
- Confirms 58/58 labels valid, distribution H=23/D=17/A=18.
- No migration, no schema change, no DB write, no live fetch, no raw payload, no model training.

## Scope

| Item | Value |
|---|---|
| Task type | data dry-run / governance |
| One task / one branch / one PR | yes |
| Combines feature + cleanup | no |
| Business code changed | no |
| FotMob code changed | no |

## Files Changed

| Path | Purpose |
|---|---|
| `scripts/ops/training_dataset_leakage_dry_run.js` | New read-only script: scans eligible matches, classifies 32 columns by leakage risk, validates labels |
| `tests/unit/training_dataset_leakage_dry_run.test.js` | Unit tests: field coverage, classification categories, label validation, read-only safety |
| `docs/_reports/training_dataset_leakage_dry_run_20260619.md` | Dry-run report with full field taxonomy, risk flags, recommendations |

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | 1 report |
| Reports added | `docs/_reports/training_dataset_leakage_dry_run_20260619.md` covering field taxonomy (32 columns), label validation, risk flags, recommendations |
| Manifests added | 0 |
| Review reports added | 0 |
| Decision reports added | 0 |
| Next plans added | 0 |

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| Business code changed | no |
| FotMob code changed | no |
| DB used | yes (read-only SELECT in explicit READ ONLY transaction) |
| Browser automation used | no |
| Scraper run | no |
| Model training performed | no |
| Model output generated | no |

## Validation

| Validation | Result |
|---|---|
| Host validation | N/A |
| Container validation | 11/11 unit tests pass, eslint clean, git diff --check clean |
| GitHub Production Gate | Pending CI |

## CI Gate Scope

- What the validation proves: All 32 matches columns classified by leakage risk. 58/58 labels valid and complete. Read-only transaction enforced. No writes, no model training, no live fetch.
- What the validation does not prove: raw_match_data JSONB field safety (100+ paths not individually audited — all known to be post-match). Time-gating implementation correctness (not yet built).
- Host unavailable results: N/A
- Container validation results: 11/11 tests pass, eslint 0 errors

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Rollback Plan

- N/A. This is a read-only dry-run. No DB writes were performed. No state was modified. No rollback needed. If the script or report contains errors, they can be corrected in a follow-up PR.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:
- Confirm 58-sample smoke dataset scope and purpose
- Confirm 7 safe pre-match features (league_name, season, home_team, away_team, match_date, venue, referee)
- Define explicit time-gating strategy for all derived features
- Decide on multi-league/multi-season expansion before any production model training
- Authorize time-gating infrastructure build-out

## PR Type

- [x] governance-only
- [ ] runtime-code-change
- [ ] docs-only
- [ ] test-only
- [ ] ci-fix
- [ ] data-artifact

## Runtime Behavior

- Runtime code change included: yes (new script, no existing code paths changed)
- Runtime code paths changed: new `scripts/ops/training_dataset_leakage_dry_run.js`
- Runtime behavior changed: no — read-only, no DB writes, no model training
- Default behavior: dry-run only

## Artifact Scope

- Docs/report/manifest changes included: yes
- Added/modified report lines: 1 new report, ~140 lines
- Copies full historical state: no
- Includes large artifact: no

## Business Progress

- Business progress: All 32 matches columns classified. 58 training-eligible samples audited. Labels 100% valid. 7 safe features identified. 10 leakage fields banned.
- Blocker removed: Feature leakage taxonomy now documented
- Blocker remaining: Time-gating infrastructure not built; dataset too small for production model

## Ingestion Convergence Gate

n/a — this PR is training dataset leakage audit, not ingestion pipeline work.

## Safety Status

- no live fetch: yes
- no detail fetch: yes
- no network request: yes
- no DB writes: yes
- no raw_match_data inserts: yes
- no matches writes: yes
- no parser/features/training/prediction: yes
- no full body/raw_data/pageProps saved or printed: yes
- no model training: yes
- no model output: yes

## Tests Run

- [x] lint (eslint clean)
- [x] unit tests (11/11 pass)
- [x] git diff --check (clean)
- [x] DB SELECT-only safety check

Commands and results:

```
# Unit tests: 11/11 pass, 0 fail
# ESLint: clean, 0 errors
# git diff --check: clean
```

## Repository Hygiene / Debt Impact

- New files added: 3
- File lifecycle: `scripts/ops/training_dataset_leakage_dry_run.js` (permanent), `tests/unit/training_dataset_leakage_dry_run.test.js` (permanent), `docs/_reports/training_dataset_leakage_dry_run_20260619.md` (phase-artifact)
- Permanent files: 2
- Phase-only artifacts: 1
- Does this PR increase repository noise? no

## Artifact limits checklist

- [x] No full HTML/pageProps/raw_data/source body saved
- [x] No large report unless justified
- [x] No full historical recap copied
- [x] No orphan helper/script without lifecycle
- [x] Tests protect runtime behavior where applicable

## Review Notes

- Reviewer focus: Field classification accuracy, leakage analysis completeness, time-gating requirements
- Residual risk: raw_match_data JSONB fields not individually audited — all known post-match but not exhaustively catalogued
- Follow-up PR: Time-gating infrastructure or multi-league dataset expansion (requires separate authorization)