### PR TITLE
feat(chore): harden DB write guard — production-like DB host blocked by default

### DIFF
--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -241,6 +241,10 @@ table-level gates (`ALLOW_RAW_MATCH_DATA_WRITE`, `ALLOW_MATCHES_WRITE`,
 `ALLOW_ODDS_WRITE`, `ALLOW_TRAINING_WRITE`), and schema-level gates
 (`ALLOW_SCHEMA_WRITE`). DRY_RUN defaults to `true`. Production environment
 (`NODE_ENV=production` / `APP_ENV=production`) blocks write by default.
+Production-like DB hosts (RDS, Cloud SQL, Supabase, Railway, Render, Heroku, etc.)
+are blocked by default with no override. New env vars that bypass the production
+host block must not be introduced without explicit user authorization and separate
+audit.
 
 Test-debt work must be handled in a separate audit or repair task. Do not fix
 tests as part of workflow hardening unless the task explicitly scopes governance

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,6 +10,9 @@ Last updated: 2026-06-21
 - `main` includes PR #1463 (P0 AI Workflow Gate CI enforcement).
 - `main` includes PR #1464 (local CI gatekeeper entrypoint).
 - `main` includes PR #1567 (authoritative workflow enforcement dry-run).
+- `main` includes PR #1569 (p0_db_write_safety_gate_fix_phase1 — unified guard + 8 scripts).
+- `p0_db_write_guard_hardening_production_host_block` hardens the guard: production-like
+  DB hosts are now blocked by default (previously warning-only). No production override exists.
 - Remote GitHub Actions `production-gate.yml` is the final CI authority.
 - Local `make ci-local-pr` is a pre-push helper, not a full replacement for remote CI.
 - AI workflow governance rules are enforced by:
@@ -23,7 +26,9 @@ Last updated: 2026-06-21
 ## Current SC-002 status (DB write safety gate)
 
 - SC-002 is **not fully fixed**. This is a partial mitigation.
-- `p0_db_write_safety_gate_fix_phase1` has started.
+- `p0_db_write_safety_gate_fix_phase1` merged: unified guard helper + 8 script integrations.
+- `p0_db_write_guard_hardening_production_host_block`: production-like DB host is now blocked
+  by default (was warning-only). No production override exists. DB write remains blocked.
 - A unified guard helper (`scripts/ops/helpers/db_write_guard.js`) has been added.
 - 8 of 12 target P0 scripts now integrate the guard before DB write operations.
 - 4 scripts were skipped (see PR body): already have extensive controlled write

--- a/scripts/ops/helpers/db_write_guard.js
+++ b/scripts/ops/helpers/db_write_guard.js
@@ -28,7 +28,9 @@
  *
  * ### Production protection
  *   NODE_ENV=production or APP_ENV=production blocks write by default.
- *   DB hosts matching known production patterns print high-risk warnings.
+ *   DB hosts matching known production patterns (RDS, Cloud SQL, Supabase,
+ *   Railway, Render, Heroku, etc.) BLOCK write by default — no override exists.
+ *   Future explicit authorization required for any production-like host access.
  *
  * ## Usage
  *
