### PR TITLE
ci: fix mypy changed-line false positives

### DIFF
--- a/scripts/devops/static_quality_changed_lines.py
+++ b/scripts/devops/static_quality_changed_lines.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
+import posixpath
 import re
 import subprocess
 import sys
@@ -50,6 +52,10 @@ FALLBACK_DIAG_DISPLAY_LIMIT = 20
 
 # Minimum number of parts expected in a unified diff hunk header.
 MIN_HUNK_HEADER_PARTS = 3
+
+# Internal marker for a file whose diff could not be read.  Diagnostics in
+# these files remain blocking because changed-line classification is unsafe.
+UNRESOLVED_CHANGED_LINE_PREFIX = "__unresolved_changed_line__:"
 
 # ---------------------------------------------------------------------------
 # Safe decoding helper
@@ -152,8 +158,8 @@ def _parse_hunk_new_start(hunk_header: str) -> int | None:
     return int(new_part)
 
 
-def _collect_changed_lines_for_file(git_base: str, file: str) -> set[int]:
-    """Return the set of changed (added) line numbers for a single file."""
+def _collect_changed_lines_for_file_with_status(git_base: str, file: str) -> tuple[set[int], bool]:
+    """Return changed lines and whether the diff was parsed safely."""
     try:
         result = subprocess.run(
             ["git", "diff", f"{git_base}...HEAD", "--", file],
@@ -162,17 +168,22 @@ def _collect_changed_lines_for_file(git_base: str, file: str) -> set[int]:
             check=False,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return set()
+        return set(), False
 
     if result.returncode != 0:
-        return set()
+        return set(), False
 
     lines: set[int] = set()
     current_new_line: int | None = None
 
     for diff_line in _safe_decode(result.stdout).splitlines():
         if diff_line.startswith("@@") and "@@" in diff_line[2:]:
-            current_new_line = _parse_hunk_new_start(diff_line)
+            try:
+                current_new_line = _parse_hunk_new_start(diff_line)
+            except ValueError:
+                return set(), False
+            if current_new_line is None:
+                return set(), False
             continue
 
         if current_new_line is None:
@@ -185,6 +196,12 @@ def _collect_changed_lines_for_file(git_base: str, file: str) -> set[int]:
             # Context or unchanged line — advance the new-line counter.
             current_new_line += 1
 
+    return lines, True
+
+
+def _collect_changed_lines_for_file(git_base: str, file: str) -> set[int]:
+    """Return the set of changed (added) line numbers for a single file."""
+    lines, _parsed = _collect_changed_lines_for_file_with_status(git_base, file)
     return lines
 
 
@@ -202,9 +219,12 @@ def get_changed_line_ranges(files: list[str]) -> dict[str, set[int]]:
 
     changed: dict[str, set[int]] = {}
     for file in files:
-        file_lines = _collect_changed_lines_for_file(git_base, file)
-        if file_lines:
-            changed[file] = file_lines
+        normalised = _normalize_path(file)
+        file_lines, parsed = _collect_changed_lines_for_file_with_status(git_base, file)
+        if parsed:
+            changed[normalised] = file_lines
+        else:
+            changed[f"{UNRESOLVED_CHANGED_LINE_PREFIX}{normalised}"] = set()
 
     return changed
 
@@ -266,11 +286,37 @@ def _normalize_path(file_path: str) -> str:
     well-known container mount-point prefixes so both sources produce the same
     key for the ``changed_lines`` dict.
     """
-    known_prefixes: tuple[str, ...] = ("/app/",)
+    normalised = file_path.strip().replace("\\", "/")
+    cwd = Path.cwd().as_posix()
+    known_prefixes: tuple[str, ...] = (
+        f"{cwd}/",
+        "/app/",
+        "/home/runner/work/FootballPrediction/FootballPrediction/",
+    )
     for prefix in known_prefixes:
-        if file_path.startswith(prefix):
-            return file_path[len(prefix) :]
-    return file_path
+        if normalised.startswith(prefix):
+            normalised = normalised[len(prefix) :]
+            break
+    return posixpath.normpath(normalised)
+
+
+def _is_unmapped_absolute_path(file_path: str) -> bool:
+    """Return True when a diagnostic path could not be made repo-relative."""
+    return file_path.startswith("/") or bool(re.match(r"^[A-Za-z]:/", file_path))
+
+
+def _split_changed_line_data(
+    changed_lines: dict[str, set[int]],
+) -> tuple[dict[str, set[int]], set[str]]:
+    """Separate resolved changed-line data from fail-safe unresolved markers."""
+    resolved: dict[str, set[int]] = {}
+    unresolved: set[str] = set()
+    for file_path, lines in changed_lines.items():
+        if file_path.startswith(UNRESOLVED_CHANGED_LINE_PREFIX):
+            unresolved.add(file_path[len(UNRESOLVED_CHANGED_LINE_PREFIX) :])
+        else:
+            resolved[file_path] = lines
+    return resolved, unresolved
 
 
 def classify_diagnostics(
@@ -283,23 +329,38 @@ def classify_diagnostics(
     """
     new: list[dict] = []
     existing: list[dict] = []
+    if not changed_lines:
+        return diagnostics.copy(), existing
+
+    resolved_changed_lines, unresolved_files = _split_changed_line_data(changed_lines)
 
     for diag in diagnostics:
         file_path = diag.get("filename", "")
         line = diag.get("location", {}).get("row", 0)
 
-        if not file_path or line == 0:
+        if not file_path or not isinstance(line, int) or line <= 0:
             # Can't map — treat as new (fail-safe).
             new.append(diag)
             continue
 
         normalised = _normalize_path(file_path)
-        changed = changed_lines.get(normalised, set())
-        if not changed:
-            # No changed-line data for this file — treat as new (fail-safe).
+        if _is_unmapped_absolute_path(normalised):
+            # Unknown absolute path — can't safely compare against git diff.
             new.append(diag)
             continue
 
+        if normalised in unresolved_files:
+            # The file was a target, but its diff could not be parsed safely.
+            new.append(diag)
+            continue
+
+        if normalised not in resolved_changed_lines:
+            # Mypy can emit diagnostics in imported files.  If the file is not
+            # part of the resolved changed-file set, it is historical context.
+            existing.append(diag)
+            continue
+
+        changed = resolved_changed_lines[normalised]
         if line in changed:
             new.append(diag)
         else:

--- a/tests/unit/devops/test_static_quality_changed_lines.py
+++ b/tests/unit/devops/test_static_quality_changed_lines.py
@@ -29,6 +29,7 @@ _collect_changed_lines_for_file = _static_ql._collect_changed_lines_for_file
 _normalize_path = _static_ql._normalize_path
 _classify_diagnostics = _static_ql.classify_diagnostics
 _parse_mypy_output = _static_ql.parse_mypy_output
+_UNRESOLVED_CHANGED_LINE_PREFIX = _static_ql.UNRESOLVED_CHANGED_LINE_PREFIX
 
 
 class TestParseHunkNewStart:
@@ -95,6 +96,16 @@ index 1111111..2222222 100644
  logger.info("limiter ok")
 """
 
+DIFF_DELETED_ONLY = """\
+diff --git a/fake.py b/fake.py
+index 1111111..2222222 100644
+--- a/fake.py
++++ b/fake.py
+@@ -10,2 +10,0 @@ def old():
+-    old_call()
+-    old_return()
+"""
+
 
 class TestChangedLineDetection:
     """Verify that changed lines are correctly extracted from unified diffs,
@@ -132,6 +143,14 @@ class TestChangedLineDetection:
             lines = _collect_changed_lines_for_file("HEAD~1", "fake.py")
             assert lines == set()
 
+    def test_deleted_only_hunk_produces_no_new_changed_lines(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = DIFF_DELETED_ONLY.encode("utf-8")
+
+            lines = _collect_changed_lines_for_file("HEAD~1", "fake.py")
+            assert lines == set()
+
 
 # ---------------------------------------------------------------------------
 # Path normalization tests
@@ -152,12 +171,15 @@ class TestNormalizePath:
         assert _normalize_path("src/main.py") == "src/main.py"
 
     def test_dot_slash_unchanged(self):
-        """Preserve ./ prefix — it is not a known container mount."""
-        assert _normalize_path("./src/main.py") == "./src/main.py"
+        assert _normalize_path("./src/main.py") == "src/main.py"
 
     def test_unknown_absolute_path_unchanged(self):
         path = "/home/runner/work/FootballPrediction/FootballPrediction/src/main.py"
-        assert _normalize_path(path) == path
+        assert _normalize_path(path) == "src/main.py"
+
+    def test_current_repo_absolute_path_stripped(self):
+        path = Path.cwd() / "src" / "main.py"
+        assert _normalize_path(str(path)) == "src/main.py"
 
     def test_already_relative_test_path_unchanged(self):
         assert _normalize_path("tests/unit/foo.py") == "tests/unit/foo.py"
@@ -216,6 +238,20 @@ class TestClassifyDiagnosticsPathNormalization:
         new, existing = _classify_diagnostics(diags, changed)
         assert len(new) == 1
         assert len(existing) == 0
+
+    def test_unresolved_target_path_fallback_new(self):
+        diags = [
+            {
+                "filename": "src/main.py",
+                "location": {"row": 72, "column": 1},
+                "code": "no-untyped-def",
+                "message": "Function is missing a return type annotation",
+            }
+        ]
+        changed = {f"{_UNRESOLVED_CHANGED_LINE_PREFIX}src/main.py": set()}
+        new, existing = _classify_diagnostics(diags, changed)
+        assert len(new) == 1
+        assert existing == []
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +335,46 @@ class TestMypyChangedLineClassification:
         new, existing = _classify_diagnostics(diags, changed)
         assert len(new) == 1  # only line 247
         assert len(existing) == 2  # lines 160, 293
+
+    def test_1676_core_case_only_actual_changed_mypy_line_blocks(self):
+        diags = _parse_mypy_output(
+            """\
+src/main.py:72: error: Function is missing a return type annotation  [no-untyped-def]
+src/main.py:250: error: Missing type parameters for generic type "dict"  [type-arg]
+"""
+        )
+        changed = {"src/main.py": {250, 251}}
+        new, existing = _classify_diagnostics(diags, changed)
+        assert [(d["location"]["row"], d["code"]) for d in new] == [(250, "type-arg")]
+        assert [(d["location"]["row"], d["code"]) for d in existing] == [(72, "no-untyped-def")]
+
+    def test_1676_unchanged_mypy_line_only_does_not_block(self):
+        diags = _parse_mypy_output(
+            "src/main.py:72: error: Function is missing a return type annotation  [no-untyped-def]"
+        )
+        changed = {"src/main.py": {250, 251}}
+        new, existing = _classify_diagnostics(diags, changed)
+        assert new == []
+        assert len(existing) == 1
+
+    def test_repo_root_absolute_mypy_path_matches_changed_lines(self):
+        absolute_path = Path.cwd() / "src" / "main.py"
+        diags = _parse_mypy_output(
+            f'{absolute_path}:250: error: Missing type parameters for generic type "dict"  [type-arg]'
+        )
+        changed = {"src/main.py": {250, 251}}
+        new, existing = _classify_diagnostics(diags, changed)
+        assert len(new) == 1
+        assert existing == []
+
+    def test_only_test_file_changed_does_not_make_src_main_new(self):
+        diags = _parse_mypy_output(
+            "src/main.py:72: error: Function is missing a return type annotation  [no-untyped-def]"
+        )
+        changed = {"tests/unit/api/test_main_predict_contract.py": {91, 92}}
+        new, existing = _classify_diagnostics(diags, changed)
+        assert new == []
+        assert len(existing) == 1
 
     def test_docker_path_matches_normalized_changed(self):
         diags = _parse_mypy_output(MYPY_OUTPUT_DOCKER_PATHS)


### PR DESCRIPTION
## Summary

Fix a false-positive/cascade issue in the mypy changed-line gate introduced by #1679.

The gate should only block mypy diagnostics that are actually located on PR changed lines. Historical diagnostics elsewhere in the same file must remain warnings, not NEW blocking errors.

This PR tightens mypy diagnostic classification and adds focused tests for path normalization and changed-line matching.

## Scope

| Item | Value |
|---|---|
| Task type | workflow-governance |
| One task / one branch / one PR | yes |
| Purpose | Fix mypy changed-line false positives |
| Runtime behavior change | no |
| Business logic change | no |
| API behavior change | no |
| Docker change | no |
| DB schema / migration change | no |
| Secret / env change | no |
| Workflow file change | no |

## CI Gate Scope

| Item | Value |
|---|---|
| Gate affected | mypy changed-line classification only |
| Blocking behavior preserved | yes |
| NEW changed-line mypy errors block | yes |
| Unchanged historical mypy errors warn | yes |
| Ruff gate changed | no |
| Gatekeeper disabled or weakened | no |
| Workflow files changed | no |

## PR Authorization Matrix

| Item | Value |
|---|---|
| Task type | workflow-governance |
| Authorized paths | `scripts/devops/**`, `tests/unit/devops/**` |
| Mixed task authorization | no |
| High-risk categories present | yes: CI gate behavior |
| Requires Dangerous File Authorization | yes |

## Dangerous File Authorization

Authorized changes:

- Fix mypy changed-line classification.
- Ensure diagnostics outside actual changed lines are reported as EXISTING warnings.
- Preserve NEW blocking behavior for diagnostics on changed lines.
- Preserve fail-safe behavior when paths, lines, or diff base cannot be resolved.
- Add focused unit tests for the false-positive case.

Not authorized:

- No `src/**` changes.
- No #1676 branch changes.
- No API behavior changes.
- No predictor/model changes.
- No Docker changes.
- No DB or migration changes.
- No scraper/training/pipeline changes.
- No secret/env changes.
- No workflow file changes.
- No docs/_reports additions.
- No branch protection or workflow bypass changes.

## Diagnosis

#1676 exposed a false-positive/cascade issue after #1679:

- mypy diagnostics outside the PR's actual changed lines were classified as NEW/blocking.
- Subsequent attempts to fix #1676 expanded changed lines and caused more historical diagnostics to become blocking.
- The correct behavior is to warn on unchanged historical errors and block only changed-line errors.

## Behavior Preservation

- Mypy is not disabled.
- Ruff is not disabled.
- Gatekeeper is not disabled.
- Static quality standards are not relaxed.
- NEW mypy diagnostics on changed lines still block.
- Historical diagnostics outside changed lines remain visible as warnings.
- Fail-safe behavior remains conservative when classification inputs cannot be resolved.

## Files Changed

- `scripts/devops/static_quality_changed_lines.py`
- `tests/unit/devops/test_static_quality_changed_lines.py`

## Validation

- focused devops tests pass
- AST / UTF-8 passes
- ruff check passes
- ruff format passes

## Relationship to #1676

This PR does not modify #1676.

After this PR is merged and main CI is green, #1676 should be cleaned up or refreshed and re-run against the corrected gate.

## Documentation Impact

No source-of-truth documentation changed.

Reason: targeted gate fix covered by tests and PR body.

## Safety Impact

- No business source files changed.
- No Dockerfile or docker-compose file changed.
- No DB connection is made by the code change.
- No SQL is executed by the code change.
- No migration is created or run.
- No secret/env file is read or modified.
- No scraper/training/pipeline is executed by the code change.
- No project runtime service is started by the code change.

## No deletion / no move / no rename confirmation

Confirmed:

- No files deleted.
- No files moved.
- No files renamed.
- No legacy entrypoints deleted.
- No archive files changed.

## SC-002 status

SC-002 status: not applicable.

Reason: this PR changes CI changed-line classification only. It does not change data ingestion, DB schema, runtime API behavior, source inventory, raw acquisition, parser/features/training, or prediction behavior.

## Remaining risks

- This PR changes CI gate classification behavior, so the primary risk is under-classifying a genuinely changed-line mypy diagnostic.
- Mitigation: tests cover changed-line NEW blocking, unchanged-line EXISTING warning, `/app` and repo-root path normalization, unresolved diff/path fail-safe blocking, note-line parsing, test-only changed file isolation, and deleted-only hunks.
- Residual risk is limited to unusual mypy path formats not covered by current normalization; unknown absolute paths still fail-safe block.

## Report Lifecycle

No committed audit report is added.

Temporary reports are written to `/tmp` only.

## Debt Impact

| Item | Value |
|---|---|
| New files added | none |
| Permanent files | none |
| Phase-only files | none |
| Temporary helpers | none committed; `/tmp` reports only |
| Files superseded | none |
| Files deleted/archived | none |
| Cleanup needed later | no |
| Repository noise increased? | no |
| Next cleanup trigger | none |

## Rollback Plan

Revert this PR to restore the #1679 mypy changed-line classification behavior.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

1. Merge this PR if CI is green.
2. Wait for main CI green.
3. Restore #1676 to a clean minimal state if needed.
4. Re-run #1676 CI.
