### PR TITLE
feat: add FotMob envelope legacy adapter dry run

### DIFF
--- a/docs/data/fotmob_parser_output_envelope_legacy_adapter_dry_run.md
+++ b/docs/data/fotmob_parser_output_envelope_legacy_adapter_dry_run.md
@@ -1,0 +1,205 @@
+# FotMob Parser Output Envelope Legacy Adapter Dry Run
+
+- lifecycle: source-of-truth
+- scope: dry-run-only adapter implementation for DATA-L1E-2
+- parent documents: DATA-L1F-2B (`docs/data/fotmob_nextdata_thin_parsers_output_shape_audit.md`), DATA-L1E-1 (`src/parsers/fotmob/FotMobParserOutputEnvelope.js`)
+- branch: `feat/data-l1e-2-fotmob-envelope-legacy-adapter-dry-run`
+
+---
+
+## 1. 背景
+
+用户已接受 DATA-L1F-2B 推荐的 Boundary A：`NextDataParser.transformToApiFormat` 输出。
+
+本 PR 实现 DATA-L1E-2：一个 dry-run-only legacy adapter，把 `transformToApiFormat` 输出包装成 `FotMobParserOutputEnvelope` 兼容结构。
+
+**这不是 production integration。** Adapter 是纯函数，不接入 runtime，不修改 `NextDataParser`、`FotMobStrategy`、`FotMobRawDetailFetcher`、parser index exports、feature engine、training、backtest、DB、raw storage、scraper、collector、CI。
+
+---
+
+## 2. Adapter boundary
+
+| 维度 | 值 |
+| --- | --- |
+| **输入边界** | `NextDataParser.transformToApiFormat` 输出 `{ matchId, content, general, header, _meta }` |
+| **Adapter 文件** | `src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js` |
+| **测试文件** | `tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js` |
+| **文档文件** | `docs/data/fotmob_parser_output_envelope_legacy_adapter_dry_run.md` |
+| **依赖** | `FotMobParserOutputEnvelope.js`（使用其 constants、factory、validator） |
+| **不依赖** | NextDataParser（不 import、不调用 transformToApiFormat）、FotMobStrategy、FotMobRawDetailFetcher、feature engine、DB |
+
+---
+
+## 3. Mapping strategy
+
+### 3.1 matchId
+
+`transformOutput.matchId` → `envelope.match_id`（字符串形式）。作为 `metadata_only` / `audit_only` 字段进入 fields 数组——允许用于 join/filter，禁止作为模型特征。
+
+### 3.2 content / general / header
+
+整块进入 fields 数组，标记为 `raw_only` / `forbidden_raw_only`。这些是原始 pageProps 数据块，只能作为审计证据，不能直接作为模型特征。
+
+### 3.3 content.stats / content.shotmap / content.events / content.playerStats
+
+标记为 `postmatch` / `forbidden_postmatch`。这些是比赛中或比赛后才能产生的数据（xG/shots/possession/shotmap/events/playerStats），绝对禁止进入赛前模型。
+
+### 3.4 content.lineup / content.injury / content.odds / content.table / content.form
+
+标记为 `unknown_timing` / `forbidden_unknown_timing`。这些字段可能在赛前可知（如 lineup 在开赛前 1 小时公布），但没有 `observed_at`/`cutoff` 证据，第一版保守禁止。
+
+### 3.5 _meta 子字段
+
+`source` / `hasStats` / `hasLineup` / `hasShotmap` 逐个展平进入 fields 数组，标记为 `audit_only`。
+
+### 3.6 _meta.extractedAt
+
+作为 `audit_only` 字段始终保留，附带明确的 warning：
+- 如果 `captured_at` 或 `fetched_at` 存在：标注为补充审计证据
+- 如果两者都不存在：明确警告不要将 `extractedAt` 当作 `captured_at`/`fetched_at`
+
+### 3.7 payload metadata 缺失处理
+
+| 字段 | 预期来源 | 缺失时的值 | 处理原则 |
+| --- | --- | --- | --- |
+| `payload_type` | 硬编码 | `parser_input` | adapter 已知输入类型 |
+| `data_version` | FotMobRawDetailFetcher | `'unknown'`（未传 options 时）；`null`（显式传 null 时） | 不伪造 |
+| `payload_hash` | FotMobRawDetailFetcher | `null` | 不伪造 |
+| `storage_path` | FotMobRawDetailFetcher | `null` | 不伪造 |
+| `captured_at` | FotMobRawDetailFetcher | `null` | 不伪造；不从 `extractedAt` 冒充 |
+| `fetched_at` | FotMobRawDetailFetcher | `null` | 不伪造 |
+| `source_url` | FotMobRawDetailFetcher | `null` | adapter 没有 |
+| `final_url` | FotMobRawDetailFetcher | `null` | adapter 没有 |
+
+### 3.8 parser metadata
+
+| 字段 | 值 | 说明 |
+| --- | --- | --- |
+| `parser_name` | `NextDataParser.transformToApiFormat` | adapter 明确标注 parser 来源 |
+| `parser_version` | `legacy-static` | 标注这是静态 legacy 分析版本 |
+| `parsed_at` | `null` | 不伪造 parser 执行时间 |
+
+---
+
+## 4. Safety strategy
+
+### 4.1 分类优先级
+
+1. **postmatch 前缀匹配** → `forbidden_postmatch`（最高优先级）
+2. **unknown_timing 前缀匹配** → `forbidden_unknown_timing`
+3. **raw_only 前缀匹配** → `forbidden_raw_only`
+4. **默认** → `forbidden_unknown_timing`（保守兜底）
+
+### 4.2 明确 forbidden_postmatch 的字段
+
+```text
+content.stats          — 比赛统计数据（xG/shots/possession/corners/fouls 等）
+content.shotmap        — 射门图数据
+content.events         — 比赛事件时间线
+content.playerStats    — 球员评分/统计
+content.momentum       — 比赛动量数据
+content.matchFacts     — 比赛事实数据
+header.teams.score     — 比分（赛后才知道）
+header.status.scoreStr — 比分字符串
+header.status.winner   — 胜者
+header.status.result   — 比赛结果
+general.score/result/winner — 同上
+```
+
+这些字段全部标记：
+- `field_contract_class`: `unsafe_postmatch`
+- `timing_class`: `postmatch`
+- `model_eligibility`: `forbidden_postmatch`
+
+### 4.3 明确 forbidden_unknown_timing 的字段
+
+```text
+content.lineup        — lineup 时机不确定（可能赛前 1h 公告，也可能赛后更新）
+content.injury        — 伤病信息时机不确定
+content.odds          — 赔率数据时机不确定
+content.table         — 积分榜快照时机不确定
+content.form          — 近期战绩快照时机不确定
+content.standings     — 排名数据时机不确定
+```
+
+标记为：
+- `field_contract_class`: `unknown_timing`
+- `timing_class`: `unknown_timing`
+- `model_eligibility`: `forbidden_unknown_timing`
+
+### 4.4 第一版保守策略
+
+- **本 adapter 不产生任何 `ALLOWED_CANDIDATE` 或 `CANDIDATE_IF_CUTOFF_VALID` 标记。**
+- 所有看似赛前可知的字段（matchId、team name、match date）也被保守标记（`audit_only` 或 `forbidden_raw_only`）。
+- 目标不是最大化 safe fields，而是防止假 safe 泄漏。
+
+---
+
+## 5. What changed
+
+| 文件 | 操作 | 说明 |
+| --- | --- | --- |
+| `src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js` | 新增 | Dry-run adapter 纯函数模块 |
+| `tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js` | 新增 | 57 个单元测试 |
+| `docs/data/fotmob_parser_output_envelope_legacy_adapter_dry_run.md` | 新增 | 本文档 |
+
+---
+
+## 6. What did not change
+
+- 没有改 `NextDataParser.js`
+- 没有改 `FotMobStrategy.js`
+- 没有改 `FotMobRawDetailFetcher.js`
+- 没有改 `FotMobParserOutputEnvelope.js`
+- 没有改 `src/parsers/fotmob/index.js`
+- 没有接 runtime
+- 没有访问 FotMob 网络
+- 没有运行采集
+- 没有写 DB/raw/data
+- 没有改 feature/training/backtest
+
+---
+
+## 7. Test coverage
+
+| 测试类 | 测试数 | 覆盖内容 |
+| --- | --- | --- |
+| `classifyField` | 18 | 所有路径前缀匹配（postmatch/unknown/raw）、优先级、默认 fallback |
+| `flattenTransformOutputFields` | 12 | happy path 各区块、matchId、content 整块、stats/shotmap/lineup/events 标记、\_meta 展平、精简输入保守性 |
+| `adaptTransformToApiFormatOutputToEnvelope` | 27 | happy path envelope shape、payload/parser metadata 默认值、warnings、matchId 保留、安全标记验证、metadata 保留/不覆盖、options 覆盖、invalid input（null/undefined/空/字符串/数字/最小合法）、保守策略、schema validation（3 种场景）、data_version 处理 |
+
+全部 57 个测试通过。
+
+---
+
+## 8. Remaining gaps
+
+| gap | 说明 |
+| --- | --- |
+| 只验证 transformToApiFormat output | 没有证明真实 DB 中所有 raw_match_data 都能适配 |
+| 没有运行真实 parser | 测试使用手工构造的 fixture，不是真实 FotMob 数据 |
+| 没有确认 production scheduler | 不确定生产环境中哪个 scheduler/cron 实际调用 NextDataParser |
+| 没有确认 feature engine 消费 envelope | Feature engine 仍通过 SQL 直接读 raw_match_data，不 import adapter |
+| 没有生成 safe_prematch 白名单 | 第一版全部保守标记，没有字段被放行 |
+| 没有 field-level flatten | 只有顶层和高风险区块展平，嵌套字段未深度展开 |
+| metadata 主要来自 options | adapter 本身不查询 FotMobRawDetailFetcher 或 DB 来补 metadata |
+
+---
+
+## 9. Next recommended task
+
+推荐：
+
+```text
+DATA-L1E-3: Fixture-Based Envelope Dry-Run Evidence
+```
+
+DATA-L1E-3 应该：
+1. 使用真实 transformToApiFormat 输出的 snapshot fixture（从已审计的文档或测试中提取）。
+2. 验证 adapter 对真实 FotMob 数据结构的兼容性。
+3. 确认 envelope 是否足够支持后续字段级合同校验。
+4. 仍然 dry-run——不接 runtime、不写 DB。
+
+**Do not start automatically.**
+
+**Recommended next task only after user confirmation.**

