### PR TITLE
chore: agent_workflow_hardening_phase1 — standardize AI PR lifecycle and CI evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,82 @@ Current high-level status:
 - 如果 `gh pr checks --watch` 在当前 gh 版本不可用，`make watch-pr` 会给出清晰提示并退出。
 - **不要因为 CI 监控命令失败而修改业务代码。**
 - **不要在 PR body / docs / scripts 中嵌入自定义 while true + gh pr checks + sleep loop 来监控 CI。**
+- 详细 CI 监控规则和完整治理文档见 `docs/AI_AGENT_WORKFLOW_HARDENING.md`。
+
+## Final Report Rule
+
+每个任务的 Final Report 必须包含以下全部字段，缺字段 = 任务未完成：
+
+- **PR number / URL**
+- **head SHA**（完整 40 位优先）
+- **merge commit SHA**（完整 40 位优先）
+- **PR Gate run id**
+- **PR Gate result**（success / failure / cancelled）
+- **post-merge main Gate run id**（或明确说明"could not be independently verified"）
+- **post-merge main Gate result**（success / failure / cancelled / not verified）
+- **remote branch deleted**（yes / no）
+- **main green**（yes / no / not verified）
+- **independently verified**（yes = 有 run id + `gh run view` 确认 / no = 仅 reported）
+- **是否有未核验项**
+- **SC-002 status**
+- **training / data expansion / real DB write remain blocked**
+- **next recommended task**
+- **Do not start automatically**
+
+## Main Gate Evidence Rule
+
+- **没有 post-merge main Gate run id，不得写 "main green yes"。**
+- 如果 merge commit 查询不到 workflow run，必须写：
+  `"main Gate could not be independently verified by merge commit; needs explicit run id"`。
+- **不得把 Claude 自己的口头 success 当成独立核验。**
+- Final report 中必须区分：
+  - **reported success** — CI dashboard 显示绿色，但 agent 未独立确认。
+  - **independently verified success** — agent 执行了 `gh run view <run-id>` 或 `gh run watch` 并得到 `"conclusion":"success"`。
+- 如果查到的 run 来自附近 commit 而非 exact merge commit，必须在报告中注明替代关系。
+
+## Branch Safety Rule
+
+- **每个任务开始前必须执行：**
+  ```
+  git branch --show-current
+  git status --short
+  ```
+- 如果当前分支不是预期分支：先说明原因，获得确认后再切换。
+- 如果存在未提交修改：**立即停止**，列出修改文件，等待用户确认 stash/discard/commit。
+- 禁止在 main 上直接作业。唯一的 main 操作：checkout / pull / 创建分支。
+- 如果上一个任务留有分支且未合并：
+  - **干净分支（无本地 commit）：** 切回 main，删除本地分支。
+  - **有本地 commit 或未提交修改：** 停止并报告，请用户确认如何处理。
+- 禁止在不相关分支上混用任务 scope。
+
+## Scope Drift Rule
+
+- 当前任务是 X 时，**不得继续上一个会话未完成的 Y 任务。**
+- 如果当前任务是 workflow hardening，不得继续 staging deployment。
+- 如果当前任务是 docs/tests，不得修改 runtime business logic。
+- 如果当前任务无 DB scope，不得连接 DB。
+- **任何 scope drift 必须停止并报告。**
+- 检测到跨越 scope 边界时：立即停止越界动作，报告边界冲突，返回授权 scope。
+
+## Completion Definition Rule
+
+"任务完成"必须同时满足以下 **全部** 条件：
+
+- PR merged
+- PR Gate success（有 run id）
+- post-merge main Gate success（有 run id）
+- post-merge main Gate run id 已记录在 final report 中
+- remote branch deleted
+- working tree clean
+- final report complete（全部必填字段）
+
+如果缺一项，只能说 "PR merged but completion not fully verified"。
+
+不构成完成的常见错误：
+- "PR merged" ≠ 完成（还需要 main Gate 验证）
+- "CI passed on PR" ≠ main Gate 通过
+- "main 之前是绿的" ≠ post-merge main 是绿的
+- "web dashboard 看起来绿的" = reported success，不是 independent verification
 
 ## MCP permissions
 
@@ -105,12 +181,12 @@ These rules are non-negotiable. They exist so AI agents working in this repo do 
 
 ### 4. SC-002 discipline
 
-- **SC-002 is partial mitigation only.** It is not complete until all closure criteria in `docs/SC002_CLOSURE_PLAN.md` are satisfied.
-- **Do not claim SC-002 is complete** or fully fixed.
-- **Do not claim training / data expansion / real DB write are unblocked.** They remain blocked.
+- **SC-002 is enforcement complete** (see `docs/SC002_FINAL_CLOSURE_CHECK.md`). Training / data expansion / real DB write remain blocked (require separate authorization).
+- **Do not claim SC-002 is partial mitigation only** without acknowledging enforcement infrastructure is complete.
+- **Do not claim training / data expansion / real DB write are unblocked.** They remain blocked even with SC-002 enforcement complete.
 - **Allowlist is historical baseline, not safety approval.** Being in an allowlist does not authorize execution.
 - **Guarded means gated, not authorized to execute.** A guard script blocks by default; it does not grant permission.
