### PR TITLE
fix(docker): support Debian 13 apt sources

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -33,8 +33,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_TRUSTED_HOST=pypi.tuna.tsinghua.edu.cn
 
 # 配置镜像源
-RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list || \
-    sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list
+RUN if [ -f /etc/apt/sources.list ]; then \
+        sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list || \
+        sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list; \
+    elif [ -f /etc/apt/sources.list.d/debian.sources ]; then \
+        sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources || \
+        sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources; \
+    else \
+        echo "ERROR: No supported Debian apt sources file found" >&2; \
+        exit 1; \
+    fi
 
 # 安装构建依赖 (带重试机制)
 RUN for i in 1 2 3; do \
@@ -88,8 +96,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     L2_REQUESTS_PER_SECOND=2
 
 # 配置镜像源
-RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list || \
-    sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list
+RUN if [ -f /etc/apt/sources.list ]; then \
+        sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list || \
+        sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list; \
+    elif [ -f /etc/apt/sources.list.d/debian.sources ]; then \
+        sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources || \
+        sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources; \
+    else \
+        echo "ERROR: No supported Debian apt sources file found" >&2; \
+        exit 1; \
+    fi
 
 # 安装运行时依赖 (最小化)
 RUN for i in 1 2 3; do \


### PR DESCRIPTION
## Summary

Updates `deploy/docker/Dockerfile` so its apt mirror setup supports both:

- legacy `/etc/apt/sources.list` (Debian 12 and earlier)
- Debian 13 DEB822 `/etc/apt/sources.list.d/debian.sources`

This prevents deploy Dockerfile builds from failing when `python:3.11-slim` resolves to Debian 13 / Trixie, where the legacy file does not exist.

Closes #1628.

## Scope

- Replace two `sed -i ... /etc/apt/sources.list` RUN blocks with conditional `if/elif/else/fi` blocks that check which apt sources file exists.
- Preserves existing mirror priority: Tsinghua first, USTC fallback.
- Does not change package lists, pip logic, image CMD, or runtime behavior.

## Documentation Impact

No user-facing documentation change. This is a deploy Dockerfile compatibility fix. The issue (#1628) and PR description document the Debian 13 DEB822 behavior change.

## Safety Impact

- No DB changes.
- No migration.
- No SC-002 role deployment.
- No staging service changes.
- No Docker daemon or compose changes.
- No scraper/training/data expansion.

## Validation

- `git diff --check` passed.
- Verified `debian.sources` compatibility added in both builder and runner stages.
- Verified #1627 remains fixed (no `main_production.py` regression).
- Docker build validation: apt source setup step passed successfully in local build (builder stage). Build failed later at pip install due to unrelated Tsinghua mirror 403 — not a #1628 regression.

## CI Gate Scope

- Static checks: eslint, Python style, Gatekeeper commit/push hooks — all passed.
- Docker Build Validation: CI job expected to run.

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed. Only `deploy/docker/Dockerfile` modified with 20 insertions and 4 deletions.

## Rollback Plan

Revert this PR to restore the previous two-line sed blocks. This is low risk because the change only affects apt source setup during image build and does not affect runtime code, DB, migration, SC-002, or staging services.

## Next Recommended Task

**Do not start automatically.**

Recommended next task only after user confirmation:
- `local_staging_phase5g_select_third_pr_runtime_missing_modules_plan` — plan fix for #1630 (`src/core/structured_logging.py` missing).

## SC-002 status

SC-002 enforcement is complete. This PR does not touch SC-002 paths, DB writes, training, or data expansion. All SC-002 guardrails remain intact.

## Remaining risks

- Local Docker build failed at `pip install` due to Tsinghua PyPI mirror 403 — this is a pre-existing network issue, not caused by this PR.
- CI Docker Build Validation may fail for the same reason — if so, it should be treated as a pre-existing infrastructure issue, not a #1628 regression.
