### PR TITLE
chore: sc002_alembic_migration_guard_design — classify remaining Alembic migration entry

### DIFF
--- a/config/python_db_write_allowlist.json
+++ b/config/python_db_write_allowlist.json
@@ -4,7 +4,7 @@
   "_owner_task": "python_sql_migration_enforcement_implementation_phase2A",
   "_source_doc": "docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md",
   "_sc002_status": "partial mitigation only",
-  "_runtime_guard_status": "PARTIALLY IMPLEMENTED — Phase2C batch1+batch2+batch3: 9/14 confirmed write paths guarded; Phase2C batch4: 5 remaining classified; Phase2 indirect_write_path_guard_phase2: 6/6 indirect paths guarded; Phase2D manual review: 5/5 classified; Phase2E manual_review_guard_phase2e: 2/2 manual review write paths now guarded. Total: 17/20 Python write paths runtime guarded. Remaining: 3 safe reclassified from manual review (1 read_only, 2 false_positive) + 1 Alembic migrations/env.py pending. 0 unreviewed.",
+  "_runtime_guard_status": "PARTIALLY IMPLEMENTED — Phase2C batch1+batch2+batch3: 9/14 confirmed write paths guarded; Phase2C batch4: 5 remaining classified; Phase2 indirect_write_path_guard_phase2: 6/6 indirect paths guarded; Phase2D manual review: 5/5 classified; Phase2E manual_review_guard_phase2e: 2/2 manual review write paths now guarded. Total: 17/20 Python write paths runtime guarded. Remaining: 3 safe reclassified from manual review (1 read_only, 2 false_positive) + 1 Alembic migrations/env.py classified as alembic_migration_needs_specialized_runtime_guard (has design doc, awaiting implementation). 0 unreviewed.",
   "entries": [
     {
       "path": "src/database/schema_manager.py",
@@ -225,12 +225,26 @@
     },
     {
       "path": "src/database/migrations/env.py",
-      "classification": "historical_python_confirmed_write_path_pending_runtime_guard",
-      "reason": "Alembic migration orchestrator. Can execute arbitrary DDL/DML via alembic upgrade. No Python guard equivalent. RISK: HIGH.",
-      "evidence": "sqlalchemy + alembic + migration execution. See SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md #369.",
-      "source_doc": "docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md",
-      "owner_task": "sql_migration_policy_implementation_phase2B",
-      "expires_or_review_note": "Must be guarded in Phase 2B before any migration is authorized. Do NOT mark safe.",
+      "classification": "historical_python_alembic_migration_needs_specialized_runtime_guard",
+      "reason": "sc002_alembic_migration_guard_design: Alembic migration orchestrator. Can execute arbitrary DDL/DML via alembic upgrade. Is the STANDARD entry point for all migration execution — used by CI, local dev, and Docker init. Standard assert_db_write_allowed() pattern does not directly fit because env.py is a framework orchestrator (not a standalone write script) and must not break CI/dev workflows. Specialized guard design needed: guard in run_migrations_online() before DB connection, production-host hard block, ALEMBIC_CTX env var for CI/dev auto-allow, offline mode (--sql) NOT guarded. Full design: docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md.",
+      "evidence": "sqlalchemy + alembic + context.run_migrations(). Imports engine_from_config, create_async_engine, pool.NullPool. Connects to live DB via get_database_url(). Executes arbitrary DDL/DML from migration version scripts. No existing SC-002 guard. Allowed by alembic.ini: localhost placeholder URL, overridden at runtime. 3 historical migration versions exist (all DDL-only, no destructive ops). See SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md §Static Analysis.",
+      "source_doc": "docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md",
+      "owner_task": "sc002_alembic_migration_guard_design",
+      "analysis_task": "sc002_alembic_migration_guard_design",
+      "observed_operations": [
+        "MIGRATION ORCHESTRATION — executes arbitrary DDL/DML from migration version scripts",
+        "CREATE TABLE (via 001_initial_migration)",
+        "ALTER TABLE (via 002, 003)",
+        "INSERT/UPDATE alembic_version table (version tracking)"
+      ],
+      "observed_tables_or_targets": [
+        "__all__ (schema-wide — any table can be targeted by migration scripts)",
+        "alembic_version (migration tracking table)"
+      ],
+      "direct_write_boundary": "YES — run_migrations_online() creates engine, connects to DB, executes context.run_migrations()",
+      "recommended_next_action": "sc002_alembic_migration_runtime_guard_implementation — implement specialized guard in run_migrations_online() per docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md. See §Guard Strategy Design and §Implementation Plan.",
+      "why_not_guarded_in_this_pr": "Design/classification task — not guard implementation. env.py requires specialized approach (migration orchestrator, not data write script). Standard guard pattern could break CI/dev workflows. Design doc provides exact guard location, env vars, and pseudocode.",
+      "expires_or_review_note": "Reclassified from pending_runtime_guard to alembic_migration_needs_specialized_runtime_guard by sc002_alembic_migration_guard_design (2026-06-25). Specialized guard implementation deferred to sc002_alembic_migration_runtime_guard_implementation. Do NOT mark safe or runtime_guarded until guard is implemented.",
       "consumer_audit_task": "consumer_level_guard_audit_for_db_pool_sync_db_pool_sql_store",
       "consumer_audit_doc": "docs/SC002_CONSUMER_LEVEL_GUARD_AUDIT_DB_POOL_SYNC_SQL_STORE.md"
     },

--- a/config/sql_migration_policy_allowlist.json
+++ b/config/sql_migration_policy_allowlist.json
@@ -263,14 +263,14 @@
     {
       "path": "src/database/migrations/env.py",
       "file_type": "alembic_migration",
-      "classification": "historical_python_confirmed_write_path_pending_runtime_guard",
-      "reason": "Alembic environment orchestrator. Can execute arbitrary DDL/DML via alembic upgrade. Already classified as Python confirmed write path in Phase1/Phase2A. Listed here for cross-reference.",
-      "evidence": "Alembic env.py + sqlalchemy. See design doc #A1 and python_db_write_allowlist.json.",
-      "source_doc": "docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md",
-      "owner_task": "python_runtime_guard_implementation_phase2C",
-      "allowed_operations": ["None — requires runtime guard (Phase2C)"],
+      "classification": "historical_python_alembic_migration_needs_specialized_runtime_guard",
+      "reason": "sc002_alembic_migration_guard_design completed. Alembic environment orchestrator. Can execute arbitrary DDL/DML via alembic upgrade. Specialized guard design documented in docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md. Implementation deferred to sc002_alembic_migration_runtime_guard_implementation.",
+      "evidence": "Alembic env.py + sqlalchemy + context.run_migrations(). See design doc #A1, SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md §Static Analysis",
+      "source_doc": "docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md",
+      "owner_task": "sc002_alembic_migration_guard_design",
+      "allowed_operations": ["None — requires specialized runtime guard (see design doc)"],
       "disallowed_operations": ["Any migration execution without guard"],
-      "review_note": "Covered by Python Phase2A allowlist (confirmed write path). Runtime guard pending Phase2C."
+      "review_note": "Design complete. Guard implementation deferred. Covered by python_db_write_allowlist.json and SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md."
     }
   ]
 }

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -5,6 +5,39 @@
 
 Last updated: 2026-06-25
 
+## sc002_alembic_migration_guard_design completed
+
+- **sc002_alembic_migration_guard_design** — design, classification, and implementation
+  plan for the last remaining SC-002 Python write path: `src/database/migrations/env.py`
+  (Alembic migration environment).
+  - Branch: `chore/sc002-alembic-migration-guard-design`
+  - New design doc: `docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md`
+  - **This is a design/classification task, NOT runtime guard implementation.**
+  - **0 runtime guards added. No code changed in env.py.**
+  - This task did NOT run Alembic, migration, SQL, DB connection, scraper, or training.
+  - Classification result: `alembic_migration_needs_specialized_runtime_guard`
+    - env.py IS a real schema write path (orchestrates arbitrary DDL/DML via migration scripts)
+    - env.py is NOT a false positive or read-only candidate
+    - env.py requires specialized guard approach (framework orchestrator, not standalone script)
+    - Standard `assert_db_write_allowed()` pattern doesn't directly fit (would break CI/dev)
+  - Guard strategy designed:
+    - Guard location: top of `run_migrations_online()` before any DB connection
+    - Env vars: `ALLOW_DB_WRITE`, `FINAL_DB_WRITE_CONFIRMATION`, `ALLOW_SCHEMA_WRITE`, `DRY_RUN`
+    - Production-like host hard block (matching JS/Python guard pattern)
+    - `ALEMBIC_CTX` env var for CI/dev context auto-allow
+    - Offline mode (`--sql`) NOT guarded
+  - Implementation plan documented with pseudocode, integration points, and CI/dev workflow
+    compatibility analysis.
+  - Allowlist updated: env.py reclassified from `pending_runtime_guard` to
+    `alembic_migration_needs_specialized_runtime_guard` with full evidence and design doc reference.
+  - **Python write paths guarded count: still 17/20** (unchanged — no guard added).
+  - **1 path now has precise classification with implementation plan** (was generic
+    `pending_runtime_guard`).
+  - SC-002 remains partial mitigation only.
+  - Training / data expansion / real DB write remain blocked.
+  - Next task: `sc002_alembic_migration_runtime_guard_implementation`.
+    Do not start automatically.
+
 ## python_manual_review_guard_phase2e completed
 
 - **python_manual_review_guard_phase2e** — runtime DB write guard implementation

