### PR TITLE
fix(core): remove stale structured_logging import

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -9,9 +9,21 @@ FootballPrediction 核心功能模块 (V4.20 重构版)
 
 """
 
+import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
+
+from src.core.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerError,
+    CircuitBreakerOpenError,
+    CircuitState,
+    api_breaker,
+    database_breaker,
+    network_breaker,
+)
+from src.core.graceful_shutdown import GracefulShutdownManager, graceful_shutdown
 
 
 class Config:
@@ -27,11 +39,11 @@ class Config:
         """加载配置文件 - 自动处理文件不存在或格式错误的情况"""
         if self.config_file.exists():
             try:
-                with open(self.config_file, encoding="utf-8") as f:
+                with self.config_file.open(encoding="utf-8") as f:
                     self._config = json.load(f)
             except Exception as e:
                 # 配置文件损坏时记录警告，但不中断程序执行
-                logging.warning(f"配置文件加载失败: {e}")
+                logging.warning("配置文件加载失败: %s", e)
 
     def get(self, key: str, default: Any = None) -> Any:
         """获取配置项 - 支持默认值，确保程序健壮性"""
@@ -45,8 +57,8 @@ class Config:
         """保存配置到文件 - 自动创建目录，确保配置持久化"""
         if not self.config_dir.exists():
             self.config_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.config_file, "w", encoding="utf-8") as f:
-            # ensure_ascii=False保证中文字符正确显示
+        with self.config_file.open("w", encoding="utf-8") as f:
+            # ensure_ascii=False ensures Chinese characters display correctly
             json.dump(self._config, f, ensure_ascii=False, indent=2)
 
 
@@ -67,12 +79,10 @@ class Logger:
 
         return logger
 
-
     @staticmethod
     def get_logger(name: str, level: str = "INFO") -> logging.Logger:
         """获取日志器 - 兼容 get_logger 的简单封装"""
-        logger = Logger.setup_logger(name, level)
-        return logger
+        return Logger.setup_logger(name, level)
 
 
 class FootballPredictionError(Exception):
@@ -108,48 +118,15 @@ __all__ = [
 # V105.0 新增模块
 # ============================================================================
 
-from src.core.circuit_breaker import (
-    CircuitBreaker,
-    CircuitBreakerError,
-    CircuitBreakerOpenError,
-    CircuitState,
-    api_breaker,
-    database_breaker,
-    network_breaker,
-)
-from src.core.graceful_shutdown import GracefulShutdownManager, graceful_shutdown
-from src.core.structured_logging import (
-    ComponentLogger,
-    EventCode,
-    HarvestStats,
-    LogContext,
-    LogLevel,
-    get_logger,
-    log_context,
-    performance_timer,
-    setup_structured_logging,
-)
 
 __all__ += [
-    # Circuit Breaker
     "CircuitBreaker",
     "CircuitBreakerError",
     "CircuitBreakerOpenError",
     "CircuitState",
-    # Structured Logging
-    "ComponentLogger",
-    "EventCode",
-    # Graceful Shutdown
     "GracefulShutdownManager",
-    "HarvestStats",
-    "LogContext",
-    "LogLevel",
     "api_breaker",
     "database_breaker",
-    "network_breaker",
-    "get_logger",
     "graceful_shutdown",
-    "log_context",
-    "performance_timer",
-    "setup_structured_logging",
+    "network_breaker",
 ]


### PR DESCRIPTION
## Summary

Removes stale `structured_logging` imports and `__all__` entries from `src/core/__init__.py`.

`src/core/structured_logging.py` is not present in the repository, and the exported structured logging symbols have no external Python consumers. This PR removes the dead imports and cleans Gatekeeper-required ruff issues in the same file.

Closes #1630.

## Scope

- Remove the stale `from .structured_logging import ...` block.
- Remove the corresponding structured logging entries from `__all__`.
- Clean 11 Gatekeeper-required ruff issues in the same file (import order, typing, formatting).
- No new module or stub is added.
- No runtime logging feature is introduced.

## Documentation Impact

No user-facing documentation change. This PR removes dead exports for a missing module and performs Gatekeeper-required same-file lint cleanup. Future real structured logging work should be tracked separately as feature work, not as part of this P0 import fix.

## Safety Impact

- No DB changes.
- No migration.
- No SC-002 role deployment.
- No staging service changes.
- No Docker or compose changes.
- No scraper/training/data expansion.

## Validation

- Verified `src/core/structured_logging.py` does not exist.
- Verified `src/core/__init__.py` no longer references `structured_logging`.
- `ruff check src/core/__init__.py` — All checks passed.
- `ruff format` — File already formatted.
- `python3 -m py_compile src/core/__init__.py` — Passed.
- `git diff --check` — Passed.

## CI Gate Scope

- eslint, ruff, Gatekeeper commit/push hooks — all passed.
- Docker Build Validation — expected to run.

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed. Only `src/core/__init__.py` modified (19 insertions, 42 deletions net).

## Rollback Plan

Revert this PR to restore the previous `structured_logging` import, `__all__` entries, and file state.

Rollback is low risk: this PR only removes dead imports/exports and fixes pre-existing lint issues in the same file. No behavior changes.

## Next Recommended Task

**Do not start automatically.**

Recommended next task only after user confirmation:
- `local_staging_phase5i_select_fourth_pr_1631_football_logic_plan` — plan fix for #1631 (`src/constants/football_logic` import warning).

## SC-002 status

SC-002 enforcement is complete. This PR does not touch SC-002 paths, DB writes, training, or data expansion. All SC-002 guardrails remain intact.

## Remaining risks

- `import src.core` still fails due to missing `fastapi` dependency — unrelated to this fix.
- The `structlog` dependency remains in `requirements.txt` for future real structured logging implementation.
