### PR TITLE
fix(data): select distinct smelt targets by data version priority

### DIFF
--- a/scripts/ops/smelt_all.js
+++ b/scripts/ops/smelt_all.js
@@ -63,6 +63,7 @@ function printPreview(result) {
     for (const entry of result.previewEntries) {
         console.log(`\n┌─ match_id: ${entry.match_id}`);
         console.log(`├─ external_id: ${entry.external_id || '(null)'}`);
+        console.log(`├─ data_version: ${entry.data_version || '(unknown)'}`);
         console.log(`├─ teams: ${entry.home_team || '?'} vs ${entry.away_team || '?'}`);
         console.log(`├─ has_raw_data: ${entry.has_raw_data}`);
         console.log(`├─ would_write: ${entry.would_write_l3_features}`);

--- a/src/feature_engine/smelter/FeatureSmelter.js
+++ b/src/feature_engine/smelter/FeatureSmelter.js
@@ -237,8 +237,21 @@ class FeatureSmelter {
 
     /**
      * 获取待处理的比赛列表（带重试）
+     *
+     * V5.2.1: Target selection now returns distinct match_id rows with
+     * data_version priority.  LIMIT applies to distinct matches, not
+     * raw_match_data rows.
+     *
+     * Data version priority (highest first):
+     *   1. fotmob_live_v1
+     *   2. fotmob_pageprops_v2
+     *   3. fotmob_html_hyd_v1
+     *   4. other (non-legacy)
+     *
+     * Excluded versions: PHASE4.23, PHASE4.43_SYNTHETIC
+     *
      * @param {boolean} fullRecalculate - 是否全量重算
-     * @param {number} limit - 批量大小
+     * @param {number} limit - 批量大小（distinct match_id 数量）
      * @returns {Promise<Array>}
      */
     async getPendingMatches(fullRecalculate = false, limit = 1000) {
@@ -246,38 +259,96 @@ class FeatureSmelter {
             let query;
             if (fullRecalculate) {
                 query = `
+                    WITH ranked AS (
+                        SELECT
+                            m.match_id,
+                            m.external_id,
+                            m.home_team,
+                            m.away_team,
+                            m.match_date,
+                            m.home_score,
+                            m.away_score,
+                            r.raw_data,
+                            r.data_version,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY m.match_id
+                                ORDER BY
+                                    CASE r.data_version
+                                        WHEN 'fotmob_live_v1' THEN 1
+                                        WHEN 'fotmob_pageprops_v2' THEN 2
+                                        WHEN 'fotmob_html_hyd_v1' THEN 3
+                                        ELSE 99
+                                    END,
+                                    m.match_date DESC NULLS LAST,
+                                    m.match_id,
+                                    r.data_version
+                            ) AS rn
+                        FROM matches m
+                        INNER JOIN raw_match_data r ON m.match_id = r.match_id
+                        WHERE m.external_id IS NOT NULL
+                          AND COALESCE(r.data_version, '') NOT IN ('PHASE4.23', 'PHASE4.43_SYNTHETIC')
+                    )
                     SELECT
-                        m.match_id,
-                        m.external_id,
-                        m.home_team,
-                        m.away_team,
-                        m.match_date,
-                        m.home_score,
-                        m.away_score,
-                        r.raw_data
-                    FROM matches m
-                    INNER JOIN raw_match_data r ON m.match_id = r.match_id
-                    WHERE m.external_id IS NOT NULL
-                    ORDER BY m.match_date DESC
+                        match_id,
+                        external_id,
+                        home_team,
+                        away_team,
+                        match_date,
+                        home_score,
+                        away_score,
+                        raw_data,
+                        data_version
+                    FROM ranked
+                    WHERE rn = 1
+                    ORDER BY match_date DESC NULLS LAST, match_id
                     LIMIT $1
                 `;
             } else {
                 query = `
+                    WITH ranked AS (
+                        SELECT
+                            m.match_id,
+                            m.external_id,
+                            m.home_team,
+                            m.away_team,
+                            m.match_date,
+                            m.home_score,
+                            m.away_score,
+                            r.raw_data,
+                            r.data_version,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY m.match_id
+                                ORDER BY
+                                    CASE r.data_version
+                                        WHEN 'fotmob_live_v1' THEN 1
+                                        WHEN 'fotmob_pageprops_v2' THEN 2
+                                        WHEN 'fotmob_html_hyd_v1' THEN 3
+                                        ELSE 99
+                                    END,
+                                    m.match_date DESC NULLS LAST,
+                                    m.match_id,
+                                    r.data_version
+                            ) AS rn
+                        FROM matches m
+                        INNER JOIN raw_match_data r ON m.match_id = r.match_id
+                        LEFT JOIN l3_features l3 ON m.match_id = l3.match_id
+                        WHERE m.external_id IS NOT NULL
+                          AND l3.match_id IS NULL
+                          AND COALESCE(r.data_version, '') NOT IN ('PHASE4.23', 'PHASE4.43_SYNTHETIC')
+                    )
                     SELECT
-                        m.match_id,
-                        m.external_id,
-                        m.home_team,
-                        m.away_team,
-                        m.match_date,
-                        m.home_score,
-                        m.away_score,
-                        r.raw_data
-                    FROM matches m
-                    INNER JOIN raw_match_data r ON m.match_id = r.match_id
-                    LEFT JOIN l3_features l3 ON m.match_id = l3.match_id
-                    WHERE m.external_id IS NOT NULL
-                      AND l3.match_id IS NULL
-                    ORDER BY m.match_date DESC
+                        match_id,
+                        external_id,
+                        home_team,
+                        away_team,
+                        match_date,
+                        home_score,
+                        away_score,
+                        raw_data,
+                        data_version
+                    FROM ranked
+                    WHERE rn = 1
+                    ORDER BY match_date DESC NULLS LAST, match_id
                     LIMIT $1
                 `;
             }
@@ -597,6 +668,7 @@ class FeatureSmelter {
             external_id: match.external_id || null,
             home_team: match.home_team || null,
             away_team: match.away_team || null,
+            data_version: match.data_version || null,
             has_raw_data: Boolean(match.raw_data),
             extractors: {},
             error: null,

--- a/tests/unit/feature_engine/smelter/test_feature_smelter_target_selection.js
+++ b/tests/unit/feature_engine/smelter/test_feature_smelter_target_selection.js
@@ -1,0 +1,91 @@
+/**
+ * FeatureSmelter target selection unit tests
+ * =========================================
+ *
+ * V5.2.1: Verify getPendingMatches uses distinct match_id selection
+ * with data_version priority, and excludes PHASE legacy versions.
+ *
+ * @module tests/unit/feature_engine/smelter/test_feature_smelter_target_selection
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+// ============================================================================
+// Static query structure verification (no DB required)
+// ============================================================================
+
+// Load FeatureSmelter source to inspect the query strings
+const fs = require('fs');
+const path = require('path');
+
+const SMELTER_SRC = path.join(__dirname, '..', '..', '..', '..', 'src', 'feature_engine', 'smelter', 'FeatureSmelter.js');
+const source = fs.readFileSync(SMELTER_SRC, 'utf-8');
+
+describe('getPendingMatches target selection query', () => {
+
+    it('should use ROW_NUMBER() for distinct match_id selection', () => {
+        assert.ok(source.includes('ROW_NUMBER()'), 'missing ROW_NUMBER()');
+        assert.ok(source.includes('PARTITION BY m.match_id'), 'missing PARTITION BY m.match_id');
+        assert.ok(source.includes('WHERE rn = 1'), 'missing WHERE rn = 1 filter');
+    });
+
+    it('should include data_version priority ordering', () => {
+        assert.ok(source.includes("'fotmob_live_v1' THEN 1"), 'missing fotmob_live_v1 priority');
+        assert.ok(source.includes("'fotmob_pageprops_v2' THEN 2"), 'missing fotmob_pageprops_v2 priority');
+        assert.ok(source.includes("'fotmob_html_hyd_v1' THEN 3"), 'missing fotmob_html_hyd_v1 priority');
+    });
+
+    it('should exclude PHASE legacy and synthetic versions', () => {
+        assert.ok(source.includes("PHASE4.23"), 'missing PHASE4.23 exclusion');
+        assert.ok(source.includes("PHASE4.43_SYNTHETIC"), 'missing PHASE4.43_SYNTHETIC exclusion');
+        assert.ok(source.includes("NOT IN"), 'missing NOT IN clause for exclusion');
+    });
+
+    it('should have deterministic ORDER BY with match_date DESC and match_id', () => {
+        assert.ok(source.includes('match_date DESC NULLS LAST'), 'missing match_date DESC NULLS LAST');
+        assert.ok(source.includes('ORDER BY'), 'missing outer ORDER BY');
+    });
+
+    it('should include data_version in the SELECT columns', () => {
+        assert.ok(source.includes('r.data_version'), 'missing r.data_version in SELECT');
+    });
+});
+
+
+// ============================================================================
+// Preview entry structure verification
+// ============================================================================
+
+describe('_buildPreviewEntry structure', () => {
+
+    it('should include data_version in preview entries', () => {
+        assert.ok(source.includes('data_version: match.data_version'), 'missing data_version in preview entry');
+    });
+
+    it('should still set actual_db_write=false in preview', () => {
+        assert.ok(source.includes('actual_db_write: false'), 'missing actual_db_write: false');
+    });
+});
+
+
+// ============================================================================
+// smelt_all.js preview output
+// ============================================================================
+
+const SMELT_ALL_SRC = path.join(__dirname, '..', '..', '..', '..', 'scripts', 'ops', 'smelt_all.js');
+const smeltAllSource = fs.readFileSync(SMELT_ALL_SRC, 'utf-8');
+
+describe('smelt_all.js preview output', () => {
+
+    it('should display data_version in preview entries', () => {
+        assert.ok(smeltAllSource.includes('data_version:'), 'missing data_version display in preview');
+    });
+
+    it('should still show NO-WRITE PREVIEW and suppressed messages', () => {
+        assert.ok(smeltAllSource.includes('NO-WRITE PREVIEW'), 'missing NO-WRITE PREVIEW header');
+        assert.ok(smeltAllSource.includes('INSERT/UPDATE suppressed'), 'missing suppressed message');
+    });
+});


### PR DESCRIPTION
## Summary

Fix FeatureSmelter pending target selection to return distinct match_id targets with data_version priority.

Previously --limit 5 selected 5 raw_match_data JOIN rows (which could be only 2 distinct matches), causing ON CONFLICT overwrite risk. Now --limit 5 selects 5 distinct match_id targets, each with the best available data_version.

## Scope

| Item | Status |
|---|---|
| Task type | source-code |
| Runtime behavior change | Yes — target selection query changed |
| DB write during validation | No |
| Smelt during validation | No |
| Training run during validation | No |
| Prediction run during validation | No |
| Backtest during validation | No |
| Network/scraper/browser | No |

## Why

GOLD-AUDIT-2P found that `getPendingMatches()` uses `INNER JOIN raw_match_data` (1:N) with LIMIT applied to raw rows, not distinct matches. This means:
- Same match_id appears multiple times when it has multiple data_versions
- ON CONFLICT DO UPDATE causes the last write to overwrite previous ones
- Data version priority is undefined

## Files Changed

- `src/feature_engine/smelter/FeatureSmelter.js` — getPendingMatches queries + _buildPreviewEntry
- `scripts/ops/smelt_all.js` — preview output shows data_version
- `tests/unit/feature_engine/smelter/test_feature_smelter_target_selection.js` — new tests

## Safety Impact

This PR does not:
- write DB
- smelt / batch smelt / controlled smelt
- train / training dry-run
- run prediction / backtest
- access FotMob network
- modify migrations / .github
- change DB write authorization logic (gatekeeper/env flags unchanged)

## Validation

```text
# New tests
node --test tests/unit/feature_engine/smelter/test_feature_smelter_target_selection.js
# 9 passed, 0 failed

# Existing tests (no regression)
node --test tests/unit/FeatureSmelter.test.js
# 22 passed, 0 failed

node --test tests/unit/FeatureSmelterNoWritePreview.test.js
# all passed, 0 failed

Gatekeeper commit: PASS
```

## CI Gate Scope

Expected gate scope: source-code changes to FeatureSmelter query logic + new static tests. No runtime DB write, no smelt, no network.

## No deletion / no move / no rename confirmation

No files deleted, moved, or renamed. Two files modified, one test file created.

## Documentation Impact

This PR changes the semantic contract of `FeatureSmelter.getPendingMatches()`: the `limit` parameter now limits distinct match_id targets, not raw_match_data JOIN rows. Each target is selected via data_version priority ordering (fotmob_live_v1 preferred). This is a behavioral fix documented in the JSDoc comments on the method. No separate documentation file is added because the change is self-documenting in code.

The downstream behavior change: a `--limit 5` preview (or future write) will now process 5 distinct matches instead of potentially 2-3 matches with duplicate data_versions. The ON CONFLICT DO UPDATE in saveFeatures still applies as before.

## Rollback Plan

Revert this single commit. No DB rollback needed (no data written). The original query logic (raw-row LIMIT without data_version priority) is restored.

## SC-002 status

No DB write. No smelt. No training. No prediction. No backtest. No data expansion.

## Remaining risks

- The fix only affects new smelt runs. Existing l3_features rows written before this fix may have been generated from non-preferred data_versions (the ON CONFLICT behavior meant the last-write-wins, which could be any version depending on JOIN order). For the single row written in 2M (#53_20252026_4830747), the contract-filter audit in 2N confirmed the row is safe regardless — contract filter strips all postmatch leakage regardless of data_version.
- Full recalculate mode uses the same CTE pattern but without the l3_features LEFT JOIN exclusion. This has not been tested against real data.
- Batch smelt and training dry-run remain blocked.

## Next Recommended Task

Do not start automatically.

Recommended next task only after user confirmation:

GOLD-AUDIT-2R — re-run controlled 5-row no-write preview after target-selection fix to confirm 5 distinct match_ids are selected.