### PR TITLE
feat: add FotMob adapter metadata payload handoff

### DIFF
--- a/docs/data/fotmob_adapter_metadata_extension_implementation.md
+++ b/docs/data/fotmob_adapter_metadata_extension_implementation.md
@@ -1,0 +1,213 @@
+# FotMob Adapter Metadata Extension Implementation
+
+- lifecycle: source-of-truth
+- scope: DATA-L1E-5B adapter metadata extension implementation
+- parent document: DATA-L1E-5A docs-only design
+- runtime behavior change: no (no production runtime integration)
+
+---
+
+## 1. 背景
+
+DATA-L1E-5A 已设计 `fetched_at` / `source_url` / `final_url` metadata extension。
+DATA-L1E-5B 本次实现最小 adapter/envelope 扩展。
+
+本任务不接 runtime、不访问 FotMob、不写 DB/raw/data。
+
+当前已完成背景：
+
+- DATA-L1E-1: `FotMobParserOutputEnvelope` schema 已落地
+- DATA-L1E-2: `FotMobParserOutputEnvelopeLegacyAdapter` dry-run-only adapter 已实现
+- DATA-L1E-3: static fixtures 已验证 adapter 兼容性，保持 0 safe fields
+- DATA-L1E-4: metadata handoff dry-run plan 已完成
+- DATA-L1E-5: fixture-level metadata handoff test 已完成
+- DATA-L1E-5A: docs-only adapter metadata extension design 已完成并合并（PR #1710）
+
+本任务实现 DATA-L1E-5A 设计中的以下 3 个 metadata 字段的 adapter 和 envelope 支持：
+
+1. `fetched_at` — 抓取动作发生时间
+2. `source_url` — 请求 URL
+3. `final_url` — 重定向后的最终 URL
+
+---
+
+## 2. What changed
+
+| 文件 | 变更类型 | 说明 |
+| --- | --- | --- |
+| `src/parsers/fotmob/FotMobParserOutputEnvelope.js` | 修改 | `createEmptyEnvelope` payload 新增 `fetched_at: null` |
+| `src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js` | 修改 | `_buildPayloadMeta` 支持 `sourceUrl`/`finalUrl`/`fetchedAt` options |
+| `tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js` | 修改 | 新增 11 个 metadata extension 测试 |
+| `tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeMetadataHandoff.fixture.test.js` | 修改 | 更新 `buildAdapterOptionsFromRawRecord` 和所有相关断言 |
+| `docs/data/fotmob_adapter_metadata_extension_implementation.md` | 新增 | 本文档 |
+
+未修改的文件：
+
+- `tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.fixture.test.js` — 无需修改，自动兼容
+
+---
+
+## 3. Metadata mapping
+
+| Adapter option | Envelope payload 字段 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| `options.sourceUrl` | `payload.source_url` | `string \| null` | `null` |
+| `options.finalUrl` | `payload.final_url` | `string \| null` | `null` |
+| `options.fetchedAt` | `payload.fetched_at` | `string \| null` | `null` |
+| `options.capturedAt` | `payload.captured_at` | `string \| null` | `null` |
+
+映射规则：
+
+- 所有字段都是 optional。未传 option 时，对应 payload 字段保持 `null`。
+- `fetchedAt` 之前只用于 warning context，现在也同时写入 `payload.fetched_at`。
+- `sourceUrl` 和 `finalUrl` 之前硬编码为 `null`，现在从 options 读取。
+- `capturedAt` → `payload.captured_at` 逻辑保持不变。
+
+`buildAdapterOptionsFromRawRecord` 中的 fallback chain：
+
+```javascript
+sourceUrl: rawRecord.source_url ?? rawRecord.sourceUrl ?? rawRecord.raw_data?._meta?.request_url ?? null,
+finalUrl: rawRecord.final_url ?? rawRecord.finalUrl ?? rawRecord.raw_data?._meta?.final_url ?? null,
+fetchedAt: rawRecord.fetched_at ?? rawRecord.fetchedAt ?? rawRecord.raw_data?._meta?.fetched_at ?? null,
+```
+
+---
+
+## 4. Safety guarantees
+
+- `fetched_at` / `source_url` / `final_url` 是 audit/provenance/replay metadata。
+- 它们不是 model fields。
+- 它们不进入 `ALLOWED_CANDIDATE`。
+- 它们不进入 `CANDIDATE_IF_CUTOFF_VALID`。
+- 不从 `_meta.extractedAt` 推导 `fetched_at`。
+- 不从 `matchTimeUTC` / `utcTime` 推导 `fetched_at`。
+- 不从 `parsedAt` 推导 `fetched_at`。
+- 缺失时保持 `null`，不伪造。
+- 不改 `PAYLOAD_TYPES` / `MODEL_ELIGIBILITY` / field classification。
+- `validateEnvelopeShape` 不受影响（只检查 `payload` 是否为 object 和 `payload_type` 是否存在）。
+- 0 safe fields 策略不变。
+
+---
+
+## 5. Tests
+
+### 5.1 运行命令
+
+```bash
+node --test tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js
+node --test tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeMetadataHandoff.fixture.test.js
+node --test tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.fixture.test.js
+```
+
+### 5.2 结果
+
+| 测试文件 | 测试数 | 通过 | 失败 |
+| --- | --- | --- | --- |
+| `FotMobParserOutputEnvelopeLegacyAdapter.test.js` | 68 | 68 | 0 |
+| `FotMobParserOutputEnvelopeMetadataHandoff.fixture.test.js` | 15 | 15 | 0 |
+| `FotMobParserOutputEnvelopeLegacyAdapter.fixture.test.js` | 27 | 27 | 0 |
+
+总计：110 tests, 110 pass, 0 fail.
+
+### 5.3 测试覆盖
+
+**Adapter unit test 新增覆盖：**
+
+- `sourceUrl` → `payload.source_url`
+- `finalUrl` → `payload.final_url`
+- `fetchedAt` → `payload.fetched_at`
+- 缺失 `sourceUrl`/`finalUrl`/`fetchedAt` → `null`
+- `fetchedAt` 不覆盖 `captured_at`（两个独立字段）
+- `_meta.extractedAt` 不覆盖 `fetched_at`
+- `matchTimeUTC`/`utcTime` 不覆盖 `fetched_at`
+- 所有 metadata 字段不产生 `ALLOWED_CANDIDATE` / `CANDIDATE_IF_CUTOFF_VALID`
+- `fetched_at`/`source_url`/`final_url` 不出现在 `envelope.fields` 中
+
+**Metadata handoff fixture test 更新覆盖：**
+
+- `options.sourceUrl` === `rawRecord.source_url`
+- `options.finalUrl` === `rawRecord.final_url`
+- `options.fetchedAt` === `rawRecord.fetched_at`
+- `envelope.payload.source_url` === `rawRecord.source_url`
+- `envelope.payload.final_url` === `rawRecord.final_url`
+- `envelope.payload.fetched_at` === `rawRecord.fetched_at`
+- `envelope.payload.captured_at` === `rawRecord.captured_at`
+- `envelope.payload.fetched_at` ≠ `envelope.payload.captured_at`
+- `envelope.payload.fetched_at` ≠ `transformOutput._meta.extractedAt`
+- `envelope.payload.fetched_at` ≠ `transformOutput.general.matchTimeUTC`
+- `envelope.payload.fetched_at` ≠ `transformOutput.header.status.utcTime`
+- minimal record 缺失 metadata → 全部 `null`
+- minimal matchTimeUTC/utcTime 不当 captured_at 或 fetched_at
+- 0 safe fields
+
+---
+
+## 6. What did not change
+
+- 没有改 `NextDataParser`
+- 没有改 `FotMobStrategy`
+- 没有改 `FotMobRawDetailFetcher`
+- 没有改 `RawMatchDataVersionSelector`
+- 没有改 `src/parsers/fotmob/index.js`
+- 没有接 runtime
+- 没有访问 FotMob 网络
+- 没有运行采集（scraper / collector / browser）
+- 没有写 DB / raw / data
+- 没有改 feature engine
+- 没有改 training / backtest
+- 没有改 pipeline
+- 没有改 `.github/**` / CI workflows
+- 没有改 Docker / compose / migrations
+- 没有启动 DATA-L1E-6
+- 没有启动 DATA-L2
+- 没有处理 deep flatten
+- 没有删除 / 移动 / 重命名任何文件
+
+---
+
+## 7. Remaining gaps
+
+- **deep flatten 仍未处理**，是独立问题（非 DATA-L1E-5B scope）。
+- **local raw record replay dry-run 仍未实现**，需要 DATA-L1E-6。
+- **runtime integration 仍未实现**，需要 DATA-L2 或类似任务。
+- **URL sanitizer policy**（是否移除敏感 query params、是否截断、是否保存完整 URL）未定义。
+- **`fetched_at` clock source**（`Date.now()` vs `new Date().toISOString()`、时区 UTC vs local）未在 adapter 层面强制。
+
+---
+
+## 8. Recommended next task
+
+默认推荐：
+
+```text
+DATA-L1E-6: Local Raw Record Replay Dry-Run Design
+```
+
+也可以考虑：
+
+```text
+Deep flatten 可作为独立 DATA-L1E-5C 或 DATA-L1E-3A，但不要自动启动。
+```
+
+Do not start automatically.
+
+Recommended next task only after user confirmation.
+
+---
+
+## 9. Envelope payload contract (post-DATA-L1E-5B)
+
+```javascript
+payload: {
+    payload_type: 'parser_input',
+    payload_hash: 'sha256:...' | null,
+    captured_at: '2026-07-04T01:00:05.000Z' | null,
+    data_version: 'fotmob_html_hyd_v1' | 'unknown',
+    storage_path: null,
+    source_url: 'https://...' | null,
+    final_url: 'https://...' | null,
+    fetched_at: '2026-07-04T01:00:00.000Z' | null,
+}
+```
+
+所有新增字段都是 nullable metadata，不是模型字段。

