### PR TITLE
ci: add Python AST and UTF-8 parse validation

### DIFF
--- a/.github/workflows/production-gate.yml
+++ b/.github/workflows/production-gate.yml
@@ -162,6 +162,9 @@ jobs:
           fi
           rm -f "${PR_BODY_FILE}"
 
+      - name: Validate Python UTF-8 and AST parse
+        run: python3 scripts/devops/check_python_ast_utf8.py
+
   docker-build:
     name: Docker Build Validation
     runs-on: ubuntu-latest

--- a/scripts/devops/check_python_ast_utf8.py
+++ b/scripts/devops/check_python_ast_utf8.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 
 import argparse
 import ast
+from dataclasses import asdict, dataclass
 import fnmatch
 import json
+from pathlib import Path
 import subprocess
 import sys
-from dataclasses import asdict, dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -75,7 +75,7 @@ def _run_git_ls_files(paths: list[str]) -> list[str]:
     return [f for f in files if f.endswith(".py")]
 
 
-def _is_excluded(path: str, exclude_globs: "Iterable[str]") -> bool:
+def _is_excluded(path: str, exclude_globs: Iterable[str]) -> bool:
     """Return True if *path* matches any of the *exclude_globs* patterns."""
     normalized = path.replace("\\", "/")
     return any(fnmatch.fnmatch(normalized, pattern) for pattern in exclude_globs)
@@ -178,17 +178,14 @@ def main(argv: list[str]) -> int:
             ),
         )
     else:
-        print(
-            f"Python UTF-8 / AST validation checked {len(checked_files)} files."
-        )
+        print(f"Python UTF-8 / AST validation checked {len(checked_files)} files.")
         if issues:
             print(f"Found {len(issues)} Python parse/encoding issue(s):")
             for issue in issues:
                 line = "?" if issue.line is None else issue.line
                 column = "?" if issue.column is None else issue.column
                 print(
-                    f"{issue.path}:{line}:{column}: "
-                    f"{issue.kind}: {issue.message}",
+                    f"{issue.path}:{line}:{column}: {issue.kind}: {issue.message}",
                 )
         else:
             print("All checked Python files decode as UTF-8 and parse as AST.")

