### PR TITLE
fix: support ast constant numbers in safe evaluator

### DIFF
--- a/src/core/math/evaluator.py
+++ b/src/core/math/evaluator.py
@@ -65,7 +65,7 @@ def _eval_node(node: ast.AST, variables: dict[str, Any]) -> Any:  # noqa: C901, 
     if isinstance(node, ast.Constant):  # Python 3.8+
         return node.value
     # ast.Num removed in Python 3.12+; guard with hasattr for compat.
-    if hasattr(ast, "Num") and isinstance(node, ast.Num):  # type: ignore[attr-defined]
+    if hasattr(ast, "Num") and isinstance(node, ast.Num):
         return node.n
     if isinstance(node, ast.Name):
         if node.id in variables:

--- a/src/core/math/evaluator.py
+++ b/src/core/math/evaluator.py
@@ -62,10 +62,11 @@ def safe_eval(expression: str, variables: dict[str, Any] | None = None) -> Any:
 
 def _eval_node(node: ast.AST, variables: dict[str, Any]) -> Any:  # noqa: C901, PLR0911
     """递归求值 AST 节点"""
-    if isinstance(node, ast.Num):  # Python 3.7
-        return node.n
     if isinstance(node, ast.Constant):  # Python 3.8+
         return node.value
+    # ast.Num removed in Python 3.12+; guard with hasattr for compat.
+    if hasattr(ast, "Num") and isinstance(node, ast.Num):  # type: ignore[attr-defined]
+        return node.n
     if isinstance(node, ast.Name):
         if node.id in variables:
             return variables[node.id]

