### PR TITLE
test(config): stabilize DB settings env branch coverage

### DIFF
--- a/tests/unit/config_package_test.py
+++ b/tests/unit/config_package_test.py
@@ -304,6 +304,7 @@ def test_database_settings_auto_inject_env_branches(monkeypatch):
     )
     monkeypatch.setenv("DB_PASSWORD", "docker-secret")
     monkeypatch.delenv("DB_HOST", raising=False)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
     monkeypatch.delenv("REDIS_HOST", raising=False)
 
     monkeypatch.setattr(db_settings, "detect_environment", lambda: fake_env_type.DOCKER)


### PR DESCRIPTION
## Summary

Fixes the post-merge main Gate regression from PR #1645 by making the DB settings auto-inject branch test deterministic when CI sets `ENVIRONMENT=test`.

## Scope

- Update `tests/unit/config_package_test.py` to clear `ENVIRONMENT` before asserting the default `development` branch behavior.
- No runtime code changes.
- No Docker / Compose / env / SQL / migration / workflow file changes.

## Documentation Impact

No documentation files were changed. This is a test-only correction for CI determinism after the DB config policy PR.

## Safety Impact

No production or staging behavior changes. The test change only removes CI environment contamination from a unit test branch assertion.

## CI Gate Scope

Expected CI scope is the standard Production Gate for this PR plus AI Workflow Gate. This PR specifically targets the failing Python unit coverage path observed on main run `28262413644`.

## Validation

- `git diff --check`: passed.
- `python3 -m py_compile tests/unit/config_package_test.py`: passed.
- Commit Gatekeeper: passed.
- Push Gatekeeper: passed.

## No deletion / no move / no rename confirmation

No files were deleted. No files were moved. No files were renamed. This PR changes one existing test file only.

## SC-002 status

SC-002 staging DB role deployment remains pending and was not executed. This PR does not connect to staging, does not run migration, and does not deploy DB roles.

## Remaining risks

No known runtime risk. This PR is a deterministic test fix for CI's `ENVIRONMENT=test` context.

## Rollback Plan

Revert this PR. Runtime behavior is unaffected because only a unit test setup line is changed.

## Next Recommended Task

Recommended next task only after user confirmation: resume Phase 5R closure checks for #1632/#1633 after main Gate is green. Do not start automatically.