### PR TITLE
hotfix: update static test to accept Phase2A design doc wording

### DIFF
--- a/tests/unit/python_sql_migration_enforcement_design_phase1_static.test.js
+++ b/tests/unit/python_sql_migration_enforcement_design_phase1_static.test.js
@@ -158,7 +158,8 @@ test('Design document declares design-only / no runtime behavior changed', () =>
     'Design document must declare what it does NOT do'
   );
   assert.ok(
-    doc.includes('Implement any guard') || doc.includes('implement any guard'),
+    doc.includes('Implement any guard') || doc.includes('implement any guard')
+      || doc.includes('Implement any Python guard'),
     'Design document must state no guard implementation'
   );
 });
@@ -346,7 +347,9 @@ test('No runtime guard implementation present in changed files', () => {
   // Verify the design doc does not contain implementation code
   const doc = readFile('docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md');
   assert.ok(
-    doc.includes('does NOT') && doc.includes('Implement any guard'),
+    doc.includes('does NOT') && (
+      doc.includes('Implement any guard') || doc.includes('Implement any Python guard')
+    ),
     'Design document must explicitly state no guard implementation'
   );
   // Confirm no Python guard helper was created


### PR DESCRIPTION
## Summary

Hotfix for post-merge main CI failure in #1597. The Phase2A implementation updated the design doc summary wording which changed "Implement any guard" to "Implement any Python guard, scanner, or enforcement". Two static test assertions needed to accept the updated phrasing.

## Scope

- Update 2 assertions in tests/unit/python_sql_migration_enforcement_design_phase1_static.test.js
- Tests #8 and #16 now accept both old and new design doc wording

## Documentation Impact

None. This is a test-only fix.

## Safety Impact

No runtime behavior changed. No scripts executed. No DB connection.

## Validation

- node --test tests/unit/python_sql_migration_enforcement_design_phase1_static.test.js: 22/22 pass
- Gatekeeper (commit mode): PASS

## CI Gate Scope

This hotfix only changes test assertions. No gate behavior changes.

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed.

## Rollback Plan

Revert merge commit. No runtime state to rollback.

## Next Recommended Task

Merge and verify main green. Do not start automatically. Recommended next task only after user confirmation.