### PR TITLE
docs(data): define controlled small-batch smelt readiness plan

### DIFF
--- a/docs/data/controlled_small_batch_smelt_readiness_plan.md
+++ b/docs/data/controlled_small_batch_smelt_readiness_plan.md
@@ -1,0 +1,175 @@
+# Controlled Small-Batch Smelt Readiness Plan
+
+Status: plan-only / no-write
+
+## Purpose
+
+Define the readiness criteria and execution guardrails for a future controlled small-batch smelt from `raw_match_data` into `l3_features`.
+
+This document does not authorize a write.
+
+## Current protected state
+
+- Prematch-safe contract document exists (`docs/data/l3_prematch_safe_feature_contract.md`).
+- Machine-readable L3 contract exists (`config/features/l3_prematch_safe_contract.v0.json`).
+- Training entrypoints are protected by contract filter (`scripts/ops/train_model.py`, `scripts/model_training/train_baseline_v1.py`).
+- Prediction path is protected by contract filter (`src/database/repositories/prediction_repo.py`).
+- `dataset_generator.py` is marked legacy / non-production (`src/ml/dataset/dataset_generator.py`, `docs/data/dataset_generation_legacy_status.md`).
+
+## Absolute blocked actions in this plan
+
+- No DB write.
+- No smelt.
+- No batch smelt.
+- No controlled smelt.
+- No training.
+- No prediction run.
+- No backtest.
+- No FotMob network.
+- No scraper / collector / browser.
+
+## Readiness checks before any future write
+
+A future controlled smelt may only be considered after all are true:
+
+1. Worktree clean.
+2. Main CI green.
+3. Current branch is main or explicitly authorized smelt branch.
+4. `l3_prematch_contract` exists and tests pass.
+5. Training entrypoints use the contract filter.
+6. Prediction path uses the contract filter.
+7. `dataset_generator.py` is marked legacy / non-production.
+8. SELECT-only DB baseline captured immediately before write.
+9. Target match list is explicit and small.
+10. `--preview --no-write` has been run successfully for the exact target.
+11. Expected delta is documented before write.
+12. Rollback SQL is documented before write.
+13. User explicitly authorizes the write task.
+
+## Recommended batch size
+
+Start with:
+
+- 1 match if re-validating write mechanics;
+- 5 matches for first small-batch expansion;
+- never jump directly to all pending matches.
+
+## Preferred target selection
+
+Prefer:
+
+- `data_version = 'fotmob_live_v1'`
+- `matches.external_id IS NOT NULL`
+- no existing `l3_features` row
+- recent enough for parser compatibility
+- no synthetic data versions
+- no legacy PHASE synthetic rows
+
+Avoid:
+
+- `PHASE4.43_SYNTHETIC`
+- `PHASE4.23`
+- unknown or synthetic data versions
+- rows without `external_id`
+- rows already present in `l3_features`
+
+## Required pre-write baseline
+
+Capture:
+
+```sql
+SELECT COUNT(*) FROM raw_match_data;
+SELECT COUNT(*) FROM matches;
+SELECT COUNT(*) FROM l3_features;
+SELECT data_version, COUNT(*) FROM raw_match_data GROUP BY data_version;
+```
+
+Also capture explicit target match IDs.
+
+## Required preview
+
+Before any future write:
+
+```bash
+node scripts/ops/smelt_all.js --preview --no-write --limit <N>
+```
+
+Preview must show:
+
+- target match IDs;
+- `data_version`;
+- expected feature group counts;
+- `actual_db_write=false`;
+- raw/matches/l3 counts unchanged.
+
+## Required future write envelope
+
+Future write must be a separate task and must include explicit user authorization.
+
+The write entrypoint is `scripts/ops/smelt_all.js`. Write mode is active when **none** of `--dry-run`, `--no-write`, or `--preview` is passed.
+
+FeatureSmelter reads from `raw_match_data` (JOIN `matches` on `match_id`, LEFT JOIN `l3_features` on `match_id`), generates features via extractors, and writes only to `l3_features` table (INSERT/UPDATE operations only). It does **not** write to `raw_match_data` or `matches`.
+
+Expected environment:
+
+- Dev container with DB access.
+- `l3_features` table exists (created by migration `V26.4__create_l3_features_table.sql`).
+- No additional environment variables required beyond standard DB connection config.
+
+The future write must be limited:
+
+```bash
+node scripts/ops/smelt_all.js --limit <N>
+```
+
+Only after required environment confirmations.
+
+## Required post-write verification
+
+After future write, verify:
+
+```sql
+SELECT COUNT(*) FROM raw_match_data;
+SELECT COUNT(*) FROM matches;
+SELECT COUNT(*) FROM l3_features;
+```
+
+Expected:
+
+- `raw_match_data` delta = 0
+- `matches` delta = 0
+- `l3_features` delta = N
+- every inserted row has non-empty prematch-safe groups after contract filtering
+- no training/prediction/backtest automatically follows
+
+## Rollback plan
+
+For a controlled write, rollback must be explicit and limited to the inserted match IDs:
+
+```sql
+DELETE FROM l3_features
+WHERE match_id IN ('...');
+```
+
+Rollback must not be executed unless user explicitly authorizes it.
+
+## Training dry-run policy
+
+Training dry-run remains blocked after smelt unless:
+
+1. smelt target rows are verified;
+2. contract-filtered training feature matrix is inspected;
+3. no tactical/rating/postmatch leakage appears;
+4. user explicitly authorizes training dry-run as a separate task.
+
+## Next task after this plan
+
+Possible next task:
+
+GOLD-AUDIT-2L: Controlled small-batch smelt preview only
+
+or
+
+GOLD-AUDIT-2L: Controlled small-batch smelt write for 1–5 explicitly listed matches
+
+No task should start automatically.