--- a/src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js
+++ b/src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js
@@ -1,0 +1,362 @@
+/**
+ * FotMobParserOutputEnvelopeLegacyAdapter — Dry-Run Legacy Adapter
+ * ===============================================================
+ *
+ * 将 NextDataParser.transformToApiFormat 输出包装为 FotMobParserOutputEnvelope。
+ *
+ * 纯函数模块：无网络、无 DB、无文件 I/O、无副作用。
+ * 不 import NextDataParser，不运行 transformToApiFormat。
+ * 只接受已生成好的 transformToApiFormat output object。
+ *
+ * Boundary: NextDataParser.transformToApiFormat output (Boundary A from DATA-L1F-2B)
+ *
+ * Parent docs:
+ *   - DATA-L1E: FotMob parser output envelope implementation plan
+ *   - DATA-L1E-1: FotMobParserOutputEnvelope schema (PR #1699)
+ *   - DATA-L1F-2B: NextDataParser + thin parsers output shape audit (PR #1703)
+ *
+ * lifecycle: permanent
+ * @module parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter
+ */
+
+'use strict';
+
+const {
+    FIELD_CONTRACT_CLASSES,
+    TIMING_CLASSES,
+    MODEL_ELIGIBILITY,
+    PAYLOAD_TYPES,
+    createEmptyEnvelope,
+    createFieldEntry,
+} = require('./FotMobParserOutputEnvelope');
+
+// ===========================================================================
+// 字段路径分类规则
+// ===========================================================================
+
+const POSTMATCH_PATH_PREFIXES = Object.freeze([
+    'content.stats',
+    'content.shotmap',
+    'content.events',
+    'content.playerStats',
+    'content.momentum',
+    'content.matchFacts',
+    'header.teams.score',
+    'header.status.scoreStr',
+    'header.status.winner',
+    'header.status.result',
+    'general.score',
+    'general.result',
+    'general.winner',
+]);
+
+const UNKNOWN_TIMING_PATH_PREFIXES = Object.freeze([
+    'content.lineup',
+    'content.injury',
+    'content.injuries',
+    'content.odds',
+    'content.table',
+    'content.form',
+    'content.standings',
+    'general.leagueTable',
+    'general.standings',
+    'general.form',
+]);
+
+const RAW_ONLY_PATH_PREFIXES = Object.freeze([
+    'content',
+    'content.',
+    'general',
+    'general.',
+    'header',
+    'header.',
+    '_meta',
+    '_meta.',
+    '__NEXT_DATA__',
+    'pageProps',
+    'raw',
+]);
+
+// ===========================================================================
+// 字段分类辅助函数
+// ===========================================================================
+
+function _matchPath(prefixes, fieldPath) {
+    for (const prefix of prefixes) {
+        if (fieldPath === prefix || fieldPath.startsWith(prefix + '.') || fieldPath.startsWith(prefix + '[')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _matchPathPrefixOnly(prefixes, fieldPath) {
+    for (const prefix of prefixes) {
+        if (fieldPath === prefix || fieldPath.startsWith(prefix)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * 根据字段路径和值，保守分类字段的 timing 和 eligibility。
+ * 分类优先级：postmatch → unknown_timing → raw_only → default(unknown)
+ */
+function classifyField(fieldPath, value, context = {}) {
+    if (_matchPath(POSTMATCH_PATH_PREFIXES, fieldPath)) {
+        return {
+            timingClass: TIMING_CLASSES.POSTMATCH,
+            modelEligibility: MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH,
+            contractClass: FIELD_CONTRACT_CLASSES.UNSAFE_POSTMATCH,
+        };
+    }
+    if (_matchPath(UNKNOWN_TIMING_PATH_PREFIXES, fieldPath)) {
+        return {
+            timingClass: TIMING_CLASSES.UNKNOWN_TIMING,
+            modelEligibility: MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING,
+            contractClass: FIELD_CONTRACT_CLASSES.UNKNOWN_TIMING,
+        };
+    }
+    if (_matchPathPrefixOnly(RAW_ONLY_PATH_PREFIXES, fieldPath)) {
+        return {
+            timingClass: TIMING_CLASSES.RAW_ONLY,
+            modelEligibility: MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY,
+            contractClass: FIELD_CONTRACT_CLASSES.DEBUG_OR_RAW_ONLY,
+        };
+    }
+    return {
+        timingClass: TIMING_CLASSES.UNKNOWN_TIMING,
+        modelEligibility: MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING,
+        contractClass: FIELD_CONTRACT_CLASSES.UNKNOWN_TIMING,
+    };
+}
+
+// ===========================================================================
+// field entry 构建辅助
+// ===========================================================================
+
+function _addMatchIdField(fields, transformOutput) {
+    if (transformOutput.matchId !== undefined && transformOutput.matchId !== null) {
+        fields.push(createFieldEntry({
+            name: 'matchId',
+            value: String(transformOutput.matchId),
+            field_path: 'matchId',
+            field_contract_class: FIELD_CONTRACT_CLASSES.METADATA_ONLY,
+            timing_class: TIMING_CLASSES.FIXTURE_METADATA,
+            model_eligibility: MODEL_ELIGIBILITY.AUDIT_ONLY,
+            warnings: ['matchId is metadata_only — allowed for join/filter, forbidden as feature'],
+        }));
+    }
+}
+
+function _addRawBlockField(fields, blockName, value, warning) {
+    if (value !== undefined && value !== null) {
+        fields.push(createFieldEntry({
+            name: blockName,
+            value,
+            field_path: blockName,
+            field_contract_class: FIELD_CONTRACT_CLASSES.DEBUG_OR_RAW_ONLY,
+            timing_class: TIMING_CLASSES.RAW_ONLY,
+            model_eligibility: MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY,
+            warnings: [warning],
+        }));
+    }
+}
+
+function _addClassifiedContentField(fields, fieldPath, value, warnings) {
+    const classification = classifyField(fieldPath, value);
+    fields.push(createFieldEntry({
+        name: fieldPath,
+        value,
+        field_path: fieldPath,
+        field_contract_class: classification.contractClass,
+        timing_class: classification.timingClass,
+        model_eligibility: classification.modelEligibility,
+        warnings,
+    }));
+}
+
+function _addMetaFields(fields, _meta) {
+    const metaSubFields = ['source', 'hasStats', 'hasLineup', 'hasShotmap'];
+    for (const key of metaSubFields) {
+        if (_meta[key] !== undefined && _meta[key] !== null) {
+            fields.push(createFieldEntry({
+                name: `_meta.${key}`,
+                value: _meta[key],
+                field_path: `_meta.${key}`,
+                field_contract_class: FIELD_CONTRACT_CLASSES.DEBUG_OR_RAW_ONLY,
+                timing_class: TIMING_CLASSES.RAW_ONLY,
+                model_eligibility: MODEL_ELIGIBILITY.AUDIT_ONLY,
+                warnings: ['_meta field — audit/evidence only, not a model feature'],
+            }));
+        }
+    }
+}
+
+// ===========================================================================
+// 字段 flatten
+// ===========================================================================
+
+function _addContentSubFields(fields, content, _meta) {
+    const subFields = [
+        { key: 'hasStats', path: 'content.stats',
+            warnings: ['postmatch match statistics (xG, shots, possession, corners, fouls, etc.)', 'forbidden from entering prematch model'] },
+        { key: 'hasShotmap', path: 'content.shotmap',
+            warnings: ['postmatch shotmap data — forbidden from entering prematch model'] },
+        { key: 'hasLineup', path: 'content.lineup',
+            warnings: ['lineup timing unknown — may be prematch or postmatch', 'forbidden without observed_at and cutoff evidence'] },
+    ];
+
+    // extra sub-fields not gated by _meta flags
+    const extraSubFields = [
+        { condition: content && content.events, path: 'content.events',
+            warnings: ['match events/timeline — postmatch data'] },
+    ];
+
+    for (const sf of subFields) {
+        if (_meta[sf.key] || (content && content[sf.path.split('.')[1]])) {
+            const value = (content && content[sf.path.split('.')[1]]) || null;
+            _addClassifiedContentField(fields, sf.path, value, sf.warnings);
+        }
+    }
+    for (const sf of extraSubFields) {
+        if (sf.condition) {
+            const fieldKey = sf.path.split('.')[1];
+            _addClassifiedContentField(fields, sf.path, content[fieldKey], sf.warnings);
+        }
+    }
+}
+
+function flattenTransformOutputFields(transformOutput) {
+    const fields = [];
+    const _meta = transformOutput._meta || {};
+    const content = transformOutput.content;
+
+    _addMatchIdField(fields, transformOutput);
+    _addRawBlockField(fields, 'content', content, 'content is raw pageProps content — use as evidence only, not as model feature');
+    _addContentSubFields(fields, content, _meta);
+    _addRawBlockField(fields, 'general', transformOutput.general, 'general is raw pageProps data — use as evidence only');
+    _addRawBlockField(fields, 'header', transformOutput.header, 'header is raw pageProps data — use as evidence only');
+    _addMetaFields(fields, _meta);
+
+    return fields;
+}
+
+// ===========================================================================
+// envelope metadata 构建辅助
+// ===========================================================================
+
+function _validateInput(transformOutput) {
+    if (!transformOutput || typeof transformOutput !== 'object') {
+        throw new Error(
+            'adaptTransformToApiFormatOutputToEnvelope: transformOutput must be a non-null object, ' +
+            `received ${transformOutput === null ? 'null' : typeof transformOutput}`
+        );
+    }
+    if (transformOutput.matchId === undefined || transformOutput.matchId === null) {
+        throw new Error(
+            'adaptTransformToApiFormatOutputToEnvelope: transformOutput.matchId is required, ' +
+            `received ${JSON.stringify(transformOutput.matchId)}`
+        );
+    }
+}
+
+function _buildPayloadMeta(safeOpts) {
+    return {
+        payload_type: PAYLOAD_TYPES.PARSER_INPUT,
+        payload_hash: safeOpts.payloadHash !== undefined ? safeOpts.payloadHash : null,
+        captured_at: safeOpts.capturedAt !== undefined ? safeOpts.capturedAt : null,
+        data_version: safeOpts.dataVersion !== undefined
+            ? (safeOpts.dataVersion === null ? null : String(safeOpts.dataVersion))
+            : 'unknown',
+        storage_path: safeOpts.storagePath !== undefined ? safeOpts.storagePath : null,
+        source_url: null,
+        final_url: null,
+    };
+}
+
+function _buildEnvelopeWarnings(dataVersion, payloadHash, capturedAt, fetchedAt) {
+    const warnings = [];
+    if (dataVersion === 'unknown') {
+        warnings.push('payload.data_version is unknown — canonical version not confirmed in this payload');
+    }
+    if (payloadHash === null) {
+        warnings.push('payload.payload_hash is null — hash not computed at adapter level');
+    }
+    if (capturedAt === null && fetchedAt === null) {
+        warnings.push(
+            'payload.captured_at and fetched_at are both null — ' +
+            'transformOutput._meta.extractedAt exists but is not equivalent to captured_at/fetched_at'
+        );
+    }
+    return warnings;
+}
+
+function _addExtractedAtField(envelope, legacyExtractedAt, capturedAt, fetchedAt) {
+    if (!legacyExtractedAt) return;
+    const extractedWarnings = [
+        'legacy extractedAt from NextDataParser._meta — this is parser execution time, not data capture time',
+    ];
+    if (capturedAt !== null || fetchedAt !== null) {
+        extractedWarnings.push('captured_at or fetched_at is present — extractedAt is retained as supplementary audit evidence only');
+    } else {
+        extractedWarnings.push('null is acceptable for missing capture metadata — do not use extractedAt as captured_at');
+    }
+    envelope.fields.push(createFieldEntry({
+        name: '_meta.extractedAt',
+        value: legacyExtractedAt,
+        field_path: '_meta.extractedAt',
+        field_contract_class: FIELD_CONTRACT_CLASSES.DEBUG_OR_RAW_ONLY,
+        timing_class: TIMING_CLASSES.RAW_ONLY,
+        model_eligibility: MODEL_ELIGIBILITY.AUDIT_ONLY,
+        warnings: extractedWarnings,
+    }));
+}
+
+// ===========================================================================
+// 主入口
+// ===========================================================================
+
+function adaptTransformToApiFormatOutputToEnvelope(transformOutput, options = {}) {
+    _validateInput(transformOutput);
+
+    const safeOpts = options && typeof options === 'object' ? options : {};
+    const payloadMeta = _buildPayloadMeta(safeOpts);
+    const envelopeWarnings = _buildEnvelopeWarnings(
+        payloadMeta.data_version, payloadMeta.payload_hash, payloadMeta.captured_at,
+        safeOpts.fetchedAt !== undefined ? safeOpts.fetchedAt : null
+    );
+
+    const legacyExtractedAt = transformOutput._meta && transformOutput._meta.extractedAt
+        ? String(transformOutput._meta.extractedAt)
+        : null;
+
+    const envelope = createEmptyEnvelope({
+        match_id: String(transformOutput.matchId),
+        source: safeOpts.source || 'fotmob',
+        payload: payloadMeta,
+        parser: {
+            parser_name: safeOpts.parserName || 'NextDataParser.transformToApiFormat',
+            parser_version: safeOpts.parserVersion || 'legacy-static',
+            parsed_at: safeOpts.parsedAt !== undefined ? safeOpts.parsedAt : null,
+        },
+        warnings: envelopeWarnings,
+    });
+
+    envelope.fields = flattenTransformOutputFields(transformOutput);
+    _addExtractedAtField(envelope, legacyExtractedAt, payloadMeta.captured_at,
+        safeOpts.fetchedAt !== undefined ? safeOpts.fetchedAt : null);
+
+    return envelope;
+}
+
+// ===========================================================================
+// 导出
+// ===========================================================================
+
+module.exports = {
+    adaptTransformToApiFormatOutputToEnvelope,
+    classifyField,
+    flattenTransformOutputFields,
+};

--- a/tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js
+++ b/tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js
@@ -1,0 +1,583 @@
+/**
+ * FotMobParserOutputEnvelopeLegacyAdapter 单元测试
+ * ===============================================
+ *
+ * 测试 dry-run adapter 的 field 分类、metadata 映射、invalid input 处理和 envelope shape。
+ * 纯静态测试：不访问网络、文件、DB、FotMob parser runtime。
+ *
+ * lifecycle: permanent
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    adaptTransformToApiFormatOutputToEnvelope,
+    classifyField,
+    flattenTransformOutputFields,
+} = require('../../../../src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter');
+
+const {
+    MODEL_ELIGIBILITY,
+    TIMING_CLASSES,
+    FIELD_CONTRACT_CLASSES,
+    validateEnvelopeShape,
+    isForbidden,
+} = require('../../../../src/parsers/fotmob/FotMobParserOutputEnvelope');
+
+// ===========================================================================
+// Fixtures
+// ===========================================================================
+
+/**
+ * 标准 happy-path transformToApiFormat 输出。
+ */
+const HAPPY_PATH_TRANSFORM_OUTPUT = Object.freeze({
+    matchId: '4193673',
+    content: {
+        stats: {
+            expectedGoals: { home: 1.2, away: 0.8 },
+            shots: { home: 10, away: 8 },
+            Periods: { All: { stats: [] } },
+        },
+        lineup: {
+            home: { starters: [{ id: 1, name: 'Player A' }], bench: [] },
+            away: { starters: [{ id: 2, name: 'Player B' }], bench: [] },
+        },
+        shotmap: [{ id: 1, xG: 0.2 }, { id: 2, xG: 0.1 }],
+        events: [{ id: 1, type: 'Goal', minute: 23 }],
+    },
+    general: {
+        homeTeam: { id: 1, name: 'Home FC' },
+        awayTeam: { id: 2, name: 'Away FC' },
+        matchTimeUTC: '2026-07-04T12:00:00Z',
+    },
+    header: {
+        status: { utcTime: '2026-07-04T12:00:00Z', scoreStr: '2-1' },
+        teams: [
+            { name: 'Home FC', score: 2 },
+            { name: 'Away FC', score: 1 },
+        ],
+    },
+    _meta: {
+        source: 'web_infiltration',
+        extractedAt: '2026-07-04T00:00:00.000Z',
+        hasStats: true,
+        hasLineup: true,
+        hasShotmap: true,
+    },
+});
+
+/**
+ * 精简 transformToApiFormat 输出（无 content 数据）。
+ */
+const MINIMAL_TRANSFORM_OUTPUT = Object.freeze({
+    matchId: '1',
+    general: { homeTeam: { name: 'A' }, awayTeam: { name: 'B' } },
+    header: { status: { utcTime: '2026-07-04T12:00:00Z' } },
+    content: {},
+    _meta: { source: 'web_infiltration' },
+});
+
+// ===========================================================================
+// classifyField 测试
+// ===========================================================================
+
+describe('classifyField', () => {
+    test('content.stats 应标记为 forbidden_postmatch', () => {
+        const result = classifyField('content.stats', { some: 'data' });
+        assert.equal(result.timingClass, TIMING_CLASSES.POSTMATCH);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+        assert.equal(result.contractClass, FIELD_CONTRACT_CLASSES.UNSAFE_POSTMATCH);
+    });
+
+    test('content.stats.expectedGoals 应标记为 forbidden_postmatch（前缀匹配）', () => {
+        const result = classifyField('content.stats.expectedGoals', { home: 1.2 });
+        assert.equal(result.timingClass, TIMING_CLASSES.POSTMATCH);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('content.shotmap 应标记为 forbidden_postmatch', () => {
+        const result = classifyField('content.shotmap', []);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('content.shotmap[0].xG 应标记为 forbidden_postmatch（前缀匹配）', () => {
+        const result = classifyField('content.shotmap[0].xG', 0.2);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('content.events 应标记为 forbidden_postmatch', () => {
+        const result = classifyField('content.events', []);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('content.playerStats 应标记为 forbidden_postmatch', () => {
+        const result = classifyField('content.playerStats', {});
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('content.lineup 应标记为 forbidden_unknown_timing', () => {
+        const result = classifyField('content.lineup', { home: [] });
+        assert.equal(result.timingClass, TIMING_CLASSES.UNKNOWN_TIMING);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+        assert.equal(result.contractClass, FIELD_CONTRACT_CLASSES.UNKNOWN_TIMING);
+    });
+
+    test('content.injury 应标记为 forbidden_unknown_timing', () => {
+        const result = classifyField('content.injury', []);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+
+    test('content.odds 应标记为 forbidden_unknown_timing', () => {
+        const result = classifyField('content.odds', {});
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+
+    test('content.form 应标记为 forbidden_unknown_timing', () => {
+        const result = classifyField('content.form', []);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+
+    test('content.table 应标记为 forbidden_unknown_timing', () => {
+        const result = classifyField('content.table', []);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+
+    test('general 应标记为 forbidden_raw_only', () => {
+        const result = classifyField('general', {});
+        assert.equal(result.timingClass, TIMING_CLASSES.RAW_ONLY);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY);
+    });
+
+    test('header 应标记为 forbidden_raw_only', () => {
+        const result = classifyField('header', {});
+        assert.equal(result.timingClass, TIMING_CLASSES.RAW_ONLY);
+    });
+
+    test('content 应标记为 forbidden_raw_only', () => {
+        const result = classifyField('content', {});
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY);
+    });
+
+    test('_meta.source 应标记为 forbidden_raw_only（前缀匹配）', () => {
+        const result = classifyField('_meta.source', 'web_infiltration');
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY);
+    });
+
+    test('未见已知前缀的路径应默认为 forbidden_unknown_timing', () => {
+        const result = classifyField('unknown.custom.field', 'value');
+        assert.equal(result.timingClass, TIMING_CLASSES.UNKNOWN_TIMING);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+
+    test('postmatch 前缀优先级高于 raw_only（content.stats 匹配 postmatch 而非 raw content）', () => {
+        const result = classifyField('content.stats.shots', { home: 10 });
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('unknown_timing 前缀优先级高于 raw_only（content.lineup 匹配 unknown_timing 而非 raw content）', () => {
+        const result = classifyField('content.lineup.home', []);
+        assert.equal(result.modelEligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+});
+
+// ===========================================================================
+// flattenTransformOutputFields 测试
+// ===========================================================================
+
+describe('flattenTransformOutputFields', () => {
+    test('happy path: 应产生 field entries 数组', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        assert.ok(Array.isArray(fields));
+        assert.ok(fields.length > 0, `expected non-empty fields array, got ${fields.length}`);
+    });
+
+    test('happy path: matchId 字段应存在且标记为 audit_only', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const matchIdEntry = fields.find(f => f.field_path === 'matchId');
+        assert.ok(matchIdEntry, 'matchId entry not found');
+        assert.equal(matchIdEntry.value, '4193673');
+        assert.equal(matchIdEntry.model_eligibility, MODEL_ELIGIBILITY.AUDIT_ONLY);
+    });
+
+    test('happy path: content.stats 应存在且标记为 forbidden_postmatch', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const statsEntry = fields.find(f => f.field_path === 'content.stats');
+        assert.ok(statsEntry, 'content.stats entry not found');
+        assert.equal(statsEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('happy path: content.shotmap 应存在且标记为 forbidden_postmatch', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const shotmapEntry = fields.find(f => f.field_path === 'content.shotmap');
+        assert.ok(shotmapEntry, 'content.shotmap entry not found');
+        assert.equal(shotmapEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('happy path: content.lineup 应存在且标记为 forbidden_unknown_timing', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const lineupEntry = fields.find(f => f.field_path === 'content.lineup');
+        assert.ok(lineupEntry, 'content.lineup entry not found');
+        assert.equal(lineupEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+
+    test('happy path: content.events 应存在且标记为 forbidden_postmatch', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const eventsEntry = fields.find(f => f.field_path === 'content.events');
+        assert.ok(eventsEntry, 'content.events entry not found');
+        assert.equal(eventsEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH);
+    });
+
+    test('happy path: content 整块应标记为 forbidden_raw_only', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const contentEntry = fields.find(f => f.field_path === 'content');
+        assert.ok(contentEntry, 'content entry not found');
+        assert.equal(contentEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY);
+    });
+
+    test('happy path: general 整块应标记为 forbidden_raw_only', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const generalEntry = fields.find(f => f.field_path === 'general');
+        assert.ok(generalEntry, 'general entry not found');
+        assert.equal(generalEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY);
+    });
+
+    test('happy path: header 整块应标记为 forbidden_raw_only', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const headerEntry = fields.find(f => f.field_path === 'header');
+        assert.ok(headerEntry, 'header entry not found');
+        assert.equal(headerEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_RAW_ONLY);
+    });
+
+    test('happy path: _meta 子字段应逐个展平且标记为 audit_only', () => {
+        const fields = flattenTransformOutputFields(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const metaSource = fields.find(f => f.field_path === '_meta.source');
+        assert.ok(metaSource, '_meta.source entry not found');
+        assert.equal(metaSource.value, 'web_infiltration');
+        assert.equal(metaSource.model_eligibility, MODEL_ELIGIBILITY.AUDIT_ONLY);
+
+        const metaHasStats = fields.find(f => f.field_path === '_meta.hasStats');
+        assert.ok(metaHasStats, '_meta.hasStats entry not found');
+        assert.equal(metaHasStats.value, true);
+
+        const metaHasLineup = fields.find(f => f.field_path === '_meta.hasLineup');
+        assert.ok(metaHasLineup, '_meta.hasLineup entry not found');
+        assert.equal(metaHasLineup.value, true);
+
+        const metaHasShotmap = fields.find(f => f.field_path === '_meta.hasShotmap');
+        assert.ok(metaHasShotmap, '_meta.hasShotmap entry not found');
+        assert.equal(metaHasShotmap.value, true);
+    });
+
+    test('minimal: 精简输入不产生 safe_prematch field', () => {
+        const fields = flattenTransformOutputFields(MINIMAL_TRANSFORM_OUTPUT);
+        for (const f of fields) {
+            assert.notEqual(
+                f.model_eligibility,
+                MODEL_ELIGIBILITY.ALLOWED_CANDIDATE,
+                `field ${f.field_path} should not be ALLOWED_CANDIDATE in minimal input`
+            );
+            assert.notEqual(
+                f.model_eligibility,
+                MODEL_ELIGIBILITY.CANDIDATE_IF_CUTOFF_VALID,
+                `field ${f.field_path} should not be CANDIDATE_IF_CUTOFF_VALID in minimal input`
+            );
+        }
+    });
+
+    test('minimal: 所有非 metadata/audit field 应被 isForbidden 判定为 forbidden', () => {
+        const fields = flattenTransformOutputFields(MINIMAL_TRANSFORM_OUTPUT);
+        for (const f of fields) {
+            // audit_only fields (matchId, _meta.*) 不是 forbidden——它们是审计追踪字段
+            if (f.model_eligibility === MODEL_ELIGIBILITY.AUDIT_ONLY) {
+                continue;
+            }
+            assert.ok(isForbidden(f), `field ${f.field_path} with eligibility "${f.model_eligibility}" should be forbidden in minimal input`);
+        }
+    });
+});
+
+// ===========================================================================
+// adaptTransformToApiFormatOutputToEnvelope 测试
+// ===========================================================================
+
+describe('adaptTransformToApiFormatOutputToEnvelope', () => {
+    // --- happy path ---
+
+    test('happy path: 应返回 envelope-compatible 对象', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+
+        // 必须通过 schema validation
+        const validation = validateEnvelopeShape(envelope);
+        assert.ok(validation.valid, `envelope should pass shape validation: ${validation.errors.join('; ')}`);
+
+        // 核心字段检查
+        assert.equal(envelope.match_id, '4193673');
+        assert.equal(envelope.source, 'fotmob');
+        assert.ok(Array.isArray(envelope.fields));
+        assert.ok(envelope.fields.length > 0);
+    });
+
+    test('happy path: payload metadata 默认值', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+
+        assert.equal(envelope.payload.payload_type, 'parser_input');
+        assert.equal(envelope.payload.data_version, 'unknown');
+        assert.equal(envelope.payload.payload_hash, null);
+        assert.equal(envelope.payload.storage_path, null);
+        assert.equal(envelope.payload.captured_at, null);
+        assert.equal(envelope.payload.source_url, null);
+        assert.equal(envelope.payload.final_url, null);
+    });
+
+    test('happy path: parser metadata 默认值', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+
+        assert.equal(envelope.parser.parser_name, 'NextDataParser.transformToApiFormat');
+        assert.equal(envelope.parser.parser_version, 'legacy-static');
+        assert.equal(envelope.parser.parsed_at, null);
+    });
+
+    test('happy path: warnings 应反映 metadata 缺失', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+
+        assert.ok(Array.isArray(envelope.warnings));
+        const hasVersionWarning = envelope.warnings.some(w => w.includes('data_version is unknown'));
+        assert.ok(hasVersionWarning, 'should warn about unknown data_version');
+
+        const hasHashWarning = envelope.warnings.some(w => w.includes('payload_hash is null'));
+        assert.ok(hasHashWarning, 'should warn about null payload_hash');
+    });
+
+    test('happy path: matchId 被正确保留', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+        assert.equal(envelope.match_id, '4193673');
+    });
+
+    test('happy path: 不应产生任何 ALLOWED_CANDIDATE field（保守策略）', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+        for (const f of envelope.fields) {
+            assert.notEqual(
+                f.model_eligibility,
+                MODEL_ELIGIBILITY.ALLOWED_CANDIDATE,
+                `field ${f.field_path} should not be ALLOWED_CANDIDATE — dry-run is conservative`
+            );
+        }
+    });
+
+    test('happy path: content.stats / content.shotmap / content.events 均标记 forbidden_postmatch', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const riskyFields = ['content.stats', 'content.shotmap', 'content.events'];
+        for (const path of riskyFields) {
+            const entry = envelope.fields.find(f => f.field_path === path);
+            assert.ok(entry, `${path} entry should exist`);
+            assert.equal(
+                entry.model_eligibility,
+                MODEL_ELIGIBILITY.FORBIDDEN_POSTMATCH,
+                `${path} should be FORBIDDEN_POSTMATCH`
+            );
+        }
+    });
+
+    test('happy path: content.lineup 标记 forbidden_unknown_timing', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const lineupEntry = envelope.fields.find(f => f.field_path === 'content.lineup');
+        assert.ok(lineupEntry);
+        assert.equal(lineupEntry.model_eligibility, MODEL_ELIGIBILITY.FORBIDDEN_UNKNOWN_TIMING);
+    });
+
+    // --- metadata preservation ---
+
+    test('metadata: options 传入的 dataVersion / payloadHash / fetchedAt 应被正确保留', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            dataVersion: 'fotmob_html_hyd_v1',
+            payloadHash: 'abc123',
+            storagePath: null,
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+        });
+
+        assert.equal(envelope.payload.data_version, 'fotmob_html_hyd_v1');
+        assert.equal(envelope.payload.payload_hash, 'abc123');
+        assert.equal(envelope.payload.storage_path, null);
+        assert.equal(envelope.payload.captured_at, null);
+        // fetchedAt 不是 envelope schema 标准字段——它不在 payload 块中。
+        // adapter 通过 captured_at 承载采集时间，fetchedAt 应映射到 captured_at。
+        // 但按照当前设计，fetchedAt 和 capturedAt 是独立字段。
+        // 如果 options 传了 fetchedAt 但没传 capturedAt，captured_at 仍为 null。
+        // 这是设计决定：不自动映射 fetchedAt → captured_at，避免语义混淆。
+    });
+
+    test('metadata: transformOutput._meta.extractedAt 不覆盖 captured_at', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            capturedAt: '2026-07-04T02:00:00.000Z',
+        });
+
+        assert.equal(envelope.payload.captured_at, '2026-07-04T02:00:00.000Z');
+
+        // _meta.extractedAt 应作为 audit-only field 存在
+        const extractedEntry = envelope.fields.find(f => f.field_path === '_meta.extractedAt');
+        assert.ok(extractedEntry, '_meta.extractedAt audit field should exist');
+        assert.equal(extractedEntry.model_eligibility, MODEL_ELIGIBILITY.AUDIT_ONLY);
+    });
+
+    test('metadata: 当 captured_at 存在时，_meta.extractedAt 仍需存在作为补充审计证据', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            capturedAt: '2026-07-04T02:00:00.000Z',
+        });
+        // extractedAt 应该作为 audit_only field 保留（不是冒充 captured_at，而是补充证据）
+        const extractedEntry = envelope.fields.find(f => f.field_path === '_meta.extractedAt');
+        assert.ok(extractedEntry, '_meta.extractedAt audit field should exist alongside captured_at');
+        assert.equal(extractedEntry.model_eligibility, MODEL_ELIGIBILITY.AUDIT_ONLY);
+        assert.ok(
+            extractedEntry.warnings.some(w => w.includes('captured_at or fetched_at is present')),
+            'should warn that extractedAt is supplementary when captured_at exists'
+        );
+    });
+
+    // --- options 覆盖 ---
+
+    test('options: parserName / parserVersion / source 可被覆盖', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            parserName: 'CustomParser',
+            parserVersion: 'v2.0',
+            source: 'fotmob_test',
+        });
+
+        assert.equal(envelope.parser.parser_name, 'CustomParser');
+        assert.equal(envelope.parser.parser_version, 'v2.0');
+        assert.equal(envelope.source, 'fotmob_test');
+    });
+
+    test('options: parsedAt 不应该被伪造——明确传 null 时应为 null', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            parsedAt: null,
+        });
+        assert.equal(envelope.parser.parsed_at, null);
+    });
+
+    // --- invalid input ---
+
+    test('invalid: null 输入应抛出明确的 validation error', () => {
+        assert.throws(
+            () => adaptTransformToApiFormatOutputToEnvelope(null),
+            /transformOutput must be a non-null object/
+        );
+    });
+
+    test('invalid: undefined 输入应抛出明确的 validation error', () => {
+        assert.throws(
+            () => adaptTransformToApiFormatOutputToEnvelope(undefined),
+            /transformOutput must be a non-null object/
+        );
+    });
+
+    test('invalid: 空对象（无 matchId）应抛出明确的 validation error', () => {
+        assert.throws(
+            () => adaptTransformToApiFormatOutputToEnvelope({}),
+            /matchId is required/
+        );
+    });
+
+    test('invalid: { matchId: "1" } 但无其他字段应能成功（最少合法输入）', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope({ matchId: '1' });
+        const validation = validateEnvelopeShape(envelope);
+        assert.ok(validation.valid, `minimal envelope should pass: ${validation.errors.join('; ')}`);
+        assert.equal(envelope.match_id, '1');
+        // fields 数组可能只包含 matchId entry
+        assert.ok(Array.isArray(envelope.fields));
+    });
+
+    test('invalid: 字符串输入应抛出 error（非对象）', () => {
+        assert.throws(
+            () => adaptTransformToApiFormatOutputToEnvelope('not_an_object'),
+            /transformOutput must be a non-null object/
+        );
+    });
+
+    test('invalid: 数字输入应抛出 error（非对象）', () => {
+        assert.throws(
+            () => adaptTransformToApiFormatOutputToEnvelope(42),
+            /transformOutput must be a non-null object/
+        );
+    });
+
+    // --- conservative unknown timing ---
+
+    test('conservative: 精简输入不产生任何 safe_prematch 标记', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(MINIMAL_TRANSFORM_OUTPUT);
+
+        for (const f of envelope.fields) {
+            const allowed = f.model_eligibility === MODEL_ELIGIBILITY.ALLOWED_CANDIDATE;
+            assert.ok(!allowed, `field "${f.field_path}" must not be ALLOWED_CANDIDATE in dry-run`);
+        }
+    });
+
+    test('conservative: 所有非 audit 的 field 应被 isForbidden 判定为 forbidden', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(MINIMAL_TRANSFORM_OUTPUT);
+
+        for (const f of envelope.fields) {
+            // audit_only fields (matchId, _meta.*) 是审计追踪字段，不是 forbidden
+            if (f.model_eligibility === MODEL_ELIGIBILITY.AUDIT_ONLY) {
+                continue;
+            }
+            assert.ok(
+                isForbidden(f),
+                `field "${f.field_path}" with eligibility "${f.model_eligibility}" should be forbidden`
+            );
+        }
+    });
+
+    // --- schema validation ---
+
+    test('schema: happy path envelope 通过 validateEnvelopeShape', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+        const validation = validateEnvelopeShape(envelope);
+        assert.ok(validation.valid, `validation errors: ${validation.errors.join('; ')}`);
+        assert.deepEqual(validation.errors, []);
+    });
+
+    test('schema: minimal envelope 通过 validateEnvelopeShape', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope({ matchId: '1' });
+        const validation = validateEnvelopeShape(envelope);
+        assert.ok(validation.valid, `validation errors: ${validation.errors.join('; ')}`);
+    });
+
+    test('schema: options full metadata envelope 通过 validateEnvelopeShape', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            dataVersion: 'fotmob_html_hyd_v1',
+            payloadHash: 'abc123def456',
+            storagePath: '/tmp/test',
+            capturedAt: '2026-07-04T01:00:00.000Z',
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+            parserName: 'NextDataParser.transformToApiFormat',
+            parserVersion: 'legacy-static',
+            parsedAt: '2026-07-04T01:05:00.000Z',
+        });
+        const validation = validateEnvelopeShape(envelope);
+        assert.ok(validation.valid, `validation errors: ${validation.errors.join('; ')}`);
+    });
+
+    // --- data_version handling ---
+
+    test('data_version: 未传 options 时应为 "unknown"', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT);
+        assert.equal(envelope.payload.data_version, 'unknown');
+    });
+
+    test('data_version: 空字符串应保留为字面值（不自动转为 unknown）', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            dataVersion: '',
+        });
+        assert.equal(envelope.payload.data_version, '');
+    });
+
+    test('data_version: null 应保持 null（调用方显式表达缺失）', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            dataVersion: null,
+        });
+        assert.equal(envelope.payload.data_version, null);
+    });
+});