@@ -226,18 +228,37 @@ function requireDbWriteGuards(options = {}) {
         ? true
         : normalizeBooleanEnv(dryRunEnv) !== false;
 
-    // ── 3. Production DB host warning ───────────────────────────────────────
+    // ── 3. Production DB host detection ─────────────────────────────────────
     const prodDb = checkProductionDbHost();
     warnings.push(...prodDb.warnings);
 
-    // ── 4. Universal gates ──────────────────────────────────────────────────
+    // ── 4. Production DB host block ─────────────────────────────────────────
+    // Hard block: production-like DB host is NOT allowed in this phase.
+    // No override env var exists.  Future explicit authorization required.
+    if (prodDb.suspicious) {
+        const matchedPatterns = prodDb.warnings.join('; ');
+        return {
+            allowed: false,
+            dryRun: null,
+            error: [
+                `[${script}] BLOCKED: DB_HOST / DATABASE_URL appears production-like.`,
+                `Matched: ${matchedPatterns}`,
+                'DB write to production-like hosts is blocked by default.',
+                'No production override is implemented in this phase.',
+            ].join(' '),
+            missingGates: [],
+            warnings,
+        };
+    }
+
+    // ── 5. Universal gates ──────────────────────────────────────────────────
     for (const gate of REQUIRED_UNIVERSAL_GATES) {
         if (!isTruthy(gate)) {
             missingGates.push(gate);
         }
     }
 
-    // ── 5. Table-level gates ────────────────────────────────────────────────
+    // ── 6. Table-level gates ────────────────────────────────────────────────
     const requiredTableGates = new Set();
     for (const table of tables) {
         for (const entry of TABLE_GATE_MAP) {
@@ -254,20 +275,15 @@ function requireDbWriteGuards(options = {}) {
         }
     }
 
-    // ── 6. Schema-level gate for high-risk operations ────────────────────────
+    // ── 7. Schema-level gate for high-risk operations ────────────────────────
     const hasHighRiskOp = operations.some(op => HIGH_RISK_OPERATIONS.has(String(op).toUpperCase()));
     if (hasHighRiskOp && !isTruthy('ALLOW_SCHEMA_WRITE')) {
         missingGates.push('ALLOW_SCHEMA_WRITE');
     }
 
-    // ── 7. Decision ─────────────────────────────────────────────────────────
+    // ── 8. Decision ─────────────────────────────────────────────────────────
     if (!isDryRunMode && missingGates.length === 0) {
         // All gates satisfied, not dry-run → allowed
-        if (prodDb.suspicious) {
-            warnings.push(
-                'WARNING: DB host matches production pattern but write is proceeding. Ensure this is intentional.'
-            );
-        }
         return {
             allowed: true,
             dryRun: false,

--- a/tests/unit/db_write_guard.test.js
+++ b/tests/unit/db_write_guard.test.js
@@ -443,7 +443,7 @@ test('Scenario 10b: APP_ENV=production blocks write', (t) => {
     guardBlocked(t, result);
 });
 
-test('Scenario 10c: production DB host generates warnings', (t) => {
+test('Scenario 10c: production DB host (RDS) BLOCKED even with all gates satisfied', (t) => {
     clearEnv();
     setEnv('DB_HOST', 'mydb.rds.amazonaws.com');
     setEnv('ALLOW_DB_WRITE', 'yes');
@@ -458,8 +458,159 @@ test('Scenario 10c: production DB host generates warnings', (t) => {
         operations: ['INSERT'],
     });
 
-    guardAllowed(t, result); // not blocked, but warns
-    assert.ok(result.warnings.length > 0, 'Should have production DB host warnings');
+    guardBlocked(t, result);
+    assert.ok(result.error.includes('production-like'), 'Error must mention production-like');
+    assert.ok(result.warnings.length > 0, 'Warnings should still be present');
+});
+
+test('Scenario 10d: DATABASE_URL supabase blocked with all gates', (t) => {
+    clearEnv();
+    setEnv('DATABASE_URL', 'postgres://user:pass@db.supabase.co:5432/db');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_MATCHES_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['matches'],
+        operations: ['INSERT'],
+    });
+
+    guardBlocked(t, result);
+    assert.ok(result.error.includes('production-like'), 'Error must mention production-like');
+});
+
+test('Scenario 10e: DB_HOST railway.app blocked with all gates', (t) => {
+    clearEnv();
+    setEnv('DB_HOST', 'db.railway.app');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_RAW_MATCH_DATA_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['raw_match_data'],
+        operations: ['INSERT'],
+    });
+
+    guardBlocked(t, result);
+});
+
+test('Scenario 10f: DB_HOST render.com blocked with all gates', (t) => {
+    clearEnv();
+    setEnv('DB_HOST', 'mydb.render.com');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_RAW_MATCH_DATA_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['raw_match_data'],
+        operations: ['INSERT'],
+    });
+
+    guardBlocked(t, result);
+});
+
+test('Scenario 10g: DB_HOST heroku blocked with all gates', (t) => {
+    clearEnv();
+    setEnv('DB_HOST', 'ec2-1-2-3-4.heroku.com');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_RAW_MATCH_DATA_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['raw_match_data'],
+        operations: ['INSERT'],
+    });
+
+    guardBlocked(t, result);
+});
+
+test('Scenario 10h: DB_HOST prod-db blocked with all gates', (t) => {
+    clearEnv();
+    setEnv('DB_HOST', 'my-prod-db.internal');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_RAW_MATCH_DATA_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['raw_match_data'],
+        operations: ['INSERT'],
+    });
+
+    guardBlocked(t, result);
+});
+
+test('Scenario 10i: localhost still allowed with all gates', (t) => {
+    clearEnv();
+    setEnv('DB_HOST', '127.0.0.1');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_RAW_MATCH_DATA_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['raw_match_data'],
+        operations: ['INSERT'],
+    });
+
+    guardAllowed(t, result);
+});
+
+test('Scenario 10j: localhost "db" still allowed with all gates', (t) => {
+    clearEnv();
+    setEnv('DB_HOST', 'db');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_RAW_MATCH_DATA_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['raw_match_data'],
+        operations: ['INSERT'],
+    });
+
+    guardAllowed(t, result);
+});
+
+test('Scenario 10k: suspicious host error contains host info and no-override message', (t) => {
+    clearEnv();
+    setEnv('DB_HOST', 'mydb.rds.amazonaws.com');
+    setEnv('ALLOW_DB_WRITE', 'yes');
+    setEnv('FINAL_DB_WRITE_CONFIRMATION', 'yes');
+    setEnv('ALLOW_RAW_MATCH_DATA_WRITE', 'yes');
+    setEnv('DRY_RUN', 'false');
+    const { requireDbWriteGuards } = loadGuard();
+
+    const result = requireDbWriteGuards({
+        script: 'test.js',
+        tables: ['raw_match_data'],
+        operations: ['INSERT'],
+    });
+
+    assert.ok(result.error.includes('mydb.rds.amazonaws.com'), 'Error must include the host');
+    assert.ok(result.error.includes('production-like'), 'Error must mention production-like');
+    assert.ok(
+        result.error.includes('No production override'),
+        'Error must state no production override is implemented'
+    );
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

`p0_db_write_guard_hardening_production_host_block` — small hardening PR.

Changes `db_write_guard.js` so that production-like DB hosts (RDS, Cloud SQL, Supabase, Railway, Render, Heroku, etc.) are **blocked by default** instead of generating only warnings. Previously, if all env gates were satisfied, a script could still write to a production-looking DB host. This is no longer allowed.

This is NOT `p0_db_write_safety_gate_fix_phase2`. No new scripts are integrated.

## Scope

| Item | Value |
|---|---|
| Task type | runtime-code-change |
| One task / one branch / one PR | yes |
| DB writes performed | no |
| Network access | no |
| Training performed | no |
| New docs/_reports | no |
| Phase2 scripts added | no |

## Files Changed

| Path | Purpose |
|---|---|
| `scripts/ops/helpers/db_write_guard.js` | Production host: warning → block-by-default |
| `tests/unit/db_write_guard.test.js` | 8 new production-host-block scenarios |
| `docs/PROJECT_STATUS.md` | Note hardening status |
| `docs/CODEX_WORKFLOW.md` | Production host block rule |

## What changed

### Before (warning-only)
Production-like DB host → warnings appended → if all gates satisfied → **ALLOWED**

### After (block-by-default)
Production-like DB host → **BLOCKED** regardless of gate state. Error message includes matched host and "No production override is implemented in this phase."

No new env var (no `ALLOW_PRODUCTION_DB_WRITE`, etc.). Future explicit authorization required.

### Unchanged
- NODE_ENV/APP_ENV=production block (unchanged)
- DRY_RUN default true (unchanged)
- Table-level / schema-level gates (unchanged)
- Local hosts (127.0.0.1, localhost, "db") still allowed

## Test Coverage (39 scenarios)

| # | Scenario | Status |
|---|---|---|
| 1-9c | Existing scenarios (unchanged) | PASS |
| 10a-b | NODE_ENV/APP_ENV production block (unchanged) | PASS |
| 10c | RDS host BLOCKED with all gates | PASS |
| 10d | Supabase DATABASE_URL BLOCKED | PASS |
| 10e | Railway BLOCKED | PASS |
| 10f | Render BLOCKED | PASS |
| 10g | Heroku BLOCKED | PASS |
| 10h | prod-db pattern BLOCKED | PASS |
| 10i | localhost still allowed | PASS |
| 10j | "db" still allowed | PASS |
| 10k | Error contains host + no-override message | PASS |
| 11-13 | Remaining scenarios (unchanged) | PASS |

## Validation

| Validation | Result |
|---|---|
| Guard unit tests (39 scenarios) | PASS |
| Lint (eslint) | PASS |
| Gatekeeper (cold start, repo hygiene, ProxyProvider, smoke) | PASS |
| git diff --check | PASS |
| hidden/bidi scan | PASS |
| payload marker scan | PASS |

## Safety Status

- no live fetch: yes
- no network request: yes
- no DB writes: yes
- no raw_match_data inserts: yes
- no training: yes
- no production DB connection: yes
- no new docs/_reports: yes

## SC-002 Status

**NOT fully fixed.** Partial mitigation only. This PR hardens the guard so production-like hosts are blocked. Phase2 (remaining script integrations) still needed.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- `p0_db_write_safety_gate_fix_phase2` — integrate guard into remaining P0 scripts.

## Repository Hygiene

- New files: 0
- Files deleted/renamed/moved: 0
- New docs/_reports: 0
- Permanent files modified: 4
- No increase in repository noise

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | 0 |
| Reports added | 0 |
| Manifests added | 0 |
| Source-of-truth docs updated | PROJECT_STATUS.md, CODEX_WORKFLOW.md |
| Concrete impact | Updated DB write guard hardening status; production-host-block rule in Codex workflow |

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Archive operation performed | no |
| Business code changed | no (guard hardening only) |
| FotMob code changed | no |
| DB used | no |
| Browser automation used | no |
| Scraper run | no |
| Production DB accessed | no |

## CI Gate Scope

- What the validation proves: The guard correctly blocks production-like DB hosts (RDS, Supabase, Railway, Render, Heroku, prod-db patterns) even when all env gates are satisfied. Local hosts remain allowed. 39 test scenarios pass. The hardening does not affect dry-run, production env, table-level, or schema-level gate semantics.
- What the validation does not prove: That no other production host patterns exist in the wild. That the guard cannot be bypassed by scripts that don'''t use it.
- Host unavailable results: n/a (container validation passed).

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |

## Rollback Plan

Revert this PR. The change is a single block addition in the guard helper. Before revert, production-like DB hosts are blocked; after revert, they return to warning-only. No other behavior is affected. No data, schema, or migration impact.
