### PR TITLE
fix(docker): remove stale main_production copy

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -127,7 +127,6 @@ RUN chmod -R 755 ./scripts && \
     find ./scripts -name "*.sh" -exec chmod +x {} \;
 
 # 4. 入口脚本
-COPY main_production.py ./
 
 # ============================================
 # 创建运行时目录并设置权限


### PR DESCRIPTION
## Summary

Removes a stale `COPY main_production.py ./` line from `deploy/docker/Dockerfile`.

`main_production.py` is not present in the repository, so this line blocks clean deploy Dockerfile builds.

Closes #1627.

## Scope

- Remove one stale Dockerfile COPY instruction at line 130.
- No other Dockerfile changes.
- No runtime behavior changes.
- No code changes outside `deploy/docker/Dockerfile`.

## Documentation Impact

No documentation changes needed. This is a one-line build fix that removes a reference to a non-existent file. Skill docs that reference `main_production.py` (v26-harvest, feature-engineering) remain valid as CLI usage examples and are intentionally preserved.

## Safety Impact

- **No DB changes.**
- **No migration.**
- **No SC-002 role deployment.**
- **No staging service changes.**
- **No Docker daemon or compose changes.**
- The removed file does not exist in the repo — removing the COPY cannot cause a regression.

## Validation

- `grep -RIn "main_production.py" deploy/docker/Dockerfile` returns no match.
- `find . -name "main_production.py"` returns no results (file does not exist).
- `git diff --check` passed (no whitespace issues).
- Docker build intentionally not run — #1628 (Debian 13 apt sources) remains open and is outside this PR's scope.

## CI Gate Scope

- Static checks: eslint, Python style, Gatekeeper commit hook — all passed.
- Docker build: intentionally skipped (see #1628).
- No runtime tests affected.

## No deletion / no move / no rename confirmation

This PR only deletes one line from one Dockerfile. No files are deleted, moved, or renamed.

## Rollback Plan

Revert the commit: `git revert <commit-sha>`. Alternatively, restore the deleted line by adding back `COPY main_production.py ./` at `deploy/docker/Dockerfile` line 130. Zero data loss, zero state change.

## Next Recommended Task

**Do not start automatically.**

Recommended next task only after user confirmation:
- `local_staging_phase5e_review_and_merge_pr_1627_after_user_approval` — review and merge this PR after PR Gate passes.
- Then `local_staging_phase5d_execute_second_pr_1628_apt_sources_compat` — fix Debian 13 apt source compatibility (#1628).

## SC-002 status

SC-002 enforcement is complete. This PR does not touch SC-002 paths, DB writes, training, or data expansion. All SC-002 guardrails remain intact.

## Remaining risks

- The harvester CMD (`scripts/collectors/full_l1_l2_harvest.py`) also references a missing file — tracked separately as #1629 (P1).
- Docker build may still fail due to #1628 (Debian 13 apt sources) — tracked separately and will be addressed in the next PR batch.