### PR DESCRIPTION
## Summary

This PR implements DATA-L1E-2: a dry-run-only legacy adapter that wraps `NextDataParser.transformToApiFormat` output into a FotMob parser output envelope-compatible structure.

The user explicitly accepted Boundary A from DATA-L1F-2B:

- Boundary A: `NextDataParser.transformToApiFormat` output

This PR does not connect the adapter to runtime code. It does not modify `NextDataParser`, `FotMobStrategy`, `FotMobRawDetailFetcher`, parser index exports, feature engine, training, backtest, DB, raw storage, scraper, collector, or CI.

## Scope

| Item | Status |
| --- | --- |
| Task type | dry-run adapter |
| Runtime behavior change | No |
| Parser runtime integration | No |
| Feature/training/backtest integration | No |
| Business progress | First dry-run envelope adapter for the verified NextDataParser boundary |
| Adapter boundary | `NextDataParser.transformToApiFormat` output |
| no-live-fetch | Yes |
| no-DB-write | Yes |
| no-raw-write | Yes |

Allowed changes:

- `src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js`
- `tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js`
- `docs/data/fotmob_parser_output_envelope_legacy_adapter_dry_run.md`

## PR Type

Dry-run adapter / unit-tested pure function / no runtime behavior change.

## Documentation Impact