--- a/src/parsers/fotmob/FotMobParserOutputEnvelope.js
+++ b/src/parsers/fotmob/FotMobParserOutputEnvelope.js
@@ -195,6 +195,7 @@ function createEmptyEnvelope(overrides = {}) {
             storage_path: null,
             source_url: null,
             final_url: null,
+            fetched_at: null,
         },
 
         /** parser 层面的元数据。 */

--- a/src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js
+++ b/src/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.js
@@ -271,8 +271,9 @@ function _buildPayloadMeta(safeOpts) {
             ? (safeOpts.dataVersion === null ? null : String(safeOpts.dataVersion))
             : 'unknown',
         storage_path: safeOpts.storagePath !== undefined ? safeOpts.storagePath : null,
-        source_url: null,
-        final_url: null,
+        source_url: safeOpts.sourceUrl !== undefined ? safeOpts.sourceUrl : null,
+        final_url: safeOpts.finalUrl !== undefined ? safeOpts.finalUrl : null,
+        fetched_at: safeOpts.fetchedAt !== undefined ? safeOpts.fetchedAt : null,
     };
 }
 

--- a/tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js
+++ b/tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js
@@ -331,6 +331,7 @@ describe('adaptTransformToApiFormatOutputToEnvelope', () => {
         assert.equal(envelope.payload.captured_at, null);
         assert.equal(envelope.payload.source_url, null);
         assert.equal(envelope.payload.final_url, null);
+        assert.equal(envelope.payload.fetched_at, null);
     });
 
     test('happy path: parser metadata 默认值', () => {
@@ -391,23 +392,22 @@ describe('adaptTransformToApiFormatOutputToEnvelope', () => {
 
     // --- metadata preservation ---
 
-    test('metadata: options 传入的 dataVersion / payloadHash / fetchedAt 应被正确保留', () => {
+    test('metadata: options 传入的 dataVersion / payloadHash / capturedAt / fetchedAt 应被正确保留', () => {
         const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
             dataVersion: 'fotmob_html_hyd_v1',
             payloadHash: 'abc123',
             storagePath: null,
+            capturedAt: '2026-07-04T01:00:05.000Z',
             fetchedAt: '2026-07-04T01:00:00.000Z',
         });
 
         assert.equal(envelope.payload.data_version, 'fotmob_html_hyd_v1');
         assert.equal(envelope.payload.payload_hash, 'abc123');
         assert.equal(envelope.payload.storage_path, null);
-        assert.equal(envelope.payload.captured_at, null);
-        // fetchedAt 不是 envelope schema 标准字段——它不在 payload 块中。
-        // adapter 通过 captured_at 承载采集时间，fetchedAt 应映射到 captured_at。
-        // 但按照当前设计，fetchedAt 和 capturedAt 是独立字段。
-        // 如果 options 传了 fetchedAt 但没传 capturedAt，captured_at 仍为 null。
-        // 这是设计决定：不自动映射 fetchedAt → captured_at，避免语义混淆。
+        assert.equal(envelope.payload.captured_at, '2026-07-04T01:00:05.000Z');
+        assert.equal(envelope.payload.fetched_at, '2026-07-04T01:00:00.000Z');
+        // fetchedAt 和 capturedAt 是独立字段，fetchedAt 不覆盖 capturedAt
+        assert.notEqual(envelope.payload.fetched_at, envelope.payload.captured_at);
     });
 
     test('metadata: transformOutput._meta.extractedAt 不覆盖 captured_at', () => {
@@ -579,5 +579,110 @@ describe('adaptTransformToApiFormatOutputToEnvelope', () => {
             dataVersion: null,
         });
         assert.equal(envelope.payload.data_version, null);
+    });
+
+    // --- metadata extension: sourceUrl / finalUrl / fetchedAt ---
+
+    test('metadata extension: sourceUrl 写入 envelope.payload.source_url', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            sourceUrl: 'https://example.invalid/fotmob/match/4193673',
+        });
+        assert.equal(envelope.payload.source_url, 'https://example.invalid/fotmob/match/4193673');
+    });
+
+    test('metadata extension: finalUrl 写入 envelope.payload.final_url', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            finalUrl: 'https://example.invalid/fotmob/match/4193673#final',
+        });
+        assert.equal(envelope.payload.final_url, 'https://example.invalid/fotmob/match/4193673#final');
+    });
+
+    test('metadata extension: fetchedAt 写入 envelope.payload.fetched_at', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+        });
+        assert.equal(envelope.payload.fetched_at, '2026-07-04T01:00:00.000Z');
+    });
+
+    test('metadata extension: sourceUrl 缺失时 payload.source_url 为 null', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {});
+        assert.equal(envelope.payload.source_url, null);
+    });
+
+    test('metadata extension: finalUrl 缺失时 payload.final_url 为 null', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {});
+        assert.equal(envelope.payload.final_url, null);
+    });
+
+    test('metadata extension: fetchedAt 缺失时 payload.fetched_at 为 null', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {});
+        assert.equal(envelope.payload.fetched_at, null);
+    });
+
+    test('metadata extension: fetchedAt 不覆盖 captured_at（两个独立字段）', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            capturedAt: '2026-07-04T01:00:05.000Z',
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+        });
+        assert.equal(envelope.payload.captured_at, '2026-07-04T01:00:05.000Z');
+        assert.equal(envelope.payload.fetched_at, '2026-07-04T01:00:00.000Z');
+        assert.notEqual(envelope.payload.fetched_at, envelope.payload.captured_at);
+    });
+
+    test('metadata extension: _meta.extractedAt 不覆盖 fetched_at', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+        });
+        assert.equal(envelope.payload.fetched_at, '2026-07-04T01:00:00.000Z');
+        const extractedEntry = envelope.fields.find(f => f.field_path === '_meta.extractedAt');
+        assert.ok(extractedEntry, '_meta.extractedAt audit field should exist');
+        assert.notEqual(envelope.payload.fetched_at, extractedEntry.value,
+            'fetched_at must not equal _meta.extractedAt');
+    });
+
+    test('metadata extension: matchTimeUTC / utcTime 不覆盖 fetched_at', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+        });
+        assert.notEqual(envelope.payload.fetched_at, HAPPY_PATH_TRANSFORM_OUTPUT.general.matchTimeUTC,
+            'fetched_at must not equal matchTimeUTC');
+        assert.notEqual(envelope.payload.fetched_at, HAPPY_PATH_TRANSFORM_OUTPUT.header.status.utcTime,
+            'fetched_at must not equal utcTime');
+    });
+
+    test('metadata extension: 所有 metadata 字段不产生 ALLOWED_CANDIDATE', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            sourceUrl: 'https://example.invalid/fotmob/match/4193673',
+            finalUrl: 'https://example.invalid/fotmob/match/4193673#final',
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+            capturedAt: '2026-07-04T01:00:05.000Z',
+        });
+        for (const f of envelope.fields) {
+            assert.notEqual(
+                f.model_eligibility,
+                MODEL_ELIGIBILITY.ALLOWED_CANDIDATE,
+                `field "${f.field_path}" must not be ALLOWED_CANDIDATE`
+            );
+            assert.notEqual(
+                f.model_eligibility,
+                MODEL_ELIGIBILITY.CANDIDATE_IF_CUTOFF_VALID,
+                `field "${f.field_path}" must not be CANDIDATE_IF_CUTOFF_VALID`
+            );
+        }
+    });
+
+    test('metadata extension: fetched_at/source_url/final_url 不存在于 envelope.fields 中', () => {
+        const envelope = adaptTransformToApiFormatOutputToEnvelope(HAPPY_PATH_TRANSFORM_OUTPUT, {
+            sourceUrl: 'https://example.invalid/fotmob/match/4193673',
+            finalUrl: 'https://example.invalid/fotmob/match/4193673#final',
+            fetchedAt: '2026-07-04T01:00:00.000Z',
+        });
+        // payload metadata 应该只在 envelope.payload 中，不出现在 envelope.fields
+        const payloadMetaPaths = ['payload.fetched_at', 'payload.source_url', 'payload.final_url'];
+        for (const metaPath of payloadMetaPaths) {
+            const entry = envelope.fields.find(f => f.field_path === metaPath);
+            assert.equal(entry, undefined,
+                `"${metaPath}" should not appear in envelope.fields — payload metadata only`);
+        }
     });
 });