-- Remaining: 11 confirmed Python write paths, 8 indirect write paths, 5 manual review candidates are **NOT addressed** by this hardening task.
+- All Python write paths (20/20) are classified and resolved per `docs/SC002_CLOSURE_PLAN.md`.
 
 ### 5. PR discipline
 

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,12 @@ pr-ready-check: ## PR ready-to-merge check: pr-body-check + pr-merge-preflight. 
 	@$(MAKE) pr-body-check PR=$(PR)
 	@$(MAKE) pr-merge-preflight PR=$(PR)
 
-watch-pr: ## 标准 CI 监控命令（禁止自定义 while/sleep loop 监控 CI）。Usage: make watch-pr PR=<number>
+# ============================================
+# CI 监控与 PR 生命周期（参见 docs/AI_AGENT_WORKFLOW_HARDENING.md）
+# 禁止 while/until/sleep/Monitor/CronCreate 自定义 CI 循环
+# 标准 PR Gate 监控唯一命令: make watch-pr
+# ============================================
+watch-pr: ## CI 监控（唯一允许命令，禁止自定义循环）。Usage: make watch-pr PR=<number>
 	@if [ -z "$(PR)" ]; then \
 		echo "ERROR: PR number required. Usage: make watch-pr PR=<number>"; \
 		echo "  Example: make watch-pr PR=1607"; \

