### PR TITLE
ci: enable PR matrix blocking for pull requests

### DIFF
--- a/.github/workflows/production-gate.yml
+++ b/.github/workflows/production-gate.yml
@@ -147,7 +147,7 @@ jobs:
             gh pr view "${{ github.event.pull_request.number }}" --json body --jq '.body' > "${PR_BODY_FILE}"
             if [ -s "${PR_BODY_FILE}" ]; then
               echo "[AI Workflow Gate] PR body fetched ($(wc -l < "${PR_BODY_FILE}") lines, $(wc -c < "${PR_BODY_FILE}") bytes)."
-              python3 scripts/ops/ai_workflow_gate.py --pr-body-file "${PR_BODY_FILE}"
+              python3 scripts/ops/ai_workflow_gate.py --pr-body-file "${PR_BODY_FILE}" --block-matrix
             else
               echo "[AI Workflow Gate] PR body empty after fetch — running git-diff checks only."
               python3 scripts/ops/ai_workflow_gate.py --pr-body-file "${PR_BODY_FILE}" --skip-body-checks


### PR DESCRIPTION
## Summary

Enable the #1651 PR authorization matrix narrow blocking mode in CI for pull request events only.

This PR passes `--block-matrix` to the existing AI Workflow Gate invocation only for PR body validation (non-empty PR body).

The enabled blocking subset is the narrow A-D subset implemented in PR #1660:

- unknown task type
- docs-only touching source files
- test-only touching source files
- env-secret files changed

This PR does not change the matrix helper, gate implementation, tests, docs, Docker, DB, or SC-002.

Refs #1651.

## Scope

| Item | Value |
|---|---|
| Task type | workflow-governance |
| One task / one branch / one PR | yes |
| Implementation phase | CI workflow enablement for existing `--block-matrix` flag |
| Workflow changed | yes: AI Workflow Gate PR invocation only |
| AI Workflow Gate code changed | no |
| Matrix helper changed | no |
| Tests changed | no |
| Docs/template changed | no |
| Blocking enforcement enabled in CI | yes: PR events only |
| Push/main behavior changed | no |
| `--skip-body-checks` paths changed | no |
| Unknown path category blocks PRs | no |
| Broad matrix enforcement enabled | no |
| Business code changed | no |
| Docker/deploy behavior changed | no |
| DB / SQL / migration changed | no |
| SC-002 changed | no |
| #1637 touched | no |
| #1656 touched | no |

## PR Authorization Matrix

| Item | Value |
|---|---|
| Task type | workflow-governance |
| Authorized path categories | workflow-governance |
| Authorized paths | `.github/workflows/production-gate.yml` |
| Mixed task authorization | no |
| High-risk categories present | yes: workflow-governance |
| Requires Dangerous File Authorization | yes |
| Matrix enforcement expectation | blocking-enabled-for-pr-events-only |

## Files Changed

| Path | Purpose |
|---|---|
| `.github/workflows/production-gate.yml` | Passes `--block-matrix` to the existing AI Workflow Gate PR invocation (non-empty body path only). |

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | no |
| Reports added | no |
| Source-of-truth docs updated | no |
| If not updated, explicit reason | PR #1658 documented the matrix contract; PR #1660 implemented the optional flag. This PR only enables the existing flag in CI. |

## Dangerous File Authorization

This PR intentionally touches the Production Gate workflow file.

User authorization for Phase 5R8-I explicitly allows only `.github/workflows/production-gate.yml`.

The change: `--block-matrix` appended to the PR body validation invocation (line 150). The `--skip-body-checks` paths for empty PR body and push events remain unchanged.

This PR does NOT modify any of:
- `scripts/ops/ai_workflow_gate.py`
- `scripts/ops/helpers/pr_authorization_matrix.py`
- tests, docs, PR template, CODEOWNERS
- Docker/deploy, DB/migration/SQL, SC-002
- runtime source code

## Safety Impact

| Item | Value |
|---|---|
| Existing files deleted | 0 |
| Workflow trigger changed | no |
| Push/main behavior changed | no |
| AI Workflow Gate code changed | no |
| Matrix helper changed | no |
| Unknown path category blocks PRs | no |
| Broad matrix enforcement enabled | no |

## Validation

| Validation | Result |
|---|---|
| `git diff --check` | clean |
| `git diff --name-only` | `.github/workflows/production-gate.yml` |
| `rg -n "block-matrix" .github/workflows/` | line 150 only (PR non-empty body path) |
| `rg -n "skip-body-checks" .github/workflows/` | lines 153, 161 (unchanged) |
| GitHub Production Gate | pending |

## CI Gate Scope

- What the validation proves: The workflow diff is a 1-line addition to the PR body invocation. Push/main `--skip-body-checks` paths are unchanged.
- What the validation does not prove: Full matrix enforcement behavior in CI (this PR enables it — the CI run itself will validate).

## Rollback Plan

Revert this PR. Removes `--block-matrix` from CI, returning matrix to report-only.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- Phase 5R8-J: post-merge audit of PR Gate and main Gate to verify blocking enforcement is active on PR events but not on push events.

## PR Type

- [x] governance-only

## Runtime Behavior

- Runtime code change included: no
- CI workflow change only
- Human confirmation: User explicitly authorized Phase 5R8-I.

## Safety Status

- no live fetch: yes
- no DB writes: yes
- no raw write execution: yes
- no parser/features/training/prediction: yes

## Tests Run

- [x] git diff --check

Commands:

```
git diff --check  # clean
git diff --name-only  # .github/workflows/production-gate.yml
rg -n "block-matrix" .github/workflows/  # line 150 only
```

## Repository Hygiene / Debt Impact

* New files: none
* Files deleted: none
* Current-state doc updated? no

## SC-002 status

* SC-002 is partial mitigation only. Unchanged.

## Remaining risks

* Only A-D narrow subset is blocking. #1651 remains open for broader enforcement.


## No deletion / no move / no rename confirmation

| Item | Value |
|---|---|
| Deleted files | 0 |
| Moved files | 0 |
| Renamed files | 0 |
| Created docs/_archive content | no |
| Performed archive move | no |