### PR TITLE
feat(data): add smoke training dataset dry-run

### DIFF
--- a/docs/_reports/smoke_training_dataset_dry_run_20260619.md
+++ b/docs/_reports/smoke_training_dataset_dry_run_20260619.md
@@ -1,0 +1,95 @@
+# Smoke Training Dataset Dry-Run
+- lifecycle: phase-artifact
+- scope: read-only smoke training dataset builder dry-run
+- date: 2026-06-19
+- branch: `data/smoke-training-dataset-dry-run`
+
+## 结论
+
+这是 **dry-run，不是真实训练**。本次新增 `scripts/ops/smoke_training_dataset_dry_run.js` 和对应单测，只读构造 Ligue 1 `is_training_eligible=true` 样本的 `X/y` 预览，不训练模型，不写 DB，不生成模型文件。
+
+本次保持：
+- no DB write / no migration / no schema change
+- no live fetch / no raw payload output
+- no model training / no model output / no prediction change
+- no `matches` / `raw_match_data` 变更
+
+## 数据集结果
+
+| 指标 | 结果 |
+| --- | --- |
+| `sample_count` | `58` |
+| `label_column` | `actual_result` |
+| `x_shape` | `[58, 7]` |
+| `y_shape` | `[58]` |
+| `leakage_columns_detected` | `[]` |
+
+### X 字段列表
+
+1. `league_name`
+2. `season`
+3. `home_team`
+4. `away_team`
+5. `match_date`
+6. `venue`
+7. `referee`
+
+### y 字段
+
+`actual_result`
+
+### 标签分布
+
+| label | count |
+| --- | ---: |
+| `home_win` | 23 |
+| `draw` | 17 |
+| `away_win` | 18 |
+
+### 缺失率
+
+| feature | missing_count | total_count | missing_rate |
+| --- | ---: | ---: | ---: |
+| `league_name` | 0 | 58 | 0 |
+| `season` | 0 | 58 | 0 |
+| `home_team` | 0 | 58 | 0 |
+| `away_team` | 0 | 58 | 0 |
+| `match_date` | 0 | 58 | 0 |
+| `venue` | 58 | 58 | 1 |
+| `referee` | 58 | 58 | 1 |
+
+## 明确排除字段
+
+已从 `X` 明确排除：
+- `actual_result`
+- `home_score` / `away_score`
+- `home_corners` / `away_corners`
+- `home_yellow_cards` / `away_yellow_cards`
+- `home_red_cards` / `away_red_cards`
+- `status` / `is_finished`
+- `pipeline_status` / `pipeline_status_reason`
+- `source_type` / `evidence_level`
+- `is_training_eligible`
+- `raw_match_data`
+- 其他 governance / provenance / timestamp / identity 字段
+
+## 泄漏检查
+
+本次 `X` 仅由 7 个批准的赛前字段组成，`y` 只来自 `actual_result`。`leakage_columns_detected=[]`，未发现赛后统计字段或 governance 字段误入 `X`。
+
+## 风险与限制
+
+1. `58` 条样本只适合 smoke / integration dataset，不适合正式训练。
+2. `venue` 与 `referee` 当前缺失率均为 `100%`，正式训练前需要决定是否保留、填补或删除这两个字段。
+3. 本次仅验证只读数据集构造路径，不代表模型质量、泛化能力或正式训练 readiness。
+
+## 验证命令
+
+```text
+docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'cd /app/.codex-tmp/smoke-training-dataset-dry-run && node scripts/ops/smoke_training_dataset_dry_run.js --json'
+docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'cd /app/.codex-tmp/smoke-training-dataset-dry-run && node --test tests/unit/smoke_training_dataset_dry_run.test.js'
+docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'cd /app/.codex-tmp/smoke-training-dataset-dry-run && node /app/node_modules/eslint/bin/eslint.js --no-ignore scripts/ops/smoke_training_dataset_dry_run.js tests/unit/smoke_training_dataset_dry_run.test.js'
+git diff --check
+```
+
+下一步必须用户明确确认；本报告不构成真实训练、导出、模型产出或任何写操作授权。