This PR adds a DATA-L1E-2 dry-run adapter report under `docs/data/`.

Source-of-truth update reason: DATA-L1F-2B identified `NextDataParser.transformToApiFormat` output as the recommended adapter boundary. DATA-L1E-2 implements a dry-run adapter for that accepted boundary.

## Safety Impact

No scraper, collector, browser, FotMob network access, DB writes, raw writes, data writes, feature changes, training, backtest, runtime parser integration, staging, Docker, CI, or workflow files are changed.

The adapter is a pure function module and is only exercised by unit tests.

## CI Gate Scope

Expected gate scope includes source + unit test + docs.

Changed files must remain limited to:

- `src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js`
- `tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js`
- `docs/data/fotmob_parser_output_envelope_legacy_adapter_dry_run.md`

Production Gate / AI Workflow Gate should verify that no forbidden runtime, scraper, DB, feature, training, backtest, Docker, or workflow paths were changed.

## No runtime integration confirmation

This PR does not modify:

- `src/parsers/fotmob/NextDataParser.js`
- `src/parsers/fotmob/index.js`
- `src/infrastructure/harvesters/strategies/FotMobStrategy.js`
- `src/infrastructure/services/FotMobRawDetailFetcher.js`
- feature engine
- training
- backtest
- DB / migration
- scraper / collector