--- a/scripts/devops/check_python_ast_utf8.py
+++ b/scripts/devops/check_python_ast_utf8.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate tracked Python files can be decoded as UTF-8 and parsed as AST.
+
+This script intentionally does not import project modules. It only reads
+tracked Python source files as text, validates strict UTF-8 decoding, and
+runs ast.parse on each file.
+
+Usage:
+    python scripts/devops/check_python_ast_utf8.py
+    python scripts/devops/check_python_ast_utf8.py --json
+    python scripts/devops/check_python_ast_utf8.py --paths src/ tests/
+    python scripts/devops/check_python_ast_utf8.py --exclude-glob "archive_vault_2026/*"
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import json
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+DEFAULT_EXCLUDE_GLOBS = (
+    ".git/*",
+    ".venv/*",
+    "venv/*",
+    "**/__pycache__/*",
+    ".mypy_cache/*",
+    ".ruff_cache/*",
+    ".pytest_cache/*",
+    "htmlcov/*",
+    "node_modules/*",
+    "archive_vault_2026/*",
+)
+
+
+@dataclass(frozen=True)
+class ParseIssue:
+    """A single Python parse or encoding issue with location info."""
+
+    path: str
+    line: int | None
+    column: int | None
+    kind: str
+    message: str
+
+
+def _run_git_ls_files(paths: list[str]) -> list[str]:
+    """Return the list of tracked Python files via git ls-files."""
+    cmd = ["git", "ls-files"]
+    if paths:
+        cmd.extend(["--", *paths])
+    else:
+        cmd.append("*.py")
+
+    result = subprocess.run(
+        cmd,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git ls-files failed")
+
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return [f for f in files if f.endswith(".py")]
+
+
+def _is_excluded(path: str, exclude_globs: Iterable[str]) -> bool:
+    """Return True if *path* matches any of the *exclude_globs* patterns."""
+    normalized = path.replace("\\", "/")
+    return any(fnmatch.fnmatch(normalized, pattern) for pattern in exclude_globs)
+
+
+def validate_file(path: str) -> ParseIssue | None:
+    """Validate that *path* decodes as strict UTF-8 and parses as Python AST.
+
+    Returns a ``ParseIssue`` on failure, ``None`` on success.
+    """
+    file_path = Path(path)
+
+    try:
+        text = file_path.read_text(encoding="utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        return ParseIssue(
+            path=path,
+            line=None,
+            column=(exc.start + 1) if exc.start is not None else None,
+            kind="UnicodeDecodeError",
+            message=str(exc),
+        )
+    except OSError as exc:
+        return ParseIssue(
+            path=path,
+            line=None,
+            column=None,
+            kind=type(exc).__name__,
+            message=str(exc),
+        )
+
+    try:
+        ast.parse(text, filename=path)
+    except SyntaxError as exc:
+        return ParseIssue(
+            path=path,
+            line=exc.lineno,
+            column=exc.offset,
+            kind=type(exc).__name__,
+            message=exc.msg,
+        )
+
+    return None
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments for the validation script."""
+    parser = argparse.ArgumentParser(
+        description="Validate tracked Python files decode as UTF-8 and parse as AST.",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=[],
+        help="Optional tracked paths or pathspecs to check. Defaults to all tracked *.py.",
+    )
+    parser.add_argument(
+        "--exclude-glob",
+        action="append",
+        default=[],
+        help="Additional glob pattern to exclude. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    """Entry point — run UTF-8 / AST validation and return exit code."""
+    args = parse_args(argv)
+
+    try:
+        files = _run_git_ls_files(args.paths)
+    except Exception as exc:
+        print(f"check_python_ast_utf8: tool error: {exc}", file=sys.stderr)
+        return 2
+
+    exclude_globs = (*DEFAULT_EXCLUDE_GLOBS, *tuple(args.exclude_glob))
+    checked_files = [f for f in files if not _is_excluded(f, exclude_globs)]
+
+    issues: list[ParseIssue] = []
+    for path in checked_files:
+        issue = validate_file(path)
+        if issue is not None:
+            issues.append(issue)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "checked_files": len(checked_files),
+                    "issues": [asdict(issue) for issue in issues],
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            ),
+        )
+    else:
+        print(f"Python UTF-8 / AST validation checked {len(checked_files)} files.")
+        if issues:
+            print(f"Found {len(issues)} Python parse/encoding issue(s):")
+            for issue in issues:
+                line = "?" if issue.line is None else issue.line
+                column = "?" if issue.column is None else issue.column
+                print(
+                    f"{issue.path}:{line}:{column}: "
+                    f"{issue.kind}: {issue.message}",
+                )
+        else:
+            print("All checked Python files decode as UTF-8 and parse as AST.")
+
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/devops/check_python_ast_utf8.py
+++ b/scripts/devops/check_python_ast_utf8.py
@@ -20,9 +20,12 @@ import fnmatch
 import json
 import subprocess
 import sys
-from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 DEFAULT_EXCLUDE_GLOBS = (
@@ -72,7 +75,7 @@ def _run_git_ls_files(paths: list[str]) -> list[str]:
     return [f for f in files if f.endswith(".py")]
 
 
-def _is_excluded(path: str, exclude_globs: Iterable[str]) -> bool:
+def _is_excluded(path: str, exclude_globs: "Iterable[str]") -> bool:
     """Return True if *path* matches any of the *exclude_globs* patterns."""
     normalized = path.replace("\\", "/")
     return any(fnmatch.fnmatch(normalized, pattern) for pattern in exclude_globs)
@@ -175,7 +178,9 @@ def main(argv: list[str]) -> int:
             ),
         )
     else:
-        print(f"Python UTF-8 / AST validation checked {len(checked_files)} files.")
+        print(
+            f"Python UTF-8 / AST validation checked {len(checked_files)} files."
+        )
         if issues:
             print(f"Found {len(issues)} Python parse/encoding issue(s):")
             for issue in issues:

--- a/scripts/ops/local_pr_gate_preflight.py
+++ b/scripts/ops/local_pr_gate_preflight.py
@@ -514,9 +514,7 @@ def check_python_ast_utf8(changed: set[str]) -> CheckResult:
     """Validate changed Python files decode as UTF-8 and parse as AST."""
     py_files = [p for p in changed if p.endswith(".py")]
     if not py_files:
-        return CheckResult(
-            "python-ast-utf8", "SKIP", "No Python files changed"
-        )
+        return CheckResult("python-ast-utf8", "SKIP", "No Python files changed")
 
     t0 = time.time()
     script = str(ROOT / "scripts/devops/check_python_ast_utf8.py")
@@ -540,9 +538,7 @@ def check_python_ast_utf8(changed: set[str]) -> CheckResult:
     output = result.stdout + result.stderr
     if result.returncode == 0:
         last_line = output.strip().splitlines()[-1] or "OK"
-        return CheckResult(
-            "python-ast-utf8", "PASS", last_line, duration_ms=duration_ms
-        )
+        return CheckResult("python-ast-utf8", "PASS", last_line, duration_ms=duration_ms)
     return CheckResult(
         "python-ast-utf8",
         "FAIL",

--- a/scripts/ops/local_pr_gate_preflight.py
+++ b/scripts/ops/local_pr_gate_preflight.py
@@ -514,12 +514,15 @@ def check_python_ast_utf8(changed: set[str]) -> CheckResult:
     """Validate changed Python files decode as UTF-8 and parse as AST."""
     py_files = [p for p in changed if p.endswith(".py")]
     if not py_files:
-        return CheckResult("python-ast-utf8", "SKIP", "No Python files changed")
+        return CheckResult(
+            "python-ast-utf8", "SKIP", "No Python files changed"
+        )
 
     t0 = time.time()
+    script = str(ROOT / "scripts/devops/check_python_ast_utf8.py")
     try:
         result = subprocess.run(
-            [sys.executable, str(ROOT / "scripts/devops/check_python_ast_utf8.py"), "--paths", *py_files],
+            [sys.executable, script, "--paths", *py_files],
             cwd=str(ROOT),
             capture_output=True,
             text=True,
@@ -528,15 +531,24 @@ def check_python_ast_utf8(changed: set[str]) -> CheckResult:
         )
     except Exception as exc:
         return CheckResult(
-            "python-ast-utf8", "ERROR", f"Failed to run check_python_ast_utf8: {exc}"
+            "python-ast-utf8",
+            "ERROR",
+            f"Failed to run check_python_ast_utf8: {exc}",
         )
 
     duration_ms = (time.time() - t0) * 1000
     output = result.stdout + result.stderr
     if result.returncode == 0:
-        return CheckResult("python-ast-utf8", "PASS", output.strip().splitlines()[-1] or "OK", duration_ms=duration_ms)
+        last_line = output.strip().splitlines()[-1] or "OK"
+        return CheckResult(
+            "python-ast-utf8", "PASS", last_line, duration_ms=duration_ms
+        )
     return CheckResult(
-        "python-ast-utf8", "FAIL", "Python parse/encoding errors found", output.strip().splitlines(), duration_ms=duration_ms
+        "python-ast-utf8",
+        "FAIL",
+        "Python parse/encoding errors found",
+        output.strip().splitlines(),
+        duration_ms=duration_ms,
     )
 
 

--- a/scripts/ops/local_pr_gate_preflight.py
+++ b/scripts/ops/local_pr_gate_preflight.py
@@ -506,6 +506,41 @@ def check_npm(changed: set[str]) -> CheckResult:
 
 
 # ---------------------------------------------------------------------------
+# Python UTF-8 / AST parse validation
+# ---------------------------------------------------------------------------
+
+
+def check_python_ast_utf8(changed: set[str]) -> CheckResult:
+    """Validate changed Python files decode as UTF-8 and parse as AST."""
+    py_files = [p for p in changed if p.endswith(".py")]
+    if not py_files:
+        return CheckResult("python-ast-utf8", "SKIP", "No Python files changed")
+
+    t0 = time.time()
+    try:
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts/devops/check_python_ast_utf8.py"), "--paths", *py_files],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except Exception as exc:
+        return CheckResult(
+            "python-ast-utf8", "ERROR", f"Failed to run check_python_ast_utf8: {exc}"
+        )
+
+    duration_ms = (time.time() - t0) * 1000
+    output = result.stdout + result.stderr
+    if result.returncode == 0:
+        return CheckResult("python-ast-utf8", "PASS", output.strip().splitlines()[-1] or "OK", duration_ms=duration_ms)
+    return CheckResult(
+        "python-ast-utf8", "FAIL", "Python parse/encoding errors found", output.strip().splitlines(), duration_ms=duration_ms
+    )
+
+
+# ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
 
@@ -513,6 +548,7 @@ BASE_PHASES = (
     ("git-diff-integrity", check_git_diff, "changes"),
     ("hidden-bidi-scan", check_hidden_bidi, "changed"),
     ("secret-marker-scan", check_secret_markers, "changed"),
+    ("python-ast-utf8", check_python_ast_utf8, "changed"),
     ("pr-body-validation", check_pr_body, "body_changes"),
     ("forbidden-claims", check_forbidden, "body"),
     ("changed-files-hardening", check_hardening, "changes_added_body"),

--- a/tests/unit/devops/test_check_python_ast_utf8.py
+++ b/tests/unit/devops/test_check_python_ast_utf8.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.devops.check_python_ast_utf8 import _is_excluded, validate_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_validate_file_accepts_valid_python(tmp_path: Path) -> None:
+    target = tmp_path / "valid.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert validate_file(str(target)) is None
+
+
+def test_validate_file_reports_invalid_utf8(tmp_path: Path) -> None:
+    target = tmp_path / "invalid_utf8.py"
+    target.write_bytes(b"\xff\xfe\x00")
+
+    issue = validate_file(str(target))
+
+    assert issue is not None
+    assert issue.kind == "UnicodeDecodeError"
+
+
+def test_validate_file_reports_syntax_error(tmp_path: Path) -> None:
+    target = tmp_path / "bad_syntax.py"
+    target.write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+    issue = validate_file(str(target))
+
+    assert issue is not None
+    assert issue.kind == "SyntaxError"
+    assert issue.line == 1
+
+
+def test_is_excluded_matches_globs() -> None:
+    assert _is_excluded(".venv/lib/example.py", [".venv/*"])
+    assert _is_excluded("pkg/__pycache__/x.py", ["**/__pycache__/*"])
+    assert not _is_excluded("src/example.py", [".venv/*"])


### PR DESCRIPTION
## Summary

Add a lightweight Python UTF-8 / AST parse validation check to CI so corrupted Python files fail before entering `main`.

This is a follow-up after #1665, which repaired parse/encoding/static-analysis fallout across tracked Python files.

## Scope

| Item | Value |
|---|---|
| Task type | workflow-governance |
| One task / one branch / one PR | yes |
| Combines feature + cleanup, audit + repair, merge + new work, or docs governance + business code | no |
| Merge-only zero-change task | no |
| Business code changed | no |
| FotMob code changed | no |

## PR Authorization Matrix

| Item | Value |
|---|---|
| Task type | workflow-governance |
| Authorized path categories | workflow-governance, tests |
| Authorized paths | .github/workflows/production-gate.yml, scripts/devops/check_python_ast_utf8.py, scripts/ops/local_pr_gate_preflight.py, tests/unit/devops/test_check_python_ast_utf8.py |
| Mixed task authorization | no |
| High-risk categories present | yes: workflow-governance |
| Requires Dangerous File Authorization | yes |
| Matrix enforcement expectation | blocking |

## Dangerous File Authorization

This PR intentionally modifies CI workflow files and adds a new CI validation script.

- **User authorization**: This is TECHDEBT-J1 as explicitly authorized — add Python UTF-8 / AST parse validation to CI Production Gate.
- **Why these files must be changed**: To add a new validation gate, the production-gate.yml workflow must include the new step; the check script must exist in scripts/devops/; the local preflight must register the check.
- **Rollback plan**: Revert this PR to remove the new CI parse/encoding validation step and script.
- **Validation plan**: The new script has been tested locally against all 422 tracked Python files (0 errors); 4 unit tests pass; ruff check and format pass with --no-cache; no Docker, no DB, no runtime impact.

## Files Changed

| File | Change | Reason |
|---|---|---|
| `.github/workflows/production-gate.yml` | +3 lines | Add `Validate Python UTF-8 and AST parse` step after AI Workflow Gate |
| `scripts/devops/check_python_ast_utf8.py` | new | Validation script: strict UTF-8 decode + ast.parse on tracked .py files |
| `scripts/ops/local_pr_gate_preflight.py` | +36 lines | Add `python-ast-utf8` check to BASE_PHASES (fast mode) |
| `tests/unit/devops/test_check_python_ast_utf8.py` | new | 4 unit tests: valid file, invalid UTF-8, syntax error, exclude globs |

## Implementation

- Adds `scripts/devops/check_python_ast_utf8.py`.
- The script checks tracked Python files with strict UTF-8 decode and `ast.parse`.
- The script does not import project modules.
- The script does not connect to DB.
- The script does not read env/secrets.
- The script emits `file:line:column` diagnostics.
- CI Production Gate now runs this validation as a standalone host-level step.
- Local PR Gate Preflight runs it on changed Python files in fast mode.

## Documentation Impact

| Item | Value |
|---|---|
| New docs added | 0 |
| Reports added | 0 |
| Adds docs/_reports artifact | no |
| Source-of-truth docs updated | no |
| If not updated, explicit reason | CI infrastructure change only; no business/user-facing docs affected |

## Safety Impact

- No runtime code path changed.
- No Dockerfile or docker-compose file changed.
- No DB connection is made.
- No SQL is executed.
- No migration is created or run.
- No secret/env file is read or modified.
- No scraper/training/pipeline is executed.

## CI Gate Scope

- What the validation proves: All tracked Python files decode as strict UTF-8 and parse as valid Python AST.
- What the validation does not prove: Runtime importability, functional correctness, type safety.
- The check does not replace ruff, mypy, tests, or AI Workflow Gate.

## Validation

| Validation | Result |
|---|---|
| `python3 scripts/devops/check_python_ast_utf8.py` | 422 files, 0 errors |
| `pytest tests/unit/devops/test_check_python_ast_utf8.py --noconftest` | 4/4 pass |
| `ruff check --no-cache` on all new/modified files | All checks passed |
| `ruff format --no-cache` on all new/modified files | 3 files left unchanged |

## No deletion / no move / no rename confirmation

- No files deleted.
- No files moved.
- No files renamed.

## SC-002 status

SC-002 is not affected.

- No DB connection was made.
- No SQL was executed.
- No migration was created or run.
- No DB write path was changed.
- This PR does not change SC-002 guard coverage.

## Remaining risks

- This check validates syntax and encoding only.
- It does not prove runtime importability.
- It does not replace ruff, mypy, tests, or AI Workflow Gate.
- `archive_vault_2026/*` is excluded by default; archive files with parse errors are not caught.

## Rollback Plan

Revert this PR to remove the new CI parse/encoding validation.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- Handle remaining archive-vault cleanup separately if needed.