--- a/tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeMetadataHandoff.fixture.test.js
+++ b/tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeMetadataHandoff.fixture.test.js
@@ -54,6 +54,16 @@ function buildAdapterOptionsFromRawRecord(rawRecord) {
             rawRecord.storage_path
             ?? rawRecord.storagePath
             ?? null,
+        sourceUrl:
+            rawRecord.source_url
+            ?? rawRecord.sourceUrl
+            ?? rawRecord.raw_data?._meta?.request_url
+            ?? null,
+        finalUrl:
+            rawRecord.final_url
+            ?? rawRecord.finalUrl
+            ?? rawRecord.raw_data?._meta?.final_url
+            ?? null,
         capturedAt:
             rawRecord.captured_at
             ?? rawRecord.capturedAt
@@ -103,6 +113,8 @@ describe('DATA-L1E-5 metadata handoff fixture', () => {
         assert.equal(options.dataVersion, 'fotmob_html_hyd_v1');
         assert.equal(options.payloadHash, 'sha256:fixture-data-hash-001');
         assert.equal(options.storagePath, null);
+        assert.equal(options.sourceUrl, 'https://example.invalid/fotmob/match/fixture-metadata-001');
+        assert.equal(options.finalUrl, 'https://example.invalid/fotmob/match/fixture-metadata-001#final');
         assert.equal(options.capturedAt, '2026-07-04T01:00:05.000Z');
         assert.equal(options.fetchedAt, '2026-07-04T01:00:00.000Z');
         assert.equal(options.parsedAt, null);
@@ -126,16 +138,20 @@ describe('DATA-L1E-5 metadata handoff fixture', () => {
         assert.equal(envelope.payload.data_version, 'fotmob_html_hyd_v1');
         assert.equal(envelope.payload.payload_hash, 'sha256:fixture-data-hash-001');
         assert.equal(envelope.payload.storage_path, null);
+        assert.equal(envelope.payload.source_url, 'https://example.invalid/fotmob/match/fixture-metadata-001');
+        assert.equal(envelope.payload.final_url, 'https://example.invalid/fotmob/match/fixture-metadata-001#final');
         assert.equal(envelope.payload.captured_at, '2026-07-04T01:00:05.000Z');
+        assert.equal(envelope.payload.fetched_at, '2026-07-04T01:00:00.000Z');
         assert.equal(envelope.parser.parser_name, 'NextDataParser.transformToApiFormat');
         assert.equal(envelope.parser.parser_version, 'legacy-static');
         assert.equal(envelope.parser.parsed_at, null);
     });
 
-    test('fetchedAt 不冒充 capturedAt', () => {
+    test('fetchedAt 不冒充 capturedAt（两个独立字段）', () => {
         assert.equal(envelope.payload.captured_at, rawRecord.captured_at);
-        assert.notEqual(envelope.payload.captured_at, rawRecord.fetched_at);
-        assert.equal(Object.prototype.hasOwnProperty.call(envelope.payload, 'fetched_at'), false);
+        assert.equal(envelope.payload.fetched_at, rawRecord.fetched_at);
+        assert.notEqual(envelope.payload.captured_at, envelope.payload.fetched_at);
+        assert.notEqual(envelope.payload.fetched_at, envelope.payload.captured_at);
     });
 
     test('_meta.extractedAt 保留为 audit-only 且不覆盖 captured_at', () => {
@@ -155,14 +171,28 @@ describe('DATA-L1E-5 metadata handoff fixture', () => {
         assert.notEqual(envelope.payload.captured_at, transformOutput.header.status.utcTime);
     });
 
-    test('source_url / final_url 当前保持 null', () => {
+    test('source_url / final_url 通过 adapter options 进入 envelope payload', () => {
         assert.ok(rawRecord.source_url);
         assert.ok(rawRecord.final_url);
         assert.ok(rawRecord.raw_data._meta.request_url);
         assert.ok(rawRecord.raw_data._meta.final_url);
-        // Current adapter has no sourceUrl/finalUrl options. Future adapter extension required.
-        assert.equal(envelope.payload.source_url, null);
-        assert.equal(envelope.payload.final_url, null);
+        // DATA-L1E-5B: adapter now supports sourceUrl/finalUrl options.
+        assert.equal(envelope.payload.source_url, rawRecord.source_url);
+        assert.equal(envelope.payload.final_url, rawRecord.final_url);
+    });
+
+    test('fetched_at 不等于 _meta.extractedAt（语义不混淆）', () => {
+        const extractedEntry = fieldByPath(envelope.fields, '_meta.extractedAt');
+        assert.ok(extractedEntry, '_meta.extractedAt should exist');
+        assert.notEqual(envelope.payload.fetched_at, extractedEntry.value,
+            'fetched_at must not equal _meta.extractedAt');
+    });
+
+    test('fetched_at 不等于 matchTimeUTC / utcTime（比赛时间不混入 metadata 时间）', () => {
+        assert.notEqual(envelope.payload.fetched_at, transformOutput.general.matchTimeUTC,
+            'fetched_at must not equal matchTimeUTC');
+        assert.notEqual(envelope.payload.fetched_at, transformOutput.header.status.utcTime,
+            'fetched_at must not equal utcTime');
     });
 
     test('不产生任何 safe field', () => {
@@ -234,6 +264,8 @@ describe('DATA-L1E-5 missing metadata fixture behavior', () => {
         assert.equal(options.dataVersion, 'unknown');
         assert.equal(options.payloadHash, null);
         assert.equal(options.storagePath, null);
+        assert.equal(options.sourceUrl, null);
+        assert.equal(options.finalUrl, null);
         assert.equal(options.capturedAt, null);
         assert.equal(options.fetchedAt, null);
     });
@@ -244,13 +276,19 @@ describe('DATA-L1E-5 missing metadata fixture behavior', () => {
         assert.equal(envelope.payload.data_version, 'unknown');
         assert.equal(envelope.payload.payload_hash, null);
         assert.equal(envelope.payload.storage_path, null);
+        assert.equal(envelope.payload.source_url, null);
+        assert.equal(envelope.payload.final_url, null);
         assert.equal(envelope.payload.captured_at, null);
+        assert.equal(envelope.payload.fetched_at, null);
     });
 
-    test('minimal matchTimeUTC / utcTime 不会被当作 captured_at', () => {
+    test('minimal matchTimeUTC / utcTime 不会被当作 captured_at 或 fetched_at', () => {
         assert.notEqual(envelope.payload.captured_at, minimalTransformOutput.general.matchTimeUTC);
         assert.notEqual(envelope.payload.captured_at, minimalTransformOutput.header.status.utcTime);
         assert.equal(envelope.payload.captured_at, null);
+        assert.notEqual(envelope.payload.fetched_at, minimalTransformOutput.general.matchTimeUTC);
+        assert.notEqual(envelope.payload.fetched_at, minimalTransformOutput.header.status.utcTime);
+        assert.equal(envelope.payload.fetched_at, null);
     });
 
     test('minimal fixture 不产生任何 safe field', () => {


### PR DESCRIPTION
## Summary

This PR implements DATA-L1E-5B: the minimal FotMob adapter metadata extension.

DATA-L1E-5A designed how to close the adapter metadata gap for:

- `fetched_at`
- `source_url`
- `final_url`

This PR implements that design in the envelope schema and legacy adapter, then updates targeted unit tests and the metadata handoff fixture test.

## Scope

| Item | Status |
| --- | --- |
| Task type | source-code |
| Task type details | adapter metadata extension implementation |
| Runtime behavior change | No production runtime integration |
| Adapter code change | Yes, metadata-only |
| Envelope schema change | Yes, nullable `payload.fetched_at` |
| Parser runtime integration | No |
| Feature/training/backtest integration | No |
| Business progress | Preserves fetched/source/final metadata for audit/provenance/replay before local raw-record replay |
| no-live-fetch | Yes |
| no-DB-write | Yes |
| no-raw-write | Yes |

Allowed changes are limited to envelope/adapter metadata handling, targeted tests, and implementation documentation.

## PR Type

Source-code / metadata-only adapter extension / targeted tests / docs / no runtime integration.

## Documentation Impact

This PR adds:

- `docs/data/fotmob_adapter_metadata_extension_implementation.md`

Source-of-truth update reason: DATA-L1E-5A designed the metadata extension. DATA-L1E-5B implements the minimal metadata-only behavior.

## Safety Impact

No scraper, collector, browser, FotMob network access, DB writes, raw writes, data writes, feature changes, training, backtest, runtime parser integration, staging, Docker, CI, workflow files, migrations, or runtime imports are changed.

The changed metadata fields are audit/provenance/replay-only and are not model features.

## CI Gate Scope

Expected gate scope includes envelope, adapter, targeted tests, and docs.

Changed files must remain limited to the authorized DATA-L1E-5B files.

Production Gate / AI Workflow Gate should verify that no forbidden runtime, scraper, DB, feature, training, backtest, Docker, migration, or workflow paths were changed.

## No runtime integration confirmation

This PR does not modify:

- `src/parsers/fotmob/NextDataParser.js`
- `src/parsers/fotmob/index.js`
- `src/infrastructure/harvesters/strategies/FotMobStrategy.js`
- `src/infrastructure/services/FotMobRawDetailFetcher.js`
- `src/infrastructure/services/RawMatchDataVersionSelector.js`
- feature engine
- training
- backtest
- DB / migration
- scraper / collector
- Docker
- `.github/**`

No existing runtime module imports a new path.

## Metadata extension summary

This PR implements:

- `payload.fetched_at`, nullable, default null
- `options.fetchedAt` → `payload.fetched_at`
- `options.sourceUrl` → `payload.source_url`
- `options.finalUrl` → `payload.final_url`
- preserves `options.capturedAt` → `payload.captured_at`
- missing metadata remains null
- `_meta.extractedAt` does not become `fetched_at`
- match kickoff time does not become `fetched_at` or `captured_at`
- parsed time does not become `fetched_at`

## Model safety summary

`fetched_at`, `source_url`, and `final_url` are payload metadata only.

They are audit/provenance/replay evidence and must not become model features.

The tests confirm no `ALLOWED_CANDIDATE` or `CANDIDATE_IF_CUTOFF_VALID` is produced from these metadata fields.

## Tests

Targeted tests run:

- `node --test tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.test.js` — 68 pass / 0 fail
- `node --test tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeMetadataHandoff.fixture.test.js` — 15 pass / 0 fail
- `node --test tests/unit/parsers/fotmob/FotMobParserOutputEnvelopeLegacyAdapter.fixture.test.js` — 27 pass / 0 fail

Total: 110 tests, 110 pass, 0 fail.

## Rollback Plan

Revert this PR.

No DB rollback, scraper rollback, raw data rollback, model rollback, migration rollback, or runtime rollback is needed because there is no production runtime integration and no DB/raw/data write.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

- DATA-L1E-6: Local Raw Record Replay Dry-Run Design

Deep flatten remains a separate issue and is not addressed by this PR.

## SC-002 status

SC-002 is not changed by this PR.

This PR does not modify Gatekeeper, AI Workflow Gate, branch protection, CODEOWNERS, CI workflows, or enforcement logic.

## Remaining risks

This PR implements adapter/envelope metadata support only.

It does not prove real DB data distribution, production scheduler usage, staging usage, external FotMob availability, or feature-engine consumption of envelopes.

It does not implement local raw-record replay.

It does not address deep flatten coverage.

## No deletion / no move / no rename confirmation

This PR does not delete, move, or rename any existing files.

No legacy code, fixtures, tests, or documentation files are removed or relocated.

The only file operations are: modify 4 existing files, create 1 new file.

## Report Lifecycle

Lifecycle: DATA-L1E-5B adapter metadata extension implementation.

Retention: keep this document until a future explicitly authorized PR updates or supersedes it.

## Not Included

- No NextDataParser changes
- No FotMobStrategy changes
- No FotMobRawDetailFetcher changes
- No RawMatchDataVersionSelector changes
- No `src/parsers/fotmob/index.js` changes
- No scraper / collector execution
- No FotMob network access
- No browser collection
- No raw payload generation
- No raw data writes
- No data directory writes
- No DB writes
- No parser runtime integration
- No runtime import from existing modules
- No feature implementation
- No training / pipeline changes
- No backtest execution
- No `.github/**` changes
- No CI / workflow changes
- No Docker changes
- No DB / migration changes
- No staging server access
- No DATA-L1E-6
- No DATA-L2
- No CLEANUP-L1A
- No L3I
- No L4
- No deep flatten implementation
- No cleanup / delete / move / rename of legacy files

## Validation

- Confirmed worktree was clean before starting
- Synced from latest `origin/main` (7f872ad)
- Confirmed latest main CI status before branch creation (all green)
- Implemented nullable `payload.fetched_at` in envelope schema
- Implemented `fetchedAt/sourceUrl/finalUrl` adapter options handoff
- Updated targeted adapter tests (68 pass, 0 fail)
- Updated metadata handoff fixture test (15 pass, 0 fail)
- Fixture regression test unchanged and passing (27 pass, 0 fail)
- Verified changed files are limited to authorized DATA-L1E-5B files
- Hidden Unicode control character scan passed
- Ran targeted tests — all 110 pass / 0 fail
- Verified no forbidden runtime paths were modified

## Debt Impact

- Runtime behavior changed: 0 production integration
- Existing parser runtime behavior changed: 0
- Existing adapter metadata behavior extended: yes
- Existing model feature behavior changed: 0
- Existing production imports changed: 0
- Legacy files deleted/renamed: 0
- Cleanup needed later: no immediate cleanup from this PR