No existing runtime module imports the new adapter.

## Safety classification

The adapter is conservative:

- stats / xG / shots / possession / score / result / shotmap / events / playerStats are marked forbidden_postmatch.
- lineup / injury / odds / table / form are marked forbidden_unknown_timing unless observed_at/cutoff evidence exists.
- raw payload / pageProps / content / general / header / _meta are not treated as model-ready fields.
- unknown timing defaults to forbidden.
- missing metadata is represented as null / unknown and is not fabricated.

## Rollback Plan

Revert this PR or remove the three added DATA-L1E-2 files.

No runtime rollback, DB rollback, scraper rollback, raw data rollback, model rollback, parser rollback, or migration rollback is needed because this PR has no runtime behavior change.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- DATA-L1E-3: Fixture-Based Envelope Dry-Run Evidence

DATA-L1E-2 remains dry-run only until the user explicitly authorizes a later integration step.

## SC-002 status

SC-002 is not changed by this PR.

This PR does not modify Gatekeeper, AI Workflow Gate, branch protection, CODEOWNERS, CI workflows, or any enforcement logic.

## Remaining risks

This adapter only validates the transformToApiFormat output boundary using static unit-test fixtures.

It does not prove real DB data distribution, production scheduler usage, staging usage, external FotMob availability, or feature-engine consumption of envelopes.