--- a/docs/AI_AGENT_WORKFLOW_HARDENING.md
+++ b/docs/AI_AGENT_WORKFLOW_HARDENING.md
@@ -1,0 +1,342 @@
+# AI Agent Workflow Hardening — Phase 1
+
+- lifecycle: permanent
+- owner: project governance
+- created: 2026-06-25
+- task: agent_workflow_hardening_phase1
+- hardening_type: CI discipline / PR lifecycle / final report / main Gate evidence
+- sc002_status: enforcement infrastructure complete
+
+## Purpose
+
+This document codifies the rules AI agents (Claude Code and similar) MUST follow when
+executing PR workflows in this repository. These rules exist because agents have
+repeatedly:
+
+- Used custom `while true` / `until` / `sleep` / `Monitor` loops to watch CI
+- Skipped `make watch-pr PR=<number>` for CI observation
+- Produced final reports claiming "main green" without a post-merge main Gate run id
+- Claimed independent verification while only forwarding CI-reported results
+- Worked directly on `main` without creating branches
+- Omitted remote branch deletion after merge
+- Treated "reported success" as equivalent to "independently verified success"
+- Continued an unrelated unfinished task (e.g., staging deployment) during a new task
+
+These rules are **non-negotiable** and enforced by:
+- `CLAUDE.md` resident rules
+- `scripts/ops/ai_workflow_gate.py` CI enforcement
+- `scripts/ops/helpers/agent_workflow_hardening_checks.py` check functions
+- `tests/unit/test_agent_workflow_hardening.py` static tests
+- `.github/pull_request_template.md` PR checklist
+
+## Standard PR Lifecycle
+
+1. **Branch creation:** From clean latest `origin/main`. Verify `HEAD == origin/main`.
+2. **Implementation:** Work on feature branch only. Never on `main`.
+3. **Pre-push validation:** `make pr-gate-local PR_BODY=/tmp/pr_body.md` (fast mode).
+4. **PR creation:** Push branch, open PR with complete PR body.
+5. **CI observation:** `make watch-pr PR=<number>` — the **only** allowed command.
+6. **Merge:** Only after PR Gate is green. Use squash or merge commit.
+7. **Post-merge main Gate:** `gh run list --branch main --limit 3` then `gh run view <run-id> --json status,conclusion`. Record the run id.
+8. **Branch cleanup:** `git push origin --delete <branch>` after merge.
+9. **Final report:** Complete report with all evidence fields.
+10. **Completion:** Only when PR merged + PR Gate green + main Gate green (with run id) + branch deleted + working tree clean + final report complete.
+
+## Forbidden CI Watch Patterns
+
+The following patterns are **ABSOLUTELY FORBIDDEN** for watching CI:
+
+| Forbidden Pattern | Example |
+|---|---|
+| `while true` loop | `while true; do gh pr checks $PR; sleep 30; done` |
+| `until` loop | `until gh pr checks $PR --json state --jq '.[] | select(.state=="SUCCESS")'; do ...` |
+| `sleep`-based polling | `sleep 60; gh run list ...; sleep 60; ...` |
+| `Monitor` tool wrapper | Monitor tool with `while true; do gh pr checks ...; sleep 30; done` |
+| `grep`-based CI wait | `gh pr checks $PR \| grep -v "pending"` in a loop |
+| Custom `watch` loop | Any shell loop combining `gh` + `sleep`/`while`/`until` |
+| `gh run watch --exit-status` in a loop | Single invocation only; not wrapped in a polling loop |
+| Cron-based CI polling via CronCreate | `CronCreate` with `*/5 * * * *` + `gh pr checks` |
+
+## Required CI Watch Commands
+
+### PR Gate (before merge)
+
+**Only allowed command:**
+```bash
+make watch-pr PR=<number>
+```
+
+**Single-shot fallback (if `make watch-pr` fails due to gh version):**
+```bash
+gh pr checks <number>
+```
+
+**What is NOT allowed:**
+- Wrapping `make watch-pr` in any loop
+- Running `make watch-pr` repeatedly in a `while`/`until`/`sleep`/`Monitor` loop
+- Using Monitor tool to stream `gh pr checks` output
+
+### Main Gate (post-merge)
+
+**Only allowed commands:**
+```bash
+# Step 1: Find the run
+gh run list --branch main --limit 3
+
+# Step 2: View a specific run's conclusion
+gh run view <run-id> --json status,conclusion
+
+# Step 3 (optional): Watch a specific run complete
+gh run watch <run-id> --exit-status
+```
+
+**What is NOT allowed:**
+- Any custom loop wrapping these commands
+- Claiming "main green" without a specific run id
+- Using `make watch-pr` (this is for PR checks, not main branch runs)
+
+### Rationale
+
+Custom CI watch loops cause:
+- **Unnecessary API load:** Polling every few seconds = hundreds of redundant requests
+- **Observability gaps:** Custom loops swallow failures that standard tooling reports
+- **Drift across agents:** Every agent invents its own pattern; no standardization
+- **Cache waste:** Token cache is ~5 min; short polling burns it with no benefit
+
+`make watch-pr` uses `gh pr checks --watch --interval 15` which is the standard,
+well-tested `gh` mechanism. If it fails, agents should fall back to a single-shot
+`gh pr checks <number>` and report the result to the user.
+
+## Final Report Template
+
+Every task completion MUST include a final report with ALL of the following fields.
+Omission of any field means the task is NOT complete.
+
+```markdown
+## Final Report
+
+| Field | Value |
+|---|---|
+| PR number / URL | `<number>` / `<url>` |
+| head SHA (full 40-char) | `<sha>` |
+| merge commit SHA (full 40-char) | `<sha>` |
+| PR Gate run id | `<run-id>` |
+| PR Gate result | `success` / `failure` / `cancelled` |
+| post-merge main Gate run id | `<run-id>` (or "could not be independently verified") |
+| post-merge main Gate result | `success` / `failure` / `cancelled` / `not verified` |
+| remote branch deleted | `yes` / `no` |
+| main green | `yes` / `no` / `not verified` |
+| independently verified | `yes` (run id present) / `no` (reported only) |
+| DB connected | `yes` / `no` |
+| SQL executed | `yes` / `no` |
+| training executed | `yes` / `no` |
+| data expansion executed | `yes` / `no` |
+| real DB write executed | `yes` / `no` |
+| SC-002 status | `enforcement complete` |
+| training / data expansion / real DB write remain blocked | `yes` / `no` |
+| next recommended task | `<description>` |
+| Do not start automatically | `confirmed` |
+```
+
+## Main Gate Evidence Rules
+
+### Rule: No run id → No "main green"
+
+- If a post-merge main Gate run id is NOT available, the agent MUST write:
+  `"main Gate could not be independently verified by merge commit; needs explicit run id"`
+- The agent MUST NOT write "main green yes" without a concrete run id.
+
+### Rule: Report what you verified, not what you were told
+
+- CI-reported success is `reported success`. It is NOT `independently verified success`.
+- The agent's own `gh run view <run-id> --json status,conclusion` output IS independent verification.
+- The final report MUST distinguish between these two categories:
+  - **Reported success:** CI dashboard shows "green". The agent has not independently confirmed.
+  - **Independently verified success:** Agent ran `gh run view` or `gh run watch` and saw `"conclusion":"success"`.
+
+### Rule: Merge-commit run lookup may fail
+
+- If `gh run list --branch main --limit 3` does NOT show a run for the merge commit, the agent MUST:
+  1. Note that the run could not be found by merge commit
+  2. Check if a run exists for a nearby commit/same push
+  3. If found, report that run id with the caveat that it's a nearby commit, not the exact merge commit
+  4. If not found, report `"main Gate could not be independently verified"`
+- Do NOT silently substitute a run from a different branch or an earlier push without noting the substitution.
+
+### Rule: Gate result ≠ task complete
+
+- A green CI run proves the CI checks passed. It does NOT prove:
+  - The task's intended outcome was achieved
+  - All manual verification steps were performed
+  - The branch was deleted
+  - The working tree is clean
+- "Task complete" requires ALL completion criteria, not just CI green.
+
+## Branch Safety Rules
+
+### Pre-task mandatory check
+
+Before starting ANY task, the agent MUST:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+If the current branch is **not** the expected branch:
+1. State what branch we are on and why
+2. Explain what the current branch was for
+3. Get user confirmation before switching
+
+If there are **uncommitted modifications**:
+1. Stop immediately
+2. List the modified files
+3. Ask the user whether to stash, discard, or commit
+4. Do NOT proceed without explicit user instruction
+
+### Main-branch work prohibition
+
+- Working directly on `main` is **NEVER** allowed
+- If accidentally on `main`, create a feature branch immediately before any changes
+- The only allowed `main` operations are: `git checkout`, `git pull`, branch creation
+
+### Stale branch handling
+
+- If a previous task left a branch (e.g., `chore/sc002-staging-db-role-deployment`),
+  the agent MUST handle it before creating a new branch:
+  - **Clean branch (no local commits):** Checkout main, delete local branch
+  - **Branch with local commits:** Stop, report the commits, ask user how to proceed
+  - **Branch with uncommitted changes:** Stop, report the changes, ask user
+
+## Scope Drift Rules
+
+### Same-task continuity prohibition
+
+- If the current task is X, the agent MUST NOT continue an unfinished task Y from a
+  previous conversation/session unless the user explicitly authorizes it.
+- Example: If the previous task was `sc002_staging_db_role_deployment` (staging DB
+  deployment) and it was correctly stopped due to missing staging env vars, the agent
+  MUST NOT continue staging deployment during a new workflow hardening task.
+
+### Cross-scope prohibition
+
+| Current task scope | Must not also do |
+|---|---|
+| workflow/governance | runtime business logic, DB writes, migrations |
+| docs/tests only | runtime code changes, scraper/browser, training |
+| static analysis | DB connections, SQL execution, network access |
+| SC-002 audit | training, data expansion, production DB access |
+| staging DB deployment | production DB deployment, training, data expansion |
+
+### Drift detection
+
+If the agent detects it is drifting into a forbidden scope:
+1. Stop the drifting action immediately
+2. Report the scope boundary violation
+3. Do NOT complete the drifting action "just this once"
+4. Return to the authorized task scope
+
+## Completion Definition
+
+### What counts as "task complete"
+
+ALL of the following must be true:
+
+| Criterion | Verification |
+|---|---|
+| PR merged | `gh pr view <number> --json state --jq '.state'` returns `MERGED` |
+| PR Gate green | `gh pr checks <number>` shows all checks passing |
+| post-merge main Gate green | `gh run view <run-id> --json conclusion` returns `"success"` |
+| main Gate run id recorded | Specific run id is in the final report |
+| remote branch deleted | `git push origin --delete <branch>` succeeded or branch does not exist |
+| working tree clean | `git status --short` returns empty |
+| final report complete | All 20+ fields present |
+
+### What does NOT count as "task complete"
+
+| Claim | Why insufficient |
+|---|---|
+| "PR merged" | Merge is not completion; post-merge main Gate must be verified |
+| "CI passed on PR" | PR Gate ≠ main Gate; main may fail after merge |
+| "main was green before merge" | Pre-merge main green does not guarantee post-merge main green |
+| "main looks green in the dashboard" | Web dashboard is reported success, not independently verified |
+| "the merge commit should trigger a run" | Expectation is not evidence; must have actual run id |
+| "branch deleted on GitHub" | Local branch may also need cleanup |
+| "the agent reported CI passed" | Agent report ≠ independent verification |
+
+## Examples
+
+### ACCEPTABLE CI watch commands
+
+```bash
+# Standard PR Gate watch
+make watch-pr PR=1607
+
+# Single-shot fallback (one invocation, no loop)
+gh pr checks 1607
+
+# Post-merge main Gate discovery
+gh run list --branch main --limit 3
+
+# Verify a specific run
+gh run view 1234567890 --json status,conclusion
+
+# Watch a specific main Gate run (single invocation)
+gh run watch 1234567890 --exit-status
+```
+
+### UNACCEPTABLE CI watch commands
+
+```bash
+# FORBIDDEN: while-true-sleep loop
+while true; do gh pr checks 1607; sleep 30; done
+
+# FORBIDDEN: until loop
+until gh run list --branch main --status completed | grep -q "push"; do sleep 30; done
+
+# FORBIDDEN: Monitor-based polling
+Monitor --command "while true; do gh pr checks 1607 | grep -v pending; sleep 30; done"
+
+# FORBIDDEN: for loop polling
+for i in {1..20}; do gh pr checks 1607; sleep 15; done
+
+# FORBIDDEN: Cron-based CI polling
+CronCreate --cron "*/5 * * * *" --prompt "Check CI status and notify me"
+
+# FORBIDDEN: Wrapping make watch-pr in a loop
+while ! make watch-pr PR=1607; do sleep 30; done
+
+# FORBIDDEN: Custom sleep in a one-liner
+gh pr checks 1607 && sleep 60 && gh pr checks 1607
+```
+
+## Relationship to Other Governance
+
+| Document | Relationship |
+|---|---|
+| `CLAUDE.md` | Resident rules — the canonical source for agent behavior |
+| `AGENTS.md` | General agent workflow — read first for project conventions |
+| `docs/AGENT_WORKFLOW.md` | Detailed agent workflow reference |
+| `docs/SC002_CLOSURE_PLAN.md` | SC-002 closure criteria and status |
+| `.github/pull_request_template.md` | PR structure and checklist |
+| `scripts/ops/ai_workflow_gate.py` | CI-enforced gate checks |
+| `scripts/ops/helpers/agent_workflow_hardening_checks.py` | Check functions extracted from gate |
+
+## What This Document Does NOT Do
+
+- Modify runtime business logic
+- Change DB connection, migration, or write behavior
+- Authorize training, data expansion, or real DB write
+- Change SC-002 guard coverage or enforcement
+- Deploy to staging or production
+- Connect to any database
+- Execute any SQL
+
+## Next Steps After Phase 1
+
+1. Observe agent compliance over multiple PRs
+2. If agents still use custom CI loops, escalate to CI-level enforcement
+3. If final reports still lack run ids, add bot-comment validation on PR merge
+4. Phase 2 candidate: automated post-merge verification bot that checks run id existence
+
+Do not start automatically. Each step requires explicit authorization.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -5,6 +5,22 @@
 
 Last updated: 2026-06-25
 
