### PR TITLE
chore: add authoritative workflow enforcement dry run

### DIFF
--- a/docs/_reports/authoritative_workflow_enforcement_dry_run_20260621.md
+++ b/docs/_reports/authoritative_workflow_enforcement_dry_run_20260621.md
@@ -1,0 +1,109 @@
+# Authoritative Workflow Enforcement Dry Run
+
+- lifecycle: phase-artifact
+- date: 2026-06-21
+- branch: `chore/authoritative-workflow-enforcement-dry-run`
+- script: `scripts/ops/authoritative_workflow_enforcement_dry_run.js`
+- test: `tests/unit/authoritative_workflow_enforcement_dry_run.test.js`
+- authoritative backlinks: `docs/PROJECT_STATUS.md`, `docs/DOCUMENTATION_GOVERNANCE.md`, `docs/CODEX_WORKFLOW.md`
+
+## Safety
+
+- Static scan only.
+- No network, no database connection, no database write, no raw write.
+- No data acquisition, no model training, no model artifact generation.
+- No business logic, data collection logic, or training logic changed.
+- No file deletion, move, rename, or new authoritative document entrypoint.
+
+## Summary Answers
+
+| Question | Answer |
+| --- | --- |
+| Project already has authoritative docs? | Yes. |
+| Current authoritative entrypoints? | `PROJECT_STATUS`, `DOCUMENTATION_GOVERNANCE`, `CODEX_WORKFLOW`, `AGENT_WORKFLOW`, PR template, `AGENTS.md`, `CLAUDE.md`, `DATA_SOURCE_STRATEGY`, `docs/data/FOTMOB_CURRENT_STATE.md`. |
+| Which docs are stale? | `PROJECT_STATUS`, `DOCUMENTATION_GOVERNANCE`, `CODEX_WORKFLOW`, `CHANGELOG`, `README.md`. |
+| Is `docs/_reports` overgrown? | Yes: 434 report files after this report, about 57k lines; manifests remain 171. |
+| Recent 3 dry-run conclusions reflected? | No. All 3 are missing from `PROJECT_STATUS.md`. |
+| Are agents clearly forced to maintain authoritative docs? | Partially. Rules prefer source-of-truth updates, but completion is not hard-gated. |
+| PR template forces authoritative-doc update status? | No. It has documentation/debt fields but no explicit authoritative-doc status. |
+| Gatekeeper/CI blocks report-only PR without source-of-truth update? | No. Current gate counts doc sprawl but does not enforce backflow. |
+| Add CI check? | Yes. |
+| Modify PR template? | Yes. |
+| Modify `CODEX_WORKFLOW.md`? | Yes. |
+| Modify `DOCUMENTATION_GOVERNANCE.md`? | Yes. |
+| Enter `authoritative_workflow_enforcement_fix_phase1`? | Yes, after user confirmation. |
+
+## Current Authoritative Docs
+
+Recommended as current entrypoints:
+
+- `docs/PROJECT_STATUS.md`
+- `docs/DOCUMENTATION_GOVERNANCE.md`
+- `docs/CODEX_WORKFLOW.md`
+- `docs/AGENT_WORKFLOW.md`
+- `.github/pull_request_template.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/DATA_SOURCE_STRATEGY.md`
+- `docs/data/FOTMOB_CURRENT_STATE.md`
+
+Do not create replacements such as `PROJECT_STATUS_V2.md`, `NEW_WORKFLOW.md`, `NEW_RULES.md`, or a new workflow authority document.
+
+## Stale / Drift Findings
+
+- `docs/PROJECT_STATUS.md` last updated `2026-06-07`; the audited dry-runs are dated `2026-06-20`.
+- `docs/PROJECT_STATUS.md` reports `docs/_reports` count as 363, but this branch has 434 after this report.
+- `docs/DOCUMENTATION_GOVERNANCE.md` and `docs/CODEX_WORKFLOW.md` still list existing docs such as `PROJECT_STATUS` and `DATA_SOURCE_STRATEGY` as planned.
+- `docs/CHANGELOG.md` is historical and does not reflect June 2026 governance/data safety conclusions.
+- `README.md` still presents production-ready posture without pointing readers to current blockers in `PROJECT_STATUS`.
+
+## Recent Dry-Run Backflow
+
+| Report | Reflected in `PROJECT_STATUS.md`? | Required status delta |
+| --- | --- | --- |
+| `formal_training_cohort_inventory_dry_run_20260620.md` | No | Formal training remains blocked: 58 smoke/integration candidates, 0 formal candidates with odds, no model training authorization. |
+| `technical_debt_workflow_audit_dry_run_20260620.md` | No | Technical debt audit blocks data expansion and formal training until P0 debt is handled. |
+| `p0_db_write_safety_gate_dry_run_20260620.md` | No | DB write gate is audit-only: 122 production DB-write scripts detected, 66 P0, 110 with no gate. |
+
+## Enforcement Gaps
+
+P0:
+
+- PRs can add `docs/_reports/*.md` without updating `PROJECT_STATUS` or another authoritative doc.
+- AI Workflow Gate does not block report-only PRs that skip authoritative-doc backflow.
+- Recent key dry-run conclusions have not been reflected in `PROJECT_STATUS.md`.
+- PR template lacks an explicit authoritative/source-of-truth doc update status.
+
+P1:
+
+- `CODEX_WORKFLOW.md` lacks a hard completion standard for source-of-truth update or explicit no-update justification.
+- `DOCUMENTATION_GOVERNANCE.md` describes backflow as eventual/next-task behavior, not an enforced PR gate.
+- `documentation_governance_check.py` exists but is not wired as a general Production Gate source-of-truth backflow check.
+- Current doc-sprawl gate allows up to 5 new reports/manifests without backlink enforcement.
+
+P2:
+
+- 425 existing reports lack an obvious backlink to current authoritative docs.
+- Legacy `.github/PULL_REQUEST_TEMPLATE.md` exists alongside active lowercase template.
+- `README.md` and `CHANGELOG.md` are not aligned with current governance/blocker state.
+- Planned docs listed in governance remain missing or unresolved.
+
+## Recommended Fix Phase1
+
+Minimum files to modify after user confirmation:
+
+- `.github/pull_request_template.md`
+- `scripts/ops/ai_workflow_gate.py`
+- `tests/unit/test_ai_workflow_gate.py`
+- `docs/DOCUMENTATION_GOVERNANCE.md`
+- `docs/CODEX_WORKFLOW.md`
+- `docs/PROJECT_STATUS.md`
+
+Minimum checks:
+
+- If a PR adds `docs/_reports/*.md`, require either an authoritative doc update or an explicit PR-body no-update justification.
+- Require PR template row: authoritative/source-of-truth docs updated `yes/no` plus reason.
+- Fail hollow Documentation Impact answers.
+- Keep `_reports` as evidence only; active conclusions must flow to current-state docs.
+
+Recommendation: enter `authoritative_workflow_enforcement_fix_phase1` only after explicit user approval. Do not start automatically.