--- a/tests/unit/data/test_controlled_small_batch_smelt_readiness_plan.py
+++ b/tests/unit/data/test_controlled_small_batch_smelt_readiness_plan.py
@@ -1,0 +1,30 @@
+"""Static guard tests for controlled small-batch smelt readiness plan.
+
+These tests perform text-only checks. They do NOT connect to a database,
+do NOT run smelt, and do NOT write any data.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_controlled_small_batch_smelt_plan_guardrails() -> None:
+    """Verify the smelt readiness plan contains all required no-write guardrails."""
+    doc = ROOT / "docs/data/controlled_small_batch_smelt_readiness_plan.md"
+    text = doc.read_text(encoding="utf-8")
+
+    required = [
+        "Status: plan-only / no-write",
+        "This document does not authorize a write",
+        "No DB write",
+        "No smelt",
+        "Training dry-run remains blocked",
+        "explicit user authorization",
+        "`raw_match_data` delta = 0",
+        "`l3_features` delta = N",
+        "`dataset_generator.py` is marked legacy / non-production",
+    ]
+
+    for marker in required:
+        assert marker in text, f"Missing required guardrail: {marker!r}"


### PR DESCRIPTION
## Summary

Defines a plan-only readiness document for a future controlled small-batch smelt from `raw_match_data` into `l3_features`.

This PR does not authorize or perform any DB write.

## Scope

| Item | Status |
|---|---|
| Task type | source-code |
| Runtime behavior change | No |
| DB write during validation | No |
| Smelt during validation | No |
| Training run during validation | No |
| Prediction run during validation | No |
| Backtest during validation | No |
| Network/scraper/browser | No |

## Background

Current main has:

- prematch-safe feature contract (#1720)
- machine-readable allowlist / denylist (#1721)
- training entrypoints enforcement (#1721)
- prediction path enforcement (#1722)
- `dataset_generator.py` legacy / non-production status (#1723)

This PR defines readiness criteria before any future controlled write.

## Files Changed

- `docs/data/controlled_small_batch_smelt_readiness_plan.md` — new readiness plan document
- `tests/unit/data/test_controlled_small_batch_smelt_readiness_plan.py` — new static guard tests

## Safety Impact

This PR does not:

- write DB;
- smelt;
- batch smelt;
- controlled smelt;
- train;
- run prediction;
- run backtest;
- access FotMob network;
- run scraper / collector / browser;
- modify migrations;
- modify `.github/**`;
- change production training or prediction behavior.

## Validation

```text
python -m pytest tests/unit/data/test_controlled_small_batch_smelt_readiness_plan.py -q
====================== 1 passed in 0.02s ======================

rg -n "plan-only|no-write|does not authorize a write|No DB write|No smelt|Training dry-run remains blocked|explicit user authorization|raw_match_data.*delta|l3_features.*delta|legacy / non-production" docs/data/controlled_small_batch_smelt_readiness_plan.md tests
# All 10 required guardrail keywords present

ruff check: 0 violations — PASS (after auto-fix)
ruff format: 1 file already formatted
Gatekeeper commit: PASS
Gatekeeper pr: PASS

DB readiness check: skipped / unavailable (SSL rejection)
No-write preview: skipped / unavailable (requires DB)
```

## CI Gate Scope

Expected gate scope: docs/static test only.

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed. Two files created.

## Documentation Impact

This PR adds `docs/data/controlled_small_batch_smelt_readiness_plan.md` — a plan-only document that defines the readiness criteria and execution guardrails for a future controlled small-batch smelt. It documents:

- The current five-layer protection state.
- 13 readiness checks required before any write.
- Recommended batch sizes (1 or 5).
- Preferred and avoided target selection criteria.
- Required pre-write SELECT-only baseline queries.
- Required `--preview --no-write` confirmation.
- Required future write envelope parameters.
- Post-write verification queries and expected deltas.
- Rollback SQL template.
- Training dry-run policy (remains blocked).

## Rollback Plan

Revert this single commit. No DB rollback needed. Two files:
1. `docs/data/controlled_small_batch_smelt_readiness_plan.md` — new file, reverting deletes it.
2. `tests/unit/data/test_controlled_small_batch_smelt_readiness_plan.py` — new file, reverting deletes it.

## SC-002 status

No DB write. No smelt. No training. No prediction. No backtest. No data expansion.

## Remaining risks

- This PR is plan-only. A future controlled smelt requires explicit user authorization.
- DB readiness baseline could not be captured (DB unavailable). Must be done before any write.
- Training dry-run remains blocked until smelt outputs are inspected and separately authorized.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

GOLD-AUDIT-2L — controlled small-batch smelt preview only (--preview --no-write --limit 1), or controlled 1-row write if explicitly authorized.
