### PR TITLE
fix(deploy): make API image default command explicit

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -176,9 +176,9 @@ USER appuser
 EXPOSE 8000
 
 # ============================================
-# 默认命令 - V37.0 L1/L2 全量采集
+# 默认命令 - FastAPI API server
 # ============================================
-CMD ["python", "scripts/collectors/full_l1_l2_harvest.py", "--verbose"]
+CMD ["python", "-m", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
 
 # ============================================
 # 镜像规格

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,11 @@ services:
       - app_data:/app/data
       - app_logs:/app/logs
       # V25.2: 移除本地 src 挂载以避免权限问题，使用镜像内代码
+    command: >
+      sh -c "
+      echo 'pipeline_worker command is not configured. Refusing to inherit API image default CMD. See #1629.' >&2;
+      exit 1
+      "
     depends_on:
       db:
         condition: service_healthy
@@ -424,6 +429,80 @@ services:
       - app_data:/app/data
       - app_logs:/app/logs
       - odds_data:/app/data/odds
+    command: >
+      sh -c "
+      echo '启动赔率采集服务...' &&
+      echo '数据源: ${ODDS_SOURCE:-oddsportal}' &&
+      echo '采集计划: ${ODDS_SCRAPER_SCHEDULE:-0 */4 * * *}' &&
+      pip install croniter playwright &&
+      python -m playwright install chromium &&
+      python -c '
+      import asyncio
+      import time
+      import logging
+      from croniter import croniter
+      from datetime import datetime
+      from pathlib import Path
+
+      logging.basicConfig(level=logging.INFO, format=\"%(asctime)s [%(levelname)s] %(message)s\")
+      logger = logging.getLogger(__name__)
+
+      # 导入采集模块
+      import sys
+      sys.path.insert(0, \"/app\")
+
+      from src.api.collectors.odds_scraper_playwright import OddsPortalScraper
+
+      schedule = \"${ODDS_SCRAPER_SCHEDULE:-0 */4 * * *}\"
+
+      async def run_collection():
+          \"\"\"执行一次赔率采集\"\"\"
+          scraper = OddsPortalScraper(
+              headless=True,
+              batch_size=int(\"${ODDS_BATCH_SIZE:-50}\")
+          )
+
+          try:
+              results = await scraper.collect_recent_matches()
+              logger.info(f\"采集完成: {len(results)} 场比赛赔率\")
+              return results
+          except Exception as e:
+              logger.error(f\"采集失败: {e}\")
+              return []
+          finally:
+              await scraper.close()
+
+      logger.info(f\"赔率采集服务已启动，计划: {schedule}\")
+
+      # 计算下次执行时间
+      cron = croniter(schedule, datetime.now())
+      next_run = cron.get_next(datetime)
+
+      while True:
+          now = datetime.now()
+          if now >= next_run:
+              try:
+                  logger.info(\"=\" * 50)
+                  logger.info(\"开始执行赔率采集...\")
+                  logger.info(\"=\" * 50)
+
+                  asyncio.run(run_collection())
+
+              except Exception as e:
+                  logger.error(f\"采集异常: {e}\")
+                  import traceback
+                  traceback.print_exc()
+
+              # 更新下次执行时间
+              cron = croniter(schedule, datetime.now())
+              next_run = cron.get_next(datetime)
+              logger.info(f\"下次执行时间: {next_run.isoformat()}\")
+          else:
+              # 计算剩余时间并休眠
+              wait_seconds = min((next_run - now).total_seconds(), 60)
+              time.sleep(wait_seconds)
+      '
+      "
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Fix #1629 by making the production Docker image default command start the FastAPI API server instead of a stale/non-existent harvester script.

The old image default CMD pointed to:

```text
python scripts/collectors/full_l1_l2_harvest.py --verbose
```

That script no longer exists. This PR changes the default CMD to the API server and ensures compose services do not accidentally inherit the API default where a non-API role is intended.

Refs #1629. The issue should be closed only after this PR is merged and the post-merge main Gate succeeds.

## Scope

| Item                           | Value                             |
| ------------------------------ | --------------------------------- |
| Task type                      | Docker/deploy runtime command fix |
| PR type                        | focused deploy runtime fix        |
| One task / one branch / one PR | yes                               |
| Dockerfile changed             | yes, `deploy/docker/Dockerfile`   |
| Compose changed                | yes, `docker-compose.yml`         |
| Runtime behavior changed       | yes, image/service command semantics |
| Business progress              | #1629 confirmed stale default CMD fixed |
| Business source code changed   | no                                |
| Tests changed                  | no                                |
| GitHub workflows changed       | no                                |
| DB / SQL / migration changed   | no                                |
| SC-002 changed                 | no                                |
| #1637 touched                  | no                                |
| #1653 touched                  | no                                |
| no-live-fetch                  | yes                               |
| no-DB-write                    | yes                               |
| no-raw-write                   | yes                               |

## Documentation Impact

No repository documentation file is changed in this focused deploy/runtime-command PR. The behavior is captured in the PR body because the only durable runtime truth changed here is the Dockerfile default CMD and explicit compose service commands. A follow-up pipeline_worker runtime-command task can update operator docs once an authoritative worker entrypoint exists.

## Files Changed

| Path                       | Purpose                                                                                |
| -------------------------- | -------------------------------------------------------------------------------------- |
| `deploy/docker/Dockerfile` | Change default CMD from stale harvester script to FastAPI API server.                  |
| `docker-compose.yml`       | Add explicit commands for non-API services so they do not inherit the API default CMD. |

## Behavior Change

### Docker image default

Before:

```text
python scripts/collectors/full_l1_l2_harvest.py --verbose
```

After:

```text
python -m uvicorn src.main:app --host 0.0.0.0 --port 8000
```

### predictor_api

Existing compose command remains unchanged.

### odds_scraper

An explicit command is added from the existing `docs/V51_2_DOCKER_COMPOSE_PATCH.yml` service template so the service does not inherit the API default CMD.

### pipeline_worker

No unique, reliable existing pipeline worker startup entrypoint was found. Static search found multiple historical/manual/legacy pipeline-adjacent commands, including production harvest, smelt, predict, odds harvest, and autonomous engine references, but none is an authoritative `pipeline_worker` command for this service.

A fail-fast command was added instead:

```text
sh -c "echo 'pipeline_worker command is not configured. Refusing to inherit API image default CMD. See #1629.' >&2; exit 1"
```

This is a safety fix only. It prevents `pipeline_worker` from silently inheriting the API server CMD. A real `pipeline_worker` runtime command remains a separate follow-up task.

## Dangerous File Authorization

This PR intentionally modifies two high-risk runtime/deploy files:

* `deploy/docker/Dockerfile`
* `docker-compose.yml`

User authorization for this phase explicitly allowed edits to exactly these two files for #1629 command semantics. The change is limited to the Docker image default CMD and explicit compose commands for non-API services. Rollback is a normal PR revert, and validation is static diff/content checks plus CI Gate.

## Safety Impact

This PR does not modify:

* source code
* tests
* GitHub workflows
* env files
* SQL or migrations
* SC-002
* #1637
* #1653

This PR did not manually execute:

* Docker build
* docker compose
* API startup
* worker startup
* scraper startup
* harvester / scraper / training / pipeline commands
* SQL / psql
* Alembic / migration
* `/predict`
* `/health/quick`

The local `git commit` and `git push` hooks did run the repository Gatekeeper without bypass. Those hooks automatically used the dev container and cold-start DB blueprint checks; no hook bypass was used.

## Validation

Local static validation completed:

* `git diff --check` passed
* Static text checks for Dockerfile CMD passed
* Static compose service command checks passed
* YAML parse check passed with local PyYAML

Repository hook validation completed without `--no-verify`:

* Commit-mode Gatekeeper passed
* Pre-push PR-mode Gatekeeper passed
* ESLint passed through Gatekeeper
* ProxyProvider contract test passed
* Commit-mode smoke tests passed
* Incremental JS tests passed in pre-push Gatekeeper
* Recon core coverage gate passed in pre-push Gatekeeper

PR Gate / Production Gate result: pending rerun after PR body correction.

## CI Gate Scope

CI Production Gate should validate static/unit gates and Docker Build Validation should verify the production image still builds. This PR does not locally run the production image or validate runtime DB-dependent startup outside the repository's automatic commit/push Gatekeeper hooks.

## No deletion / no move / no rename confirmation

No files are deleted, moved, or renamed. The only repository changes are edits to `deploy/docker/Dockerfile` and `docker-compose.yml`.

## Rollback Plan

Revert this PR with a normal GitHub revert or equivalent follow-up PR. That restores the previous Dockerfile CMD and removes the explicit compose commands added here, returning deployment command behavior to the pre-PR state while leaving source code, migrations, workflows, and env files untouched.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation: plan a dedicated `pipeline_worker` runtime command issue/task, because this PR intentionally uses fail-fast instead of inventing a worker command.

After this PR is merged, first verify main Gate success, then close #1629 only if the merged main run succeeds.

## SC-002 status

SC-002 is not changed and no role deployment was attempted. This PR does not modify SC-002 scripts, DB write guards, SQL, migrations, or deployment roles.

## Remaining risks

* Runtime behavior for `pipeline_worker` still requires a dedicated follow-up because this PR intentionally uses fail-fast instead of inventing a worker command.
* `odds_scraper` runtime depends on Playwright/croniter behavior and is not executed in this PR.
* This PR does not execute staging or production deployment.
* #1637 remains pending and untouched.

## Debt Impact

| Item | Value |
| ---- | ----- |
| New files added | none |
| Permanent files changed | `deploy/docker/Dockerfile`, `docker-compose.yml` |
| Phase-only files | none |
| Temporary helpers | none |
| Files superseded | none |
| Files deleted/archived | none |
| Cleanup needed later | pipeline_worker needs an authoritative runtime command decision |
| Repository noise increased? | no |
| Next cleanup trigger | after dedicated pipeline_worker runtime command issue/task |