--- a/tests/integration/test_core_math_finance_contract.py
+++ b/tests/integration/test_core_math_finance_contract.py
@@ -11,16 +11,10 @@ mathematical foundation layer. All tests use real function calls with zero mocks
 No DB, Docker, network, or secrets are required.
 """
 
-import ast as _ast_mod
 import importlib.util
 from pathlib import Path
 
 import pytest
-
-# evaluator.py uses ast.Num which was removed in Python 3.12+.
-# This is a known pre-existing source compatibility issue (not a test bug).
-# Tests that exercise safe_eval are skipped when ast.Num is unavailable.
-_SAFE_EVAL_WORKS = hasattr(_ast_mod, "Num")
 
 _SRC = Path(__file__).parent.parent.parent / "src"
 
@@ -93,9 +87,6 @@ class TestKellyCriterion:
         assert sharpe_ratio([5, 5, 5]) == pytest.approx(0.0)
 
 
-@pytest.mark.skipif(
-    not _SAFE_EVAL_WORKS, reason="ast.Num removed in Python 3.12+; pre-existing source compat issue"
-)
 class TestSafeEvalIntegration:
     """safe_eval exercises the AST-based expression evaluator."""
 
@@ -120,7 +111,7 @@ class TestSafeEvalIntegration:
 
     def test_nested_function_calls(self):
         """Functions can be composed."""
-        assert core_safe_eval("abs(max(-3, -7))") == 7
+        assert core_safe_eval("max(abs(-3), abs(-7))") == 7
 
     def test_rejects_undefined_variable(self):
         """A variable not in the variables dict raises ValueError."""
@@ -138,9 +129,6 @@ class TestSafeEvalIntegration:
             core_safe_eval("2 + +")
 
 
-@pytest.mark.skipif(
-    not _SAFE_EVAL_WORKS, reason="ast.Num removed in Python 3.12+; pre-existing source compat issue"
-)
 class TestFinanceWithSafeEval:
     """Integration: finance formulas expressed via safe_eval with real results."""
 


### PR DESCRIPTION
## Summary

Fix `src/core/math/evaluator.py` AST numeric constant compatibility for Python 3.12+ by reordering the constant handling to check `ast.Constant` first and guarding the legacy `ast.Num` path with `hasattr`.

This follows #1670, where 9 safe_eval integration tests were skipped on Python 3.12+ due to `ast.Num` being removed from the `ast` module.

After this fix, all 51 integration tests pass with 0 skipped (up from 42 passed / 9 skipped).

## Scope

| Item | Value |
|---|---|
| Task type | source-code |
| One task / one branch / one PR | yes |
| Purpose | Python 3.12+ AST numeric compatibility |
| Runtime behavior change | narrow compatibility fix only |
| Business logic change | no |
| Docker change | no |
| DB schema / migration change | no |
| Secret / env change | no |
| Workflow / Gatekeeper change | no |
| Test impact | previously skipped safe_eval integration tests now run and pass |

## PR Authorization Matrix

| Item | Value |
|---|---|
| Task type | source-code |
| Authorized path categories | active source, tests |
| Authorized paths | `src/core/math/evaluator.py`, `tests/integration/test_core_math_finance_contract.py` |
| Mixed task authorization | yes: narrow source compatibility fix plus related test update |
| High-risk categories present | yes: expression evaluator safety boundary |
| Requires Dangerous File Authorization | yes |
| Matrix enforcement expectation | blocking |

## Dangerous File Authorization

This PR touches a safe expression evaluator. The change is authorized only for numeric AST compatibility.

Safety constraints verified:

- No function calls are enabled (existing `ast.Call` path unchanged).
- No attribute access is enabled.
- No variable/name lookup is enabled (existing `ast.Name` path unchanged).
- No imports are enabled.
- No eval/exec is added.
- No DB, Docker, network, scraper, training, or runtime API path is touched.
- Boolean constants are not treated as numeric values — the `ast.Constant` path returns the value unchanged (same as before).
- The security boundary grep confirms zero new dangerous AST capabilities.

## Implementation

- `src/core/math/evaluator.py`: reorder `_eval_node` constant checks — `ast.Constant` (Python 3.8+) first, then `ast.Num` guarded by `hasattr(ast, "Num")` for Python 3.7-3.11 backward compatibility.
- `tests/integration/test_core_math_finance_contract.py`: remove `_SAFE_EVAL_WORKS` guard and `@pytest.mark.skipif` decorators from `TestSafeEvalIntegration` and `TestFinanceWithSafeEval`. Fix one test assertion (`max(abs(-3), abs(-7))` instead of mathematically incorrect `abs(max(-3, -7))`).

## Documentation Impact

No user-facing documentation changed.

## Safety Impact

- No Dockerfile or docker-compose file changed.
- No DB connection is made.
- No SQL is executed.
- No migration is created or run.
- No secret/env file is read or modified.
- No scraper/training/pipeline is executed.
- No project runtime API is called.
- No workflow or Gatekeeper file changed.

## CI Gate Scope

Existing CI gates remain unchanged:

- Run Gatekeeper
- AI Workflow Gate
- Python AST / UTF-8 gate
- Docker Build Validation

## Validation

Local validation performed (host, Python 3.14.4):

- targeted pytest for `tests/integration/test_core_math_finance_contract.py`: **17 passed, 0 skipped, 0 failed**
- all integration pytest (4 files): **51 passed, 0 skipped, 0 failed** (up from 42/9/0 before fix)
- `python3 scripts/devops/check_python_ast_utf8.py`: 426 files checked, all pass
- ruff check on changed files: all checks passed
- ruff format check on changed files: already formatted
- safe_eval safety boundary grep: zero new dangerous AST capabilities

## No deletion / no move / no rename confirmation

- No files deleted.
- No files moved.
- No files renamed.

## SC-002 status

SC-002 is not affected.

- No DB connection was made.
- No SQL was executed.
- No migration was created or run.
- No DB write path was changed.

## Remaining risks

- The `evaluator.py` code still contains legacy `ast.Num` handling under `hasattr` guard for backward compatibility with Python < 3.8. This is acceptable as a compatibility shim.
- Integration coverage for the math module is now complete for the current safe_eval surface. Future expansions of `ALLOWED_OPERATORS` or `ALLOWED_FUNCTIONS` should add corresponding tests.

## Rollback Plan

Revert this PR to restore the previous `ast.Num`-first ordering and the integration test skip behavior.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- Expand integration coverage for config/settings modules, or address the pre-existing test debt (over-mocking in DB write guard tests) identified in TECHDEBT-K0.