--- a/scripts/ops/authoritative_workflow_enforcement_dry_run.js
+++ b/scripts/ops/authoritative_workflow_enforcement_dry_run.js
@@ -1,0 +1,628 @@
+#!/usr/bin/env node
+'use strict';
+
+// lifecycle: permanent
+// scope: read-only authoritative workflow enforcement audit; static scan only, no network, no DB, no scanned-script execution
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PHASE = 'AUTHORITATIVE_WORKFLOW_ENFORCEMENT_DRY_RUN';
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const REPORT_BACKLINK_TARGETS = [
+    'docs/PROJECT_STATUS.md',
+    'docs/DOCUMENTATION_GOVERNANCE.md',
+    'docs/CODEX_WORKFLOW.md',
+    'docs/AGENT_WORKFLOW.md',
+    'docs/DATA_SOURCE_STRATEGY.md',
+    'docs/data/FOTMOB_CURRENT_STATE.md',
+];
+
+const AUTHORITATIVE_CANDIDATES = [
+    { path: 'docs/PROJECT_STATUS.md', role: 'current project status ledger', recommended: true },
+    { path: 'docs/DOCUMENTATION_GOVERNANCE.md', role: 'documentation governance rules', recommended: true },
+    { path: 'docs/CODEX_WORKFLOW.md', role: 'Codex agent workflow rules', recommended: true },
+    { path: 'docs/AGENT_WORKFLOW.md', role: 'agent workflow hardening rules', recommended: true },
+    { path: '.github/pull_request_template.md', role: 'active PR template', recommended: true },
+    { path: 'AGENTS.md', role: 'agent entrypoint', recommended: true },
+    { path: 'CLAUDE.md', role: 'Claude agent entrypoint', recommended: true },
+    { path: 'docs/DATA_SOURCE_STRATEGY.md', role: 'data source strategy', recommended: true },
+    { path: 'docs/data/FOTMOB_CURRENT_STATE.md', role: 'FotMob current state', recommended: true },
+    { path: 'docs/CHANGELOG.md', role: 'historical changelog', recommended: false },
+    { path: 'README.md', role: 'public project overview', recommended: false },
+    { path: '.github/PULL_REQUEST_TEMPLATE.md', role: 'legacy uppercase PR template', recommended: false },
+];
+
+const REQUIRED_AUTH_DOCS = [
+    'docs/PROJECT_STATUS.md',
+    'docs/DOCUMENTATION_GOVERNANCE.md',
+    'docs/CODEX_WORKFLOW.md',
+    '.github/pull_request_template.md',
+    'AGENTS.md',
+];
+
+const PLANNED_DOCS_FROM_GOVERNANCE = [
+    'docs/FOTMOB_CURRENT_STATE.md',
+    'docs/CANONICAL_MATCH_SCHEMA.md',
+    'docs/DEVELOPMENT_WORKFLOW.md',
+    'docs/README.md',
+];
+
+const RECENT_REPORTS = [
+    {
+        task: 'formal_training_cohort_inventory_dry_run',
+        path: 'docs/_reports/formal_training_cohort_inventory_dry_run_20260620.md',
+        terms: ['formal_training_cohort_inventory', 'formal cohort', '58 rows', 'multi-league'],
+        projectStatusDelta:
+            'Formal training remains blocked: 58 smoke/integration candidates, 0 formal candidates with odds, no model training authorization.',
+    },
+    {
+        task: 'technical_debt_workflow_audit_dry_run',
+        path: 'docs/_reports/technical_debt_workflow_audit_dry_run_20260620.md',
+        terms: ['technical_debt_workflow_audit', 'EXTREMELY_HIGH', 'SC-002', 'cutoff time'],
+        projectStatusDelta:
+            'Technical debt audit blocks data expansion and formal training until P0 debt is handled.',
+    },
+    {
+        task: 'p0_db_write_safety_gate_dry_run',
+        path: 'docs/_reports/p0_db_write_safety_gate_dry_run_20260620.md',
+        terms: ['p0_db_write_safety_gate', '122', 'ALLOW_DB_WRITE', 'SC-002'],
+        projectStatusDelta:
+            'P0 DB write gate is audit-only: 122 production DB-write scripts detected, 66 P0, 110 with no gate.',
+    },
+];
+
+function readText(repoRoot, relPath) {
+    const absPath = path.join(repoRoot, relPath);
+    if (!fs.existsSync(absPath)) return null;
+    return fs.readFileSync(absPath, 'utf8');
+}
+
+function exists(repoRoot, relPath) {
+    return fs.existsSync(path.join(repoRoot, relPath));
+}
+
+function listFiles(repoRoot, relDir, predicate = () => true) {
+    const dir = path.join(repoRoot, relDir);
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir, { withFileTypes: true })
+        .filter(entry => entry.isFile())
+        .map(entry => path.join(relDir, entry.name).replace(/\\/g, '/'))
+        .filter(predicate)
+        .sort();
+}
+
+function countLines(text) {
+    if (!text) return 0;
+    return text.split('\n').length;
+}
+
+function extractLifecycle(text) {
+    if (!text) return null;
+    const match = text.match(/lifecycle:\s*([^\n]+)/i);
+    return match ? match[1].trim() : null;
+}
+
+function extractLastUpdated(text) {
+    if (!text) return null;
+    const match = text.match(/Last updated:\s*(\d{4}-\d{2}-\d{2})/i);
+    return match ? match[1] : null;
+}
+
+function dateFromReportPath(reportPath) {
+    const match = reportPath.match(/(?:_|-)(20\d{6})(?:\.|_|-)/);
+    if (!match) return null;
+    const raw = match[1];
+    return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`;
+}
+
+function containsAny(text, terms) {
+    const lower = String(text || '').toLowerCase();
+    return terms.some(term => lower.includes(String(term).toLowerCase()));
+}
+
+function buildAuthoritativeDocs(repoRoot) {
+    return AUTHORITATIVE_CANDIDATES
+        .filter(doc => exists(repoRoot, doc.path))
+        .map(doc => {
+            const text = readText(repoRoot, doc.path) || '';
+            return {
+                path: doc.path,
+                role: doc.role,
+                recommended_authoritative_entrypoint: doc.recommended,
+                lifecycle: extractLifecycle(text),
+                line_count: countLines(text),
+                last_updated: extractLastUpdated(text),
+            };
+        });
+}
+
+function buildMissingAuthoritativeDocs(repoRoot) {
+    const missingRequired = REQUIRED_AUTH_DOCS
+        .filter(relPath => !exists(repoRoot, relPath))
+        .map(relPath => ({ path: relPath, severity: 'P0', reason: 'required authoritative workflow doc missing' }));
+    const missingPlanned = PLANNED_DOCS_FROM_GOVERNANCE
+        .filter(relPath => !exists(repoRoot, relPath))
+        .map(relPath => ({ path: relPath, severity: 'P2', reason: 'planned/mentioned source-of-truth doc is absent' }));
+    return [...missingRequired, ...missingPlanned];
+}
+
+function buildReportsInventory(repoRoot) {
+    const reportFiles = listFiles(repoRoot, 'docs/_reports', file => file.endsWith('.md'));
+    const manifestFiles = listFiles(repoRoot, 'docs/_manifests', file => file.endsWith('.json'));
+    const totalReportLines = reportFiles.reduce((sum, file) => {
+        const text = readText(repoRoot, file) || '';
+        return sum + countLines(text);
+    }, 0);
+    return {
+        reports_count: reportFiles.length,
+        manifests_count: manifestFiles.length,
+        reports_total_lines: totalReportLines,
+        overgrown: reportFiles.length > 120 || totalReportLines > 12000,
+        overgrown_reason: reportFiles.length > 120
+            ? 'docs/_reports exceeds 120-file governance budget signal'
+            : null,
+        report_files: reportFiles,
+        manifest_files: manifestFiles,
+    };
+}
+
+function buildReportsWithoutBacklink(repoRoot, reportFiles) {
+    return reportFiles.filter(file => {
+        const text = readText(repoRoot, file) || '';
+        return !REPORT_BACKLINK_TARGETS.some(target => text.includes(target));
+    });
+}
+
+function parseClaimedCount(text, label) {
+    const regex = new RegExp(`${label}[^\\n]*contains\\s+(\\d+)`, 'i');
+    const match = String(text || '').match(regex);
+    return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function latestRecentReportDate() {
+    return RECENT_REPORTS
+        .map(report => dateFromReportPath(report.path))
+        .filter(Boolean)
+        .sort()
+        .pop();
+}
+
+function addProjectStatusStaleness(stale, projectStatus, inventory) {
+    const newestRecentDate = latestRecentReportDate();
+    const projectLastUpdated = extractLastUpdated(projectStatus);
+    if (projectLastUpdated && newestRecentDate && projectLastUpdated < newestRecentDate) {
+        stale.push({
+            path: 'docs/PROJECT_STATUS.md',
+            severity: 'P0',
+            reason: `last updated ${projectLastUpdated}, but recent governance/data dry-runs exist on ${newestRecentDate}`,
+        });
+    }
+
+    const claimedReports = parseClaimedCount(projectStatus, 'docs/_reports/');
+    if (claimedReports !== null && claimedReports !== inventory.reports_count) {
+        stale.push({
+            path: 'docs/PROJECT_STATUS.md',
+            severity: 'P2',
+            reason: `reports count claims ${claimedReports}, actual ${inventory.reports_count}`,
+        });
+    }
+
+    const claimedManifests = parseClaimedCount(projectStatus, 'docs/_manifests/');
+    if (claimedManifests !== null && claimedManifests !== inventory.manifests_count) {
+        stale.push({
+            path: 'docs/PROJECT_STATUS.md',
+            severity: 'P2',
+            reason: `manifests count claims ${claimedManifests}, actual ${inventory.manifests_count}`,
+        });
+    }
+}
+
+function addPlannedStatusDrift(stale, repoRoot, file, text) {
+    for (const existingDoc of ['docs/PROJECT_STATUS.md', 'docs/DATA_SOURCE_STRATEGY.md']) {
+        if (exists(repoRoot, existingDoc) && text.includes(`${existingDoc} | planned`)) {
+            stale.push({
+                path: file,
+                severity: 'P1',
+                reason: `${existingDoc} exists but is still listed as planned`,
+            });
+        }
+    }
+}
+
+function addOverviewDocDrift(stale, changelog, readme) {
+    if (!containsAny(changelog, ['2026-06-20', 'workflow', 'governance', 'P0 DB write'])) {
+        stale.push({
+            path: 'docs/CHANGELOG.md',
+            severity: 'P2',
+            reason: 'changelog does not reflect June 2026 workflow/governance dry-run conclusions',
+        });
+    }
+
+    if (readme.includes('Production-Ready') && !readme.includes('docs/PROJECT_STATUS.md')) {
+        stale.push({
+            path: 'README.md',
+            severity: 'P2',
+            reason: 'README still signals Production-Ready but does not point readers to PROJECT_STATUS current blockers',
+        });
+    }
+}
+
+function buildStaleAuthoritativeDocs(repoRoot, inventory) {
+    const stale = [];
+    const projectStatus = readText(repoRoot, 'docs/PROJECT_STATUS.md') || '';
+    const docGov = readText(repoRoot, 'docs/DOCUMENTATION_GOVERNANCE.md') || '';
+    const codexWorkflow = readText(repoRoot, 'docs/CODEX_WORKFLOW.md') || '';
+    const changelog = readText(repoRoot, 'docs/CHANGELOG.md') || '';
+    const readme = readText(repoRoot, 'README.md') || '';
+
+    addProjectStatusStaleness(stale, projectStatus, inventory);
+    addPlannedStatusDrift(stale, repoRoot, 'docs/DOCUMENTATION_GOVERNANCE.md', docGov);
+    addPlannedStatusDrift(stale, repoRoot, 'docs/CODEX_WORKFLOW.md', codexWorkflow);
+    addOverviewDocDrift(stale, changelog, readme);
+
+    return stale;
+}
+
+function buildRecentReportReflection(repoRoot) {
+    const projectStatus = readText(repoRoot, 'docs/PROJECT_STATUS.md') || '';
+    return RECENT_REPORTS.map(report => {
+        const reportText = readText(repoRoot, report.path) || '';
+        const existsFlag = Boolean(reportText);
+        const reflected = existsFlag && containsAny(projectStatus, report.terms);
+        return {
+            task: report.task,
+            report_path: report.path,
+            report_exists: existsFlag,
+            reflected_in_project_status: reflected,
+            needs_project_status_delta: existsFlag && !reflected,
+            required_project_status_summary: report.projectStatusDelta,
+        };
+    });
+}
+
+function hasPrTemplateDocChecklist(templateText) {
+    return /Source-of-truth docs updated/i.test(templateText) ||
+        /authoritative docs updated/i.test(templateText) ||
+        /权威文档/.test(templateText);
+}
+
+function buildAiWorkflowRuleGaps(repoRoot) {
+    const gaps = [];
+    const codex = readText(repoRoot, 'docs/CODEX_WORKFLOW.md') || '';
+    const docGov = readText(repoRoot, 'docs/DOCUMENTATION_GOVERNANCE.md') || '';
+    const agents = readText(repoRoot, 'AGENTS.md') || '';
+    const claude = readText(repoRoot, 'CLAUDE.md') || '';
+    const combined = [codex, docGov, agents, claude].join('\n');
+
+    if (!containsAny(combined, ['Read current source-of-truth docs', '权威文档', 'source-of-truth docs first'])) {
+        gaps.push({ severity: 'P0', gap: 'AI agents are not clearly required to read source-of-truth docs first' });
+    }
+    if (!containsAny(combined, ['Never develop directly on `main`', '不在 `main` 分支直接开发'])) {
+        gaps.push({ severity: 'P0', gap: 'main branch direct-work prohibition is missing' });
+    }
+    if (!containsAny(combined, ['DB write', 'DB writes', '写库', 'raw write', 'training'])) {
+        gaps.push({ severity: 'P0', gap: 'high-risk no-write/no-training rules are missing' });
+    }
+    if (!containsAny(codex, ['skip source-of-truth updates while adding more reports']) ||
+        !containsAny(docGov, ['First update main docs'])) {
+        gaps.push({ severity: 'P0', gap: 'workflow docs do not prohibit reports without source-of-truth update' });
+    }
+    if (!/completion|完成标准|Final Report/i.test(codex) ||
+        !/source-of-truth docs updated|Current-state doc updated|权威文档更新/.test(codex)) {
+        gaps.push({
+            severity: 'P1',
+            gap: 'CODEX_WORKFLOW has final report guidance but no explicit completion standard requiring source-of-truth update or justified no-update',
+        });
+    }
+    if (!containsAny(combined, ['报告结论回流', 'source-of-truth summary', 'summarized or linked from a source-of-truth doc'])) {
+        gaps.push({ severity: 'P1', gap: 'report conclusions are not hard-required to flow back into authoritative docs before completion' });
+    }
+
+    return gaps;
+}
+
+function buildPrTemplateGaps(repoRoot) {
+    const template = readText(repoRoot, '.github/pull_request_template.md') || '';
+    const uppercaseTemplateExists = exists(repoRoot, '.github/PULL_REQUEST_TEMPLATE.md');
+    const gaps = [];
+
+    if (!template.includes('## Files Changed')) {
+        gaps.push({ severity: 'P1', gap: 'active PR template does not require changed files declaration' });
+    }
+    if (!hasPrTemplateDocChecklist(template)) {
+        gaps.push({ severity: 'P0', gap: 'active PR template does not require explicit authoritative/source-of-truth doc update status' });
+    }
+    if (!/Reports added/.test(template)) {
+        gaps.push({ severity: 'P1', gap: 'active PR template does not require reports-added declaration' });
+    }
+    if (!/Current-state doc updated/.test(template)) {
+        gaps.push({ severity: 'P1', gap: 'active PR template only asks current-state doc update in debt section, not Documentation Impact gate' });
+    }
+    if (!/Reason for new docs|reason.*report|why.*report/i.test(template)) {
+        gaps.push({ severity: 'P1', gap: 'active PR template does not require justification when docs/_reports is added without source-of-truth update' });
+    }
+    if (uppercaseTemplateExists) {
+        gaps.push({ severity: 'P2', gap: 'legacy .github/PULL_REQUEST_TEMPLATE.md exists and can confuse reviewers despite lowercase template being active' });
+    }
+
+    return gaps;
+}
+
+function buildGatekeeperGaps(repoRoot) {
+    const aiGate = readText(repoRoot, 'scripts/ops/ai_workflow_gate.py') || '';
+    const gatekeeper = readText(repoRoot, 'scripts/devops/gatekeeper.sh') || '';
+    const workflow = readText(repoRoot, '.github/workflows/production-gate.yml') || '';
+    const docGovChecker = readText(repoRoot, 'scripts/ops/documentation_governance_check.py') || '';
+    const gaps = [];
+
+    if (!aiGate.includes('check_doc_sprawl')) {
+        gaps.push({ severity: 'P0', gap: 'AI Workflow Gate lacks docs/_reports/doc-sprawl check' });
+    }
+    if (!/Source-of-truth docs updated|authoritative.*updated|PROJECT_STATUS/.test(aiGate)) {
+        gaps.push({ severity: 'P0', gap: 'AI Workflow Gate does not block report-only PRs that skip PROJECT_STATUS or other authoritative docs' });
+    }
+    if (!/documentation_governance_check/.test(workflow) && !/documentation_governance_check/.test(gatekeeper)) {
+        gaps.push({ severity: 'P1', gap: 'documentation_governance_check.py exists but is not wired into Production Gate/gatekeeper as a general PR check' });
+    }
+    if (docGovChecker.includes('ALLOWED_ADDED') && !docGovChecker.includes('source-of-truth')) {
+        gaps.push({ severity: 'P1', gap: 'documentation_governance_check focuses on allowlists/budgets, not report conclusion backflow' });
+    }
+    if (aiGate.includes('MAX_DOC_SPRAWL_NEW_FILES = 5')) {
+        gaps.push({ severity: 'P1', gap: 'doc sprawl gate allows up to 5 report/manifest files and does not require authoritative-doc linkage' });
+    }
+    if (workflow.includes('--skip-body-checks')) {
+        gaps.push({ severity: 'P1', gap: 'push events skip PR body governance checks; branch protection must compensate' });
+    }
+
+    return gaps;
+}
+
+function groupBySeverity(items) {
+    return {
+        P0: items.filter(item => item.severity === 'P0'),
+        P1: items.filter(item => item.severity === 'P1'),
+        P2: items.filter(item => item.severity === 'P2'),
+    };
+}
+
+function buildRecommendedSteps(context) {
+    return {
+        P0: [
+            'Modify PR template to require authoritative/source-of-truth doc update status and report-backflow justification.',
+            'Add AI Workflow Gate check: if docs/_reports/*.md is added, require PROJECT_STATUS/DOCUMENTATION_GOVERNANCE/CODEX_WORKFLOW/DATA_SOURCE_STRATEGY/FOTMOB_CURRENT_STATE update or an explicit no-update justification.',
+            'Backfill recent dry-run conclusions into PROJECT_STATUS.md after user-approved fix phase.',
+        ],
+        P1: [
+            'Update DOCUMENTATION_GOVERNANCE.md to make report conclusion backflow a hard PR completion rule.',
+            'Update CODEX_WORKFLOW.md final completion criteria: no new report without authoritative-doc update or explicit reviewer-visible reason.',
+            'Wire documentation_governance_check.py or a new focused source-of-truth backflow check into Production Gate.',
+        ],
+        P2: [
+            'Clarify active PR template by deprecating the uppercase legacy template in a later cleanup phase.',
+            'Add report backlink cleanup policy for historical reports without changing history in this dry run.',
+            'Align README and CHANGELOG with current status docs in separate scoped documentation cleanup.',
+        ],
+        fix_phase1_minimal_scope: [
+            '.github/pull_request_template.md',
+            'scripts/ops/ai_workflow_gate.py',
+            'tests/unit/test_ai_workflow_gate.py',
+            'docs/DOCUMENTATION_GOVERNANCE.md',
+            'docs/CODEX_WORKFLOW.md',
+            'docs/PROJECT_STATUS.md',
+        ],
+        should_enter_fix_phase1: context.p0Count > 0,
+    };
+}
+
+function buildAnswers(context) {
+    return {
+        project_has_authoritative_docs: true,
+        current_authoritative_entrypoints: [
+            'docs/PROJECT_STATUS.md',
+            'docs/DOCUMENTATION_GOVERNANCE.md',
+            'docs/CODEX_WORKFLOW.md',
+            'docs/AGENT_WORKFLOW.md',
+            '.github/pull_request_template.md',
+            'AGENTS.md',
+            'CLAUDE.md',
+            'docs/DATA_SOURCE_STRATEGY.md',
+            'docs/data/FOTMOB_CURRENT_STATE.md',
+        ],
+        stale_or_unmaintained_docs: context.staleDocs.map(item => item.path),
+        reports_overgrown: context.inventory.overgrown,
+        recent_three_reports_reflected: context.recentReflection.every(item => item.reflected_in_project_status),
+        ai_agent_required_to_maintain_authoritative_docs: context.aiGaps.length === 0,
+        pr_template_forces_authoritative_doc_update_status: context.prGaps.every(item => item.severity !== 'P0'),
+        gatekeeper_blocks_report_without_authoritative_update: context.gatekeeperGaps.every(item => item.severity !== 'P0'),
+        should_add_ci_check: true,
+        should_modify_pr_template: true,
+        should_modify_codex_workflow: true,
+        should_modify_documentation_governance: true,
+        should_enter_authoritative_workflow_enforcement_fix_phase1: context.p0Count > 0,
+    };
+}
+
+function buildAudit(repoRoot = REPO_ROOT) {
+    const inventory = buildReportsInventory(repoRoot);
+    const authoritativeDocs = buildAuthoritativeDocs(repoRoot);
+    const staleDocs = buildStaleAuthoritativeDocs(repoRoot, inventory);
+    const reportsWithoutBacklink = buildReportsWithoutBacklink(repoRoot, inventory.report_files);
+    const recentReflection = buildRecentReportReflection(repoRoot);
+    const aiGaps = buildAiWorkflowRuleGaps(repoRoot);
+    const prGaps = buildPrTemplateGaps(repoRoot);
+    const gatekeeperGaps = buildGatekeeperGaps(repoRoot);
+    const severityItems = [
+        ...staleDocs,
+        ...aiGaps,
+        ...prGaps,
+        ...gatekeeperGaps,
+        ...recentReflection
+            .filter(item => item.needs_project_status_delta)
+            .map(item => ({ severity: 'P0', gap: `${item.task} conclusion not reflected in PROJECT_STATUS.md` })),
+    ];
+    const grouped = groupBySeverity(severityItems);
+    const context = {
+        inventory,
+        staleDocs,
+        recentReflection,
+        aiGaps,
+        prGaps,
+        gatekeeperGaps,
+        p0Count: grouped.P0.length,
+    };
+
+    return {
+        phase: PHASE,
+        generated_at: new Date().toISOString(),
+        safety: {
+            static_scan_only: true,
+            network_used: false,
+            db_connected: false,
+            scanned_scripts_executed: false,
+            writes_performed: false,
+            training_performed: false,
+            model_files_generated: false,
+        },
+        authoritative_docs_found: authoritativeDocs,
+        missing_authoritative_docs: buildMissingAuthoritativeDocs(repoRoot),
+        stale_authoritative_docs: staleDocs,
+        reports_inventory: {
+            reports_count: inventory.reports_count,
+            manifests_count: inventory.manifests_count,
+            reports_total_lines: inventory.reports_total_lines,
+            overgrown: inventory.overgrown,
+            overgrown_reason: inventory.overgrown_reason,
+        },
+        reports_without_status_backlink: {
+            count: reportsWithoutBacklink.length,
+            paths: reportsWithoutBacklink,
+        },
+        reports_not_reflected_in_project_status: recentReflection.filter(item => item.needs_project_status_delta),
+        recent_task_reflection: recentReflection,
+        ai_workflow_rule_gaps: aiGaps,
+        pr_template_gaps: prGaps,
+        gatekeeper_gaps: gatekeeperGaps,
+        severity_summary: {
+            P0: grouped.P0.length,
+            P1: grouped.P1.length,
+            P2: grouped.P2.length,
+        },
+        recommended_authoritative_entrypoints: authoritativeDocs
+            .filter(doc => doc.recommended_authoritative_entrypoint)
+            .map(doc => doc.path),
+        docs_not_recommended_to_create: [
+            'PROJECT_STATUS_V2.md',
+            'NEW_WORKFLOW.md',
+            'NEW_RULES.md',
+            'docs/AUTHORITATIVE_WORKFLOW_V2.md',
+        ],
+        recommended_enforcement_steps: buildRecommendedSteps(context),
+        required_backflow: {
+            project_status: recentReflection
+                .filter(item => item.needs_project_status_delta)
+                .map(item => item.required_project_status_summary),
+            documentation_governance: [
+                'A report that changes active project state must update or explicitly justify not updating a source-of-truth doc in the same PR.',
+                'docs/_reports entries are evidence, not durable current truth.',
+            ],
+            codex_workflow: [
+                'Task completion requires source-of-truth update status in the PR body.',
+                'Adding docs/_reports without PROJECT_STATUS/DOCUMENTATION_GOVERNANCE/CODEX_WORKFLOW backflow is a No-Go unless explicitly justified.',
+            ],
+            ci_gatekeeper: [
+                'Detect added docs/_reports/*.md.',
+                'Require touched authoritative docs or explicit PR body justification.',
+                'Fail hollow Documentation Impact answers.',
+            ],
+        },
+        answers: buildAnswers(context),
+    };
+}
+
+function formatSummary(audit) {
+    const lines = [
+        `Phase: ${audit.phase}`,
+        `Safety: static_scan_only=${audit.safety.static_scan_only} network=${audit.safety.network_used} db=${audit.safety.db_connected} writes=${audit.safety.writes_performed}`,
+        '',
+        'Authoritative docs found:',
+        ...audit.authoritative_docs_found.map(doc => `- ${doc.path} (${doc.role})`),
+        '',
+        `docs/_reports: ${audit.reports_inventory.reports_count} files, ${audit.reports_inventory.reports_total_lines} lines, overgrown=${audit.reports_inventory.overgrown}`,
+        `reports_without_status_backlink: ${audit.reports_without_status_backlink.count}`,
+        '',
+        'Recent report reflection in PROJECT_STATUS.md:',
+        ...audit.recent_task_reflection.map(item => `- ${item.task}: reflected=${item.reflected_in_project_status}`),
+        '',
+        `Severity summary: P0=${audit.severity_summary.P0} P1=${audit.severity_summary.P1} P2=${audit.severity_summary.P2}`,
+        `Recommend fix_phase1: ${audit.answers.should_enter_authoritative_workflow_enforcement_fix_phase1 ? 'yes' : 'no'}`,
+        '',
+        'P0 enforcement steps:',
+        ...audit.recommended_enforcement_steps.P0.map(step => `- ${step}`),
+    ];
+    return `${lines.join('\n')}\n`;
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = { json: false, help: false };
+    for (const arg of argv) {
+        if (arg === '--json') options.json = true;
+        else if (arg === '--help' || arg === '-h') options.help = true;
+        else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return options;
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/ops/authoritative_workflow_enforcement_dry_run.js',
+        '  node scripts/ops/authoritative_workflow_enforcement_dry_run.js --json',
+        '',
+        'Safety:',
+        '  Static file scan only. No network, no DB connection, no script execution, no training, no writes.',
+    ].join('\n');
+}
+
+function main(argv = process.argv.slice(2)) {
+    const options = parseArgs(argv);
+    if (options.help) {
+        process.stdout.write(`${usage()}\n`);
+        return 0;
+    }
+    const audit = buildAudit();
+    process.stdout.write(options.json ? `${JSON.stringify(audit, null, 2)}\n` : formatSummary(audit));
+    return 0;
+}
+
+module.exports = {
+    PHASE,
+    AUTHORITATIVE_CANDIDATES,
+    REQUIRED_AUTH_DOCS,
+    RECENT_REPORTS,
+    REPORT_BACKLINK_TARGETS,
+    buildAudit,
+    buildAuthoritativeDocs,
+    buildMissingAuthoritativeDocs,
+    buildReportsInventory,
+    buildReportsWithoutBacklink,
+    buildRecentReportReflection,
+    buildStaleAuthoritativeDocs,
+    buildAiWorkflowRuleGaps,
+    buildPrTemplateGaps,
+    buildGatekeeperGaps,
+    hasPrTemplateDocChecklist,
+    formatSummary,
+    parseArgs,
+    usage,
+    main,
+};
+
+if (require.main === module) {
+    try {
+        process.exitCode = main();
+    } catch (error) {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+    }
+}

--- a/tests/unit/authoritative_workflow_enforcement_dry_run.test.js
+++ b/tests/unit/authoritative_workflow_enforcement_dry_run.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+// lifecycle: permanent
+// scope: unit safety coverage for authoritative workflow enforcement dry-run scanner
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+    PHASE,
+    buildAudit,
+    buildAuthoritativeDocs,
+    buildReportsInventory,
+    buildReportsWithoutBacklink,
+    buildAiWorkflowRuleGaps,
+    buildPrTemplateGaps,
+    buildGatekeeperGaps,
+    buildRecentReportReflection,
+    hasPrTemplateDocChecklist,
+    formatSummary,
+    parseArgs,
+} = require('../../scripts/ops/authoritative_workflow_enforcement_dry_run');
+
+function writeFile(root, relPath, content) {
+    const absPath = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, content);
+}
+
+function makeFixture(overrides = {}) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'authoritative-workflow-'));
+
+    writeFile(root, 'docs/PROJECT_STATUS.md', overrides.projectStatus || [
+        '# Project Status',
+        '- lifecycle: current-state',
+        'Last updated: 2026-06-07',
+        '',
+        '## Current technical debt posture',
+        '- `docs/_reports/` contains 363 historical report files.',
+        '- `docs/_manifests/` contains 171 historical manifest files.',
+    ].join('\n'));
+
+    writeFile(root, 'docs/DOCUMENTATION_GOVERNANCE.md', overrides.docGov || [
+        '# Documentation Governance',
+        '- lifecycle: permanent',
+        '',
+        '| Path | Status | Notes |',
+        '|---|---|---|',
+        '| docs/PROJECT_STATUS.md | planned | Overall project status and blockers. |',
+        '| docs/DATA_SOURCE_STRATEGY.md | planned | Strategy. |',
+        '',
+        'First update main docs such as PROJECT_STATUS before reports.',
+    ].join('\n'));
+
+    writeFile(root, 'docs/CODEX_WORKFLOW.md', overrides.codex || [
+        '# Codex Workflow',
+        '- lifecycle: permanent',
+        '',
+        'Read current source-of-truth docs before starting a task.',
+        'Never develop directly on `main`.',
+        'Do not run DB writes, raw write, network data collection, or training unless authorized.',
+        'Do not skip source-of-truth updates while adding more reports.',
+        'Final Report Format',
+    ].join('\n'));
+
+    writeFile(root, 'docs/AGENT_WORKFLOW.md', '- lifecycle: permanent\nsource-of-truth docs first\n');
+    writeFile(root, 'docs/DATA_SOURCE_STRATEGY.md', '- lifecycle: current-state\n');
+    writeFile(root, 'docs/data/FOTMOB_CURRENT_STATE.md', '- lifecycle: current-state\n');
+    writeFile(root, 'docs/CHANGELOG.md', '# Old Changelog\n2026-03-11\n');
+    writeFile(root, 'README.md', '# README\nProduction-Ready\n');
+    writeFile(root, 'AGENTS.md', '- lifecycle: permanent\n不在 `main` 分支直接开发。\n');
+    writeFile(root, 'CLAUDE.md', '- lifecycle: permanent\nRead order\n');
+
+    writeFile(root, '.github/pull_request_template.md', overrides.prTemplate || [
+        '## Files Changed',
+        '| Path | Purpose |',
+        '## Documentation Impact',
+        '| Reports added | 1 |',
+    ].join('\n'));
+    writeFile(root, '.github/PULL_REQUEST_TEMPLATE.md', '# Legacy template\n');
+    writeFile(root, '.github/workflows/production-gate.yml', overrides.workflow || [
+        'name: Production Gate',
+        'run: python3 scripts/ops/ai_workflow_gate.py --skip-body-checks',
+    ].join('\n'));
+
+    writeFile(root, 'scripts/devops/gatekeeper.sh', overrides.gatekeeper || '#!/usr/bin/env bash\n');
+    writeFile(root, 'scripts/ops/ai_workflow_gate.py', overrides.aiGate || [
+        'MAX_DOC_SPRAWL_NEW_FILES = 5',
+        'def check_doc_sprawl(): pass',
+    ].join('\n'));
+    writeFile(root, 'scripts/ops/documentation_governance_check.py', overrides.docChecker || [
+        'ALLOWED_ADDED = set()',
+        '# budget-only checker',
+    ].join('\n'));
+
+    writeFile(root, 'docs/_manifests/sample.json', '{"lifecycle":"phase-artifact"}\n');
+    writeFile(root, 'docs/_reports/no_backlink.md', '# Report\n- lifecycle: phase-artifact\n');
+    writeFile(root, 'docs/_reports/with_backlink.md', '# Report\nSee docs/PROJECT_STATUS.md\n');
+    writeFile(root, 'docs/_reports/formal_training_cohort_inventory_dry_run_20260620.md', '# Formal\n58 rows\n');
+    writeFile(root, 'docs/_reports/technical_debt_workflow_audit_dry_run_20260620.md', '# Debt\nEXTREMELY_HIGH\n');
+    writeFile(root, 'docs/_reports/p0_db_write_safety_gate_dry_run_20260620.md', '# Gate\n122\n');
+
+    return root;
+}
+
+test('parseArgs supports JSON and help flags', () => {
+    assert.equal(parseArgs(['--json']).json, true);
+    assert.equal(parseArgs(['--help']).help, true);
+    assert.equal(parseArgs(['-h']).help, true);
+    assert.throws(() => parseArgs(['--bad']), /Unknown argument/);
+});
+
+test('buildAuthoritativeDocs identifies existing authoritative documents', () => {
+    const root = makeFixture();
+    const docs = buildAuthoritativeDocs(root);
+    const paths = docs.map(doc => doc.path);
+
+    assert.ok(paths.includes('docs/PROJECT_STATUS.md'));
+    assert.ok(paths.includes('docs/DOCUMENTATION_GOVERNANCE.md'));
+    assert.ok(paths.includes('docs/CODEX_WORKFLOW.md'));
+    assert.ok(paths.includes('AGENTS.md'));
+    assert.ok(paths.includes('CLAUDE.md'));
+});
+
+test('buildReportsInventory identifies docs/_reports and docs/_manifests', () => {
+    const root = makeFixture();
+    const inventory = buildReportsInventory(root);
+
+    assert.equal(inventory.reports_count, 5);
+    assert.equal(inventory.manifests_count, 1);
+    assert.ok(inventory.report_files.includes('docs/_reports/no_backlink.md'));
+});
+
+test('buildReportsWithoutBacklink detects reports missing authoritative backlinks', () => {
+    const root = makeFixture();
+    const inventory = buildReportsInventory(root);
+    const missing = buildReportsWithoutBacklink(root, inventory.report_files);
+
+    assert.ok(missing.includes('docs/_reports/no_backlink.md'));
+    assert.equal(missing.includes('docs/_reports/with_backlink.md'), false);
+});
+
+test('hasPrTemplateDocChecklist detects authoritative document checklist wording', () => {
+    assert.equal(hasPrTemplateDocChecklist('| Source-of-truth docs updated | yes |'), true);
+    assert.equal(hasPrTemplateDocChecklist('| 权威文档更新 | yes |'), true);
+    assert.equal(hasPrTemplateDocChecklist('| Reports added | 1 |'), false);
+});
+
+test('buildPrTemplateGaps detects missing authoritative-doc checklist', () => {
+    const root = makeFixture();
+    const gaps = buildPrTemplateGaps(root);
+
+    assert.ok(gaps.some(gap => gap.severity === 'P0' && gap.gap.includes('authoritative')));
+    assert.ok(gaps.some(gap => gap.severity === 'P2' && gap.gap.includes('legacy')));
+});
+
+test('buildAiWorkflowRuleGaps recognizes complete read/update workflow wording', () => {
+    const root = makeFixture({
+        codex: [
+            '# Codex Workflow',
+            'Read current source-of-truth docs before starting a task.',
+            'Never develop directly on `main`.',
+            'Do not run DB writes, raw write, network data collection, or training unless authorized.',
+            'Do not skip source-of-truth updates while adding more reports.',
+            'Every report conclusion must be summarized or linked from a source-of-truth doc.',
+            'Final Report Format must include Current-state doc updated.',
+        ].join('\n'),
+        docGov: [
+            '# Documentation Governance',
+            '| docs/PROJECT_STATUS.md | exists | Status |',
+            'First update main docs such as PROJECT_STATUS before reports.',
+            'Report conclusions must be summarized or linked from a source-of-truth doc.',
+        ].join('\n'),
+    });
+    const gaps = buildAiWorkflowRuleGaps(root);
+
+    assert.equal(gaps.some(gap => gap.severity === 'P0'), false);
+});
+
+test('buildGatekeeperGaps detects missing report-to-authoritative enforcement', () => {
+    const root = makeFixture();
+    const gaps = buildGatekeeperGaps(root);
+
+    assert.ok(gaps.some(gap => gap.severity === 'P0' && gap.gap.includes('PROJECT_STATUS')));
+    assert.ok(gaps.some(gap => gap.severity === 'P1' && gap.gap.includes('Production Gate')));
+});
+
+test('buildRecentReportReflection detects dry-run reports not reflected in PROJECT_STATUS', () => {
+    const root = makeFixture();
+    const reflection = buildRecentReportReflection(root);
+
+    assert.equal(reflection.length, 3);
+    assert.equal(reflection.every(item => item.report_exists), true);
+    assert.equal(reflection.every(item => item.needs_project_status_delta), true);
+});
+
+test('buildAudit exposes required JSON structure and severity classification', () => {
+    const root = makeFixture();
+    const audit = buildAudit(root);
+
+    assert.equal(audit.phase, PHASE);
+    assert.ok(Array.isArray(audit.authoritative_docs_found));
+    assert.ok(Array.isArray(audit.missing_authoritative_docs));
+    assert.ok(Array.isArray(audit.stale_authoritative_docs));
+    assert.equal(typeof audit.reports_without_status_backlink.count, 'number');
+    assert.ok(Array.isArray(audit.reports_not_reflected_in_project_status));
+    assert.ok(Array.isArray(audit.ai_workflow_rule_gaps));
+    assert.ok(Array.isArray(audit.pr_template_gaps));
+    assert.ok(Array.isArray(audit.gatekeeper_gaps));
+    assert.ok(audit.recommended_enforcement_steps.P0.length > 0);
+    assert.ok(audit.severity_summary.P0 > 0);
+    assert.ok(audit.severity_summary.P1 > 0);
+    assert.ok(audit.severity_summary.P2 > 0);
+});
+
+test('formatSummary includes key human-readable fields', () => {
+    const root = makeFixture();
+    const summary = formatSummary(buildAudit(root));
+
+    assert.match(summary, /Authoritative docs found/);
+    assert.match(summary, /docs\/_reports/);
+    assert.match(summary, /Recent report reflection/);
+    assert.match(summary, /Severity summary: P0=/);
+    assert.match(summary, /Recommend fix_phase1: yes/);
+});


### PR DESCRIPTION
## Summary

Add a read-only authoritative workflow enforcement dry-run scanner, focused unit coverage, and the allowed phase report. The audit confirms the repository already has authoritative workflow/status docs, but current PR/CI gates do not prevent adding `docs/_reports` without reflecting active conclusions back into source-of-truth docs.

Head SHA: `638947eefde278cae6df383f6a523a4f1ff134dd`
Changed files: 3

## Scope

| Item | Value |
|---|---|
| Task type | governance-only / read-only audit |
| One task / one branch / one PR | yes |
| Combines feature + cleanup, audit + repair, merge + new work, or docs governance + business code | no |
| Merge-only zero-change task | no |
| Business code changed | no |
| FotMob code changed | no |

## Files Changed

| Path | Purpose |
|---|---|
| `scripts/ops/authoritative_workflow_enforcement_dry_run.js` | Static scanner for authoritative docs, `_reports` backflow, AI workflow, PR template, and gatekeeper gaps. |
| `tests/unit/authoritative_workflow_enforcement_dry_run.test.js` | Unit coverage for authoritative-doc detection, report backlink detection, PR template/gatekeeper gaps, JSON shape, severity classification, and summary fields. |
| `docs/_reports/authoritative_workflow_enforcement_dry_run_20260621.md` | Allowed phase-artifact report summarizing findings and proposed fix_phase1 scope. |

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | 1 |
| Reports added | 1 |
| Manifests added | 0 |
| Review reports added | 0 |
| Decision reports added | 0 |
| Next plans added | 0 |
| Exact allowed report paths, if any | `docs/_reports/authoritative_workflow_enforcement_dry_run_20260621.md` |
| Source-of-truth docs updated | no |
| Source-of-truth no-update reason | Task explicitly required dry-run audit and said not to modify `PROJECT_STATUS`, `DOCUMENTATION_GOVERNANCE`, `CODEX_WORKFLOW`, PR template, or gatekeeper before user-confirmed fix phase. |

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| Business code changed | no |
| FotMob code changed | no |
| DB used | no |
| Browser automation used | no |
| Scraper run | no |
| New manifest created | no |
| New next-plan created | no |
| New review report created | no |
| New decision report created | no |

## Validation

| Validation | Result |
|---|---|
| Host validation | `git diff --cached --check` PASS; hidden/bidi scan PASS; payload marker scan PASS |
| Container validation | `node --test tests/unit/authoritative_workflow_enforcement_dry_run.test.js` PASS, 11 tests; scanner summary PASS; targeted repo ESLint PASS; AI Workflow Gate diff-only PASS |
| GitHub Production Gate | PASS: Production Gate run `27892348797`; Environment/Proxy/Static/Unit Gate PASS; Docker Build Validation PASS |

## CI Gate Scope

- What the validation proves: the new scanner is importable, returns the expected JSON structure, identifies authoritative docs/reports/template/gate gaps in fixture repos, and the report stays within the allowed phase-artifact scope.
- What the validation does not prove: it does not prove any enforcement fix is active, does not update source-of-truth docs, does not validate full system behavior, and does not authorize DB, raw data, network, scraper, parser, training, or prediction work.
- Host unavailable results, if any: local git hooks were not used because this task forbids DB connection while the hook path runs a DB cold-start gate and the worktree compose path conflicts with already-running fixed-name dev containers.
- Container validation results, if any: targeted container checks passed with `--no-deps`; no db/redis dependency was started for targeted tests.

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Rollback Plan

Revert this PR to remove the scanner, its focused unit test, and the single phase report. No database, model, data artifact, schema, or runtime business state rollback is needed.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- `authoritative_workflow_enforcement_fix_phase1`, limited to PR template, AI Workflow Gate/test, `PROJECT_STATUS.md`, `DOCUMENTATION_GOVERNANCE.md`, and `CODEX_WORKFLOW.md`.

## PR Type

选择一个主类型：

- [ ] runtime-code-change
- [x] governance-only
- [ ] docs-only
- [ ] test-only
- [ ] ci-fix
- [ ] data-artifact

## Runtime Behavior

- Runtime code change included: no business runtime behavior change
- Runtime code paths changed: n/a
- Runtime behavior changed: n/a

如果这是 implementation phase 但没有 runtime code change，默认 No-Go。请说明原因、blocker 和人工确认：

- Explanation: This is not an implementation phase; it is the user-requested dry-run audit and enforcement design.
- Human confirmation: User explicitly requested this read-only dry-run task.

## Artifact Scope

- Docs/report/manifest changes included: yes
- Added/modified report lines: 109
- Added/modified manifest lines: 0
- Copies full historical state: no
- Includes large artifact: no
- Large artifact justification, if any: n/a

## Business Progress

- Business progress: none claimed; governance audit only.
- Blocker removed: none removed.
- Blocker remaining: PR/CI does not yet enforce authoritative-doc backflow; recent conclusions still need source-of-truth update in fix phase.
- Next step: user-confirmed `authoritative_workflow_enforcement_fix_phase1`.

## Ingestion Convergence Gate

Fill this section for any data ingestion, source inventory, target identity, raw write readiness,
accepted mapping, baseline, suspended target, or blocked target PR. Use `n/a` only when the PR is
not part of ingestion.

- Ingestion blocker removed: n/a
- Target state delta: n/a
- Count moved to clean_candidate: n/a
- Count moved to rejected/superseded: n/a
- Count moved to eligible_for_re_acceptance_review: n/a
- Count moved to needs_new_evidence: n/a
- Count remain_suspended: n/a
- Count still blocked: n/a
- No-progress justification: n/a; not an ingestion PR.
- Does this PR trigger architecture decision gate? n/a
- Is next step bounded? yes
- Is this the second consecutive no-progress ingestion PR? n/a

## Safety Status

- no live fetch: yes
- no detail fetch: yes
- no network request: yes for audit/runtime; GitHub git/PR operations only
- no DB writes: yes
- no raw_match_data inserts: yes
- no matches writes: yes
- no matches.external_id changes: yes
- no raw write execution: yes
- no re-acceptance execution: yes
- no suspension reversal: yes
- no rollback execution: yes
- no parser/features/training/prediction: yes
- no full body/raw_data/pageProps saved or printed: yes

If any answer is `no`, list the explicit authorization, scope, command, and verification:

- Authorization details: n/a

## Tests Run

- [x] lint
- [x] unit tests
- [ ] coverage
- [ ] formatter
- [x] git diff --check
- [x] hidden/bidi scan
- [x] full payload marker scan
- [ ] DB SELECT-only safety check, if applicable
- [x] other: scanner summary and AI Workflow Gate diff-only

Commands and results:

```text
docker compose -f docker-compose.dev.yml run --rm --no-deps dev node --test tests/unit/authoritative_workflow_enforcement_dry_run.test.js
PASS: 11 tests

docker compose -f docker-compose.dev.yml run --rm --no-deps dev node scripts/ops/authoritative_workflow_enforcement_dry_run.js
PASS: summary output generated; reports=434, missing recent reflection=3, P0=6/P1=10/P2=4

docker compose -f docker-compose.dev.yml run --rm --no-deps dev bash -lc 'npm ci --no-fund --no-audit >/dev/null && npm run lint -- --no-cache scripts/ops/authoritative_workflow_enforcement_dry_run.js'
PASS: targeted repo ESLint

git diff --cached --check
PASS

perl hidden/bidi scan on changed files
PASS: no output

rg payload/secret marker scan on changed files
PASS: no output

docker compose -f docker-compose.dev.yml run --rm --no-deps -v /home/xupeng/FootballPrediction.clean-dev/.git:/home/xupeng/FootballPrediction.clean-dev/.git:ro dev bash -lc 'git config --global --add safe.directory /app && GIT_DISCOVERY_ACROSS_FILESYSTEM=1 python3 scripts/ops/ai_workflow_gate.py --skip-body-checks'
PASS: AI workflow gate checks passed
```

## Repository Hygiene / Debt Impact

- New files added: 3
- File lifecycle for each new file:
  permanent / phase-artifact / one-shot-helper / test-fixture / temporary /
  archive-candidate / delete-after-use
  - `scripts/ops/authoritative_workflow_enforcement_dry_run.js`: permanent
  - `tests/unit/authoritative_workflow_enforcement_dry_run.test.js`: permanent
  - `docs/_reports/authoritative_workflow_enforcement_dry_run_20260621.md`: phase-artifact
- Permanent files: 2
- Phase-only artifacts: 1
- One-shot helpers (describe cleanup condition): none
- Test fixtures: none
- Files superseded: none
- Files deleted or archived: none
- Cleanup required later: report may become archive candidate after fix_phase1 backflows conclusions into source-of-truth docs.
- Current-state doc updated? no; blocked by task scope until user confirms fix phase.
- Report line count: 109
- Manifest size (lines / fields): n/a
- Does this PR increase repository noise? yes
- If yes, why is it justified: user explicitly allowed exactly one report for this dry-run audit; it is backlink-bearing and bounded.
- Next cleanup trigger: after `authoritative_workflow_enforcement_fix_phase1` updates authoritative docs.

## Artifact limits checklist

- [x] No full HTML/pageProps/raw_data/source body saved
- [x] No large report unless justified in comments above
- [x] No full historical recap copied
- [x] No orphan helper/script without lifecycle
- [x] Tests protect runtime behavior where applicable

## Review Notes

- Reviewer focus: verify the audit is static-only, report conclusions match scanner output, and fix_phase1 scope does not create new authoritative docs.
- Residual risk: current PR only diagnoses enforcement gaps; it does not activate enforcement.
- Follow-up PR, if any: `authoritative_workflow_enforcement_fix_phase1`, only after user confirmation.