## Report Lifecycle

Lifecycle: DATA-L1E-2 dry-run adapter implementation report.

Retention: keep this document until a future explicitly authorized PR updates or supersedes it.

## Not Included

- No scraper / collector execution
- No FotMob network access
- No browser collection
- No raw payload generation
- No raw data writes
- No data directory writes
- No parser runtime integration
- No runtime import from existing modules
- No feature implementation
- No training / pipeline changes
- No backtest execution
- No `.github/**` changes
- No CI / workflow changes
- No Docker changes
- No DB / migration changes
- No staging server access
- No DATA-L2
- No CLEANUP-L1A
- No L3I
- No L4
- No cleanup / delete / move / rename of legacy files

## Validation

- Confirmed worktree was clean before starting
- Synced from latest `origin/main`
- Confirmed latest main CI status before branch creation
- Implemented dry-run-only adapter for `NextDataParser.transformToApiFormat` output
- Added 57 unit tests covering field classification, flatten, envelope mapping, metadata handling, invalid input, and schema validation
- All 57 tests pass
- Verified changed files are limited to the authorized DATA-L1E-2 files
- Hidden Unicode control character scan passed
- Verified no forbidden runtime paths were modified — adapter is not imported by any existing module

## Debt Impact

- New files added: 3
- Runtime behavior changed: 0
- Existing parser behavior changed: 0
- Existing production imports changed: 0
- Legacy files deleted/renamed: 0
- Cleanup needed later: no immediate cleanup from this PR
