### PR TITLE
feat(ci): add optional PR matrix blocking flag

### DIFF
--- a/scripts/ops/ai_workflow_gate.py
+++ b/scripts/ops/ai_workflow_gate.py
@@ -159,7 +159,6 @@ DOC_SPRAWL_NAME_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
 )
 
 MAX_DOC_SPRAWL_NEW_FILES = 5
-
 REPORT_ARTIFACT_PREFIX = "docs/_reports/"
 REPORT_ARTIFACT_SUFFIX = ".md"
 SOURCE_OF_TRUTH_REASON_LABELS: tuple[str, ...] = (
@@ -201,7 +200,10 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 from scripts.ops.helpers.section_content_quality import check_section_content_quality  # noqa: E402, I001
 from scripts.ops.helpers.pr_authorization_matrix import (  # noqa: E402
+    narrow_blocking_errors,
+    parse_task_type,
     run_pr_authorization_matrix_report_only,
+    validate_authorization,
 )
 
 
@@ -610,8 +612,13 @@ def validate(  # noqa: C901
     changes: list[Change] | None = None,
     *,
     skip_body_checks: bool = False,
+    block_matrix: bool = False,
 ) -> list[str]:
-    """Run all AI workflow gate checks.  Returns a list of error strings."""
+    """Run all AI workflow gate checks.  Returns a list of error strings.
+
+    When *block_matrix* is True, the narrow A-D PR authorization matrix subset
+    is added to errors.  Default False (report-only, #1651 Phase 5R8-D/G).
+    """
 
     if changes is None:
         changes = collect_changes()
@@ -654,28 +661,31 @@ def validate(  # noqa: C901
     # 6c. Forbidden rewrite file patterns (new files only)
     if not skip_body_checks:
         errors.extend(check_forbidden_rewrite_patterns(added, pr_body))
-
     # 6d. Large risky change detection
     errors.extend(check_large_risky_change(changes, pr_body))
 
     # 6e. Forbidden safety claims
     if not skip_body_checks:
         errors.extend(check_forbidden_safety_claims(pr_body))
-
     # 7. Critical section content quality (only when body is available)
     if not skip_body_checks:
-        # Pass section_text_between to avoid circular import from helper.
         errors.extend(
             check_section_content_quality(
                 pr_body,
                 lambda heading, body: section_text_between(body, heading),
             )
         )
-
-    # 8. PR authorization matrix — report-only (#1651 Phase 5R8-D)
-    if not skip_body_checks:
+        # 8. PR authorization matrix — report-only (#1651 Phase 5R8-D)
         with contextlib.suppress(Exception):
             run_pr_authorization_matrix_report_only(changed, pr_body)
+        # 8b. optional narrow blocking (Phase 5R8-G, only when --block-matrix)
+        if block_matrix:
+            try:
+                task_type = parse_task_type(pr_body)
+                result = validate_authorization(task_type, changed, pr_body=pr_body)
+                errors.extend(narrow_blocking_errors(result))
+            except Exception as exc:
+                errors.append(f"PR authorization matrix blocking check failed: {exc}")
 
     return errors
 
@@ -701,31 +711,24 @@ def check_db_write_guard_enforcement(changed: set[str]) -> tuple[list[str], list
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser for the AI workflow gate."""
-    parser = argparse.ArgumentParser(
-        description="AI workflow gate — P0 risk checks for PRs",
-    )
+    parser = argparse.ArgumentParser(description="AI workflow gate — P0 risk checks for PRs")
     body_group = parser.add_mutually_exclusive_group()
+    body_group.add_argument("--pr-body-file", default=None, help="Read PR body from file")
     body_group.add_argument(
-        "--pr-body-file",
-        default=None,
-        help="Read PR body from this file path",
+        "--pr-body-stdin", action="store_true", default=False, help="Read PR body from stdin"
     )
-    body_group.add_argument(
-        "--pr-body-stdin",
-        action="store_true",
-        default=False,
-        help="Read PR body from stdin",
-    )
-    parser.add_argument(
-        "--base-ref",
-        default=None,
-        help="Git base ref for diff (default: auto-detect origin/main or main)",
-    )
+    parser.add_argument("--base-ref", default=None, help="Git base ref for diff")
     parser.add_argument(
         "--skip-body-checks",
         action="store_true",
         default=False,
-        help="Skip PR-body-specific checks (useful for push events)",
+        help="Skip PR-body checks (push events)",
+    )
+    parser.add_argument(
+        "--block-matrix",
+        action="store_true",
+        default=False,
+        help="Enable narrow PR matrix blocking (default: report-only)",
     )
     return parser
 
@@ -735,11 +738,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901, PLR0912
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    pr_body = read_pr_body(
-        args.pr_body_file,
-        from_stdin=args.pr_body_stdin,
-    )
-
+    pr_body = read_pr_body(args.pr_body_file, from_stdin=args.pr_body_stdin)
     if not pr_body.strip():
         if args.skip_body_checks:
             sys.stdout.write(
@@ -751,7 +750,9 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901, PLR0912
             return 1
     changes = collect_changes(args.base_ref)
     changed = changed_paths(changes)
-    errors = validate(pr_body, changes, skip_body_checks=args.skip_body_checks)
+    errors = validate(
+        pr_body, changes, skip_body_checks=args.skip_body_checks, block_matrix=args.block_matrix
+    )
     # 8. DB write guard enforcement — phase2 hard fail on changed-files violations
     try:
         db_errors, db_warnings = check_db_write_guard_enforcement(changed)

--- a/scripts/ops/helpers/pr_authorization_matrix.py
+++ b/scripts/ops/helpers/pr_authorization_matrix.py
@@ -560,6 +560,56 @@ def validate_authorization(  # noqa: C901
 
 
 # ============================================================================
+# Narrow blocking selector (#1651 Phase 5R8-G)
+# ============================================================================
+
+
+def narrow_blocking_errors(result: AuthorizationResult) -> tuple[str, ...]:
+    """Return a narrow, low-false-positive subset of matrix errors suitable for
+    gated blocking enforcement.
+
+    Only the following rules are selected (by Phase 5R8-F design):
+
+    * A. unknown task type
+    * B. docs-only task touching source files
+    * C. test-only task touching source files
+    * D. env-secret files present
+
+    All other matrix findings remain report-only.  The ``unknown`` path category
+    is intentionally excluded — it would produce false positives from CI
+    workspace transient files.
+    """
+    errors: list[str] = []
+    categories = set(result.categories.keys())
+
+    if result.task_type == TASK_TYPE_UNKNOWN:
+        errors.append(
+            "PR authorization matrix: unknown task type — "
+            "must declare task type in PR body (see PR template)."
+        )
+
+    if CATEGORY_ENV_SECRET in categories:
+        paths = sorted(result.categories.get(CATEGORY_ENV_SECRET, frozenset()))
+        errors.append(
+            f"PR authorization matrix: env-secret files must not be committed: {', '.join(paths)}"
+        )
+
+    if result.task_type == TASK_TYPE_DOCS_ONLY and CATEGORY_SOURCE in categories:
+        paths = sorted(result.categories.get(CATEGORY_SOURCE, frozenset()))
+        errors.append(
+            f"PR authorization matrix: docs-only PR touches source files: {', '.join(paths)}"
+        )
+
+    if result.task_type == TASK_TYPE_TEST_ONLY and CATEGORY_SOURCE in categories:
+        paths = sorted(result.categories.get(CATEGORY_SOURCE, frozenset()))
+        errors.append(
+            f"PR authorization matrix: test-only PR touches source files: {', '.join(paths)}"
+        )
+
+    return tuple(errors)
+
+
+# ============================================================================
 # Report-only gate integration (#1651 Phase 5R8-D)
 # ============================================================================
 

--- a/tests/unit/ops/test_ai_workflow_gate_pr_authorization_block_matrix_flag.py
+++ b/tests/unit/ops/test_ai_workflow_gate_pr_authorization_block_matrix_flag.py
@@ -1,0 +1,315 @@
+"""Tests for optional --block-matrix flag in AI Workflow Gate.
+
+lifecycle: test-fixture
+
+Validates that:
+  - default (block_matrix=False) does NOT add matrix errors to gate errors
+  - block_matrix=True adds ONLY narrow A-D subset to errors
+  - unknown path category is NOT blocked even with block_matrix=True
+  - high-risk without Dangerous File Authorization is NOT in narrow subset
+  - helper narrow_blocking_errors returns correct errors for each A-D rule
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import sys
+import textwrap
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "scripts" / "ops"))
+
+from helpers.pr_authorization_matrix import (  # noqa: E402
+    TASK_TYPE_DOCS_ONLY,
+    TASK_TYPE_SOURCE_CODE,
+    TASK_TYPE_TEST_ONLY,
+    TASK_TYPE_UNKNOWN,
+    TASK_TYPE_WORKFLOW_GOVERNANCE,
+    narrow_blocking_errors,
+    validate_authorization,
+)
+
+sys.path.insert(0, str(ROOT / "scripts" / "ops"))
+from ai_workflow_gate import Change, validate  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# narrow_blocking_errors — unit tests for the pure selector
+# ---------------------------------------------------------------------------
+
+
+def test_narrow_blocking_unknown_task_type():
+    result = validate_authorization(TASK_TYPE_UNKNOWN, ["docs/x.md"], pr_body="")
+    errors = narrow_blocking_errors(result)
+    assert len(errors) >= 1
+    assert any("unknown task type" in e.lower() for e in errors)
+
+
+def test_narrow_blocking_env_secret():
+    result = validate_authorization(
+        TASK_TYPE_DOCS_ONLY, [".env"], pr_body="| Task type | docs-only |"
+    )
+    errors = narrow_blocking_errors(result)
+    assert len(errors) >= 1
+    assert any("env-secret" in e.lower() for e in errors)
+
+
+def test_narrow_blocking_docs_only_touching_src():
+    result = validate_authorization(
+        TASK_TYPE_DOCS_ONLY,
+        ["docs/x.md", "src/foo.py"],
+        pr_body="| Task type | docs-only |",
+    )
+    errors = narrow_blocking_errors(result)
+    assert len(errors) >= 1
+    assert any("docs-only" in e.lower() and "source" in e.lower() for e in errors)
+
+
+def test_narrow_blocking_test_only_touching_src():
+    result = validate_authorization(
+        TASK_TYPE_TEST_ONLY,
+        ["tests/x.py", "src/foo.py"],
+        pr_body="| Task type | test-only |",
+    )
+    errors = narrow_blocking_errors(result)
+    assert len(errors) >= 1
+    assert any("test-only" in e.lower() and "source" in e.lower() for e in errors)
+
+
+def test_narrow_blocking_excludes_full_result_errors():
+    """narrow_blocking_errors must not return all result.errors — only A-D."""
+    # A docs-only PR touching src and missing dangerous auth — result has multiple errors
+    result = validate_authorization(
+        TASK_TYPE_DOCS_ONLY,
+        ["docs/x.md", "src/foo.py"],
+        pr_body="| Task type | docs-only |",
+    )
+    # result.errors has the "docs-only allows only" error from full matrix
+    # but narrow_blocking_errors should only return the A-D subset
+    errors = narrow_blocking_errors(result)
+    # Must contain the docs+touching src blocking error
+    assert any("docs-only" in e.lower() for e in errors)
+    # Must NOT contain dangerous-auth errors (not in A-D subset)
+    for e in errors:
+        assert "dangerous file authorization" not in e.lower(), (
+            f"Narrow blocking leaked non-A-D error: {e}"
+        )
+
+
+def test_narrow_blocking_does_not_block_unknown_category():
+    """Unknown path category must never produce narrow blocking errors."""
+    # Source-code task with src file + unknown category from CI transient
+    result = validate_authorization(
+        TASK_TYPE_SOURCE_CODE,
+        ["src/foo.py", ".eslintcache"],
+        pr_body="| Task type | source-code |",
+    )
+    # Matrix may have errors/warnings about unknown, but narrow should not flag it
+    errors = narrow_blocking_errors(result)
+    # No errors expected — source-code + src is valid, .eslintcache is unknown-excluded
+    assert len(errors) == 0, f"Unexpected narrow blocking errors: {errors}"
+
+
+def test_narrow_blocking_excludes_high_risk_no_auth():
+    """workflow-governance without Dangerous File Auth is NOT in A-D subset."""
+    result = validate_authorization(
+        TASK_TYPE_WORKFLOW_GOVERNANCE,
+        ["scripts/ops/ai_workflow_gate.py"],
+        pr_body="| Task type | workflow-governance |",
+    )
+    errors = narrow_blocking_errors(result)
+    # No A-D rule matches — workflow-governance with its own category is valid here
+    assert len(errors) == 0, f"Unexpected narrow blocking errors: {errors}"
+
+
+def test_narrow_blocking_valid_input_returns_empty():
+    result = validate_authorization(
+        TASK_TYPE_SOURCE_CODE,
+        ["src/foo.py", "tests/unit/bar.py"],
+        pr_body="| Task type | source-code |",
+    )
+    assert narrow_blocking_errors(result) == ()
+
+
+# ---------------------------------------------------------------------------
+# validate() with block_matrix flag — integration tests
+# ---------------------------------------------------------------------------
+
+
+def _complete_pr_body(task_type: str = "docs-only") -> str:
+    """Return a minimal but complete PR body that passes body checks."""
+    return textwrap.dedent(f"""\
+        ## Summary
+        Test PR.
+
+        ## Scope
+        | Task type | {task_type} |
+
+        ## Documentation Impact
+        | Item | Value |
+        |---|---|
+        | Source-of-truth docs updated | no |
+        | If not updated, explicit reason | Test-only PR body, no real documentation impact to explain. |
+
+        ## Safety Impact
+        | Item | Value |
+        |---|---|
+        | Existing files deleted | 0 |
+        | Existing files moved | 0 |
+        | Existing files renamed | 0 |
+
+        ## Validation
+        | Validation | Result |
+        |---|---|
+        | Host validation | n/a |
+        | Container validation | n/a |
+
+        ## CI Gate Scope
+        - What the validation proves: nothing in this test.
+        - What the validation does not prove: nothing in this test.
+
+        ## No deletion / no move / no rename confirmation
+        | Item | Value |
+        |---|---|
+        | Deleted files | 0 |
+        | Moved files | 0 |
+        | Renamed files | 0 |
+
+        ## Rollback Plan
+        Revert the merge commit. This is a test PR with no persistence impact.
+
+        ## Next Recommended Task
+        Do not start automatically.
+        Recommended next task only after user confirmation.
+
+        ## SC-002 status
+        SC-002 is partial mitigation only.
+        This PR does not change SC-002 guard coverage.
+    """)
+
+
+def test_validate_default_off_does_not_block_unknown_task_type():
+    """block_matrix=False: unknown task type does NOT produce gate errors."""
+    body = _complete_pr_body("non-existent-type")
+    changes_list = [Change("M", "docs/x.md")]
+    errors = validate(body, changes_list, block_matrix=False)
+    # No matrix blocking errors expected
+    matrix_errors = [e for e in errors if "matrix" in e.lower()]
+    assert len(matrix_errors) == 0, f"Default-off leaked matrix errors: {matrix_errors}"
+
+
+def test_validate_default_off_does_not_block_env_secret():
+    """block_matrix=False: env-secret does NOT produce gate errors from matrix."""
+    body = _complete_pr_body("docs-only")
+    changes_list = [Change("M", ".env")]
+    errors = validate(body, changes_list, block_matrix=False)
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert len(matrix_errors) == 0, f"Default-off leaked matrix errors: {matrix_errors}"
+
+
+def test_validate_block_matrix_on_blocks_unknown_task_type():
+    """block_matrix=True: unknown task type IS a blocking error."""
+    body = _complete_pr_body("non-existent-type")
+    changes_list = [Change("M", "docs/x.md")]
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    try:
+        sys.stdout = captured
+        errors = validate(body, changes_list, block_matrix=True)
+    finally:
+        sys.stdout = old_stdout
+
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert any("unknown task type" in e.lower() for e in matrix_errors), (
+        f"Expected unknown task type blocking error, got: {matrix_errors}"
+    )
+
+
+def test_validate_block_matrix_on_blocks_env_secret():
+    """block_matrix=True: env-secret IS a blocking error."""
+    body = _complete_pr_body("source-code")
+    changes_list = [Change("M", ".env")]
+    errors = validate(body, changes_list, block_matrix=True)
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert any("env-secret" in e.lower() for e in matrix_errors), (
+        f"Expected env-secret blocking error, got: {matrix_errors}"
+    )
+
+
+def test_validate_block_matrix_on_blocks_docs_only_with_src():
+    """block_matrix=True: docs-only touching src IS a blocking error."""
+    body = _complete_pr_body("docs-only")
+    changes_list = [Change("M", "docs/x.md"), Change("M", "src/foo.py")]
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    try:
+        sys.stdout = captured
+        errors = validate(body, changes_list, block_matrix=True)
+    finally:
+        sys.stdout = old_stdout
+
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert any("docs-only" in e.lower() and "source" in e.lower() for e in matrix_errors), (
+        f"Expected docs-only blocking error, got: {matrix_errors}"
+    )
+
+
+def test_validate_block_matrix_on_blocks_test_only_with_src():
+    """block_matrix=True: test-only touching src IS a blocking error."""
+    body = _complete_pr_body("test-only")
+    changes_list = [Change("M", "tests/x.py"), Change("M", "src/foo.py")]
+    errors = validate(body, changes_list, block_matrix=True)
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert any("test-only" in e.lower() and "source" in e.lower() for e in matrix_errors), (
+        f"Expected test-only blocking error, got: {matrix_errors}"
+    )
+
+
+def test_validate_block_matrix_on_does_not_block_unknown_category():
+    """block_matrix=True: unknown path category is NOT blocked."""
+    body = _complete_pr_body("source-code")
+    changes_list = [Change("M", "src/foo.py"), Change("M", ".eslintcache")]
+    errors = validate(body, changes_list, block_matrix=True)
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert len(matrix_errors) == 0, f"Unknown category should not block, got: {matrix_errors}"
+
+
+def test_validate_block_matrix_on_does_not_block_high_risk_no_auth():
+    """block_matrix=True: high-risk without Dangerous Auth is NOT in narrow subset."""
+    body = _complete_pr_body("workflow-governance")
+    changes_list = [Change("M", "scripts/ops/ai_workflow_gate.py")]
+    errors = validate(body, changes_list, block_matrix=True)
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert len(matrix_errors) == 0, (
+        f"High-risk-no-auth should not be in narrow blocking, got: {matrix_errors}"
+    )
+
+
+def test_validate_block_matrix_on_with_valid_matrix_passes():
+    """block_matrix=True: a valid PR should not get matrix blocking errors."""
+    body = _complete_pr_body("source-code")
+    changes_list = [Change("M", "src/foo.py"), Change("M", "tests/unit/bar.py")]
+    errors = validate(body, changes_list, block_matrix=True)
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert len(matrix_errors) == 0, (
+        f"Valid PR should not get matrix blocking errors, got: {matrix_errors}"
+    )
+
+
+def test_validate_block_matrix_skip_body_checks_skips_matrix_blocking():
+    """skip_body_checks=True skips matrix even with block_matrix=True."""
+    body = _complete_pr_body("non-existent-type")
+    changes_list = [Change("M", ".env")]
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    try:
+        sys.stdout = captured
+        errors = validate(body, changes_list, skip_body_checks=True, block_matrix=True)
+    finally:
+        sys.stdout = old_stdout
+
+    output = captured.getvalue()
+    matrix_errors = [e for e in errors if "authorization matrix" in e.lower()]
+    assert len(matrix_errors) == 0, f"skip_body_checks should skip matrix, got: {matrix_errors}"
+    assert "[PR Authorization Matrix]" not in output


### PR DESCRIPTION
## Summary

Add an optional `--block-matrix` CLI flag for the #1651 PR authorization matrix.

By default, the AI Workflow Gate remains report-only for matrix findings. This PR does not modify GitHub workflows, so CI does not enable matrix blocking yet.

When `--block-matrix` is explicitly passed, only the narrow low-risk subset is blocking:

- unknown task type
- docs-only touching source files
- test-only touching source files
- env-secret files changed

This PR does not block unknown path categories and does not enable broad matrix enforcement.

Refs #1651.

## Scope

| Item | Value |
|---|---|
| Task type | workflow-governance |
| One task / one branch / one PR | yes |
| Implementation phase | optional narrow blocking flag only |
| AI Workflow Gate behavior changed | yes: `--block-matrix` CLI flag only |
| Default AI Workflow Gate behavior changed | no |
| Blocking enforcement enabled in CI | no |
| Workflow changed | no |
| Matrix errors block PRs by default | no |
| `--block-matrix` added | yes |
| Narrow blocking subset only | yes |
| Business code changed | no |
| Docker/deploy changed | no |
| DB / SQL / migration changed | no |
| SC-002 changed | no |

## PR Authorization Matrix

| Item | Value |
|---|---|
| Task type | workflow-governance |
| Authorized path categories | workflow-governance, tests |
| Authorized paths | `scripts/ops/ai_workflow_gate.py`, `scripts/ops/helpers/pr_authorization_matrix.py`, `tests/unit/ops/test_ai_workflow_gate_pr_authorization_block_matrix_flag.py` |
| Mixed task authorization | no |
| High-risk categories present | yes: workflow-governance |
| Requires Dangerous File Authorization | yes |
| Matrix enforcement expectation | optional-blocking-flag-default-off |

## Files Changed

| Path | Purpose |
|---|---|
| `scripts/ops/ai_workflow_gate.py` | Adds `--block-matrix` CLI flag and wires optional narrow blocking into `validate()`/`main()` without changing default behavior. |
| `scripts/ops/helpers/pr_authorization_matrix.py` | Adds pure `narrow_blocking_errors()` selector for A-D rules only. |
| `tests/unit/ops/test_ai_workflow_gate_pr_authorization_block_matrix_flag.py` | 18 focused tests for narrow blocking selector + integration with validate/block_matrix flag. |

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | no |
| Reports added | no |
| Source-of-truth docs updated | no |
| If not updated, explicit reason | PR #1658 already documented the PR authorization matrix contract; this PR only adds an optional CLI flag and tests. |

## Dangerous File Authorization

This PR intentionally touches AI workflow governance code, matrix helper code, and focused unit tests. User authorization for Phase 5R8-G explicitly allows only these files. No workflow file is modified, so CI does not pass `--block-matrix` yet. Default behavior remains report-only.

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Existing files moved | 0 |
| Existing files renamed | 0 |
| Business code changed | no |
| AI Workflow Gate behavior changed | yes: optional CLI flag only |
| Default blocking behavior changed | no |
| Blocking enforcement enabled in CI | no |
| Matrix errors block PRs by default | no |
| Unknown path category blocks PRs | no |

## Validation

| Validation | Result |
|---|---|
| `python3 -m py_compile scripts/ops/ai_workflow_gate.py scripts/ops/helpers/pr_authorization_matrix.py` | success |
| `python3 -m pytest tests/unit/ops/ -q --noconftest` | 133 passed |
| `git diff --check` | clean |
| GitHub Production Gate | pending |

## CI Gate Scope

- What the validation proves: The optional CLI flag compiles. Default report-only behavior is unchanged. With `block_matrix=True`, only A-D rules become blocking. Unknown path category remains non-blocking.
- What the validation does not prove: CI workflow blocking (`.github/workflows/*` is intentionally untouched).

## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |

## Rollback Plan

Revert this PR. Rollback removes the optional `--block-matrix` flag and narrow selector/tests. Since workflows are not modified, reverting does not affect CI workflow configuration.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- Phase 5R8-H: enable `--block-matrix` in CI workflow for the narrow A-D subset only, or run another read-only review before enabling.

## PR Type

- [x] governance-only

## Runtime Behavior

- Runtime code change included: no
- Explanation: Governance gate optional flag implementation for #1651.
- Human confirmation: User explicitly authorized Phase 5R8-G.

## Safety Status

- no live fetch: yes
- no DB writes: yes
- no raw write execution: yes
- no parser/features/training/prediction: yes

## Tests Run

- [x] unit tests
- [x] git diff --check
- [x] other: py_compile

Commands:

```
python3 -m py_compile scripts/ops/ai_workflow_gate.py scripts/ops/helpers/pr_authorization_matrix.py
python3 -m pytest tests/unit/ops/ -q --noconftest  # 133 passed
git diff --check  # clean
```

## Repository Hygiene / Debt Impact

* New files: `tests/unit/ops/test_ai_workflow_gate_pr_authorization_block_matrix_flag.py` (permanent unit test)
* No files deleted or archived
* Current-state doc updated? no (deferred to CI workflow PR)

## SC-002 status

* SC-002 is partial mitigation only. This PR does not change SC-002 guard coverage.

## Remaining risks

* CI workflow does not pass `--block-matrix` yet. #1651 remains open.