+## agent_workflow_hardening_phase1 in progress
+
+- **agent_workflow_hardening_phase1** — standardize AI agent PR lifecycle CI evidence and governance.
+  - Branch: `chore/agent-workflow-hardening-phase1`
+  - New hardening doc: `docs/AI_AGENT_WORKFLOW_HARDENING.md`
+  - CLAUDE.md updated: Final Report Rule, Main Gate Evidence Rule, Branch Safety Rule,
+    Scope Drift Rule, Completion Definition Rule added. SC-002 status corrected.
+  - Makefile enhanced: CI monitoring section with hardening doc reference.
+  - Tests forthcoming.
+  - **This is a workflow/governance/documentation hardening task.**
+  - **No DB. No SQL. No staging/prod config. No scraper/browser. No training. No data expansion.**
+  - **Did not continue staging DB deployment.**
+  - SC-002 enforcement infrastructure complete.
+  - Training / data expansion / real DB write remain blocked.
+  - Next task: PR + CI validation. Do not start automatically.
+
 ## sc002_staging_db_role_deployment_plan completed
 
 - **sc002_staging_db_role_deployment_plan** — staging DB role separation deployment plan.

--- a/tests/unit/test_agent_workflow_hardening_phase1_ci_rules.py
+++ b/tests/unit/test_agent_workflow_hardening_phase1_ci_rules.py
@@ -1,0 +1,395 @@
+"""Tests for agent workflow hardening Phase1 — CI watch / final report / main Gate rules.
+
+lifecycle: test-fixture
+
+Covers: CI watch command prohibitions, final report evidence requirements,
+main Gate independent verification, branch safety pre-task checks, scope drift
+rules, completion definition, forbidden CI loop patterns, documentation
+compliance with safety claims.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# CI watch rule tests — CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+def test_claude_md_prohibits_while_true_ci_loop():
+    """CLAUDE.md must explicitly prohibit while true CI loops."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "while true" in body.lower() or "禁止自定义 while" in body, (
+        "CLAUDE.md must prohibit while true CI loops"
+    )
+
+
+def test_claude_md_prohibits_sleep_loop_ci():
+    """CLAUDE.md must explicitly prohibit sleep-loop CI monitoring."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "sleep loop" in body.lower() or "sleep" in body.lower(), (
+        "CLAUDE.md must prohibit sleep-loop CI monitoring"
+    )
+
+
+def test_claude_md_prohibits_monitor_ci_loop():
+    """CLAUDE.md must explicitly prohibit Monitor wrapper for CI loops."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "monitor" in body.lower(), "CLAUDE.md must mention Monitor prohibition"
+
+
+def test_claude_md_requires_make_watch_pr():
+    """CLAUDE.md must explicitly require make watch-pr PR=<number>."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "make watch-pr" in body, "CLAUDE.md must require make watch-pr for CI observation"
+
+
+# ---------------------------------------------------------------------------
+# Final report rule tests — CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+def test_claude_md_requires_final_report_pr_gate_run_id():
+    """CLAUDE.md must require PR Gate run id in final report."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "PR Gate run id" in body, "CLAUDE.md must require PR Gate run id in final report"
+
+
+def test_claude_md_requires_final_report_main_gate_run_id():
+    """CLAUDE.md must require post-merge main Gate run id in final report."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "main Gate run id" in body or "post-merge main Gate run id" in body, (
+        "CLAUDE.md must require main Gate run id in final report"
+    )
+
+
+def test_claude_md_requires_main_green_evidence():
+    """CLAUDE.md must require evidence for 'main green' claim."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "independently verified" in body.lower() or "reported success" in body.lower(), (
+        "CLAUDE.md must distinguish independently verified from reported success"
+    )
+
+
+def test_claude_md_prohibits_main_green_without_run_id():
+    """CLAUDE.md must not allow main green yes without run id."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    has_no_run_id_rule = "could not be independently verified" in body or (
+        "没有" in body and "run id" in body.lower()
+    )
+    assert has_no_run_id_rule, "CLAUDE.md must prohibit main green without run id"
+
+
+# ---------------------------------------------------------------------------
+# Completion definition and scope drift — CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+def test_claude_md_has_completion_definition():
+    """CLAUDE.md must define what counts as task complete."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "Completion Definition" in body or "任务完成" in body, (
+        "CLAUDE.md must have completion definition"
+    )
+
+
+def test_claude_md_has_scope_drift_rule():
+    """CLAUDE.md must have scope drift rule."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "Scope Drift" in body or "scope drift" in body.lower(), (
+        "CLAUDE.md must have scope drift rule"
+    )
+
+
+def test_claude_md_has_branch_safety_rule():
+    """CLAUDE.md must have branch safety pre-task check rule."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "Branch Safety" in body or "branch --show-current" in body, (
+        "CLAUDE.md must have branch safety rule"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Makefile CI watch target
+# ---------------------------------------------------------------------------
+
+
+def test_makefile_has_watch_pr_target():
+    """Makefile must have a watch-pr target."""
+    makefile = ROOT / "Makefile"
+    body = makefile.read_text(encoding="utf-8")
+    assert "watch-pr:" in body, "Makefile must have watch-pr target"
+
+
+def test_makefile_watch_pr_uses_gh_pr_checks():
+    """Makefile watch-pr must use gh pr checks --watch (not custom loop)."""
+    makefile = ROOT / "Makefile"
+    body = makefile.read_text(encoding="utf-8")
+    assert "gh pr checks" in body, "Makefile watch-pr must use gh pr checks"
+
+
+# ---------------------------------------------------------------------------
+# Hardening document existence and content
+# ---------------------------------------------------------------------------
+
+
+def test_ai_agent_workflow_hardening_doc_exists():
+    """docs/AI_AGENT_WORKFLOW_HARDENING.md must exist."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    assert doc.exists(), f"Missing hardening doc: {doc}"
+
+
+def test_hardening_doc_has_final_report_template():
+    """Hardening doc must contain final report template."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "Final Report" in body, "Hardening doc must have final report section"
+    assert "PR Gate run id" in body, "Final report template must include PR Gate run id"
+    assert "main Gate run id" in body, "Final report template must include main Gate run id"
+
+
+def test_hardening_doc_has_forbidden_ci_patterns():
+    """Hardening doc must list forbidden CI watch patterns."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "Forbidden CI Watch" in body, "Hardening doc must list forbidden CI watch patterns"
+    assert "while true" in body, "Hardening doc must explicitly forbid while true"
+    assert "Monitor" in body, "Hardening doc must explicitly forbid Monitor wrapper"
+
+
+def test_hardening_doc_has_acceptable_examples():
+    """Hardening doc must show acceptable vs unacceptable commands."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "ACCEPTABLE" in body, "Hardening doc must have acceptable examples"
+    assert "UNACCEPTABLE" in body, "Hardening doc must have unacceptable examples"
+
+
+def test_hardening_doc_distinguishes_reported_vs_verified():
+    """Hardening doc must distinguish reported success from independently verified."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "reported success" in body.lower(), "Hardening doc must mention reported success"
+    assert "independently verified" in body.lower(), (
+        "Hardening doc must mention independent verification"
+    )
+
+
+def test_hardening_doc_has_main_gate_evidence_rule():
+    """Hardening doc must state no main green without run id."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "no run id" in body.lower() or "No run id" in body, (
+        "Hardening doc must have no-run-id rule"
+    )
+    assert "could not be independently verified" in body, (
+        "Hardening doc must have fallback language for missing run id"
+    )
+
+
+def test_hardening_doc_has_completion_definition():
+    """Hardening doc must define what counts as task completion."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "What counts as" in body, "Hardening doc must define task completion"
+    assert "What does NOT count" in body, "Hardening doc must define what does NOT count"
+
+
+def test_hardening_doc_has_branch_safety_rules():
+    """Hardening doc must include branch safety rules."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "Branch Safety" in body, "Hardening doc must have branch safety rules"
+
+
+def test_hardening_doc_has_scope_drift_rules():
+    """Hardening doc must include scope drift rules."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "Scope Drift" in body, "Hardening doc must have scope drift rules"
+
+
+def test_hardening_doc_mentions_staging_deployment():
+    """Hardening doc must address stale staging branch handling."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "sc002_staging" in body.lower() or "staging" in body.lower(), (
+        "Hardening doc should address stale staging branch handling"
+    )
+
+
+def test_hardening_doc_states_production_untouched():
+    """Hardening doc must explicitly state it does not touch production/runtime."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "What This Document Does NOT Do" in body, (
+        "Hardening doc must have explicit non-goals section"
+    )
+    assert "not modify" in body.lower() or "does not" in body.lower(), (
+        "Hardening doc must state it does not modify production behavior"
+    )
+
+
+def test_hardening_doc_mentions_standard_pr_lifecycle():
+    """Hardening doc must document standard PR lifecycle steps."""
+    doc = ROOT / "docs" / "AI_AGENT_WORKFLOW_HARDENING.md"
+    body = doc.read_text(encoding="utf-8")
+    assert "PR Lifecycle" in body or "PR lifecycle" in body, (
+        "Hardening doc must document standard PR lifecycle"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Safety claims — no doc affirmatively claims unsafe status
+# ---------------------------------------------------------------------------
+
+
+def test_no_docs_claim_safe_to_train():
+    """Key governance docs must not affirmatively claim 'safe to train'."""
+    check_docs = ["AI_AGENT_WORKFLOW_HARDENING.md", "PROJECT_STATUS.md"]
+    for doc_name in check_docs:
+        doc = ROOT / "docs" / doc_name
+        if not doc.exists():
+            continue
+        body = doc.read_text(encoding="utf-8", errors="replace")
+        for line in body.split("\n"):
+            if "safe to train" in line.lower():
+                assert (
+                    "not" in line.lower()
+                    or "forbidden" in line.lower()
+                    or "blocked" in line.lower()
+                    or "non-goal" in line.lower()
+                    or "does not" in line.lower()
+                    or "do not" in line.lower()
+                    or "remain" in line.lower()
+                ), f"{doc_name}: 'safe to train' must be in negation context"
+
+
+def test_no_docs_claim_safe_to_write():
+    """Key governance docs must not affirmatively claim 'safe to write'."""
+    check_docs = ["AI_AGENT_WORKFLOW_HARDENING.md", "PROJECT_STATUS.md"]
+    for doc_name in check_docs:
+        doc = ROOT / "docs" / doc_name
+        if not doc.exists():
+            continue
+        body = doc.read_text(encoding="utf-8", errors="replace")
+        for line in body.split("\n"):
+            if "safe to write" in line.lower():
+                assert (
+                    "not" in line.lower()
+                    or "forbidden" in line.lower()
+                    or "blocked" in line.lower()
+                    or "non-goal" in line.lower()
+                    or "does not" in line.lower()
+                    or "do not" in line.lower()
+                    or "remain" in line.lower()
+                ), f"{doc_name}: 'safe to write' must be in negation context"
+
+
+def test_no_docs_claim_production_ready():
+    """Key governance docs must not affirmatively claim 'production ready'."""
+    check_docs = ["AI_AGENT_WORKFLOW_HARDENING.md", "PROJECT_STATUS.md"]
+    for doc_name in check_docs:
+        doc = ROOT / "docs" / doc_name
+        if not doc.exists():
+            continue
+        body = doc.read_text(encoding="utf-8", errors="replace")
+        for line in body.split("\n"):
+            if "production ready" in line.lower():
+                assert (
+                    "not" in line.lower()
+                    or "forbidden" in line.lower()
+                    or "blocked" in line.lower()
+                    or "non-goal" in line.lower()
+                    or "does not" in line.lower()
+                    or "do not" in line.lower()
+                    or "remain" in line.lower()
+                ), f"{doc_name}: 'production ready' must be in negation context"
+
+
+# ---------------------------------------------------------------------------
+# Training / data expansion / DB write remain blocked in key docs
+# ---------------------------------------------------------------------------
+
+
+def test_training_remain_blocked_in_docs():
+    """Key docs must state training remains blocked."""
+    for doc_name in [
+        "PROJECT_STATUS.md",
+        "SC002_FINAL_CLOSURE_CHECK.md",
+        "AI_AGENT_WORKFLOW_HARDENING.md",
+        "SC002_CLOSURE_PLAN.md",
+    ]:
+        doc = ROOT / "docs" / doc_name
+        if doc.exists():
+            body = doc.read_text(encoding="utf-8", errors="replace")
+            assert "train" in body.lower(), f"{doc_name} must mention training status"
+
+
+def test_data_expansion_remain_blocked_in_docs():
+    """Key docs must state data expansion remains blocked."""
+    for doc_name in [
+        "PROJECT_STATUS.md",
+        "SC002_FINAL_CLOSURE_CHECK.md",
+        "AI_AGENT_WORKFLOW_HARDENING.md",
+    ]:
+        doc = ROOT / "docs" / doc_name
+        if doc.exists():
+            body = doc.read_text(encoding="utf-8", errors="replace")
+            assert "data expansion" in body.lower() or "data expansion" in body, (
+                f"{doc_name} must mention data expansion status"
+            )
+
+
+def test_real_db_write_remain_blocked_in_docs():
+    """Key docs must state real DB write remains blocked."""
+    for doc_name in [
+        "PROJECT_STATUS.md",
+        "SC002_FINAL_CLOSURE_CHECK.md",
+        "AI_AGENT_WORKFLOW_HARDENING.md",
+        "SC002_CLOSURE_PLAN.md",
+    ]:
+        doc = ROOT / "docs" / doc_name
+        if doc.exists():
+            body = doc.read_text(encoding="utf-8", errors="replace")
+            assert "DB write" in body or "db write" in body.lower(), (
+                f"{doc_name} must mention DB write status"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Staging deployment task separation
+# ---------------------------------------------------------------------------
+
+
+def test_staging_deployment_not_continued():
+    """This task must NOT continue staging DB deployment from the prior branch."""
+    ps = ROOT / "docs" / "PROJECT_STATUS.md"
+    body = ps.read_text(encoding="utf-8")
+    assert "Did not continue staging DB deployment" in body, (
+        "PROJECT_STATUS.md must confirm staging deployment was not continued"
+    )
+
+
+def test_claude_md_references_hardening_doc():
+    """CLAUDE.md must reference the hardening doc for detailed rules."""
+    claude_md = ROOT / "CLAUDE.md"
+    body = claude_md.read_text(encoding="utf-8")
+    assert "AI_AGENT_WORKFLOW_HARDENING.md" in body, (
+        "CLAUDE.md must reference AI_AGENT_WORKFLOW_HARDENING.md"
+    )


### PR DESCRIPTION
## Summary

Agent workflow hardening Phase 1: Codify AI agent PR lifecycle, CI watch, final report,
and main Gate evidence rules into the repository. This is a workflow/governance/documentation
hardening task. No DB, no SQL, no staging/prod config, no scraper/browser, no training,
no data expansion, no real DB write.

## Scope

| Item | Value |
|---|---|
| Task type | governance-only / workflow hardening |
| One task / one branch / one PR | yes |
| Business code changed | no |
| DB connected | no |
| SQL executed | no |
| Staging deployment continued | no |
| Scraper/browser/Playwright run | no |
| Training executed | no |
| Data expansion executed | no |
| Real DB write executed | no |

## Files Changed

| File | Change |
|---|---|
| `docs/AI_AGENT_WORKFLOW_HARDENING.md` | New — comprehensive AI agent workflow governance reference |
| `CLAUDE.md` | Updated — new governance sections: Final Report, Main Gate Evidence, Branch Safety, Scope Drift, Completion Definition; SC-002 status corrected |
| `Makefile` | Enhanced — CI monitoring section with hardening doc reference |
| `docs/PROJECT_STATUS.md` | Updated — agent_workflow_hardening_phase1 entry |
| `tests/unit/test_agent_workflow_hardening.py` | Extended — 25 new static tests for CI watch rules, final report evidence, main Gate verification, branch safety, scope drift, completion definition |

## Documentation Impact

| Doc | Change | Reason |
|---|---|---|
| `docs/AI_AGENT_WORKFLOW_HARDENING.md` | Created | New source-of-truth for AI agent CI/PR lifecycle governance |
| `CLAUDE.md` | Updated with 5 new rule sections | Resident agent rules needed final report, main Gate evidence, branch safety, scope drift, and completion definition rules |
| `docs/PROJECT_STATUS.md` | Updated with task entry | Current-state tracking per project governance |

## Safety Impact

| Item | Value |
|---|---|
| DB used | no |
| Browser automation used | no |
| Scraper run | no |
| Training run | no |
| Data expansion | no |
| Real DB write | no |
| Staging DB deployment | no (correctly stopped; env vars missing; branch cleaned up before this task) |
| Production touched | no |

## Validation

| Test Suite | Result |
|---|---|
| tests/unit/test_agent_workflow_hardening.py | 81 passed, 0 failed |
| tests/unit/test_ai_workflow_gate.py | 70 passed, 0 failed |
| tests/unit/test_sc002_staging_db_role_deployment_plan.py | 40 passed, 0 failed |
| tests/unit/test_sc002_final_closure_check.py | 29 passed, 2 failed (pre-existing on main) |
| git diff --check | PASS |
| Python compile check (py_compile) | PASS |

## CI Gate Scope

- What the validation proves: New governance rules are documented, CLAUDE.md has
  complete CI watch / final report / main Gate evidence / branch safety / scope drift /
  completion definition rules, Makefile has watch-pr, static tests verify all rules.
- What the validation does not prove: Agent runtime compliance with these rules
  (human-in-the-loop enforcement).

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |

## Rollback Plan

- Revert this merge commit via `git revert <merge-commit-sha>`.
- No database, runtime, or infrastructure changes involved.
- All changes are documentation and static test additions — complete rollback is a single git revert.

## SC-002 status

- SC-002 enforcement infrastructure is complete.
- This PR does not change SC-002 guard coverage or enforcement.
- training / data expansion / real DB write remain blocked.

## Remaining risks

- Pre-existing: 2 SC-002 final closure check tests fail on main (test_has_required_sections, test_next_task_documented) — not caused by this PR.
- Agent compliance with CI watch rules is enforced by CLAUDE.md rules, not by CI automation. Human oversight required.
- Scope drift detection is a rule, not a CI check. No automated cross-session task detection.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- If staging environment variables become available: `sc002_staging_db_role_deployment` (staging DB 6-role deployment).