--- a/scripts/ops/smoke_training_dataset_dry_run.js
+++ b/scripts/ops/smoke_training_dataset_dry_run.js
@@ -1,0 +1,474 @@
+#!/usr/bin/env node
+'use strict';
+
+// lifecycle: permanent
+// scope: read-only smoke training dataset builder dry-run
+
+const PHASE = 'SMOKE_TRAINING_DATASET_DRY_RUN';
+const TARGET_LEAGUE = 'Ligue 1';
+const TARGET_SEASON = '2025/2026';
+const READ_ONLY_BEGIN_SQL = 'BEGIN READ ONLY';
+const READ_ONLY_ROLLBACK_SQL = 'ROLLBACK';
+
+const SAFE_FEATURE_COLUMNS = Object.freeze([
+    'league_name',
+    'season',
+    'home_team',
+    'away_team',
+    'match_date',
+    'venue',
+    'referee',
+]);
+
+const LABEL_COLUMN = 'actual_result';
+const VALID_LABELS = Object.freeze(['home_win', 'draw', 'away_win']);
+const VALID_LABEL_SET = new Set(VALID_LABELS);
+
+const EXPECTED_SAMPLE_COUNT = 58;
+const EXPECTED_LABEL_DISTRIBUTION = Object.freeze({
+    home_win: 23,
+    draw: 17,
+    away_win: 18,
+});
+
+const EXCLUDED_COLUMNS = Object.freeze([
+    'actual_result',
+    'home_score',
+    'away_score',
+    'home_corners',
+    'away_corners',
+    'home_yellow_cards',
+    'away_yellow_cards',
+    'home_red_cards',
+    'away_red_cards',
+    'status',
+    'is_finished',
+    'pipeline_status',
+    'source_type',
+    'evidence_level',
+    'is_training_eligible',
+    'raw_match_data',
+    'pipeline_status_reason',
+    'data_source',
+    'data_version',
+    'is_production_scope',
+    'is_reconciliation_eligible',
+    'collection_date',
+    'created_at',
+    'updated_at',
+    'match_id',
+    'external_id',
+]);
+
+const DISALLOWED_FEATURE_COLUMNS = new Set(EXCLUDED_COLUMNS);
+
+const SCAN_SQL = `
+SELECT
+    m.league_name,
+    m.season,
+    m.home_team,
+    m.away_team,
+    m.match_date,
+    m.venue,
+    m.referee,
+    m.actual_result
+FROM matches m
+WHERE m.is_training_eligible = true
+  AND m.league_name = $1
+  AND m.season = $2
+ORDER BY m.match_id
+`;
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/smoke_training_dataset_dry_run.js [--json]',
+        '',
+        'Safety:',
+        '  只读 dry-run。不会训练模型，不会写库，不会输出 raw payload。',
+    ].join('\n');
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = { json: false, help: false };
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = String(argv[index]);
+        if (arg === '--json') {
+            options.json = true;
+        } else if (arg === '--help' || arg === '-h') {
+            options.help = true;
+        } else {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+    return options;
+}
+
+function buildDbConfig() {
+    return {
+        host: process.env.DB_HOST || process.env.POSTGRES_HOST || 'db',
+        port: Number.parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.DB_NAME || process.env.POSTGRES_DB || 'football_db',
+        user: process.env.DB_USER || process.env.POSTGRES_USER || 'football_user',
+        password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD,
+        max: 1,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+    };
+}
+
+async function openReadOnlyClient(dependencies = {}) {
+    if (dependencies.client) {
+        return { client: dependencies.client, close: async () => {} };
+    }
+
+    const { Pool } = require('pg');
+    const pool = new Pool(buildDbConfig());
+    const client = await pool.connect();
+
+    return {
+        client,
+        close: async () => {
+            if (typeof client.release === 'function') {
+                client.release();
+            }
+            await pool.end();
+        },
+    };
+}
+
+function assertSelectOnlySql(sql) {
+    const normalized = String(sql || '').replace(/\s+/g, ' ').trim().toUpperCase();
+    const allowed =
+        normalized === READ_ONLY_BEGIN_SQL ||
+        normalized === READ_ONLY_ROLLBACK_SQL ||
+        normalized.startsWith('SELECT ') ||
+        normalized.startsWith('WITH ');
+
+    if (!allowed) {
+        throw new Error(`Unsafe SQL rejected by ${PHASE}: ${normalized.slice(0, 80)}`);
+    }
+}
+
+async function querySelectOnly(client, sql, params = []) {
+    assertSelectOnlySql(sql);
+    return client.query(sql, params);
+}
+
+async function scanTrainingEligibleRows(dependencies = {}) {
+    const connection = await openReadOnlyClient(dependencies);
+    let rolledBack = false;
+
+    try {
+        await querySelectOnly(connection.client, READ_ONLY_BEGIN_SQL);
+        const result = await querySelectOnly(connection.client, SCAN_SQL, [TARGET_LEAGUE, TARGET_SEASON]);
+        await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL);
+        rolledBack = true;
+        return result.rows || [];
+    } finally {
+        if (!rolledBack) {
+            try {
+                await querySelectOnly(connection.client, READ_ONLY_ROLLBACK_SQL);
+            } catch {
+                // 保留原始错误
+            }
+        }
+        await connection.close();
+    }
+}
+
+function isMissingValue(value) {
+    if (value === null || value === undefined) {
+        return true;
+    }
+    if (typeof value === 'string') {
+        return value.trim() === '';
+    }
+    return false;
+}
+
+function buildOrderedLabelDistribution(rows) {
+    const distribution = {
+        home_win: 0,
+        draw: 0,
+        away_win: 0,
+    };
+
+    for (const row of rows) {
+        if (VALID_LABEL_SET.has(row.actual_result)) {
+            distribution[row.actual_result] += 1;
+        }
+    }
+
+    return distribution;
+}
+
+function buildMissingRateByFeature(rows, featureColumns = SAFE_FEATURE_COLUMNS) {
+    const totalCount = rows.length;
+    const missingRateByFeature = {};
+
+    for (const feature of featureColumns) {
+        const missingCount = rows.filter(row => isMissingValue(row[feature])).length;
+        missingRateByFeature[feature] = {
+            missing_count: missingCount,
+            total_count: totalCount,
+            missing_rate: totalCount === 0 ? 0 : Number((missingCount / totalCount).toFixed(6)),
+        };
+    }
+
+    return missingRateByFeature;
+}
+
+function detectLeakageColumns(featureColumns = SAFE_FEATURE_COLUMNS) {
+    return featureColumns.filter(column => DISALLOWED_FEATURE_COLUMNS.has(column) || column === LABEL_COLUMN);
+}
+
+function buildMatrices(rows, featureColumns = SAFE_FEATURE_COLUMNS, labelColumn = LABEL_COLUMN) {
+    const xRows = rows.map(row => {
+        const record = {};
+        for (const column of featureColumns) {
+            record[column] = row[column];
+        }
+        return record;
+    });
+
+    const yRows = rows.map(row => row[labelColumn]);
+
+    return { xRows, yRows };
+}
+
+function sameLabelDistribution(left, right) {
+    return VALID_LABELS.every(label => (left[label] || 0) === (right[label] || 0));
+}
+
+function buildRiskFlags({ sampleCount, missingRateByFeature, invalidLabelValues }) {
+    const riskFlags = [
+        'dry_run_only_no_training_executed',
+        'read_only_select_only_no_db_write',
+        `small_sample_size_${sampleCount}_smoke_only_not_for_production_training`,
+        'categorical_encoding_required_for_team_and_context_fields',
+    ];
+
+    for (const feature of SAFE_FEATURE_COLUMNS) {
+        const missingRate = missingRateByFeature[feature]?.missing_rate ?? 0;
+        if (missingRate > 0) {
+            riskFlags.push(`${feature}_missing_rate_${missingRate}`);
+        }
+    }
+
+    if (invalidLabelValues.length > 0) {
+        riskFlags.push(`invalid_label_values_detected_${invalidLabelValues.join('|')}`);
+    }
+
+    return riskFlags;
+}
+
+function buildDryRunPayload(rows) {
+    const sampleCount = rows.length;
+    const featureColumns = [...SAFE_FEATURE_COLUMNS];
+    const labelDistribution = buildOrderedLabelDistribution(rows);
+    const missingRateByFeature = buildMissingRateByFeature(rows, featureColumns);
+    const leakageColumnsDetected = detectLeakageColumns(featureColumns);
+    const { xRows, yRows } = buildMatrices(rows, featureColumns, LABEL_COLUMN);
+    const invalidLabelValues = [...new Set(
+        rows
+            .map(row => row.actual_result)
+            .filter(value => !VALID_LABEL_SET.has(value))
+            .map(value => String(value))
+    )];
+
+    const validationChecks = {
+        expected_sample_count: EXPECTED_SAMPLE_COUNT,
+        actual_sample_count: sampleCount,
+        sample_count_matches_expected: sampleCount === EXPECTED_SAMPLE_COUNT,
+        expected_label_distribution: EXPECTED_LABEL_DISTRIBUTION,
+        actual_label_distribution: labelDistribution,
+        label_distribution_matches_expected: sameLabelDistribution(
+            labelDistribution,
+            EXPECTED_LABEL_DISTRIBUTION
+        ),
+        expected_feature_columns: featureColumns,
+        feature_columns_match_expected:
+            JSON.stringify(featureColumns) === JSON.stringify(SAFE_FEATURE_COLUMNS),
+        expected_label_column: LABEL_COLUMN,
+        label_column_matches_expected: LABEL_COLUMN === 'actual_result',
+        leakage_columns_detected_empty: leakageColumnsDetected.length === 0,
+        invalid_label_values: invalidLabelValues,
+    };
+
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        script: 'scripts/ops/smoke_training_dataset_dry_run.js',
+        generated_at: new Date().toISOString(),
+        target_scope: {
+            league_name: TARGET_LEAGUE,
+            season: TARGET_SEASON,
+            is_training_eligible: true,
+        },
+        sample_count: sampleCount,
+        feature_columns: featureColumns,
+        label_column: LABEL_COLUMN,
+        label_distribution: labelDistribution,
+        missing_rate_by_feature: missingRateByFeature,
+        x_shape: [xRows.length, featureColumns.length],
+        y_shape: [yRows.length],
+        leakage_columns_detected: leakageColumnsDetected,
+        excluded_columns: [...EXCLUDED_COLUMNS],
+        validation_checks: validationChecks,
+        risk_flags: buildRiskFlags({
+            sampleCount,
+            missingRateByFeature,
+            invalidLabelValues,
+        }),
+        recommendation:
+            '58 条样本仅适合 smoke/integration dataset dry-run；正式训练、导出或模型产出必须等待用户再次确认。',
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            db_write_executed: false,
+            live_fetch_allowed: false,
+            live_fetch_executed: false,
+            raw_payload_output_allowed: false,
+            raw_payload_output_detected: false,
+            model_training_performed: false,
+            model_output_generated: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function runDryRun(options = {}, dependencies = {}) {
+    const rows = await scanTrainingEligibleRows(dependencies);
+    return buildDryRunPayload(rows);
+}
+
+function payloadToText(payload) {
+    const labelDistribution = VALID_LABELS
+        .map(label => `  ${label}: ${payload.label_distribution[label] ?? 0}`)
+        .join('\n');
+    const missingRates = SAFE_FEATURE_COLUMNS
+        .map(feature => {
+            const stats = payload.missing_rate_by_feature[feature];
+            return `  ${feature}: missing=${stats.missing_count}/${stats.total_count} rate=${stats.missing_rate}`;
+        })
+        .join('\n');
+    const leakageColumns = payload.leakage_columns_detected.length > 0
+        ? payload.leakage_columns_detected.map(column => `  - ${column}`).join('\n')
+        : '  - none';
+    const excludedColumns = payload.excluded_columns.map(column => `  - ${column}`).join('\n');
+    const riskFlags = payload.risk_flags.map(flag => `  - ${flag}`).join('\n');
+
+    return [
+        '[DRY-RUN] Smoke training dataset builder',
+        `Phase: ${payload.phase}`,
+        `Mode: ${payload.mode}`,
+        `Sample count: ${payload.sample_count}`,
+        `Feature columns: ${payload.feature_columns.join(', ')}`,
+        `Label column: ${payload.label_column}`,
+        `X shape: [${payload.x_shape.join(', ')}]`,
+        `Y shape: [${payload.y_shape.join(', ')}]`,
+        'Label distribution:',
+        labelDistribution,
+        'Missing rate by feature:',
+        missingRates,
+        'Leakage columns detected:',
+        leakageColumns,
+        'Excluded columns:',
+        excludedColumns,
+        'Risk flags:',
+        riskFlags,
+        `Recommendation: ${payload.recommendation}`,
+    ].join('\n');
+}
+
+function writePayload(payload, json, io) {
+    const output = json
+        ? `${JSON.stringify(payload, null, 2)}\n`
+        : `${payloadToText(payload)}\n`;
+    io.stdout(output);
+}
+
+function buildFailurePayload(error) {
+    return {
+        phase: PHASE,
+        mode: 'dry_run',
+        actual_update_executed: false,
+        read_only: true,
+        script: 'scripts/ops/smoke_training_dataset_dry_run.js',
+        target_scope: {
+            league_name: TARGET_LEAGUE,
+            season: TARGET_SEASON,
+            is_training_eligible: true,
+        },
+        errors: [error.message],
+        safety: {
+            migration_in_scope: false,
+            schema_change_in_scope: false,
+            db_write_allowed: false,
+            db_write_executed: false,
+            live_fetch_allowed: false,
+            live_fetch_executed: false,
+            raw_payload_output_allowed: false,
+            raw_payload_output_detected: false,
+            model_training_performed: false,
+            model_output_generated: false,
+            read_only_transaction_used: true,
+        },
+    };
+}
+
+async function main(argv = process.argv.slice(2), io = {}) {
+    const output = {
+        stdout: io.stdout || (text => process.stdout.write(text)),
+        stderr: io.stderr || (text => process.stderr.write(text)),
+    };
+
+    let options = { json: false, help: false };
+
+    try {
+        options = parseArgs(argv);
+        if (options.help) {
+            output.stdout(`${usage()}\n`);
+            return 0;
+        }
+
+        const payload = await runDryRun(options);
+        writePayload(payload, options.json, output);
+        return 0;
+    } catch (error) {
+        const payload = buildFailurePayload(error);
+        writePayload(payload, options.json === true, output);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    main().then(code => {
+        process.exitCode = code;
+    });
+}
+
+module.exports = {
+    SAFE_FEATURE_COLUMNS,
+    LABEL_COLUMN,
+    VALID_LABELS,
+    EXPECTED_SAMPLE_COUNT,
+    EXPECTED_LABEL_DISTRIBUTION,
+    EXCLUDED_COLUMNS,
+    SCAN_SQL,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    assertSelectOnlySql,
+    buildOrderedLabelDistribution,
+    buildMissingRateByFeature,
+    detectLeakageColumns,
+    buildMatrices,
+    buildDryRunPayload,
+    runDryRun,
+    main,
+};

--- a/tests/unit/smoke_training_dataset_dry_run.test.js
+++ b/tests/unit/smoke_training_dataset_dry_run.test.js
@@ -1,0 +1,181 @@
+'use strict';
+
+// lifecycle: permanent
+// scope: unit safety coverage for smoke training dataset builder dry-run
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    SAFE_FEATURE_COLUMNS,
+    LABEL_COLUMN,
+    EXPECTED_SAMPLE_COUNT,
+    EXPECTED_LABEL_DISTRIBUTION,
+    EXCLUDED_COLUMNS,
+    SCAN_SQL,
+    READ_ONLY_BEGIN_SQL,
+    READ_ONLY_ROLLBACK_SQL,
+    parseArgs,
+    assertSelectOnlySql,
+    buildMissingRateByFeature,
+    detectLeakageColumns,
+    buildMatrices,
+    buildDryRunPayload,
+    runDryRun,
+} = require('../../scripts/ops/smoke_training_dataset_dry_run');
+
+function buildEligibleRow(overrides = {}) {
+    return {
+        league_name: 'Ligue 1',
+        season: '2025/2026',
+        home_team: 'Team A',
+        away_team: 'Team B',
+        match_date: '2025-08-16T19:00:00Z',
+        venue: null,
+        referee: null,
+        actual_result: 'home_win',
+        ...overrides,
+    };
+}
+
+function createMockClient(rows) {
+    const calls = [];
+
+    return {
+        calls,
+        async query(sql, params = []) {
+            calls.push({ sql: String(sql), params });
+
+            const normalized = String(sql).replace(/\s+/g, ' ').trim();
+            if (normalized === READ_ONLY_BEGIN_SQL || normalized === READ_ONLY_ROLLBACK_SQL) {
+                return { rows: [] };
+            }
+
+            if (normalized.startsWith('SELECT')) {
+                return { rows };
+            }
+
+            throw new Error(`Unexpected SQL in test mock: ${normalized.slice(0, 80)}`);
+        },
+    };
+}
+
+test('parseArgs supports --json and --help', () => {
+    assert.equal(parseArgs(['--json']).json, true);
+    assert.equal(parseArgs(['--help']).help, true);
+    assert.equal(parseArgs([]).json, false);
+});
+
+test('assertSelectOnlySql rejects non-select SQL', () => {
+    assert.doesNotThrow(() => assertSelectOnlySql('SELECT 1'));
+    assert.doesNotThrow(() => assertSelectOnlySql('ROLLBACK'));
+    assert.throws(() => assertSelectOnlySql('COMMIT'));
+    assert.throws(() => assertSelectOnlySql('EXPLAIN SELECT 1'));
+});
+
+test('SCAN_SQL only selects 7 safe features plus label', () => {
+    const normalized = SCAN_SQL.replace(/\s+/g, ' ').trim();
+
+    for (const column of SAFE_FEATURE_COLUMNS) {
+        assert.match(normalized, new RegExp(`m\\.${column}`));
+    }
+    assert.match(normalized, /m\.actual_result/);
+
+    for (const forbidden of [
+        'home_score',
+        'away_score',
+        'home_corners',
+        'away_corners',
+        'status',
+        'is_finished',
+        'pipeline_status',
+        'raw_match_data',
+    ]) {
+        assert.doesNotMatch(normalized, new RegExp(`\\b${forbidden}\\b`));
+    }
+});
+
+test('buildMatrices keeps X limited to safe features and y from actual_result only', () => {
+    const rows = [
+        buildEligibleRow(),
+        buildEligibleRow({
+            home_team: 'Team C',
+            away_team: 'Team D',
+            actual_result: 'draw',
+        }),
+    ];
+
+    const { xRows, yRows } = buildMatrices(rows);
+
+    assert.equal(xRows.length, 2);
+    assert.deepEqual(Object.keys(xRows[0]), SAFE_FEATURE_COLUMNS);
+    assert.deepEqual(yRows, ['home_win', 'draw']);
+    assert.equal(Object.prototype.hasOwnProperty.call(xRows[0], LABEL_COLUMN), false);
+});
+
+test('buildMissingRateByFeature computes missing rate for nullable safe fields', () => {
+    const rows = [
+        buildEligibleRow({ venue: null, referee: null }),
+        buildEligibleRow({ venue: 'Stadium', referee: 'Ref A' }),
+        buildEligibleRow({ venue: ' ', referee: null }),
+    ];
+
+    const missingRate = buildMissingRateByFeature(rows);
+
+    assert.equal(missingRate.league_name.missing_rate, 0);
+    assert.equal(missingRate.venue.missing_count, 2);
+    assert.equal(missingRate.venue.missing_rate, 0.666667);
+    assert.equal(missingRate.referee.missing_count, 2);
+    assert.equal(missingRate.referee.missing_rate, 0.666667);
+});
+
+test('detectLeakageColumns returns empty array for approved feature set', () => {
+    assert.deepEqual(detectLeakageColumns(SAFE_FEATURE_COLUMNS), []);
+});
+
+test('buildDryRunPayload includes expected validation summary and excluded columns', () => {
+    const rows = [
+        buildEligibleRow({ actual_result: 'home_win' }),
+        buildEligibleRow({ actual_result: 'draw' }),
+        buildEligibleRow({ actual_result: 'away_win' }),
+    ];
+
+    const payload = buildDryRunPayload(rows);
+
+    assert.equal(payload.mode, 'dry_run');
+    assert.equal(payload.actual_update_executed, false);
+    assert.equal(payload.sample_count, 3);
+    assert.deepEqual(payload.feature_columns, SAFE_FEATURE_COLUMNS);
+    assert.equal(payload.label_column, LABEL_COLUMN);
+    assert.deepEqual(payload.label_distribution, { home_win: 1, draw: 1, away_win: 1 });
+    assert.deepEqual(payload.x_shape, [3, 7]);
+    assert.deepEqual(payload.y_shape, [3]);
+    assert.deepEqual(payload.leakage_columns_detected, []);
+    assert.equal(payload.validation_checks.expected_sample_count, EXPECTED_SAMPLE_COUNT);
+    assert.deepEqual(
+        payload.validation_checks.expected_label_distribution,
+        EXPECTED_LABEL_DISTRIBUTION
+    );
+    assert.ok(EXCLUDED_COLUMNS.includes('raw_match_data'));
+    assert.ok(EXCLUDED_COLUMNS.includes('actual_result'));
+    assert.equal(payload.safety.db_write_executed, false);
+    assert.equal(payload.safety.model_training_performed, false);
+});
+
+test('runDryRun uses BEGIN READ ONLY, SELECT, and ROLLBACK only', async () => {
+    const rows = [
+        buildEligibleRow({ actual_result: 'home_win' }),
+        buildEligibleRow({ actual_result: 'draw' }),
+    ];
+    const mockClient = createMockClient(rows);
+
+    const payload = await runDryRun({}, { client: mockClient });
+
+    assert.equal(payload.sample_count, 2);
+    assert.deepEqual(payload.label_distribution, { home_win: 1, draw: 1, away_win: 0 });
+    assert.equal(payload.validation_checks.leakage_columns_detected_empty, true);
+    assert.equal(mockClient.calls.length, 3);
+    assert.equal(mockClient.calls[0].sql.trim(), READ_ONLY_BEGIN_SQL);
+    assert.match(mockClient.calls[1].sql.trim(), /^SELECT/);
+    assert.equal(mockClient.calls[2].sql.trim(), READ_ONLY_ROLLBACK_SQL);
+});


### PR DESCRIPTION
## Summary

- Adds a new read-only smoke dataset builder at `scripts/ops/smoke_training_dataset_dry_run.js` that scans the existing `matches` table and constructs a preview `X/y` dataset for the 58 `is_training_eligible=true` Ligue 1 2025/2026 rows.
- Restricts `X` to the approved seven pre-match fields only: `league_name`, `season`, `home_team`, `away_team`, `match_date`, `venue`, and `referee`; keeps `y` sourced only from `actual_result`.
- Verifies the current dry-run outcome for head `f1cd084a`: `sample_count=58`, `label_distribution=23/17/18`, `x_shape=[58,7]`, `y_shape=[58]`, `leakage_columns_detected=[]`, and changed files: `3`.
- Adds unit coverage for SELECT-only SQL, safe feature selection, label-only `y`, and empty leakage detection, plus a phase report capturing the dry-run evidence and limits.

## Scope

| Item | Value |
|---|---|
| Task type | smoke training dataset builder dry-run |
| One task / one branch / one PR | yes |
| Combines feature + cleanup, audit + repair, merge + new work, or docs governance + business code | no |
| Merge-only zero-change task | no |
| Business code changed | yes |
| FotMob code changed | no |

## Files Changed

| Path | Purpose |
|---|---|
| `scripts/ops/smoke_training_dataset_dry_run.js` | New read-only runtime path that builds a smoke `X/y` dataset preview from approved pre-match fields only |
| `tests/unit/smoke_training_dataset_dry_run.test.js` | Runtime behavior coverage for SELECT-only safety, feature inclusion policy, and label handling |
| `docs/_reports/smoke_training_dataset_dry_run_20260619.md` | Minimal phase report recording dry-run scope, result, missing rates, exclusions, and limits |

## Documentation Impact

A new bounded report was added at `docs/_reports/smoke_training_dataset_dry_run_20260619.md` to record the exact dry-run outcome, safety boundary, and next-step stop condition. No manifest, next-plan, review report, or decision report was added because this PR changes one runtime helper plus one behavior test and only needs one short evidence report.

| Item | Value |
|---|---|
| New docs added | no general docs |
| Reports added | 1 |
| Manifests added | 0 |
| Review reports added | 0 |
| Decision reports added | 0 |
| Next plans added | 0 |
| Exact allowed report paths, if any | `docs/_reports/smoke_training_dataset_dry_run_20260619.md` |

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| Business code changed | yes |
| FotMob code changed | no |
| DB used | yes, read-only `SELECT` against `matches` inside `BEGIN READ ONLY` + `ROLLBACK` |
| Browser automation used | no |
| Scraper run | no |
| New manifest created | no |
| New next-plan created | no |
| New review report created | no |
| New decision report created | no |

## Validation

| Validation | Result |
|---|---|
| Host validation | `git diff --check`; `python3 scripts/ops/ai_workflow_gate.py --pr-body-file /tmp/smoke_pr_body.md`; `make pr-body-check PR=1561`; `make pr-merge-preflight PR=1561` |
| Container validation | `node scripts/ops/smoke_training_dataset_dry_run.js --json`; `node --test tests/unit/smoke_training_dataset_dry_run.test.js`; `node /app/node_modules/eslint/bin/eslint.js --no-ignore scripts/ops/smoke_training_dataset_dry_run.js tests/unit/smoke_training_dataset_dry_run.test.js` |
| GitHub Production Gate | run id `27849082000`; status `completed`; conclusion `success`; head `f1cd084a`; Changed files: 3 |

## CI Gate Scope

- What the validation proves: the new runtime helper can read the current 58 eligible Ligue 1 rows, build a smoke `X/y` preview, keep `X` limited to the approved seven fields, keep `y` limited to `actual_result`, and surface missing-rate plus exclusion evidence without any write path; the current-head Production Gate run `27849082000` completed successfully for `f1cd084a`.
- What the validation does not prove: it does not prove model quality, generalization, production training readiness, feature engineering quality, or any export / training / prediction path because none of those paths were executed.
- Host unavailable results, if any: none; host-side checks were limited to git hygiene and PR-body / merge preflight validation.
- Container validation results, if any: the dry-run returned `sample_count=58`, `label_distribution={home_win:23, draw:17, away_win:18}`, `leakage_columns_detected=[]`, `x_shape=[58,7]`, `y_shape=[58]`, and the behavior test suite passed 8/8.

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Rollback Plan

If this helper should not remain in the repository, revert commit `f1cd084a2e664fd4ecfe24cab3146557bad66390` or the eventual merge commit. No DB cleanup is required because the runtime path is SELECT-only and executed zero writes. After revert, rerun `git diff --check` and `node --test tests/unit/smoke_training_dataset_dry_run.test.js` to confirm the helper and its report are fully removed.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- Decide whether `venue` and `referee` should remain as smoke-only nullable fields or be dropped / backfilled before any formal training dataset design.
- If the user wants real training readiness work, propose a separate authorized task to expand dataset size and define temporal leakage policy before any model training or export.

## PR Type

选择一个主类型：

- [x] runtime-code-change
- [ ] governance-only
- [ ] docs-only
- [ ] test-only
- [ ] ci-fix
- [ ] data-artifact

## Runtime Behavior

- Runtime code change included: yes
- Runtime code paths changed: `scripts/ops/smoke_training_dataset_dry_run.js`
- Runtime behavior changed: yes — a new SELECT-only smoke dataset builder dry-run is now available and emits the required `X/y` safety summary for the current 58 eligible rows.

如果这是 implementation phase 但没有 runtime code change，默认 No-Go。请说明原因、blocker 和人工确认：

- Explanation: not applicable because this PR adds a new runtime path.
- Human confirmation: not needed for the runtime-code-change classification; later training/export still require user confirmation.

## Artifact Scope

- Docs/report/manifest changes included: yes
- Added/modified report lines: 95
- Added/modified manifest lines: 0
- Copies full historical state: no
- Includes large artifact: no
- Large artifact justification, if any: not applicable; the report is bounded and contains only summary evidence.

## Business Progress

- Business progress: added a read-only runtime path that proves the current 58 `is_training_eligible=true` Ligue 1 rows can be assembled into a smoke `X/y` dataset using only the approved seven pre-match features.
- Blocker removed: removed uncertainty about whether the current 58 eligible rows can produce a leakage-free smoke dataset preview with `y=actual_result` and `X` restricted to the approved field set.
- Blocker remaining: formal model training, dataset export, feature enrichment, and any production-grade training design remain blocked pending explicit user confirmation and a larger leakage-safe dataset strategy.
- Next step: wait for user confirmation before any broader dataset expansion, feature engineering, or training task.

## Ingestion Convergence Gate

Fill this section for any data ingestion, source inventory, target identity, raw write readiness,
accepted mapping, baseline, suspended target, or blocked target PR. Use `n/a` only when the PR is
not part of ingestion.

- Ingestion blocker removed: n/a — this PR is a read-only training dataset smoke check over existing `matches` rows and does not change ingestion blockers.
- Target state delta: n/a — no target state changed because the PR only reads current rows and builds an in-memory `X/y` preview.
- Count moved to clean_candidate: n/a — no ingestion target state transition occurred.
- Count moved to rejected/superseded: n/a — no ingestion target state transition occurred.
- Count moved to eligible_for_re_acceptance_review: n/a — no ingestion target state transition occurred.
- Count moved to needs_new_evidence: n/a — no ingestion target state transition occurred.
- Count remain_suspended: n/a — no ingestion target state transition occurred.
- Count still blocked: n/a — no ingestion target state transition occurred.
- No-progress justification: n/a — this PR is outside ingestion and focuses on training-dataset smoke construction only.
- Does this PR trigger architecture decision gate? n/a — the PR does not touch ingestion review, mapping, or raw-write flow.
- Is next step bounded? yes — the next step is a user-confirmed decision on whether to pursue broader training-readiness work.
- Is this the second consecutive no-progress ingestion PR? n/a — the PR is not an ingestion PR.

## Safety Status

- no live fetch: yes
- no detail fetch: yes
- no network request: yes
- no DB writes: yes
- no raw_match_data inserts: yes
- no matches writes: yes
- no matches.external_id changes: yes
- no raw write execution: yes
- no re-acceptance execution: yes
- no suspension reversal: yes
- no rollback execution: yes
- no parser/features/training/prediction: yes
- no full body/raw_data/pageProps saved or printed: yes

If any answer is `no`, list the explicit authorization, scope, command, and verification:

- Authorization details: none; the runtime scope remained fully read-only.

## Tests Run

- [x] lint
- [x] unit tests
- [ ] coverage
- [ ] formatter
- [x] git diff --check
- [ ] hidden/bidi scan
- [ ] full payload marker scan
- [x] DB SELECT-only safety check, if applicable
- [x] other: local AI workflow gate

Commands and results:

```text
docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'cd /app/.codex-tmp/smoke-training-dataset-dry-run && node scripts/ops/smoke_training_dataset_dry_run.js --json'
  -> sample_count=58; feature_columns=7; label_distribution=23/17/18; leakage_columns_detected=[]; no write flags remained false

docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'cd /app/.codex-tmp/smoke-training-dataset-dry-run && node --test tests/unit/smoke_training_dataset_dry_run.test.js'
  -> 8 tests passed

docker compose -f docker-compose.dev.yml exec -T dev bash -lc 'cd /app/.codex-tmp/smoke-training-dataset-dry-run && node /app/node_modules/eslint/bin/eslint.js --no-ignore scripts/ops/smoke_training_dataset_dry_run.js tests/unit/smoke_training_dataset_dry_run.test.js'
  -> passed

git diff --check
  -> passed

python3 scripts/ops/ai_workflow_gate.py --pr-body-file /tmp/smoke_pr_body.md
  -> PASS

make pr-body-check PR=1561
  -> pending at draft-body creation time; rerun after CI/body sync

make pr-merge-preflight PR=1561
  -> pending until PR is marked ready for review
```

## Repository Hygiene / Debt Impact

- New files added: 3
- File lifecycle for each new file:
  permanent / phase-artifact / one-shot-helper / test-fixture / temporary /
  archive-candidate / delete-after-use
- Permanent files: `scripts/ops/smoke_training_dataset_dry_run.js`, `tests/unit/smoke_training_dataset_dry_run.test.js`
- Phase-only artifacts: `docs/_reports/smoke_training_dataset_dry_run_20260619.md`
- One-shot helpers (describe cleanup condition): none
- Test fixtures: none
- Files superseded: none
- Files deleted or archived: none
- Cleanup required later: if this smoke helper is replaced by a broader training-dataset gate, reevaluate whether the phase report should be archived.
- Current-state doc updated? yes / no / not needed: not needed
- Report line count: 95
- Manifest size (lines / fields): none
- Does this PR increase repository noise? yes
- If yes, why is it justified: one bounded report is required to preserve the dry-run evidence and stop condition for this specific smoke dataset task.
- Next cleanup trigger: when a later authorized training-readiness task supersedes this smoke-only evidence report.

## Artifact limits checklist

- [x] No full HTML/pageProps/raw_data/source body saved
- [x] No large report unless justified in comments above
- [x] No full historical recap copied
- [x] No orphan helper/script without lifecycle
- [x] Tests protect runtime behavior where applicable

## Review Notes

- Reviewer focus: confirm `SCAN_SQL` only reads the approved eight columns, confirm `X` never includes label/leakage/governance fields, and confirm the report matches the actual dry-run output.
- Residual risk: `venue` and `referee` are currently 100% missing, and the 58-row sample remains smoke-only rather than production-training ready.
- Follow-up PR, if any: only after user confirmation for broader training-readiness work.