### PR TITLE
test: add lightweight integration baseline

### DIFF
--- a/tests/integration/test_core_exceptions_contract.py
+++ b/tests/integration/test_core_exceptions_contract.py
@@ -1,0 +1,188 @@
+"""Integration tests for the core exceptions hierarchy.
+
+Covers:
+    1. BaseApplicationError → 25+ derived exception classes
+    2. error_code and details propagation through the inheritance chain
+    3. to_dict() round-trip fidelity
+    4. Multi-level inheritance (BaseApplicationError → DatabaseError → DatabaseConfigurationError)
+    5. Exception catching by base class
+
+These tests use zero mocks — every call exercises real exception instantiation and inheritance.
+No DB, Docker, network, or secrets are required.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+
+
+def _load(module_name: str, rel_path: str):
+    """Load a Python module from a source file without triggering package __init__.py."""
+    spec = importlib.util.spec_from_file_location(module_name, str(_SRC / rel_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {rel_path} as {module_name}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_m_exc = _load("core.exceptions", "core/exceptions.py")
+
+# Unpack all exception classes for tests
+BaseApplicationError = _m_exc.BaseApplicationError
+AuthenticationError = _m_exc.AuthenticationError
+AuthorizationError = _m_exc.AuthorizationError
+CacheError = _m_exc.CacheError
+CircuitBreakerError = _m_exc.CircuitBreakerError
+ConfigurationError = _m_exc.ConfigurationError
+ConflictError = _m_exc.ConflictError
+DataAlignmentError = _m_exc.DataAlignmentError
+DataCollectionError = _m_exc.DataCollectionError
+DatabaseConfigurationError = _m_exc.DatabaseConfigurationError
+DatabaseError = _m_exc.DatabaseError
+ExplainabilityError = _m_exc.ExplainabilityError
+ExternalAPIError = _m_exc.ExternalAPIError
+FeatureExtractionError = _m_exc.FeatureExtractionError
+HashExtractionError = _m_exc.HashExtractionError
+HealthCheckError = _m_exc.HealthCheckError
+InferenceServiceError = _m_exc.InferenceServiceError
+IntegrationError = _m_exc.IntegrationError
+ModelError = _m_exc.ModelError
+MonitoringError = _m_exc.MonitoringError
+NetworkError = _m_exc.NetworkError
+PredictionError = _m_exc.PredictionError
+ProcessingError = _m_exc.ProcessingError
+ProxyConnectionError = _m_exc.ProxyConnectionError
+ProxyError = _m_exc.ProxyError
+ProxyHealthError = _m_exc.ProxyHealthError
+RateLimitError = _m_exc.RateLimitError
+ResourceNotFoundError = _m_exc.ResourceNotFoundError
+RetryExhaustedError = _m_exc.RetryExhaustedError
+ServiceUnavailableError = _m_exc.ServiceUnavailableError
+TeamMatchingError = _m_exc.TeamMatchingError
+TimeoutError = _m_exc.TimeoutError
+URLParsingError = _m_exc.URLParsingError
+ValidationError = _m_exc.ValidationError
+
+
+class TestBaseApplicationError:
+    """Base class construction and to_dict()."""
+
+    def test_minimal_construction(self):
+        """BaseApplicationError works with only a message."""
+        err = BaseApplicationError("something went wrong")
+        assert err.message == "something went wrong"
+        assert err.error_code is None
+        assert err.details == {}
+        assert str(err) == "something went wrong"
+
+    def test_full_construction(self):
+        """All constructor arguments are preserved."""
+        err = BaseApplicationError(
+            "critical failure",
+            error_code="E001",
+            details={"host": "localhost", "port": 5432},
+        )
+        assert err.error_code == "E001"
+        assert err.details["host"] == "localhost"
+
+    def test_to_dict_round_trip(self):
+        """to_dict() returns a structured dict with all fields."""
+        err = BaseApplicationError("test", error_code="X", details={"k": "v"})
+        d = err.to_dict()
+        assert d["error_type"] == "BaseApplicationError"
+        assert d["message"] == "test"
+        assert d["error_code"] == "X"
+        assert d["details"] == {"k": "v"}
+
+
+class TestExceptionInheritance:
+    """Multi-level class hierarchy fidelity."""
+
+    def test_derived_is_instance_of_base(self):
+        """Every exception class is an instance of BaseApplicationError."""
+        err = DatabaseError("db fail")
+        assert isinstance(err, BaseApplicationError)
+        assert isinstance(err, Exception)
+
+    def test_multi_level_inheritance(self):
+        """DatabaseConfigurationError → DatabaseError → BaseApplicationError."""
+        err = DatabaseConfigurationError(
+            "bad config",
+            details={"db_name": "wrong_db"},
+        )
+        assert isinstance(err, DatabaseConfigurationError)
+        assert isinstance(err, DatabaseError)
+        assert isinstance(err, BaseApplicationError)
+
+    def test_data_alignment_subclasses(self):
+        """URLParsingError / TeamMatchingError / HashExtractionError are DataAlignmentError."""
+        url_err = URLParsingError("bad url", details={"url": "x"})
+        team_err = TeamMatchingError("no match", details={"team": "y"})
+        hash_err = HashExtractionError("hash fail", details={"url": "z"})
+
+        for e in (url_err, team_err, hash_err):
+            assert isinstance(e, DataAlignmentError)
+            assert isinstance(e, BaseApplicationError)
+
+    def test_proxy_subclasses(self):
+        """ProxyConnectionError, ProxyHealthError inherit from ProxyError."""
+        conn_err = ProxyConnectionError("conn fail")
+        health_err = ProxyHealthError("unhealthy")
+
+        for e in (conn_err, health_err):
+            assert isinstance(e, ProxyError)
+            assert isinstance(e, BaseApplicationError)
+
+
+class TestErrorCodePropagation:
+    """error_code and details propagate correctly through the hierarchy."""
+
+    def test_to_dict_preserves_subclass_type(self):
+        """to_dict reports the concrete class, not the base."""
+        err = ValidationError("invalid", error_code="V001")
+        d = err.to_dict()
+        assert d["error_type"] == "ValidationError"
+        assert d["error_code"] == "V001"
+
+    def test_catch_by_base_class(self):
+        """All derived exceptions can be caught as BaseApplicationError."""
+        with pytest.raises(RateLimitError) as exc_info:
+            raise RateLimitError("too many requests", error_code="R429")
+        assert exc_info.value.error_code == "R429"
+
+    def test_all_exception_types_to_dict(self):
+        """Every exception class produces a valid to_dict() output."""
+        exceptions = [
+            DatabaseError("db"),
+            ModelError("ml"),
+            PredictionError("pred"),
+            ConfigurationError("cfg"),
+            ValidationError("val"),
+            ExternalAPIError("api"),
+            CacheError("cache"),
+            InferenceServiceError("inf"),
+            DataCollectionError("data"),
+            AuthenticationError("auth"),
+            AuthorizationError("authz"),
+            RateLimitError("rate"),
+            ResourceNotFoundError("nf"),
+            ConflictError("conflict"),
+            ServiceUnavailableError("svc"),
+            TimeoutError("timeout"),
+            IntegrationError("int"),
+            HealthCheckError("health"),
+            MonitoringError("mon"),
+            CircuitBreakerError("cb"),
+            RetryExhaustedError("retry"),
+            NetworkError("net"),
+            ProcessingError("proc"),
+        ]
+        for err in exceptions:
+            d = err.to_dict()
+            assert "error_type" in d
+            assert "message" in d
+            assert d["message"] == err.message

--- a/tests/integration/test_core_math_finance_contract.py
+++ b/tests/integration/test_core_math_finance_contract.py
@@ -1,0 +1,159 @@
+# ruff: noqa: PLR2004 (magic values in test assertions are intentional)
+
+"""Integration tests for core math modules: finance + evaluator.
+
+Covers:
+    1. core/math/finance.py — kelly_criterion, fractional_kelly, expected_value, sharpe_ratio
+    2. core/math/evaluator.py — safe_eval with operators and variables
+
+These two modules are tested together to validate the integration of the project's
+mathematical foundation layer. All tests use real function calls with zero mocks.
+No DB, Docker, network, or secrets are required.
+"""
+
+import ast as _ast_mod
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# evaluator.py uses ast.Num which was removed in Python 3.12+.
+# This is a known pre-existing source compatibility issue (not a test bug).
+# Tests that exercise safe_eval are skipped when ast.Num is unavailable.
+_SAFE_EVAL_WORKS = hasattr(_ast_mod, "Num")
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+
+
+def _load(module_name: str, rel_path: str):
+    """Load a Python module from a source file without triggering package __init__.py."""
+    spec = importlib.util.spec_from_file_location(module_name, str(_SRC / rel_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {rel_path} as {module_name}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_m_finance = _load("core.math.finance", "core/math/finance.py")
+_m_evaluator = _load("core.math.evaluator", "core/math/evaluator.py")
+
+kelly_criterion = _m_finance.kelly_criterion
+fractional_kelly = _m_finance.fractional_kelly
+expected_value = _m_finance.expected_value
+sharpe_ratio = _m_finance.sharpe_ratio
+core_safe_eval = _m_evaluator.safe_eval
+
+
+class TestKellyCriterion:
+    """Kelly formula: f* = (bp - q) / b."""
+
+    def test_positive_ev_bet(self):
+        """A bet with positive expected value yields positive kelly fraction."""
+        result = kelly_criterion(0.55, 2.0)
+        assert result == pytest.approx(0.10)
+        assert result > 0
+
+    def test_negative_ev_bet(self):
+        """A bet with negative expected value yields kelly of 0."""
+        result = kelly_criterion(0.45, 2.0)
+        assert result == 0.0
+
+    def test_edge_probabilities(self):
+        """Probability at extremes returns 0."""
+        assert kelly_criterion(0.0, 2.0) == 0.0
+        assert kelly_criterion(1.0, 2.0) == 0.0
+
+    def test_fractional_kelly_reduces_exposure(self):
+        """fractional_kelly is always <= full_kelly."""
+        full = kelly_criterion(0.60, 2.5)
+        half = fractional_kelly(0.60, 2.5, fraction=0.5)
+        quarter = fractional_kelly(0.60, 2.5, fraction=0.25)
+        assert 0 < quarter < half < full
+
+    def test_expected_value_sign(self):
+        """EV matches intuition: positive for good odds, negative otherwise."""
+        ev_good = expected_value(0.60, 2.5)
+        ev_bad = expected_value(0.30, 2.5)
+        assert ev_good > 0
+        assert ev_bad < 0
+
+    def test_sharpe_ratio_positive_returns(self):
+        """Sharpe ratio is positive when returns exceed risk-free rate."""
+        returns = [0.05, 0.10, 0.08, 0.12, 0.07]
+        sr = sharpe_ratio(returns, risk_free_rate=0.02)
+        assert sr > 0
+
+    def test_sharpe_ratio_empty(self):
+        """Empty returns list yields 0."""
+        assert sharpe_ratio([]) == 0.0
+
+    def test_sharpe_ratio_single_value(self):
+        """Return values with zero variance yield 0. Use integers for exact arithmetic."""
+        assert sharpe_ratio([5, 5, 5]) == pytest.approx(0.0)
+
+
+@pytest.mark.skipif(
+    not _SAFE_EVAL_WORKS, reason="ast.Num removed in Python 3.12+; pre-existing source compat issue"
+)
+class TestSafeEvalIntegration:
+    """safe_eval exercises the AST-based expression evaluator."""
+
+    def test_basic_arithmetic(self):
+        """Core arithmetic operators produce expected results."""
+        assert core_safe_eval("2 + 3 * 4") == 14
+        assert core_safe_eval("10 - 2 * 3") == 4
+        assert core_safe_eval("2 ** 3") == 8
+        assert core_safe_eval("-5 + 3") == -2
+
+    def test_with_variables(self):
+        """Variables from the caller are resolved in the expression."""
+        result = core_safe_eval("x * y + z", variables={"x": 2, "y": 3, "z": 1})
+        assert result == 7
+
+    def test_allowed_functions(self):
+        """Built-in math functions abs, max, min, sum, round are available."""
+        assert core_safe_eval("abs(-5)") == 5
+        assert core_safe_eval("max(1, 2, 3)") == 3
+        assert core_safe_eval("min(1, 2, 3)") == 1
+        assert core_safe_eval("round(3.7)") == 4
+
+    def test_nested_function_calls(self):
+        """Functions can be composed."""
+        assert core_safe_eval("abs(max(-3, -7))") == 7
+
+    def test_rejects_undefined_variable(self):
+        """A variable not in the variables dict raises ValueError."""
+        with pytest.raises(ValueError, match="未定义的变量"):
+            core_safe_eval("undefined_var + 1")
+
+    def test_rejects_unsafe_operation(self):
+        """Operations beyond the allowlist raise ValueError."""
+        with pytest.raises(ValueError, match="不支持"):
+            core_safe_eval("__import__('os').system('ls')")
+
+    def test_rejects_syntax_error(self):
+        """Invalid Python syntax raises ValueError."""
+        with pytest.raises(ValueError, match="语法错误"):
+            core_safe_eval("2 + +")
+
+
+@pytest.mark.skipif(
+    not _SAFE_EVAL_WORKS, reason="ast.Num removed in Python 3.12+; pre-existing source compat issue"
+)
+class TestFinanceWithSafeEval:
+    """Integration: finance formulas expressed via safe_eval with real results."""
+
+    def test_kelly_via_safe_eval_expression(self):
+        """The kelly formula can be verified via safe_eval with variables."""
+        p, b_val = 0.55, 1.0  # probability and net odds
+        kelly_expr = "(b * p - (1 - p)) / b"
+        kelly_via_eval = core_safe_eval(kelly_expr, variables={"b": b_val, "p": p})
+        assert kelly_via_eval == pytest.approx(kelly_criterion(p, b_val + 1))
+
+    def test_expected_value_via_safe_eval(self):
+        """EV = p * (odds - 1) - (1 - p) * 1."""
+        p, odds = 0.60, 2.5
+        ev_expr = "p * (odds - 1) - (1 - p) * 1"
+        ev_via_eval = core_safe_eval(ev_expr, variables={"p": p, "odds": odds})
+        assert ev_via_eval == pytest.approx(expected_value(p, odds))

--- a/tests/integration/test_devops_ast_utf8_gate_contract.py
+++ b/tests/integration/test_devops_ast_utf8_gate_contract.py
@@ -1,0 +1,120 @@
+# ruff: noqa: PLR2004 (magic values in test assertions are intentional)
+
+"""Integration tests for the UTF-8 / AST parse validation gate.
+
+Validates the core validate_file() function from scripts/devops/check_python_ast_utf8.py
+against real files written to temporary directories.
+
+The function under test is a pure function — it reads a file, validates strict UTF-8
+decoding, and runs ast.parse. We do NOT call _run_git_ls_files or the main() entry
+point in order to keep these tests fully self-contained.
+
+No DB, Docker, network, or secrets are required. Uses tmp_path for file isolation.
+"""
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from scripts.devops.check_python_ast_utf8 import ParseIssue, validate_file
+
+
+def _write_python_file(tmp_path: Path, name: str, content: str) -> Path:
+    """Write *content* to *name* inside *tmp_path* and return the full path."""
+    file_path = tmp_path / name
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+
+
+class TestValidateFileValid:
+    """validate_file returns None for valid Python files."""
+
+    def test_simple_valid_file(self, tmp_path: Path):
+        """A minimal valid Python file passes validation."""
+        path = _write_python_file(tmp_path, "valid.py", "x = 1\n")
+        assert validate_file(str(path)) is None
+
+    def test_file_with_unicode_literals(self, tmp_path: Path):
+        """A file containing unicode string literals passes."""
+        path = _write_python_file(
+            tmp_path,
+            "unicode_literals.py",
+            '# -*- coding: utf-8 -*-\nmsg = "café 北京 モスクワ"\n',
+        )
+        assert validate_file(str(path)) is None
+
+    def test_multi_line_function(self, tmp_path: Path):
+        """A multi-line function definition passes."""
+        path = _write_python_file(
+            tmp_path,
+            "function.py",
+            "def greet(name: str) -> str:\n    return f'Hello, {name}'\n",
+        )
+        assert validate_file(str(path)) is None
+
+    def test_class_with_method(self, tmp_path: Path):
+        """A class definition passes."""
+        path = _write_python_file(
+            tmp_path,
+            "class_def.py",
+            "class Foo:\n    def bar(self) -> int:\n        return 42\n",
+        )
+        assert validate_file(str(path)) is None
+
+
+class TestValidateFileInvalid:
+    """validate_file returns a ParseIssue for broken files."""
+
+    def test_syntax_error(self, tmp_path: Path):
+        """A file with a Python syntax error returns a SyntaxError ParseIssue."""
+        path = _write_python_file(tmp_path, "broken.py", "def broken(\n")
+        issue = validate_file(str(path))
+        assert issue is not None
+        assert issue.kind == "SyntaxError"
+        assert issue.path == str(path)
+
+    def test_non_utf8_file(self, tmp_path: Path):
+        """A file with non-UTF-8 bytes returns a UnicodeDecodeError ParseIssue."""
+        path = tmp_path / "latin1.py"
+        # Write raw bytes that are valid Latin-1 but invalid UTF-8
+        path.write_bytes(b"# coding: latin1\nx = '\xff\xfe'\n")
+        issue = validate_file(str(path))
+        assert issue is not None
+        assert issue.kind == "UnicodeDecodeError"
+
+    def test_empty_file(self, tmp_path: Path):
+        """An empty file is syntactically valid Python."""
+        path = _write_python_file(tmp_path, "empty.py", "")
+        assert validate_file(str(path)) is None
+
+    def test_missing_file(self, tmp_path: Path):
+        """A non-existent path returns an OSError-related ParseIssue."""
+        issue = validate_file(str(tmp_path / "does_not_exist.py"))
+        assert issue is not None
+        assert "Error" in issue.kind or issue.kind == "FileNotFoundError"
+
+
+class TestParseIssueDataclass:
+    """ParseIssue is a frozen dataclass with structured error information."""
+
+    def test_parse_issue_fields(self):
+        """ParseIssue stores path, line, column, kind, and message."""
+        issue = ParseIssue(
+            path="tests/fake.py",
+            line=10,
+            column=5,
+            kind="SyntaxError",
+            message="invalid syntax",
+        )
+        assert issue.path == "tests/fake.py"
+        assert issue.line == 10
+        assert issue.column == 5
+        assert issue.kind == "SyntaxError"
+        assert "invalid" in issue.message
+
+    def test_parse_issue_is_immutable(self):
+        """ParseIssue is frozen and cannot be mutated."""
+        issue = ParseIssue(path="a.py", line=1, column=1, kind="X", message="m")
+        with pytest.raises(FrozenInstanceError):
+            issue.path = "b.py"  # type: ignore[misc]

--- a/tests/integration/test_team_name_pipeline_contract.py
+++ b/tests/integration/test_team_name_pipeline_contract.py
@@ -1,0 +1,193 @@
+# ruff: noqa: PLR2004 (magic values in test assertions are intentional)
+
+"""Integration tests for team name normalization, matching, and model pipeline.
+
+Covers the real module collaboration path:
+    1. constants (TEAM_ABBREVIATIONS, TEAM_SUFFIXES, SAME_CITY_DERBIES)
+    2. normalization (normalize_team_name, denoise_team_name, extract_place_name)
+    3. matching (semantic_match, calculate_similarity, match_teams)
+    4. models (MatchResult, TeamAliasMatch)
+
+These tests use zero mocks — every call exercises real module code.
+No DB, Docker, network, or secrets are required.
+
+Import strategy: use importlib to load leaf modules directly from their file paths,
+bypassing __init__.py files that cascade into fastapi, psycopg2, etc.
+"""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+
+
+def _load(module_name: str, rel_path: str):
+    """Load a Python module from a source file, registering parent packages first.
+
+    Creates stub namespace packages in sys.modules for each ancestor so that
+    relative imports (``from .sibling import ...``) resolve correctly. This
+    avoids triggering the real __init__.py files that cascade into heavy deps.
+    """
+    # Register parent namespace packages so relative imports work
+    parts = module_name.split(".")
+    for i in range(1, len(parts)):
+        parent_name = ".".join(parts[:i])
+        if parent_name not in sys.modules:
+            parent = type(sys)(parent_name)
+            parent.__path__ = []  # type: ignore[attr-defined]
+            parent.__package__ = parent_name
+            sys.modules[parent_name] = parent
+
+    spec = importlib.util.spec_from_file_location(module_name, str(_SRC / rel_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {rel_path} as {module_name}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Load modules in dependency order:
+# 1. constants (no deps) → 2. models (no deps) → 3. normalization → 4. matching
+_m_constants = _load("utils.teams.constants", "utils/teams/constants.py")
+_m_models = _load("utils.teams.models", "utils/teams/models.py")
+_m_normalization = _load("utils.teams.normalization", "utils/teams/normalization.py")
+_m_matching = _load("utils.teams.matching", "utils/teams/matching.py")
+
+# Unpack symbols for test convenience
+PLACE_NAME_PRIORITY = _m_constants.PLACE_NAME_PRIORITY
+SAME_CITY_DERBIES = _m_constants.SAME_CITY_DERBIES
+TEAM_ABBREVIATIONS = _m_constants.TEAM_ABBREVIATIONS
+TEAM_SUFFIXES = _m_constants.TEAM_SUFFIXES
+normalize_team_name = _m_normalization.normalize_team_name
+denoise_team_name = _m_normalization.denoise_team_name
+extract_place_name = _m_normalization.extract_place_name
+semantic_match = _m_matching.semantic_match
+calculate_similarity = _m_matching.calculate_similarity
+expand_team_name = _m_matching.expand_team_name
+match_teams = _m_matching.match_teams
+HIGH_SIMILARITY_THRESHOLD = _m_matching.HIGH_SIMILARITY_THRESHOLD
+REVERSE_WARNING_THRESHOLD = _m_matching.REVERSE_WARNING_THRESHOLD
+MatchResult = _m_models.MatchResult
+TeamAliasMatch = _m_models.TeamAliasMatch
+
+
+class TestNormalizationPipeline:
+    """normalize → denoise → extract_place chain on real data."""
+
+    def test_normalize_lowercase_and_strip(self):
+        """normalize_team_name lowercases, strips, and removes punctuation."""
+        assert normalize_team_name("  Manchester United  ") == "manchester united"
+        assert normalize_team_name("Arsenal!!!") == "arsenal"
+        assert normalize_team_name("") == ""
+
+    def test_abbreviation_expansion(self):
+        """TEAM_ABBREVIATIONS entries are applied by normalize_team_name."""
+        assert normalize_team_name("Man Utd") == "man united"
+        assert normalize_team_name("Spurs") == "tottenham"
+
+    def test_denoise_removes_suffixes(self):
+        """denoise_team_name strips known suffixes after normalization."""
+        result = denoise_team_name("Liverpool FC")
+        assert "liverpool" in result
+        assert "fc" not in result
+
+    def test_extract_place_name_from_priority_map(self):
+        """PLACE_NAME_PRIORITY keys are matched against the normalized name."""
+        result = extract_place_name("Manchester City FC")
+        assert result == PLACE_NAME_PRIORITY.get("manchester", "")
+
+    def test_pipeline_empty_input_safety(self):
+        """Empty or blank names pass through the pipeline without crashing."""
+        assert normalize_team_name("") == ""
+        assert denoise_team_name("") == ""
+        assert extract_place_name("") == ""
+
+
+class TestSemanticMatching:
+    """semantic_match / calculate_similarity / match_teams on real team names."""
+
+    def test_perfect_normalized_match(self):
+        """Two strings that normalize to the same value score 100."""
+        score, reason = semantic_match("Manchester United", "manchester united")
+        assert score == 100.0
+        assert "Perfect" in reason
+
+    def test_place_name_match_high_confidence(self):
+        """Teams sharing a non-derby place name get >= 90 confidence."""
+        # "Barcelona" is in PLACE_NAME_PRIORITY and has no derby indicators
+        score, _reason = semantic_match("Barcelona Giants", "Barcelona FC")
+        assert score > 85.0
+
+    def test_derby_rejection_different_teams(self):
+        """Derby rivals in same city are rejected with low score (40.0)."""
+        score, _reason = semantic_match("Manchester United", "Manchester City")
+        assert score <= 40.0
+
+    def test_high_similarity_threshold_respected(self):
+        """Scores at or above HIGH_SIMILARITY_THRESHOLD use the actual value."""
+        # "Wolves" vs "Wolverhampton" — different enough to not be perfect match
+        # but similar enough to cross HIGH_SIMILARITY_THRESHOLD
+        score, _reason = semantic_match("Wolves", "Wolverhampton")
+        # The score should be reasonably high for similar names
+        assert score > 50.0
+
+    def test_calculate_similarity_variant_expansion(self):
+        """Similarity uses expand_team_name for variant-aware matching."""
+        score = calculate_similarity("Man Utd", "Manchester United")
+        assert score > 85.0
+
+    def test_match_teams_direct_and_reversed(self):
+        """match_teams checks both direct and reversed home/away alignment."""
+        score, details = match_teams(
+            scraped_home="Arsenal",
+            scraped_away="Chelsea",
+            db_home="Arsenal",
+            db_away="Chelsea",
+        )
+        assert score > 80.0
+        assert "Arsenal" in details
+
+    def test_match_teams_reversed_detection(self):
+        """When scraped home matches DB away, reverse score may win."""
+        score, _details = match_teams(
+            scraped_home="Chelsea",
+            scraped_away="Arsenal",
+            db_home="Arsenal",
+            db_away="Chelsea",
+        )
+        assert score > 70.0
+
+
+class TestModelsIntegration:
+    """MatchResult and TeamAliasMatch dataclass creation."""
+
+    def test_match_result_construction(self):
+        """MatchResult can be constructed with real pipeline output."""
+        score, _details = match_teams("Man Utd", "Liverpool", "Manchester United", "Liverpool FC")
+        result = MatchResult(
+            fotmob_id=None,
+            scraped_home="Man Utd",
+            scraped_away="Liverpool",
+            db_home="Manchester United",
+            db_away="Liverpool FC",
+            confidence=score,
+            tier="confident" if score > 80 else "uncertain",
+            url="https://example.com/match/1",
+        )
+        assert result.confidence > 70.0
+        assert result.scraped_home == "Man Utd"
+        assert isinstance(result.confidence, float)
+
+    def test_team_alias_match_model(self):
+        """TeamAliasMatch holds normalized name with computed similarity."""
+        sim = calculate_similarity("Man Utd", "Manchester United")
+        alias_match = TeamAliasMatch(
+            normalized_name="manchester united",
+            aliases=["man utd", "man united"],
+            similarity=sim,
+            is_confident=sim > 85.0,
+        )
+        assert alias_match.is_confident
+        assert alias_match.similarity > 85.0


### PR DESCRIPTION
## Summary

Add the first lightweight integration test baseline to improve test trustworthiness after TECHDEBT-K0 found 0 integration tests and high mock usage (135 mock calls across 49 unit tests).

This PR is additive test-only work. It does not change runtime code, Docker, DB, migrations, scraper/training pipelines, or secrets.

## Scope

| Item | Value |
|---|---|
| Task type | test-only |
| One task / one branch / one PR | yes |
| Purpose | establish lightweight integration test baseline |
| Runtime behavior change | no |
| Business logic change | no |
| Docker change | no |
| DB schema / migration change | no |
| Secret / env change | no |
| Test type | integration tests |
| External services | none |
| Real DB | no |
| Real network | no |

## PR Authorization Matrix

| Item | Value |
|---|---|
| Task type | test-only |
| Authorized path categories | tests |
| Authorized paths | `tests/integration/**` (new files) |
| Mixed task authorization | no |
| High-risk categories present | no |
| Requires Dangerous File Authorization | no |
| Matrix enforcement expectation | blocking |

## Implementation

- Adds 4 lightweight integration test files under `tests/integration/` (42 test cases total, 9 conditionally skipped on Python 3.12+).
- Tests exercise real module/object cooperation with zero mocks:
  1. `test_team_name_pipeline_contract.py` — team name normalization → denoise → extract_place → semantic_match → calculate_similarity → match_teams → MatchResult model (4 modules: constants, normalization, matching, models)
  2. `test_core_exceptions_contract.py` — BaseApplicationError → 25+ derived exception classes → to_dict() → error_code propagation → multi-level inheritance chain
  3. `test_core_math_finance_contract.py` — kelly_criterion, fractional_kelly, expected_value, sharpe_ratio + safe_eval integration (2 modules: finance + evaluator cross-validation)
  4. `test_devops_ast_utf8_gate_contract.py` — validate_file() from the production AST/UTF-8 gate, tested against files in tmp_path (valid UTF-8, syntax errors, non-UTF-8 bytes, ParseIssue model)
- Uses `importlib` to load leaf modules directly from source files, bypassing `__init__.py` chains that cascade into heavy dependencies (fastapi, psycopg2, etc.).
- All tests run locally on host without Docker, DB, or network.
- 9 tests skipped on Python 3.12+ due to pre-existing `ast.Num` removal in `src/core/math/evaluator.py` (not a test issue; the module needs a compat update in a separate PR).

## Documentation Impact

No user-facing documentation changed.

## Safety Impact

- No runtime source files changed.
- No Dockerfile or docker-compose file changed.
- No DB connection is made.
- No SQL is executed.
- No migration is created or run.
- No secret/env file is read or modified.
- No scraper/training/pipeline is executed.
- No project runtime API is called.

## CI Gate Scope

This PR adds tests only. Existing CI gates remain unchanged:

- Run Gatekeeper
- AI Workflow Gate
- Python AST / UTF-8 gate
- Docker Build Validation

## Validation

Local validation performed (host, Python 3.14.4):

- targeted pytest: 42 passed, 9 skipped, 0 failed
- `python3 scripts/devops/check_python_ast_utf8.py`: 422 files checked, all pass
- ruff check on changed Python files: all checks passed
- ruff format check on changed Python files: already formatted

## No deletion / no move / no rename confirmation

- No files deleted.
- No files moved.
- No files renamed.

## SC-002 status

SC-002 is not affected.

- No DB connection was made.
- No SQL was executed.
- No migration was created or run.
- No DB write path was changed.

## Remaining risks

- This PR establishes a baseline only; it does not solve all test trustworthiness debt.
- Integration coverage remains intentionally small (4 modules / 42 test cases).
- 9 safe_eval tests are skipped on Python >= 3.12 due to `ast.Num` removal in `src/core/math/evaluator.py`; this is a pre-existing source compatibility issue.
- Future PRs should add focused integration tests for additional critical paths (config, DB pool config validation, etc.).

## Rollback Plan

Revert this PR to remove the added integration tests.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- TECHDEBT-K2: Fix `src/core/math/evaluator.py` `ast.Num` → `ast.Constant` compat (Python 3.12+), or expand integration coverage for config/settings modules.