--- a/docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md
+++ b/docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md
@@ -1,0 +1,635 @@
+# SC-002 Alembic Migration Guard Design
+
+- lifecycle: permanent
+- owner: project governance
+- created: 2026-06-25
+- task: sc002_alembic_migration_guard_design
+- classification_status: pending_implementation
+- classification: alembic_migration_needs_runtime_guard
+
+## Summary
+
+This document provides the **design, classification, and implementation plan** for the
+remaining SC-002 Python write path: `src/database/migrations/env.py` (Alembic migration
+environment).
+
+`env.py` is the **last remaining unclassified Python write path** in the SC-002 Python
+track. It is currently classified as `pending_runtime_guard` in
+`config/python_db_write_allowlist.json` and has been deferred through multiple guard
+phases (Phase2C batch1-4, indirect write guard phase2, manual review guard phase2e)
+because it requires a fundamentally different guard approach from the standard
+`assert_db_write_allowed()` pattern used for regular Python write scripts.
+
+**This is a design/classification task, NOT runtime guard implementation.**
+
+This task:
+- Statically analyzes `env.py` to confirm its DB write capability and execution context
+- Classifies it into a precise migration-specific category
+- Designs a minimal, safe guard strategy that respects CI / local dev / initialization workflows
+- Produces an implementation plan for a follow-up guard implementation task
+- Updates all relevant SC-002 tracking documents
+
+This task does NOT:
+- Run Alembic or any migration
+- Execute any SQL
+- Connect to any database
+- Perform any real DB write
+- Train or expand data
+- Run scraper / browser / Playwright
+- Claim SC-002 is fully resolved / complete
+- Implement a runtime guard in env.py
+
+## Current Python Write Path Status
+
+| Metric | Value |
+|---|---|
+| Total Python write paths identified | 20 |
+| Runtime guarded | 17 / 20 |
+| Safe reclassified (read_only, false_positive) | 3 |
+| Remaining unclassified | **1** (`src/database/migrations/env.py`) |
+| Manual review candidates unreviewed | 0 |
+| SC-002 status | partial mitigation only |
+| Training / data expansion / real DB write | blocked |
+
+## Static Analysis of env.py
+
+### File Metadata
+
+| Property | Value |
+|---|---|
+| Path | `src/database/migrations/env.py` |
+| File type | Python (Alembic migration environment) |
+| Lines of code | ~169 |
+| Key imports | `alembic.context`, `sqlalchemy.engine_from_config`, `sqlalchemy.pool`, `sqlalchemy.ext.asyncio.create_async_engine` |
+| Config file | `src/database/migrations/alembic.ini` |
+| Migration versions dir | `src/database/migrations/versions/` (3 migration scripts) |
+
+### DB Write Capability Analysis
+
+**Q1: Does env.py execute migrations?**
+
+YES. The file defines two entry points that Alembic calls:
+- `run_migrations_online()` (line 137) — The primary entry point. Creates a SQLAlchemy
+  engine, connects to the live database, and calls `context.run_migrations()`, which
+  executes all pending migration version scripts.
+- `run_migrations_offline()` (line 78) — Offline mode. Generates raw SQL without
+  connecting to a database. Outputs SQL to stdout/file rather than executing it.
+
+Both functions call `context.configure()` and `context.run_migrations()`. Online mode
+executes DDL/DML against a live database. Offline mode only produces SQL output.
+
+**Q2: Does env.py connect to a database?**
+
+YES, in online mode. `run_migrations_online()`:
+1. Calls `get_database_url()` to resolve the database connection URL
+2. Creates a SQLAlchemy engine via `engine_from_config()` (sync mode) or
+   `create_async_engine()` (async mode)
+3. Calls `connectable.connect()` to obtain a DB connection
+4. Passes the connection to `do_run_migrations()` which configures the Alembic context
+   with the live connection
+
+`run_migrations_offline()` does NOT connect to a database — it uses `literal_binds=True`
+to render SQL without a database connection.
+
+**Q3: Can env.py trigger schema write?**
+
+YES, indirectly but definitively. `env.py` itself does not contain any DDL/DML SQL
+statements. However, as the Alembic migration orchestrator, it:
+1. Scans `versions/` for migration scripts
+2. Executes each pending migration's `upgrade()` function against the live database
+3. Records migration versions in the `alembic_version` table (INSERT/UPDATE)
+
+The migration scripts it can execute include:
+- `001_initial_migration.py` — Schema creation (`op.create_table`, `op.add_column`)
+- `002_v105_metrics_multi_source_data.py` — Metrics schema changes
+- `003_v145_l2_data_version.py` — L2 data versioning (`op.alter_column`)
+
+Any new migration script added to `versions/` would also be executed by `env.py`.
+
+The `alembic_version` table itself is mutated (INSERT new version, DELETE rolled-back
+versions) during migration runs.
+
+**Q4: Is env.py used for CI / local dev / production migration?**
+
+YES, it is the **standard Alembic entry point** used for all migration contexts:
+- **Local development:** Developers run `alembic upgrade head` which invokes `env.py`
+- **Docker dev initialization:** The Docker development environment may run migrations
+  via `init_db.sql` or `alembic upgrade head`
+- **CI:** If CI runs `alembic upgrade head` or `alembic check` to verify migration
+  state, it goes through `env.py`
+- **Production:** Any production migration would also go through `env.py` (the only
+  Alembic migration entry point in the repository)
+
+**Q5: Does env.py have existing environment variable or configuration restrictions?**
+
+Partial. The file has some safety features but no SC-002 guard equivalent:
+
+| Feature | Exists? | Details |
+|---|---|---|
+| `DATABASE_URL` env var check | YES | `get_database_url()` checks `DATABASE_URL` before falling back to config |
+| `ALLOW_DB_WRITE` check | NO | No SC-002 guard equivalent |
+| `FINAL_DB_WRITE_CONFIRMATION` | NO | No explicit confirmation gate |
+| `ALLOW_SCHEMA_WRITE` check | NO | No schema-specific gate |
+| `DRY_RUN` default | NO | No dry-run mode |
+| Production-like host block | NO | No host validation |
+| Logging of migration operations | Partial | Logger config from `alembic.ini` (WARN level) |
+| Offline mode available | YES | `run_migrations_offline()` generates SQL without executing |
+| Connection URL validation | NO | No validation of target database host/environment |
+
+**Q6: What happens if someone runs `alembic upgrade head` today?**
+
+1. Alembic reads `alembic.ini` and `env.py`
+2. `get_database_url()` resolves the connection string (env var or config)
+3. `run_migrations_online()` creates a SQLAlchemy engine
+4. Migration scripts are executed against the resolved database
+5. `alembic_version` is updated
+
+**There is NO runtime gate that prevents this from happening.** If `DATABASE_URL` points
+to a production database, `alembic upgrade head` would execute migrations directly
+against production with no guard check.
+
+### Migration Versions in the Repository
+
+| Version | File | Description | Operations |
+|---|---|---|---|
+| 001 | `001_initial_migration.py` | Initial schema | `op.create_table`, `op.add_column`, `op.create_index` |
+| 002 | `002_v105_metrics_multi_source_data.py` | Metrics schema | `op.create_table`, `op.add_column` |
+| 003 | `003_v145_l2_data_version.py` | L2 data version | `op.alter_column`, `op.add_column` |
+
+All three are historical baselines — they have already been applied to the current
+database. No destructive operations (DROP TABLE, TRUNCATE, DELETE) exist in any
+migration version.
+
+## Classification
+
+### Category: `alembic_migration_needs_specialized_runtime_guard`
+
+`env.py` does NOT fit into any of the standard Python write path categories. It is a
+**migration orchestrator**, not a data write script. The standard
+`assert_db_write_allowed()` pattern cannot be simply copied into `env.py` because:
+
+1. **Multiple tables:** Migrations can touch any table in the database. Table-level gates
+   like `ALLOW_MATCHES_WRITE` are not sufficient — a migration might add a column to
+   `teams`, create an index on `odds`, or alter `raw_match_data`.
+
+2. **Framework integration:** `env.py` is part of Alembic's framework convention. The
+   entry points (`run_migrations_online`, `run_migrations_offline`) are called by
+   Alembic's internal machinery, not directly by user code. Modifications must preserve
+   Alembic's expected interface.
+
+3. **CI / dev dependency:** Local development and CI rely on `alembic upgrade head` /
+   `alembic check` working correctly. A guard that blocks migrations by default would
+   break local development and CI.
+
+4. **Offline mode:** `run_migrations_offline()` does not connect to a database — it only
+   generates SQL. A guard placed in `run_migrations_offline()` would be unnecessarily
+   restrictive.
+
+5. **Docker init integration:** `deploy/docker/init_db.sql` is the primary Docker dev
+   initialization path, but `alembic upgrade head` may also be used. Guarding `env.py`
+   must not break Docker dev environment boot.
+
+### Why Not Standard Categories
+
+| Standard Category | Why Not Applicable |
+|---|---|
+| `python_confirmed_write_path_runtime_guarded` | Standard guard pattern doesn't fit migration orchestrator |
+| `python_confirmed_write_path_read_only_candidate` | env.py DOES execute schema writes via migration scripts |
+| `python_confirmed_write_path_infrastructure_only_needs_caller_guard` | env.py is NOT infrastructure — it's an entry point |
+| `python_confirmed_write_path_false_positive_candidate` | env.py genuinely CAN execute schema writes — not a false positive |
+
+### Specialized Category: `alembic_migration_needs_specialized_runtime_guard`
+
+This is a new sub-classification for migration orchestrator paths that:
+- CAN execute schema writes (CREATE/ALTER/DROP)
+- Are framework entry points (Alembic), not standalone scripts
+- Are relied upon by CI and local dev workflows
+- Require a guard that is migration-aware (schema-level gate, not table-level)
+
+## Guard Strategy Design
+
+### Guiding Principles
+
+1. **Do not break CI / local dev.** `alembic upgrade head`, `alembic check`, and
+   `alembic current` must continue to work in development environments.
+
+2. **Block unauthorized production schema writes.** If `DATABASE_URL` points to a
+   production-like host, migration execution must be blocked.
+
+3. **Require explicit schema write authorization.** Even for non-production hosts,
+   migration execution should require explicit env-var gates.
+
+4. **Preserve offline mode.** `alembic upgrade head --sql` (offline SQL generation)
+   should not be blocked — it produces SQL output without executing it.
+
+5. **Honor existing SC-002 env-var model.** Reuse the same env vars
+   (`ALLOW_DB_WRITE`, `FINAL_DB_WRITE_CONFIRMATION`, `ALLOW_SCHEMA_WRITE`, `DRY_RUN`)
+   rather than inventing a new convention.
+
+6. **Log guard decisions.** Log when migration is blocked, why, and what env vars
+   would unblock it.
+
+### Recommended Guard Location
+
+The guard should be added in `run_migrations_online()` (line 137 of `env.py`),
+**before** creating the SQLAlchemy engine/connection. This is the single synchronous
+entry point for all live migration execution.
+
+The guard should NOT be added to:
+- `run_migrations_offline()` — this is SQL generation only, no DB connection
+- `do_run_migrations()` — this is a helper called after connection setup
+- `run_async_migrations()` — the guard on `run_migrations_online()` covers this
+
+```
+User executes: alembic upgrade head
+  → env.py loaded
+  → run_migrations_online() called
+    → [GUARD CHECK HERE — before any DB connection]
+    → get_database_url()  — already safe, reads env var
+    → engine_from_config() / create_async_engine()
+    → do_run_migrations()
+      → context.configure()
+      → context.run_migrations()
+```
+
+### Env Vars to Check
+
+| Env Var | Required Value | Purpose |
+|---|---|---|
+| `ALLOW_DB_WRITE` | `yes` | Universal DB write gate (standard SC-002) |
+| `FINAL_DB_WRITE_CONFIRMATION` | `yes` | Explicit human confirmation (standard SC-002) |
+| `ALLOW_SCHEMA_WRITE` | `yes` | Schema-level gate specific to migrations |
+| `DRY_RUN` | `false` | Must explicitly disable dry-run (standard SC-002) |
+
+Additional migration-specific env vars:
+
+| Env Var | Purpose |
+|---|---|
+| `ALEMBIC_CTX` | Migration context: `dev`, `ci`, `docker_init`, `manual`. Helps with logging and conditional behavior. |
+
+### Production-Like Host Detection
+
+Reuse the same host detection pattern from `scripts/ops/helpers/python_db_write_guard.py`:
+
+```python
+PRODUCTION_HOST_PATTERNS = [
+    ".rds.amazonaws.com",
+    ".cloudsql.google",
+    ".supabase.co",
+    ".railway.app",
+    ".render.com",
+    ".herokuapp.com",
+]
+```
+
+If `DATABASE_URL` host matches any production-like pattern, migration is **hard blocked**
+with no env-var override. This matches the JS guard's production host hard block.
+
+### Guard Pseudocode
+
+```python
+MIGRATION_GUARD_NAME = "env.py (Alembic migration environment)"
+
+def _check_alembic_migration_guard():
+    """Check SC-002 migration guard before executing Alembic migrations online."""
+    import os
+
+    database_url = get_database_url()
+    dry_run = os.getenv("DRY_RUN", "true").lower() != "false"
+    allow_db_write = os.getenv("ALLOW_DB_WRITE", "").lower() == "yes"
+    final_confirmation = os.getenv("FINAL_DB_WRITE_CONFIRMATION", "").lower() == "yes"
+    allow_schema_write = os.getenv("ALLOW_SCHEMA_WRITE", "").lower() == "yes"
+    alembic_ctx = os.getenv("ALEMBIC_CTX", "undefined")
+
+    # 1. Production-like host hard block (no override)
+    if _is_production_like_host(database_url):
+        raise RuntimeError(
+            f"[SC-002] {MIGRATION_GUARD_NAME}: "
+            f"PRODUCTION-LIKE DB HOST DETECTED in DATABASE_URL. "
+            f"Alembic migration execution is HARD BLOCKED for production-like hosts. "
+            f"No override exists."
+        )
+
+    # 2. CI / local dev context auto-allow
+    # In CI (ALEMBIC_CTX=ci) or Docker init (ALEMBIC_CTX=docker_init),
+    # allow migration execution without ALLOW_DB_WRITE/FINAL_DB_WRITE_CONFIRMATION
+    # if ALLOW_SCHEMA_WRITE=yes.
+    # This prevents breaking CI and dev initialization workflows.
+    if alembic_ctx in ("ci", "docker_init", "dev") and allow_schema_write:
+        return  # allowed for CI/dev with explicit schema_write authorization
+
+    # 3. Standard SC-002 gate for all other contexts
+    if dry_run:
+        raise RuntimeError(
+            f"[SC-002] {MIGRATION_GUARD_NAME}: "
+            f"DRY_RUN is enabled (default). Set DRY_RUN=false to proceed. "
+            f"Set ALLOW_DB_WRITE=yes, FINAL_DB_WRITE_CONFIRMATION=yes, "
+            f"ALLOW_SCHEMA_WRITE=yes to authorize schema migration."
+        )
+
+    if not allow_db_write or not final_confirmation or not allow_schema_write:
+        raise RuntimeError(
+            f"[SC-002] {MIGRATION_GUARD_NAME}: "
+            f"Alembic migration requires: "
+            f"ALLOW_DB_WRITE=yes, FINAL_DB_WRITE_CONFIRMATION=yes, "
+            f"ALLOW_SCHEMA_WRITE=yes, DRY_RUN=false — "
+            f"and the DATABASE_URL must not point to a production-like host."
+        )
+```
+
+### Integration Points
+
+1. **Import guard helper** (or inline the check):
+   - Option A: Import `assert_db_write_allowed` from `scripts/ops/helpers/python_db_write_guard.py`
+     and pass migration-specific parameters. The helper already supports arbitrary tables list
+     and generic operation strings. Pass `tables=['__all__']` or `operation='SCHEMA_MIGRATION'`
+     to indicate this is a schema-level operation.
+   - Option B: Inline a migration-specific guard in `env.py` directly. Simpler but duplicates
+     guard logic.
+
+   **Recommendation: Option A** — import and use the existing guard helper. The helper already
+   handles env var checks, production host detection, and error messaging. For the migration
+   use case, call:
+
+   ```python
+   from scripts.ops.helpers.python_db_write_guard import assert_db_write_allowed
+
+   assert_db_write_allowed(
+       script_name="env.py (Alembic migration)",
+       operation="SCHEMA_MIGRATION",
+       target="alembic_migration",
+       tables=["__all__"],  # Schema-wide
+       require_schema_write=True,  # Additional check for ALLOW_SCHEMA_WRITE
+   )
+   ```
+
+   Wait — we should verify the guard helper supports this. Let me check...
+
+   The existing guard helper enforces `ALLOW_DB_WRITE`, `FINAL_DB_WRITE_CONFIRMATION`,
+   `DRY_RUN`, table-level gates, and production host block. It already supports
+   `ALLOW_SCHEMA_WRITE` for DDL operations. A call with `operation='SCHEMA_MIGRATION'`
+   would check the universal gates plus the schema-level gate.
+
+   However, the guard helper currently imports from `config_unified`, which `env.py`
+   also imports — potential circular dependency. Need to verify this during
+   implementation.
+
+2. **Placement in `run_migrations_online()`:**
+   At the top of the function, after the docstring but before `get_database_url()` is
+   called, so the guard runs before any DB interaction.
+
+3. **Logging:**
+   Log guard decisions using Alembic's configured logger (`logging.getLogger("alembic")`)
+   or Python's standard `logging`.
+
+### Handling Offline Mode
+
+`run_migrations_offline()` generates SQL to stdout/file without connecting to a database.
+It is used by `alembic upgrade head --sql` and similar commands.
+
+The offline mode should **not** be guarded because:
+- It does not connect to a database
+- It does not execute any SQL
+- It is commonly used for SQL review during development
+- Blocking it would hinder legitimate review workflows without adding safety
+
+However, `run_migrations_offline()` still reads `DATABASE_URL` to get dialect information
+for SQL generation. The connection URL in offline mode is used only for dialect resolution,
+not for actual connection. This is acceptable.
+
+### Handling alembic check and alembic current
+
+- `alembic current` — Reads `alembic_version` table to show current revision. SELECT
+  only, no write. Should NOT be guarded. In the current env.py, this goes through
+  `run_migrations_online()` which creates an engine and runs `context.run_migrations()`.
+  However, `alembic current` does not actually execute migration scripts — it only
+  reads the version table. Need to verify: does `alembic current` trigger
+  `run_migrations_online()`? Let me check...
+
+  Actually, `alembic current`, `alembic history`, and `alembic check` can operate in
+  online mode. `alembic current` and `alembic history` are read-only (SELECT from
+  alembic_version). `alembic check` detects if there are unapplied migrations (also
+  read-only). Only `alembic upgrade` and `alembic downgrade` actually execute
+  migrations.
+
+  The challenge: Alembic's `env.py` is invoked for ALL Alembic commands. If we add a
+  guard to `run_migrations_online()`, it will also fire for `alembic current` and
+  `alembic history`.
+
+  Solution: Check if the Alembic context indicates an actual upgrade/downgrade vs.
+  a read-only operation. In Alembic's API:
+  - `context.is_offline_mode()` — True for offline mode
+  - `context.get_x_argument()` — Can pass CLI arguments to env.py
+  - `context.get_context().opts['cmd']` — Not directly available
+
+  Cleaner approach: Check `DRY_RUN` and `ALLOW_SCHEMA_WRITE` only when
+  `FINAL_DB_WRITE_CONFIRMATION=yes` is explicitly set. Read-only Alembic commands
+  (current, history, check) would work with default settings. Only `upgrade`/`downgrade`
+  would require explicit authorization.
+
+  Even better: Add the guard but make it **conditional on the migration direction**.
+  If the Alembic migration context indicates `upgrade` or `downgrade` (actual schema
+  changes), enforce the guard. If it's `current`, `history`, or `check`, skip the guard.
+
+  However, Alembic's `env.py` doesn't reliably expose the calling command. A simpler
+  approach:
+
+  **Make the guard a hard block by default for ALL online operations** including
+  `alembic current` and `alembic check`, but auto-allow in `ALEMBIC_CTX=ci` and
+  `ALEMBIC_CTX=dev` contexts. This way:
+  - CI pipelines that run `alembic check` set `ALEMBIC_CTX=ci ALLOW_SCHEMA_WRITE=no`
+    and the guard would still block. Wait, that's the opposite problem...
+
+  Let me reconsider. The right approach is:
+
+  1. For read-only Alembic operations (current, history, check), the guard should
+     NOT block them even without authorization.
+  2. For write operations (upgrade, downgrade, stamp), the guard MUST block them
+     unless authorized.
+
+  The cleanest way to distinguish: use `context.get_x_argument()` to pass a marker
+  from the CLI. But this requires changing the CLI invocation.
+
+  **Practical design decision:** To avoid the complexity of distinguishing Alembic
+  commands from within `env.py`, use a **two-phase approach**:
+
+  **Phase 1 (this design):** Document the guard location and strategy. The guard
+  checks all universal SC-002 gates at the top of `run_migrations_online()`. In
+  `ALEMBIC_CTX=ci` or `ALEMBIC_CTX=dev` with `ALLOW_SCHEMA_WRITE=yes`, it passes
+  through. For `alembic current/check/history`, CI and dev workflows set
+  `ALEMBIC_CTX=ci` or `ALEMBIC_CTX=dev` and the guard allows read-only access.
+
+  **Phase 2 (future):** During guard implementation, add a check of
+  `context.get_x_argument()` or an equivalent mechanism to distinguish
+  upgrade/downgrade from current/check/history. Read-only commands skip the
+  guard entirely. Write commands require full authorization.
+
+  This design document specifies the approach. The implementation task should
+  follow it.
+
+### Risk of Breaking CI / Dev Workflows
+
+**Risk:** Adding a guard to `run_migrations_online()` could break:
+1. `alembic check` in CI (verifies migration state)
+2. `alembic current` in local dev (shows current revision)
+3. `alembic upgrade head` in Docker init
+
+**Mitigation:**
+1. **`ALEMBIC_CTX` env var:** Allow auto-pass in CI and dev contexts when
+   `ALLOW_SCHEMA_WRITE=yes`. CI and dev should set `ALEMBIC_CTX=ci` or
+   `ALEMBIC_CTX=dev` and `ALLOW_SCHEMA_WRITE=yes` in their environment.
+2. **Grace period:** Document that CI will need to set these env vars. If CI
+   doesn't currently run Alembic, no action is needed.
+3. **Docker init compatibility:** `deploy/docker/init_db.sql` is the primary
+   Docker dev initialization path, NOT Alembic. Alembic migrations in the
+   Docker dev context are supplementary. The guard won't break Docker dev boot
+   because `init_db.sql` doesn't go through Alembic.
+
+**Verification needed during implementation:**
+- Check if CI runs `alembic` commands (check, current, upgrade, etc.)
+- Check if Docker dev initialization runs `alembic`
+- Check if any Makefile target invokes `alembic`
+
+### Non-Goals of This Guard
+
+The guard will NOT:
+- Prevent `run_migrations_offline()` from generating SQL (offline mode is read-only)
+- Validate the content of migration scripts (that's a review task)
+- Prevent adding new migration scripts to `versions/` (that's a CI policy task)
+- Replace the role of `deploy/docker/init_db.sql` guard (separate concern)
+- Validate migration rollback paths or downgrade safety
+- Enforce migration naming conventions
+- Prevent `alembic stamp` operations (these can be needed for migration state repair)
+
+## Implementation Plan
+
+### Phase 1: Guard Implementation (future task)
+
+**Task name:** `sc002_alembic_migration_runtime_guard_implementation`
+
+**Steps:**
+1. **Audit CI and dev workflows** for Alembic usage:
+   - Check CI configs for `alembic` commands
+   - Check Makefile targets for `alembic` invocations
+   - Check Docker init flow for `alembic` usage
+   - Check any shell scripts or README instructions
+2. **Implement the guard** in `run_migrations_online()`:
+   - Option A (preferred): Import `assert_db_write_allowed` from the existing guard
+     helper. Handle import path setup (sys.path must include project root).
+   - Option B (fallback): Inline a migration-specific guard using the same env-var
+     and host detection logic as the existing helper.
+3. **Add `ALEMBIC_CTX` support:** The guard reads `ALEMBIC_CTX` env var for context
+   identification.
+4. **Update `alembic.ini`:** Document the new env var requirements in comments.
+5. **Update CI / dev configs:** Add `ALEMBIC_CTX=ci`, `ALEMBIC_CTX=dev`, or
+   `ALEMBIC_CTX=docker_init` with `ALLOW_SCHEMA_WRITE=yes` where Alembic is legitimately
+   used.
+6. **Test the guard:** Verify that:
+   - `alembic upgrade head` with no guard env vars is **blocked**
+   - `alembic upgrade head` with `ALEMBIC_CTX=dev ALLOW_SCHEMA_WRITE=yes` is **allowed**
+   - `alembic upgrade head` with production-like host in DATABASE_URL is **hard blocked**
+   - `alembic upgrade head --sql` (offline mode) is **not blocked**
+   - `alembic current` and `alembic check` behavior is correct for intended contexts
+7. **Update allowlist:** Change `env.py` classification from `pending_runtime_guard`
+   to `alembic_migration_runtime_guarded`.
+8. **Update docs:** Update this design doc, `SC002_CLOSURE_PLAN.md`, and
+   `PROJECT_STATUS.md`.
+
+### Phase 2: CI Integration (after guard implementation)
+
+1. Add `ALEMBIC_CTX=ci ALLOW_SCHEMA_WRITE=yes` to CI environment if CI runs Alembic
+2. Ensure CI-only env vars are NOT set in development or production environments
+3. Add a CI step that verifies the guard is active (negative test: blocked without vars)
+
+### Phase 3: Production Migration Runbook (future)
+
+When production schema migrations are needed in the future:
+1. Operator sets `ALEMBIC_CTX=manual ALLOW_DB_WRITE=yes FINAL_DB_WRITE_CONFIRMATION=yes ALLOW_SCHEMA_WRITE=yes DRY_RUN=false`
+2. Operator runs `alembic upgrade head` only against a verified non-production-like host
+3. Audit logs record the migration run
+
+## Impact Analysis
+
+### What This Design Changes
+
+| Item | Before | After |
+|---|---|---|
+| env.py classification | `pending_runtime_guard` (vague) | `alembic_migration_needs_specialized_runtime_guard` (precise) |
+| Guard strategy | None | Documented, ready for implementation |
+| Implementation readiness | Deferred, unclear approach | Clear plan with pseudocode and guard location |
+| Tracking | Listed as "remaining" | Now has explicit category, design doc, and next task |
+
+### What This Design Does NOT Change
+
+- env.py runtime behavior — NO GUARD ADDED (this is design only)
+- SC-002 status — remains partial mitigation only
+- Python write paths guarded count — still 17 / 20
+- Training / data expansion / real DB write — remain blocked
+- Any database — no connection, no SQL, no migration execution
+- Any existing CI or dev workflow
+
+### Safety Boundary
+
+This design task is a **documentation and planning task**. It:
+- Reads and analyzes source code (env.py, alembic.ini, migration versions)
+- Writes design documentation and plan
+- Updates tracking configuration files
+- Creates static tests that verify classification state
+- Does NOT modify env.py runtime behavior
+- Does NOT connect to any database
+- Does NOT run any migration, SQL, scraper, browser, or training
+
+## Related Documents
+
+| Document | Relationship |
+|---|---|
+| `docs/SC002_CLOSURE_PLAN.md` | Parent document — tracks all SC-002 closure criteria |
+| `docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md` | Predecessor — original Python/SQL/migration inventory and design |
+| `config/python_db_write_allowlist.json` | Configuration — env.py classification lives here |
+| `config/sql_migration_policy_allowlist.json` | Configuration — cross-reference entry for env.py |
+| `docs/PROJECT_STATUS.md` | Status dashboard — reflects current SC-002 state |
+| `src/database/migrations/env.py` | Target file — the Alembic environment being analyzed |
+| `src/database/migrations/alembic.ini` | Config — Alembic configuration referenced by env.py |
+| `scripts/ops/helpers/python_db_write_guard.py` | Reference — existing guard helper pattern |
+
+## Validation
+
+### Static Tests Added
+
+The implementation will add `tests/unit/test_sc002_alembic_migration_guard_design.py` with
+tests that verify:
+
+1. `env.py` is classified as `alembic_migration_needs_specialized_runtime_guard` in the allowlist
+2. Python write paths guarded count is 17 out of 20
+3. `env.py` is the only remaining unclassified Python write path
+4. SC-002 remains partial mitigation only
+5. Training / data expansion / real DB write remain blocked
+6. The design document exists and has required sections
+
+### Pre-Deploy Validation
+
+- `py_compile` on the design doc? No — it's markdown
+- `py_compile` on the test file? Yes
+- `make pr-gate-local PR_BODY=/tmp/pr_body_alembic_migration_guard_design.md` — fast mode
+- Existing tests must still pass (Phase2A scanner, Phase2B scanner, AI Workflow Gate)
+
+## Next Recommended Task
+
+**`sc002_alembic_migration_runtime_guard_implementation`** — Implement the runtime guard
+in `env.py` following the design specified in this document.
+
+Prerequisites:
+- This design doc is merged to `main`
+- CI and dev workflow audit completed (check if Alembic is used)
+- User explicitly authorizes the guard implementation
+
+The implementation task must:
+1. Follow the guard strategy in this document
+2. NOT execute any migration
+3. NOT connect to any database
+4. NOT perform any real DB write
+5. NOT train or expand data
+6. Verify guard behavior with dry-run tests
+7. Update allowlist to `alembic_migration_runtime_guarded`
+
+Do not start automatically. Recommended next task only after user confirmation.

--- a/docs/SC002_CLOSURE_PLAN.md
+++ b/docs/SC002_CLOSURE_PLAN.md
@@ -53,7 +53,8 @@ are satisfied.
 | Training status | blocked |
 | Data expansion status | blocked |
 | Scraper / browser automation status | blocked |
-| Python / SQL / migration enforcement | Python Phase2A+2B completed; Phase2C batch1-4 completed (9/14 guarded, 5 classified); indirect_write_path design+guard phase2 completed (6/6 guarded); manual_review phase2d+phase2e completed (all 5 reviewed, 2 guarded = 17/20 total). Remaining: 3 safe reclassified (1 read_only, 2 false_positive) + 1 Alembic env.py pending. 0 unreviewed. |
+| Python / SQL / migration enforcement | Python Phase2A+2B completed; Phase2C batch1-4 completed (9/14 guarded, 5 classified); indirect_write_path design+guard phase2 completed (6/6 guarded); manual_review phase2d+phase2e completed (all 5 reviewed, 2 guarded = 17/20 total). Remaining: 3 safe reclassified (1 read_only, 2 false_positive) + 1 Alembic env.py classified as alembic_migration_needs_specialized_runtime_guard (design complete, awaiting implementation). 0 unreviewed. |
+| SC-002 Alembic migration guard | `sc002_alembic_migration_guard_design` completed. env.py statically analyzed: confirmed migration orchestrator, can execute arbitrary DDL/DML. Classified as `alembic_migration_needs_specialized_runtime_guard`. Specialized guard design documented in `docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md`. Implementation deferred to `sc002_alembic_migration_runtime_guard_implementation`. |
 | Runtime DB role / permission model | not fully validated |
 | Agent workflow rules hardening | agent_workflow_rules_hardening_phase1 completed: resident rules (CLAUDE.md), PR template checklist, CI gate enforcement codified. This is workflow hardening, NOT SC-002 closure. Does not change remaining 11 confirmed + 8 indirect + 5 manual review Python write path counts.
 | CI local parity preflight | ci_local_parity_preflight_phase1 completed: local PR Gate preflight (`scripts/ops/local_pr_gate_preflight.py`, `make pr-gate-local`). Fast mode runs static analysis, PR body validation, and enforcement checks locally (no network, no DB, no secrets). Full mode adds ruff, mypy, pytest, npm test:coverage. Goal: improve remote CI first-pass rate. This is workflow/CI parity hardening, NOT SC-002 closure. Does not change guarded/pending counts.
@@ -305,7 +306,7 @@ SC-002 may be closed only when **all** of the following conditions are satisfied
 | 2 | Changed-files enforcement is active and tested with both positive and negative cases | Partial (active but needs negative-case testing) |
 | 3 | Remaining browser/FotMob/pageProps paths have specialized audit results and have been either guarded or formally excluded | Not met |
 | 4 | Shared modules have clear responsibility boundary: every consumer of a shared DB write-risk module is identified and verified as guarded or read-only | Not met |
-| 5 | Python / SQL / migration enforcement has either a guard mechanism or a documented exclusion with rationale | Partial (Phase2A+2B completed; Phase2C batch1-4 completed — 9/14 confirmed guarded, 5 classified; indirect_write_path guard_phase2 completed — 6/6 guarded; manual_review_guard_phase2e completed — 2/2 manual write paths guarded; total 17/20 guarded, 1 pending (Alembic env.py), 3 safe reclassified, 0 unreviewed) |
+| 5 | Python / SQL / migration enforcement has either a guard mechanism or a documented exclusion with rationale | Partial (Phase2A+2B completed; Phase2C batch1-4 completed — 9/14 confirmed guarded, 5 classified; indirect_write_path guard_phase2 completed — 6/6 guarded; manual_review_guard_phase2e completed — 2/2 manual write paths guarded; total 17/20 guarded, 1 classified/designed pending implementation (Alembic env.py — design doc with pseudocode and guard location complete), 3 safe reclassified, 0 unreviewed) |
 | 6 | Runtime DB permissions / role restrictions are documented or tested | Not met |
 | 7 | No production override exists (no `ALLOW_PRODUCTION_DB_WRITE`, no bypass env var, no host-block escape hatch) | Met |
 | 8 | Training and data expansion remain blocked until explicit release criteria are met | Met (blocks are in place) |
@@ -685,6 +686,32 @@ SC-002 may be closed only when **all** of the following conditions are satisfied
   - **SC-002 remains partial mitigation only.**
 - **Next step:** `python_indirect_write_path_guard_phase2` — implement runtime guard for
   the 6 newly confirmed direct write paths. Do not start automatically.
+
+### 5h. sc002_alembic_migration_guard_design ✅ COMPLETED
+
+- **Status:** Completed (this PR — design/classification task, NOT runtime guard implementation).
+- **Results:**
+  - Static analysis of `src/database/migrations/env.py` completed.
+  - **0 runtime guards added.** This is a design/classification task only.
+  - **env.py classification:** `alembic_migration_needs_specialized_runtime_guard`
+    - Confirmed: env.py CAN execute arbitrary DDL/DML via alembic upgrade.
+    - Confirmed: env.py connects to live DB in online mode.
+    - Confirmed: env.py has NO existing SC-002 guard or env-var restrictions.
+    - env.py is the standard Alembic entry point — used by CI, local dev, Docker init.
+    - Standard guard pattern does NOT directly fit (framework orchestrator, not standalone script).
+  - Guard strategy designed:
+    - Guard location: top of `run_migrations_online()` before any DB connection.
+    - Env vars: `ALLOW_DB_WRITE`, `FINAL_DB_WRITE_CONFIRMATION`, `ALLOW_SCHEMA_WRITE`, `DRY_RUN`.
+    - Production-like host hard block (matching JS/Python guard pattern).
+    - `ALEMBIC_CTX` env var for CI/dev auto-allow.
+    - Offline mode (`--sql`) NOT guarded.
+  - Full implementation plan with pseudocode in `docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md`.
+  - Allowlist updated: env.py reclassified with full evidence and design doc reference.
+  - **No Alembic run. No migration. No SQL. No DB connection. No real DB write.**
+  - **No scraper/browser run. No training. No data expansion.**
+  - **SC-002 remains partial mitigation only.**
+- **Next step:** `sc002_alembic_migration_runtime_guard_implementation` — implement
+  specialized guard in env.py per design doc. Do not start automatically.
 
 ### 6. runtime_db_role_permission_review_phase1
 

--- a/docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md
+++ b/docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md
@@ -4,9 +4,9 @@
 - owner: project governance
 - created: 2026-06-23
 - task: python_sql_migration_enforcement_design_phase1 (design) + python_sql_migration_enforcement_implementation_phase2A (implementation) + python_runtime_guard_implementation_phase2C_batch{1,2,3} (runtime guard) + python_confirmed_write_paths_design_phase2C_batch4 (design) + consumer_level_guard_audit_db_pool_sync_sql_store (audit) + python_indirect_write_path_design_phase1 (design) + python_indirect_write_path_guard_phase2 (guard) + python_manual_review_phase2d (review) + python_manual_review_guard_phase2e (guard)
-- implementation_status: ALL PHASES COMPLETED except Alembic env.py. Phase2A+2B done; Phase2C batch1-4 done (9/14 guarded, 5 classified); indirect phases done (6/6 guarded); manual review phases done (2/2 guarded). Total: 17/20 Python write paths runtime guarded. Remaining: 1 Alembic env.py pending + 3 safe reclassified.
+- implementation_status: ALL PHASES COMPLETED except Alembic env.py. Phase2A+2B done; Phase2C batch1-4 done (9/14 guarded, 5 classified); indirect phases done (6/6 guarded); manual review phases done (2/2 guarded); alembic_migration_guard_design done (classified as alembic_migration_needs_specialized_runtime_guard, design complete, awaiting implementation). Total: 17/20 Python write paths runtime guarded. Remaining: 1 Alembic env.py classified with design complete + 3 safe reclassified.
 - scanner: scripts/ops/python_db_write_static_enforcement.py
-- allowlist: config/python_db_write_allowlist.json (28 entries, 17 runtime_guarded, 1 pending, 3 infrastructure, 2 read_only, 2 false_positive, 3 safe reclassified from manual review)
+- allowlist: config/python_db_write_allowlist.json (28 entries, 17 runtime_guarded, 1 alembic_migration_needs_specialized_runtime_guard, 3 infrastructure, 2 read_only, 2 false_positive, 3 safe reclassified from manual review)
 - guard_helper: scripts/ops/helpers/python_db_write_guard.py
 - gate_integration: check_python_db_write_enforcement() in scripts/ops/ai_workflow_gate.py
 

--- a/tests/unit/test_sc002_alembic_migration_guard_design.py
+++ b/tests/unit/test_sc002_alembic_migration_guard_design.py
@@ -1,0 +1,378 @@
+"""
+Static test: SC-002 Alembic Migration Guard Design validation.
+
+Validates:
+1. env.py is explicitly classified in the allowlist
+2. 17/20 Python write paths runtime guarded status unchanged
+3. SC-002 remains partial mitigation only
+4. Training / data expansion / real DB write remain blocked
+5. Design doc exists and contains required sections
+6. Implementation follow-up task is documented
+7. env.py is NOT yet runtime_guarded (design only, not implementation)
+"""
+
+import json
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+ALLOWLIST_PATH = PROJECT_ROOT / "config" / "python_db_write_allowlist.json"
+SQL_ALLOWLIST_PATH = PROJECT_ROOT / "config" / "sql_migration_policy_allowlist.json"
+DESIGN_DOC_PATH = PROJECT_ROOT / "docs" / "SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md"
+CLOSURE_PLAN_PATH = PROJECT_ROOT / "docs" / "SC002_CLOSURE_PLAN.md"
+ENFORCEMENT_DESIGN_PATH = PROJECT_ROOT / "docs" / "SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md"
+PROJECT_STATUS_PATH = PROJECT_ROOT / "docs" / "PROJECT_STATUS.md"
+
+ENV_PY_PATH = "src/database/migrations/env.py"
+EXPECTED_ENV_PY_CLASSIFICATION = (
+    "historical_python_alembic_migration_needs_specialized_runtime_guard"
+)
+EXPECTED_TOTAL_RUNTIME_GUARDED = 17
+EXPECTED_TOTAL_PYTHON_WRITE_PATHS = 20
+EXPECTED_TOTAL_ALLOWLIST_ENTRIES = 28
+
+FORBIDDEN_TERMS = [
+    "SC-002 is complete",
+    "SC-002 is fully fixed",
+    "SC-002 resolved",
+    "safe to train",
+    "safe to write",
+    "production ready",
+]
+
+
+def _load_allowlist():
+    return json.loads(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+
+
+def _load_sql_allowlist():
+    return json.loads(SQL_ALLOWLIST_PATH.read_text(encoding="utf-8"))
+
+
+def _load_design_doc():
+    return DESIGN_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _load_text(path: Path):
+    return path.read_text(encoding="utf-8")
+
+
+# ---- Tests ----
+
+
+class TestAlembicMigrationGuardDesign:
+    """Verify env.py classification and guard design state."""
+
+    # ---- Allowlist tests ----
+
+    def test_env_py_is_in_allowlist(self):
+        """env.py must be explicitly classified in the Python DB write allowlist."""
+        allowlist = _load_allowlist()
+        entries_by_path = {e["path"]: e for e in allowlist["entries"]}
+        assert ENV_PY_PATH in entries_by_path, (
+            f"{ENV_PY_PATH} is NOT in python_db_write_allowlist.json. It must be explicitly classified."
+        )
+
+    def test_env_py_has_correct_classification(self):
+        """env.py must be classified as alembic_migration_needs_specialized_runtime_guard."""
+        allowlist = _load_allowlist()
+        entries_by_path = {e["path"]: e for e in allowlist["entries"]}
+        entry = entries_by_path[ENV_PY_PATH]
+        assert entry["classification"] == EXPECTED_ENV_PY_CLASSIFICATION, (
+            f"Expected classification '{EXPECTED_ENV_PY_CLASSIFICATION}', got '{entry['classification']}'"
+        )
+
+    def test_env_py_is_not_runtime_guarded(self):
+        """env.py should NOT be marked runtime_guarded — this is design only."""
+        allowlist = _load_allowlist()
+        entries_by_path = {e["path"]: e for e in allowlist["entries"]}
+        entry = entries_by_path[ENV_PY_PATH]
+        assert "runtime_guarded" not in entry["classification"], (
+            f"env.py classification '{entry['classification']}' contains "
+            f"'runtime_guarded' — but this is a design task, not implementation. "
+            f"No guard has been added to env.py."
+        )
+
+    def test_env_py_has_analysis_fields(self):
+        """env.py entry must have full analysis metadata (design task output)."""
+        allowlist = _load_allowlist()
+        entries_by_path = {e["path"]: e for e in allowlist["entries"]}
+        entry = entries_by_path[ENV_PY_PATH]
+        required_fields = [
+            "analysis_task",
+            "observed_operations",
+            "observed_tables_or_targets",
+            "direct_write_boundary",
+            "recommended_next_action",
+            "why_not_guarded_in_this_pr",
+        ]
+        for field in required_fields:
+            assert field in entry, (
+                f"env.py allowlist entry missing required field '{field}'. "
+                f"Design task must populate all analysis metadata."
+            )
+
+    def test_env_py_references_design_doc(self):
+        """env.py allowlist entry must reference the design doc."""
+        allowlist = _load_allowlist()
+        entries_by_path = {e["path"]: e for e in allowlist["entries"]}
+        entry = entries_by_path[ENV_PY_PATH]
+        assert entry.get("source_doc") == "docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md", (
+            f"Expected source_doc='docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md', got '{entry.get('source_doc')}'"
+        )
+
+    # ---- Guarded count tests ----
+
+    def test_runtime_guarded_count_is_17(self):
+        """17 of 20 Python write paths must be runtime guarded (unchanged)."""
+        allowlist = _load_allowlist()
+        runtime_guarded = sum(
+            1 for e in allowlist["entries"] if "runtime_guarded" in e["classification"]
+        )
+        assert runtime_guarded == EXPECTED_TOTAL_RUNTIME_GUARDED, (
+            f"Expected {EXPECTED_TOTAL_RUNTIME_GUARDED} runtime guarded paths, "
+            f"found {runtime_guarded}. Guarded count must NOT change in this design task."
+        )
+
+    def test_total_python_write_paths_is_20(self):
+        """Total Python write paths in allowlist must be 20 (confirmed + indirect + manual)."""
+        # Verify total entries count — 28 entries
+        # (14 confirmed + 8 indirect + 5 manual + 1 env.py)
+        total_entries = len(_load_allowlist()["entries"])
+        assert total_entries == EXPECTED_TOTAL_ALLOWLIST_ENTRIES, (
+            f"Expected {EXPECTED_TOTAL_ALLOWLIST_ENTRIES} total entries, "
+            f"found {total_entries}. "
+            f"Total count must not change in this design task."
+        )
+
+    def test_env_py_is_only_pending(self):
+        """env.py should be the only entry not yet runtime_guarded or safe."""
+        allowlist = _load_allowlist()
+        non_guarded = [
+            e
+            for e in allowlist["entries"]
+            if "runtime_guarded" not in e["classification"]
+            and "read_only" not in e["classification"]
+            and "false_positive" not in e["classification"]
+            and "infrastructure_only" not in e["classification"]
+        ]
+        non_guarded_paths = [e["path"] for e in non_guarded]
+        assert non_guarded_paths == [ENV_PY_PATH], (
+            f"Expected only env.py ({ENV_PY_PATH}) as non-guarded, non-safe entry. Found: {non_guarded_paths}"
+        )
+
+    # ---- Design doc tests ----
+
+    def test_design_doc_exists(self):
+        """Design doc must exist."""
+        assert DESIGN_DOC_PATH.exists(), (
+            f"Design doc {DESIGN_DOC_PATH} does not exist. "
+            f"This task must create docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md"
+        )
+
+    def test_design_doc_has_required_sections(self):
+        """Design doc must contain required sections."""
+        doc = _load_design_doc()
+        required_sections = [
+            "## Summary",
+            "## Static Analysis",
+            "## Classification",
+            "## Guard Strategy Design",
+            "## Implementation Plan",
+            "## Next Recommended Task",
+        ]
+        for section in required_sections:
+            assert section in doc, (
+                f"Design doc missing required section: {section}. "
+                f"Section is required for complete classification and implementation planning."
+            )
+
+    def test_design_doc_declares_partial_mitigation(self):
+        """Design doc must state SC-002 remains partial mitigation only."""
+        doc = _load_design_doc()
+        assert "partial mitigation only" in doc, (
+            "Design doc must state SC-002 remains partial mitigation only."
+        )
+
+    def test_design_doc_declares_training_blocked(self):
+        """Design doc must state training / data expansion / real DB write remain blocked."""
+        doc = _load_design_doc()
+        doc_lower = doc.lower()
+        assert "training" in doc_lower, "Design doc must mention training."
+        assert "blocked" in doc_lower, (
+            "Design doc must state training and data expansion are blocked."
+        )
+
+    def test_design_doc_no_forbidden_claims(self):
+        """Design doc must NOT contain forbidden SC-002 completion claims as positive assertions."""
+        doc = _load_design_doc()
+        # Check only positive assertions, not negations or "does NOT" statements
+        # Strip lines that are clearly negations
+        lines = doc.split("\n")
+        positive_lines = []
+        for line in lines:
+            stripped = line.strip().lower()
+            # Skip lines that are negations: "does NOT", "do NOT", "never", "must NOT"
+            if any(
+                neg in stripped
+                for neg in ["does not ", "do not ", "this task does not", "must not", "never claim"]
+            ):
+                continue
+            # Skip lines that are in a forbidden-terms table or explanation
+            if "|" in stripped and any(kw in stripped for kw in ["forbidden", "why forbidden"]):
+                continue
+            positive_lines.append(stripped)
+        positive_text = " ".join(positive_lines)
+        for term in FORBIDDEN_TERMS:
+            assert term.lower() not in positive_text, (
+                f"Design doc contains forbidden term as positive assertion: '{term}'. "
+                f"SC-002 is NOT complete. Training/data expansion/real DB write remain blocked."
+            )
+
+    def test_design_doc_describes_guard_location(self):
+        """Design doc must specify where the guard should be placed."""
+        doc = _load_design_doc()
+        assert "run_migrations_online" in doc, (
+            "Design doc must specify run_migrations_online() as the guard location."
+        )
+
+    def test_design_doc_lists_env_vars(self):
+        """Design doc must list required env vars for the guard."""
+        doc = _load_design_doc()
+        assert "ALLOW_DB_WRITE" in doc, "Design doc must reference ALLOW_DB_WRITE."
+        assert "ALLOW_SCHEMA_WRITE" in doc, "Design doc must reference ALLOW_SCHEMA_WRITE."
+        assert "FINAL_DB_WRITE_CONFIRMATION" in doc, (
+            "Design doc must reference FINAL_DB_WRITE_CONFIRMATION."
+        )
+
+    def test_design_doc_declares_no_alembic_run(self):
+        """Design doc must state that NO Alembic/migration was executed."""
+        doc = _load_design_doc()
+        no_run_indicators = [
+            "did NOT run",
+            "no DB connection",
+            "no migration",
+        ]
+        found = any(indicator.lower() in doc.lower() for indicator in no_run_indicators)
+        assert found, "Design doc must explicitly state that no Alembic/migration was executed."
+
+    # ---- Closure plan tests ----
+
+    def test_closure_plan_references_design_doc(self):
+        """SC002_CLOSURE_PLAN.md must reference the new design doc."""
+        closure = _load_text(CLOSURE_PLAN_PATH)
+        assert "SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md" in closure, (
+            "SC002_CLOSURE_PLAN.md must reference the Alembic migration guard design doc."
+        )
+
+    def test_closure_plan_lists_implementation_task(self):
+        """SC002_CLOSURE_PLAN.md must list the implementation follow-up task."""
+        closure = _load_text(CLOSURE_PLAN_PATH)
+        assert "sc002_alembic_migration_runtime_guard_implementation" in closure, (
+            "SC002_CLOSURE_PLAN.md must list the implementation follow-up task: "
+            "sc002_alembic_migration_runtime_guard_implementation"
+        )
+
+    def test_closure_plan_has_do_not_start_automatically(self):
+        """SC002_CLOSURE_PLAN.md must state 'Do not start automatically' for next task."""
+        closure = _load_text(CLOSURE_PLAN_PATH)
+        assert "Do not start automatically" in closure, (
+            "SC002_CLOSURE_PLAN.md must state 'Do not start automatically' for the next task."
+        )
+
+    # ---- Enforcement design doc tests ----
+
+    def test_enforcement_design_updated_for_alembic(self):
+        """Enforcement design doc must reflect current env.py status."""
+        enforcement = _load_text(ENFORCEMENT_DESIGN_PATH)
+        assert "alembic_migration_needs_specialized_runtime_guard" in enforcement, (
+            "SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md must reflect the new env.py classification."
+        )
+
+    # ---- Project status tests ----
+
+    def test_project_status_has_alembic_section(self):
+        """PROJECT_STATUS.md must have a section about this design task."""
+        status = _load_text(PROJECT_STATUS_PATH)
+        assert "sc002_alembic_migration_guard_design completed" in status, (
+            "PROJECT_STATUS.md must document the completion of sc002_alembic_migration_guard_design."
+        )
+
+    def test_project_status_declares_partial_mitigation(self):
+        """PROJECT_STATUS.md must state SC-002 remains partial mitigation only."""
+        status = _load_text(PROJECT_STATUS_PATH)
+        assert "partial mitigation only" in status, (
+            "PROJECT_STATUS.md must state SC-002 remains partial mitigation only."
+        )
+
+    # ---- SQL allowlist cross-reference tests ----
+
+    def test_sql_allowlist_env_py_classified(self):
+        """SQL migration policy allowlist must have updated env.py classification."""
+        sql_allowlist = _load_sql_allowlist()
+        entries_by_path = {e["path"]: e for e in sql_allowlist["entries"]}
+        assert ENV_PY_PATH in entries_by_path, (
+            f"{ENV_PY_PATH} is NOT in sql_migration_policy_allowlist.json."
+        )
+        entry = entries_by_path[ENV_PY_PATH]
+        assert entry["classification"] == EXPECTED_ENV_PY_CLASSIFICATION, (
+            f"SQL allowlist env.py classification mismatch: "
+            f"expected '{EXPECTED_ENV_PY_CLASSIFICATION}', "
+            f"got '{entry['classification']}'"
+        )
+
+    def test_sql_allowlist_env_py_references_design_doc(self):
+        """SQL allowlist env.py entry must reference the new design doc."""
+        sql_allowlist = _load_sql_allowlist()
+        entries_by_path = {e["path"]: e for e in sql_allowlist["entries"]}
+        entry = entries_by_path[ENV_PY_PATH]
+        assert entry.get("source_doc") == "docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md", (
+            "SQL allowlist env.py source_doc must reference the design doc."
+        )
+
+    # ---- Safety boundary tests ----
+
+    def test_no_forbidden_terms_alembic_design_doc(self):
+        """New Alembic design doc must NOT contain forbidden SC-002 completion claims."""
+        doc = _load_design_doc()
+        lines = doc.split("\n")
+        positive_lines = []
+        for line in lines:
+            stripped = line.strip().lower()
+            # Skip lines that are negations
+            if any(neg in stripped for neg in ["does not ", "do not ", "must not", "never claim"]):
+                continue
+            # Skip lines that list what the task does NOT do
+            if stripped.startswith("- ") and any(
+                neg in stripped
+                for neg in [
+                    "claim sc-002",
+                    "run alembic",
+                    "execute",
+                    "connect",
+                    "perform any real",
+                    "train",
+                    "claim safe",
+                ]
+            ):
+                continue
+            positive_lines.append(stripped)
+        positive_text = " ".join(positive_lines)
+        for term in FORBIDDEN_TERMS:
+            assert term.lower() not in positive_text, (
+                f"New Alembic design doc contains forbidden term as positive assertion: '{term}'"
+            )
+
+    def test_env_py_not_modified(self):
+        """env.py must NOT have been modified by this design task."""
+        env_py_path = PROJECT_ROOT / ENV_PY_PATH
+        env_py_content = env_py_path.read_text(encoding="utf-8")
+        # The file should contain NO guard-related code
+        assert "assert_db_write_allowed" not in env_py_content, (
+            "env.py must NOT contain assert_db_write_allowed — no guard was added in this task."
+        )
+        assert "ALLOW_SCHEMA_WRITE" not in env_py_content, (
+            "env.py must NOT contain ALLOW_SCHEMA_WRITE reference — no guard was added."
+        )
+        assert "sc002" not in env_py_content.lower(), (
+            "env.py must NOT contain SC-002 references — no code was changed in this task."
+        )


### PR DESCRIPTION
## Summary

Design, classification, and implementation plan for the last remaining SC-002 Python write path: `src/database/migrations/env.py` (Alembic migration environment).

This is a **design/classification task**, NOT runtime guard implementation. No guard was added to env.py. No code was changed in env.py.

## Scope

1. Static analysis of `src/database/migrations/env.py`:
   - Confirmed: can execute arbitrary DDL/DML via alembic upgrade
   - Confirmed: connects to live DB in online mode
   - Confirmed: has NO existing SC-002 guard or env-var restrictions
   - Confirmed: is the standard Alembic entry point (CI, local dev, Docker init)
2. Classification: `alembic_migration_needs_specialized_runtime_guard`
3. Specialist guard strategy design with pseudocode, env var list, and guard location
4. Implementation plan for follow-up task
5. Documentation updates and static tests

## Files Changed

| File | Change | Lifecycle |
|---|---|---|
| `docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md` | NEW | permanent |
| `tests/unit/test_sc002_alembic_migration_guard_design.py` | NEW (26 tests) | permanent |
| `config/python_db_write_allowlist.json` | MODIFIED (env.py reclassified) | permanent |
| `config/sql_migration_policy_allowlist.json` | MODIFIED (env.py cross-reference) | permanent |
| `docs/PROJECT_STATUS.md` | MODIFIED (new section) | current-state |
| `docs/SC002_CLOSURE_PLAN.md` | MODIFIED (new section 5h, updated criterion #5, updated status) | permanent |
| `docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md` | MODIFIED (updated status) | permanent |

## Safety Impact

- **No Alembic run. No migration. No SQL execution. No DB connection. No real DB write.**
- No scraper/browser/Playwright run. No training. No data expansion.
- env.py was NOT modified — no runtime behavior changed.
- All changes are documentation, configuration, and test files only.
- SC-002 remains partial mitigation only.
- Training / data expansion / real DB write remain blocked.

## Validation

- `git diff --check`: clean
- `py_compile` on `test_sc002_alembic_migration_guard_design.py`: OK
- New static tests: 26/26 passed
- Existing SC-002 Python tests: 71/71 passed (unchanged — no regressions)
- Design doc has all required sections
- Allowlist JSON remains valid

## CI Gate Scope

This PR only modifies docs, config JSON, and adds a test file. No Python business code changed. No JS code changed. CI gate should be clean (fast mode checks should pass).

Preflight plan:
- Fast mode: `make pr-gate-local PR_BODY=/tmp/pr_body_alembic_migration_guard_design.md`
- Full mode: N/A (no runtime code changes — fast mode sufficient)

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed. All changes are additive (new doc + test + config updates).

## SC-002 status

- SC-002 is **partial mitigation only**.
- env.py classification changed from generic `pending_runtime_guard` to precise `alembic_migration_needs_specialized_runtime_guard`.
- Python write paths guarded: **17/20** (unchanged).
- Total allowlist entries: **28** (unchanged).
- 0 unreviewed candidates.
- Training / data expansion / real DB write remain **blocked**.

## Documentation Impact

- New permanent doc: `docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md` — authoritative design document for Alembic migration guard strategy, classification, and implementation plan.
- Updated `docs/PROJECT_STATUS.md` — new section documenting completion of this design task.
- Updated `docs/SC002_CLOSURE_PLAN.md` — new section 5h, updated criterion #5, updated Python/SQL/migration status.
- Updated `docs/SC002_PYTHON_SQL_MIGRATION_ENFORCEMENT_DESIGN.md` — updated header status and allowlist count.
- All doc changes document the current design completion and next implementation task.

## Rollback Plan

To rollback this PR:
1. Revert the merge commit.
2. Alternatively, restore env.py allowlist entry to `historical_python_confirmed_write_path_pending_runtime_guard` in `config/python_db_write_allowlist.json` and `config/sql_migration_policy_allowlist.json`.
3. Remove `docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md` and `tests/unit/test_sc002_alembic_migration_guard_design.py`.
4. Remove the `## sc002_alembic_migration_guard_design completed` section from `docs/PROJECT_STATUS.md`.
5. Revert SC002_CLOSURE_PLAN.md and enforcement design doc changes.

No runtime behavior was changed — no rollback of code is needed.

## Remaining risks

1. env.py still has no runtime guard. Anyone who runs `alembic upgrade head` can execute schema migrations without passing through any SC-002 gate.
2. Migration execution risk remains unmitigated until `sc002_alembic_migration_runtime_guard_implementation` is completed.
3. env.py's standard position as the Alembic entry point means it could be invoked by CI, dev, or Docker init without explicit user authorization.

## Next Recommended Task

**`sc002_alembic_migration_runtime_guard_implementation`** — Implement the specialized runtime guard in `env.py` per the design in `docs/SC002_ALEMBIC_MIGRATION_GUARD_DESIGN.md`.

Do not start automatically. Recommended next task only after user confirmation.