### PR TITLE
GOLD-AUDIT-2AE: Add no-write training report guard

### DIFF
--- a/docs/ml/training_no_write_report_only_guard.md
+++ b/docs/ml/training_no_write_report_only_guard.md
@@ -1,0 +1,33 @@
+# Training No-write Report-only Guard
+
+- lifecycle: permanent
+- scope: training entrypoint safety / GOLD-AUDIT-2AE
+- status: active
+
+## Contract
+
+Training entrypoints must not treat readiness audits as training execution.
+
+`--report-only --no-write` is the only mode intended for filtered feature matrix
+inspection. It:
+
+- reads eligible L3 rows with SELECT-only queries;
+- applies `l3_prematch_safe_contract.v0.json`;
+- builds matrix statistics in memory;
+- prints the report to stdout;
+- does not fit, train, calibrate, or save models;
+- does not write datasets, reports, metadata, scalers, or model artifacts.
+
+## Artifact Guard
+
+Any path that saves model artifacts must require both confirmations:
+
+```text
+ALLOW_TRAINING_WRITE=yes
+FINAL_TRAINING_WRITE_CONFIRMATION=yes
+```
+
+Without both values, artifact save paths fail closed.
+
+This guard does not authorize training. It only prevents accidental writes when
+future training execution is separately authorized.

--- a/scripts/model_training/train_baseline_v1.py
+++ b/scripts/model_training/train_baseline_v1.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
+import importlib.util
 import json
 import logging
 import os
@@ -33,6 +34,35 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MODEL_DIR = PROJECT_ROOT / "models" / "baseline_v1"
 RESULT_NAMES = ["AWAY", "DRAW", "HOME"]
 CALIBRATED_MODEL_FILENAME = "baseline_v1_result_1x2.calibrated.joblib"
+
+
+def _load_training_write_guard_module():
+    """Load training write guard without importing the broad src.ml package."""
+    module_path = PROJECT_ROOT / "src" / "ml" / "training_write_guard.py"
+    spec = importlib.util.spec_from_file_location("training_write_guard", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+require_training_write_confirmation = (
+    _load_training_write_guard_module().require_training_write_confirmation
+)
+
+
+def _load_filtered_matrix_report_module():
+    """Load report-only helper without importing the broken features package."""
+    module_path = PROJECT_ROOT / "src" / "ml" / "features" / "filtered_matrix_report.py"
+    spec = importlib.util.spec_from_file_location("filtered_matrix_report", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_report_from_connection(conn) -> dict[str, Any]:
+    """Build the filtered matrix report from a SELECT-only DB connection."""
+    return _load_filtered_matrix_report_module().build_report_from_connection(conn)
+
 
 PREMATCH_JSON_FEATURES = {
     "elo_features": [
@@ -145,9 +175,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--depth", type=int, default=4)
     parser.add_argument("--lr", type=float, default=0.05)
     parser.add_argument("--output-dir", default=str(DEFAULT_MODEL_DIR))
-    parser.add_argument("--calibration-method", default="sigmoid", choices=["sigmoid", "isotonic", "none"])
+    parser.add_argument(
+        "--calibration-method", default="sigmoid", choices=["sigmoid", "isotonic", "none"]
+    )
     parser.add_argument("--calibration-cv", type=int, default=5)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="只输出 filtered feature matrix 统计；不训练、不保存 artifact",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="禁止训练 artifact / dataset / report 文件写入",
+    )
     parser.add_argument("--include-postmatch-diagnostics", action="store_true")
     parser.add_argument("--verbose", action="store_true")
     return parser.parse_args()
@@ -273,6 +315,7 @@ def _load_contract_module():
     (which fails on SCORING.DEFAULT_AVG_TOTAL_GOALS).
     """
     import importlib.util as _util
+
     _spec = _util.spec_from_file_location(
         "l3_prematch_contract",
         PROJECT_ROOT / "src" / "ml" / "features" / "l3_prematch_contract.py",
@@ -282,7 +325,9 @@ def _load_contract_module():
     return _mod
 
 
-def _filter_l3_json_for_prematch(group_name: str, raw_json: dict[str, Any] | None) -> dict[str, Any]:
+def _filter_l3_json_for_prematch(
+    group_name: str, raw_json: dict[str, Any] | None
+) -> dict[str, Any]:
     """Filter one L3 JSONB group through the prematch-safe contract.
 
     Returns the filtered dict (may be empty if group is denied entirely).
@@ -307,7 +352,9 @@ def _filter_l3_json_for_prematch(group_name: str, raw_json: dict[str, Any] | Non
         return raw_json if raw_json is not None else {}
 
 
-def add_json_features(features: dict[str, float], payload: dict[str, Any], keys: list[str], prefix: str) -> None:
+def add_json_features(
+    features: dict[str, float], payload: dict[str, Any], keys: list[str], prefix: str
+) -> None:
     for key in keys:
         features[f"{prefix}_{key}"] = safe_float(payload.get(key))
 
@@ -343,8 +390,12 @@ def build_feature_frame(
         for key in BET365_ODDS_FEATURES:
             features[key] = safe_float(row.get(key))
 
-        features["bet365_ah_line_move"] = features["bet365_ah_close_line"] - features["bet365_ah_open_line"]
-        features["bet365_ou_line_move"] = features["bet365_ou_close_line"] - features["bet365_ou_open_line"]
+        features["bet365_ah_line_move"] = (
+            features["bet365_ah_close_line"] - features["bet365_ah_open_line"]
+        )
+        features["bet365_ou_line_move"] = (
+            features["bet365_ou_close_line"] - features["bet365_ou_open_line"]
+        )
 
         if include_postmatch_diagnostics:
             add_json_features(features, tactical, POSTMATCH_DIAGNOSTIC_FEATURES, "postmatch")
@@ -412,7 +463,9 @@ def calibrate_model(
     return calibrator
 
 
-def evaluate_model(model: Any, x_valid: pd.DataFrame, y_valid: pd.Series, logger: logging.Logger, label: str) -> tuple[float, float]:
+def evaluate_model(
+    model: Any, x_valid: pd.DataFrame, y_valid: pd.Series, logger: logging.Logger, label: str
+) -> tuple[float, float]:
     probabilities = model.predict_proba(x_valid)
     predictions = probabilities.argmax(axis=1)
     accuracy = accuracy_score(y_valid, predictions)
@@ -433,6 +486,7 @@ def persist_outputs(
     result: BaselineTrainingResult,
     output_dir: Path,
 ) -> BaselineTrainingResult:
+    require_training_write_confirmation()
     output_dir.mkdir(parents=True, exist_ok=True)
     model_path = output_dir / "baseline_v1_result_1x2.json"
     calibrated_model_path = output_dir / CALIBRATED_MODEL_FILENAME
@@ -454,12 +508,33 @@ def persist_outputs(
     return result
 
 
+def run_report_only_mode(conn) -> dict[str, Any]:
+    """Build report-only filtered feature matrix stats without fitting a model."""
+    return build_report_from_connection(conn)
+
+
 def main() -> int:
     args = parse_args()
     logger = setup_logging(args.verbose)
     generated_at = datetime.now(UTC).isoformat()
 
+    if args.report_only:
+        args.no_write = True
+
+    if args.no_write and not (args.report_only or args.dry_run):
+        raise RuntimeError(
+            "--no-write blocks training artifact writes. "
+            "Use --report-only --no-write for filtered matrix reporting."
+        )
+
+    if not (args.report_only or args.dry_run):
+        require_training_write_confirmation()
+
     with get_db_connection() as conn:
+        if args.report_only:
+            report = run_report_only_mode(conn)
+            print(json.dumps(report, ensure_ascii=False, indent=2))
+            return 0
         rows = load_training_rows(conn)
 
     if len(rows) < args.min_samples:
@@ -467,7 +542,12 @@ def main() -> int:
 
     x_frame, y = build_feature_frame(rows, args.include_postmatch_diagnostics)
     class_distribution = {RESULT_NAMES[index]: int((y == index).sum()) for index in range(3)}
-    logger.info("Loaded dataset samples=%s features=%s classes=%s", len(x_frame), x_frame.shape[1], class_distribution)
+    logger.info(
+        "Loaded dataset samples=%s features=%s classes=%s",
+        len(x_frame),
+        x_frame.shape[1],
+        class_distribution,
+    )
 
     x_train, x_valid, y_train, y_valid = train_test_split(
         x_frame,
@@ -507,7 +587,9 @@ def main() -> int:
     result.raw_log_loss = raw_loss
     result.accuracy = accuracy
     result.log_loss = loss
-    result = persist_outputs(raw_model, calibrated_model, list(x_frame.columns), result, Path(args.output_dir))
+    result = persist_outputs(
+        raw_model, calibrated_model, list(x_frame.columns), result, Path(args.output_dir)
+    )
     print(json.dumps(asdict(result), ensure_ascii=False, indent=2))
     return 0
 

--- a/scripts/ops/train_model.py
+++ b/scripts/ops/train_model.py
@@ -16,6 +16,7 @@
 # @updated 2026-03-11
 
 import argparse
+import importlib.util
 import json
 import logging
 import os
@@ -44,7 +45,6 @@ from sklearn.preprocessing import StandardScaler
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 LOG_DIR = PROJECT_ROOT / "logs"
-LOG_DIR.mkdir(exist_ok=True)
 
 sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -65,13 +65,12 @@ from src.database.repositories.prediction_repo import (
     safe_float,
 )
 
-
 # ============================================================================
 # 日志配置 - 双重输出
 # ============================================================================
 
 
-def setup_logging(verbose: bool = False) -> logging.Logger:
+def setup_logging(verbose: bool = False, *, write_file: bool = False) -> logging.Logger:
     """配置双重日志输出"""
     logger = logging.getLogger("train_model")
     logger.setLevel(logging.DEBUG if verbose else logging.INFO)
@@ -87,17 +86,46 @@ def setup_logging(verbose: bool = False) -> logging.Logger:
     console.setFormatter(formatter)
     logger.addHandler(console)
 
-    # 文件
-    log_file = LOG_DIR / "train_model.log"
-    file_handler = logging.FileHandler(log_file, encoding="utf-8")
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+    if write_file:
+        LOG_DIR.mkdir(exist_ok=True)
+        log_file = LOG_DIR / "train_model.log"
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
 
     return logger
 
 
-logger = setup_logging()
+logger = logging.getLogger("train_model")
+
+
+def _load_training_write_guard_module():
+    """Load training write guard without importing the broad src.ml package."""
+    module_path = PROJECT_ROOT / "src" / "ml" / "training_write_guard.py"
+    spec = importlib.util.spec_from_file_location("training_write_guard", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+require_training_write_confirmation = (
+    _load_training_write_guard_module().require_training_write_confirmation
+)
+
+
+def _load_filtered_matrix_report_module():
+    """Load report-only helper without importing the broken features package."""
+    module_path = PROJECT_ROOT / "src" / "ml" / "features" / "filtered_matrix_report.py"
+    spec = importlib.util.spec_from_file_location("filtered_matrix_report", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_report_from_connection(conn) -> dict:
+    """Build the filtered matrix report from a SELECT-only DB connection."""
+    return _load_filtered_matrix_report_module().build_report_from_connection(conn)
 
 
 # ============================================================================
@@ -409,6 +437,7 @@ def save_model(
     logger: logging.Logger = None,
 ) -> Tuple[str, str]:
     """保存模型、Scaler 和元数据"""
+    require_training_write_confirmation()
     import joblib
 
     model_path = MODEL_DIR / f"{output_name}.joblib"
@@ -470,8 +499,23 @@ def parse_args():
     )
     parser.add_argument("--min-samples", type=int, default=100, help="最小训练样本数 (默认: 100)")
     parser.add_argument("--json", action="store_true", help="JSON 格式输出")
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="只输出 filtered feature matrix 统计；不训练、不保存 artifact",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="禁止训练 artifact / dataset / report 文件写入",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="详细日志模式")
     return parser.parse_args()
+
+
+def run_report_only_mode(conn) -> dict:
+    """Build report-only filtered feature matrix stats without fitting a model."""
+    return build_report_from_connection(conn)
 
 
 def main():
@@ -479,12 +523,35 @@ def main():
     global logger
     args = parse_args()
 
-    # 重新配置日志级别
-    logger = setup_logging(args.verbose)
+    if args.report_only:
+        args.no_write = True
+
+    if args.no_write and not args.report_only:
+        print(
+            "--no-write blocks training artifact writes. "
+            "Use --report-only --no-write for filtered matrix reporting.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if not args.report_only:
+        require_training_write_confirmation()
+
+    # 重新配置日志级别；report-only 不写日志文件
+    logger = setup_logging(args.verbose, write_file=not args.report_only)
 
     result = None
 
     try:
+        if args.report_only:
+            conn = get_db_connection()
+            try:
+                report = run_report_only_mode(conn)
+            finally:
+                conn.close()
+            print(json.dumps(report, indent=2, ensure_ascii=False))
+            sys.exit(0)
+
         logger.info("=" * 60)
         logger.info("TITAN-V4.46.8 模型训练管道 - 工业加固版")
         logger.info("=" * 60)

--- a/src/ml/features/filtered_matrix_report.py
+++ b/src/ml/features/filtered_matrix_report.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Report-only filtered feature matrix audit helpers.
+
+lifecycle: permanent
+scope: no-write training readiness reporting
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from decimal import Decimal
+import importlib.util
+import json
+import math
+from pathlib import Path
+import re
+from typing import Any
+
+FEATURE_GROUPS = [
+    "golden_features",
+    "tactical_features",
+    "odds_movement_features",
+    "odds_features",
+    "elo_features",
+    "rolling_features",
+    "efficiency_features",
+    "draw_features",
+    "market_sentiment",
+    "stitch_summary",
+]
+
+EXCLUDED_DATA_VERSIONS = {"PHASE4.23", "PHASE4.43_SYNTHETIC"}
+METADATA_KEYS = {"_source", "_version"}
+HIGH_MISSING_THRESHOLD = 0.5
+MIN_LABEL_CLASS_COUNT = 3
+LOW_VARIANCE_UNIQUE_THRESHOLD = 2
+MIN_TRAINING_ROWS_FOR_DRY_RUN = 100
+MIN_MODEL_SIGNAL_FEATURES = 10
+LOW_VARIANCE_EXAMPLE_LIMIT = 12
+ELO_SUFFIXES = (".home_elo", ".away_elo")
+ODDS_PREFIXES = ("odds_features.", "odds_movement_features.")
+POSTMATCH_KEY_RE = re.compile(
+    r"(xg|shot|possession|momentum|corner|card|foul|pass|big_chance|"
+    r"woodwork|offside|duel|discipline|strength|stats|touch|accurate|goal|penalt)",
+    re.IGNORECASE,
+)
+ODDS_KEY_RE = re.compile(
+    r"(odds|implied_prob|steam|bookmaker|favorite_prob|prob_entropy|"
+    r"margin|has_odds_data|_error|_data_quality)",
+    re.IGNORECASE,
+)
+
+
+def _load_contract_module():
+    contract_path = Path(__file__).resolve().parent / "l3_prematch_contract.py"
+    spec = importlib.util.spec_from_file_location("l3_prematch_contract", contract_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CONTRACT_MODULE = _load_contract_module()
+
+
+def _json_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+
+
+def _is_missing(value: Any) -> bool:
+    return value is None or value == ""
+
+
+def _as_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        if value is None or value == "":
+            return None
+        number = float(value)
+        if math.isfinite(number):
+            return number
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _encode_result(home_score: Any, away_score: Any) -> str | None:
+    if home_score is None or away_score is None:
+        return None
+    home = int(home_score)
+    away = int(away_score)
+    if home > away:
+        return "HOME"
+    if home == away:
+        return "DRAW"
+    return "AWAY"
+
+
+def _is_eligible_row(row: dict[str, Any]) -> bool:
+    data_version = str(row.get("data_version") or "")
+    return bool(row.get("external_id")) and data_version not in EXCLUDED_DATA_VERSIONS
+
+
+def _flatten_filtered_payload(
+    row: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, int], dict[str, int]]:
+    payload = {
+        group: row.get(group) if isinstance(row.get(group), dict) else {}
+        for group in FEATURE_GROUPS
+    }
+    raw_counts = {group: len(payload[group]) for group in FEATURE_GROUPS}
+    filtered = _CONTRACT_MODULE.filter_l3_feature_payload(
+        payload,
+        include_conditional=False,
+        allow_diagnostic_postmatch=False,
+    )
+
+    flat: dict[str, Any] = {}
+    filtered_counts: dict[str, int] = {}
+    for group in FEATURE_GROUPS:
+        safe = filtered.get(group) if isinstance(filtered.get(group), dict) else {}
+        filtered_counts[group] = len(safe)
+        for key, value in safe.items():
+            flat[f"{group}.{key}"] = value
+    return flat, raw_counts, filtered_counts
+
+
+def build_filtered_feature_matrix_report(
+    rows: list[dict[str, Any]],
+    *,
+    coverage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a no-write, no-fit filtered matrix report from in-memory rows."""
+    eligible_rows = [row for row in rows if _is_eligible_row(row)]
+    excluded_rows = len(rows) - len(eligible_rows)
+
+    labels: Counter[str] = Counter()
+    matrix: list[dict[str, Any]] = []
+    raw_group_totals: defaultdict[str, int] = defaultdict(int)
+    filtered_group_totals: defaultdict[str, int] = defaultdict(int)
+
+    for row in eligible_rows:
+        result = _encode_result(row.get("home_score"), row.get("away_score"))
+        if result is not None:
+            labels[result] += 1
+
+        flat, raw_counts, filtered_counts = _flatten_filtered_payload(row)
+        matrix.append(flat)
+        for group, count in raw_counts.items():
+            raw_group_totals[group] += count
+        for group, count in filtered_counts.items():
+            filtered_group_totals[group] += count
+
+    columns = sorted({key for item in matrix for key in item})
+    metadata_columns = sorted(col for col in columns if col.rsplit(".", 1)[-1] in METADATA_KEYS)
+    model_columns = sorted(col for col in columns if col not in metadata_columns)
+    feature_stats = _build_feature_stats(matrix, columns)
+    model_stats = [stat for stat in feature_stats if stat["feature"] in model_columns]
+
+    high_missing = [stat for stat in model_stats if stat["missing_rate"] > HIGH_MISSING_THRESHOLD]
+    constant = [stat for stat in model_stats if stat["constant"]]
+    all_zero = [stat for stat in model_stats if stat["all_zero"]]
+    numeric = [stat for stat in model_stats if stat["numeric_convertible"]]
+    non_numeric = [stat for stat in model_stats if stat["non_numeric"]]
+    leakage = _build_leakage_summary(model_columns, columns)
+    signal = _build_signal_summary(model_columns)
+
+    readiness_status = _readiness_status(
+        rows_after_label_availability_filter=sum(labels.values()),
+        label_counts=labels,
+        model_signal_feature_columns=len(model_columns),
+        leakage=leakage,
+        signal=signal,
+        high_missing_feature_count=len(high_missing),
+        constant_feature_count=len(constant),
+    )
+
+    return {
+        "TASK": "filtered_feature_matrix_report_only",
+        "mode": "report-only",
+        "db_write": False,
+        "artifact_write": False,
+        "model_fit": False,
+        "dataset_write": False,
+        "L3 coverage": _json_safe(coverage or {}),
+        "Label audit": {
+            "eligible_l3_rows": len(eligible_rows),
+            "rows_with_scores": sum(labels.values()),
+            "home_win_count": labels.get("HOME", 0),
+            "draw_count": labels.get("DRAW", 0),
+            "away_win_count": labels.get("AWAY", 0),
+            "class_balance": _class_balance(labels),
+            "label_blocker": sum(labels.values()) == 0 or len(labels) < MIN_LABEL_CLASS_COUNT,
+        },
+        "Filtered matrix": {
+            "raw_eligible_rows": len(eligible_rows),
+            "excluded_legacy_or_synthetic_rows": excluded_rows,
+            "filtered_matrix_rows": len(matrix),
+            "filtered_matrix_columns_total": len(columns),
+            "model_signal_feature_columns": len(model_columns),
+            "metadata_columns": len(metadata_columns),
+            "excluded_metadata_names": metadata_columns,
+            "sample_feature_names": model_columns[:16],
+        },
+        "Feature quality": {
+            "constant_feature_count": len(constant),
+            "all_zero_feature_count": len(all_zero),
+            "high_missing_feature_count": len(high_missing),
+            "numeric_feature_count": len(numeric),
+            "non_numeric_feature_count": len(non_numeric),
+            "top_missing_features": [
+                {
+                    "feature": stat["feature"],
+                    "missing_rate": round(stat["missing_rate"], 4),
+                    "non_null_count": stat["non_null_count"],
+                }
+                for stat in sorted(
+                    model_stats,
+                    key=lambda item: (-item["missing_rate"], item["feature"]),
+                )[:10]
+            ],
+            "constant_feature_examples": [stat["feature"] for stat in constant[:12]],
+            "low_variance_feature_examples": [
+                stat["feature"]
+                for stat in model_stats
+                if stat["numeric_convertible"]
+                and stat["numeric_unique_count"] <= LOW_VARIANCE_UNIQUE_THRESHOLD
+            ][:LOW_VARIANCE_EXAMPLE_LIMIT],
+        },
+        "Leakage check": leakage,
+        "Signal availability": signal,
+        "Readiness": {
+            "TRAINING_READINESS_STATUS": readiness_status,
+            "SAFE_FOR_TRAINING_DRY_RUN": False,
+            "SAFE_FOR_REAL_TRAINING": False,
+            "SAFE_FOR_REAL_PREDICTION": False,
+            "SAFE_FOR_BACKTEST": False,
+        },
+        "raw_group_totals": dict(raw_group_totals),
+        "filtered_group_totals": dict(filtered_group_totals),
+    }
+
+
+def _build_feature_stats(matrix: list[dict[str, Any]], columns: list[str]) -> list[dict[str, Any]]:
+    stats = []
+    row_count = len(matrix)
+    for column in columns:
+        values = [row.get(column) for row in matrix]
+        non_missing = [value for value in values if not _is_missing(value)]
+        numbers = [_as_number(value) for value in non_missing]
+        numeric_convertible = bool(non_missing) and len(numbers) == len(non_missing)
+        unique_values = {_json_key(value) for value in non_missing}
+        numeric_unique = {value for value in numbers if value is not None}
+        all_zero = (
+            numeric_convertible
+            and len(non_missing) == row_count
+            and all(value == 0 for value in numbers)
+        )
+        stats.append(
+            {
+                "feature": column,
+                "non_null_count": len(non_missing),
+                "missing_rate": 1 - (len(non_missing) / row_count if row_count else 0),
+                "unique_value_count": len(unique_values),
+                "numeric_convertible": numeric_convertible,
+                "non_numeric": not numeric_convertible,
+                "constant": len(unique_values) <= 1,
+                "all_zero": all_zero,
+                "numeric_unique_count": len(numeric_unique),
+            }
+        )
+    return stats
+
+
+def _build_leakage_summary(model_columns: list[str], columns: list[str]) -> dict[str, int]:
+    return {
+        "postmatch_leakage_remaining_count": sum(
+            1 for column in model_columns if POSTMATCH_KEY_RE.search(column)
+        ),
+        "rating_remaining_count": sum(1 for column in model_columns if "rating" in column.lower()),
+        "default_elo_remaining_count": sum(
+            1
+            for column in model_columns
+            if column.startswith("elo_features.")
+            or "_is_default" in column
+            or column.endswith(ELO_SUFFIXES)
+        ),
+        "odds_fallback_remaining_count": sum(
+            1
+            for column in model_columns
+            if column.startswith(ODDS_PREFIXES) or ODDS_KEY_RE.search(column)
+        ),
+        "unknown_or_audit_only_remaining_count": sum(
+            1 for column in columns if "_extractedAt" in column or "audit" in column.lower()
+        ),
+    }
+
+
+def _build_signal_summary(model_columns: list[str]) -> dict[str, bool]:
+    return {
+        "odds_signal_available": any(column.startswith(ODDS_PREFIXES) for column in model_columns),
+        "elo_signal_available": any(column.startswith("elo_features.") for column in model_columns),
+        "market_value_signal_available": any("market_value" in column for column in model_columns),
+        "injury_availability_signal_available": any("injury" in column for column in model_columns),
+        "age_signal_available": any(
+            "age" in column or "u23" in column or "veteran" in column for column in model_columns
+        ),
+    }
+
+
+def _class_balance(labels: Counter[str]) -> dict[str, float]:
+    total = sum(labels.values())
+    if total == 0:
+        return {"HOME": 0.0, "DRAW": 0.0, "AWAY": 0.0}
+    return {name: round(labels.get(name, 0) / total, 4) for name in ("HOME", "DRAW", "AWAY")}
+
+
+def _readiness_status(
+    *,
+    rows_after_label_availability_filter: int,
+    label_counts: Counter[str],
+    model_signal_feature_columns: int,
+    leakage: dict[str, int],
+    signal: dict[str, bool],
+    high_missing_feature_count: int,
+    constant_feature_count: int,
+) -> str:
+    not_ready = (
+        any(value != 0 for value in leakage.values())
+        or rows_after_label_availability_filter < MIN_TRAINING_ROWS_FOR_DRY_RUN
+        or len(label_counts) < MIN_LABEL_CLASS_COUNT
+        or model_signal_feature_columns < MIN_MODEL_SIGNAL_FEATURES
+        or not signal["odds_signal_available"]
+        or not signal["elo_signal_available"]
+        or high_missing_feature_count > model_signal_feature_columns // 2
+        or constant_feature_count > model_signal_feature_columns // 2
+    )
+    return "NOT_READY" if not_ready else "READY_FOR_DRY_RUN_ONLY"
+
+
+def build_report_from_connection(conn: Any) -> dict[str, Any]:
+    """Build a report from a DB connection using SELECT-only queries."""
+    coverage = _fetch_one(conn, _COVERAGE_SQL)
+    rows = _fetch_all(conn, _ELIGIBLE_ROWS_SQL)
+    return build_filtered_feature_matrix_report(rows, coverage=coverage)
+
+
+def _fetch_one(conn: Any, query: str) -> dict[str, Any]:
+    cursor = conn.cursor()
+    try:
+        cursor.execute(query)
+        row = cursor.fetchone()
+        if row is None:
+            return {}
+        columns = [item[0] for item in cursor.description]
+        return dict(zip(columns, row, strict=False))
+    finally:
+        cursor.close()
+
+
+def _fetch_all(conn: Any, query: str) -> list[dict[str, Any]]:
+    cursor = conn.cursor()
+    try:
+        cursor.execute(query)
+        columns = [item[0] for item in cursor.description]
+        return [dict(zip(columns, row, strict=False)) for row in cursor.fetchall()]
+    finally:
+        cursor.close()
+
+
+_COVERAGE_SQL = """
+WITH eligible AS (
+  SELECT DISTINCT r.match_id
+  FROM raw_match_data r
+  JOIN matches m ON m.match_id = r.match_id
+  WHERE m.external_id IS NOT NULL
+    AND COALESCE(r.data_version, '') NOT IN ('PHASE4.23', 'PHASE4.43_SYNTHETIC')
+),
+pending AS (
+  SELECT
+    COUNT(*)::int AS pending_raw_rows,
+    COUNT(DISTINCT r.match_id)::int AS pending_distinct_matches
+  FROM raw_match_data r
+  JOIN matches m ON m.match_id = r.match_id
+  LEFT JOIN l3_features l3 ON l3.match_id = r.match_id
+  WHERE l3.match_id IS NULL
+    AND m.external_id IS NOT NULL
+    AND COALESCE(r.data_version, '') NOT IN ('PHASE4.23', 'PHASE4.43_SYNTHETIC')
+),
+coverage AS (
+  SELECT
+    COUNT(DISTINCT e.match_id)::int AS eligible_raw_distinct_matches,
+    COUNT(DISTINCT l3.match_id)::int AS covered_l3_distinct_matches
+  FROM eligible e
+  LEFT JOIN l3_features l3 ON l3.match_id = e.match_id
+),
+legacy AS (
+  SELECT COUNT(DISTINCT l3.match_id)::int AS legacy_or_synthetic_l3_count
+  FROM l3_features l3
+  JOIN raw_match_data r ON r.match_id = l3.match_id
+  WHERE COALESCE(r.data_version, '') IN ('PHASE4.23', 'PHASE4.43_SYNTHETIC')
+)
+SELECT
+  (SELECT COUNT(*)::int FROM raw_match_data) AS raw_count,
+  (SELECT COUNT(*)::int FROM matches) AS matches_count,
+  (SELECT COUNT(*)::int FROM l3_features) AS l3_count,
+  coverage.eligible_raw_distinct_matches,
+  coverage.covered_l3_distinct_matches,
+  pending.pending_raw_rows,
+  pending.pending_distinct_matches,
+  legacy.legacy_or_synthetic_l3_count
+FROM coverage, pending, legacy
+"""
+
+_ELIGIBLE_ROWS_SQL = """
+WITH ranked_raw AS (
+  SELECT
+    r.match_id,
+    r.data_version,
+    ROW_NUMBER() OVER (
+      PARTITION BY r.match_id
+      ORDER BY
+        CASE r.data_version
+          WHEN 'fotmob_live_v1' THEN 1
+          WHEN 'fotmob_pageprops_v2' THEN 2
+          WHEN 'fotmob_html_hyd_v1' THEN 3
+          ELSE 99
+        END,
+        r.data_version
+    ) AS rn
+  FROM raw_match_data r
+  JOIN matches m ON m.match_id = r.match_id
+  WHERE m.external_id IS NOT NULL
+    AND COALESCE(r.data_version, '') NOT IN ('PHASE4.23', 'PHASE4.43_SYNTHETIC')
+),
+eligible AS (
+  SELECT rr.match_id, rr.data_version
+  FROM ranked_raw rr
+  WHERE rr.rn = 1
+)
+SELECT
+  l3.match_id,
+  m.external_id,
+  m.home_team,
+  m.away_team,
+  m.match_date,
+  m.home_score,
+  m.away_score,
+  m.league_name,
+  m.season,
+  e.data_version,
+  COALESCE(l3.golden_features, '{}'::jsonb) AS golden_features,
+  COALESCE(l3.tactical_features, '{}'::jsonb) AS tactical_features,
+  COALESCE(l3.odds_movement_features, '{}'::jsonb) AS odds_movement_features,
+  COALESCE(l3.odds_features, '{}'::jsonb) AS odds_features,
+  COALESCE(l3.elo_features, '{}'::jsonb) AS elo_features,
+  COALESCE(l3.rolling_features, '{}'::jsonb) AS rolling_features,
+  COALESCE(l3.efficiency_features, '{}'::jsonb) AS efficiency_features,
+  COALESCE(l3.draw_features, '{}'::jsonb) AS draw_features,
+  COALESCE(l3.market_sentiment, '{}'::jsonb) AS market_sentiment,
+  COALESCE(l3.stitch_summary, '{}'::jsonb) AS stitch_summary
+FROM eligible e
+JOIN l3_features l3 ON l3.match_id = e.match_id
+JOIN matches m ON m.match_id = e.match_id
+ORDER BY m.match_date, l3.match_id
+"""

--- a/src/ml/training_write_guard.py
+++ b/src/ml/training_write_guard.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Training artifact write guard.
+
+lifecycle: permanent
+scope: training artifact write safety
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+TRAINING_WRITE_ENV = "ALLOW_TRAINING_WRITE"
+FINAL_TRAINING_CONFIRMATION_ENV = "FINAL_TRAINING_WRITE_CONFIRMATION"
+CONFIRMATION_VALUE = "yes"
+
+
+class TrainingWriteGuardError(RuntimeError):
+    """Raised when a training artifact write is not explicitly confirmed."""
+
+
+def training_write_confirmed(environ: Mapping[str, str] | None = None) -> bool:
+    """Return true only when both training write confirmations are present."""
+    env = os.environ if environ is None else environ
+    return (
+        env.get(TRAINING_WRITE_ENV) == CONFIRMATION_VALUE
+        and env.get(FINAL_TRAINING_CONFIRMATION_ENV) == CONFIRMATION_VALUE
+    )
+
+
+def require_training_write_confirmation(environ: Mapping[str, str] | None = None) -> None:
+    """Fail closed unless training artifact writes are explicitly confirmed."""
+    if training_write_confirmed(environ):
+        return
+
+    raise TrainingWriteGuardError(
+        "Training artifact writes require "
+        f"{TRAINING_WRITE_ENV}=yes and {FINAL_TRAINING_CONFIRMATION_ENV}=yes. "
+        "Use --report-only --no-write for filtered matrix reporting."
+    )

--- a/tests/unit/ml/test_filtered_matrix_report_only.py
+++ b/tests/unit/ml/test_filtered_matrix_report_only.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# ruff: noqa: PLR2004
+"""Tests for report-only filtered feature matrix stats.
+
+lifecycle: permanent
+scope: GOLD-AUDIT-2AE report-only matrix validation
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_SPEC = importlib.util.spec_from_file_location(
+    "filtered_matrix_report",
+    PROJECT_ROOT / "src" / "ml" / "features" / "filtered_matrix_report.py",
+)
+filtered_matrix_report = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(filtered_matrix_report)
+
+
+def _eligible_row(match_id: str, home_score: int, away_score: int) -> dict:
+    return {
+        "match_id": match_id,
+        "external_id": match_id.rsplit("_", 1)[-1],
+        "home_score": home_score,
+        "away_score": away_score,
+        "data_version": "fotmob_live_v1",
+        "golden_features": {
+            "_source": "FotMob",
+            "_version": "V3.0.0-PRO",
+            "_extractedAt": "2026-07-06T00:00:00Z",
+            "home_age_avg": 27.1,
+            "away_age_avg": 25.4,
+            "age_gap": 1.7,
+            "home_market_value_total": 120000000,
+            "away_market_value_total": 80000000,
+            "home_injury_count": 1,
+            "away_injury_count": 2,
+            "home_rating_avg": 7.5,
+            "away_rating_avg": 6.8,
+            "rating_gap": 0.7,
+        },
+        "tactical_features": {
+            "_version": "V3.0.0-PRO",
+            "_extractedAt": "2026-07-06T00:00:00Z",
+            "home_xg": 1.2,
+            "away_shots": 9,
+            "home_possession": 61,
+        },
+        "odds_movement_features": {
+            "_version": "V3.0.0-PRO",
+            "_extractedAt": "2026-07-06T00:00:00Z",
+            "_data_quality": "INCOMPLETE_ODDS",
+            "_error": "No odds data available",
+            "has_odds_data": False,
+            "current_home_odds": 0,
+            "implied_prob_home": 0.333333,
+        },
+        "odds_features": {},
+        "elo_features": {
+            "_is_default": True,
+            "home_elo": 1500,
+            "away_elo": 1500,
+            "elo_diff": 0,
+            "elo_expected_home": 0.571,
+        },
+        "rolling_features": {},
+        "efficiency_features": {},
+        "draw_features": {},
+        "market_sentiment": {},
+        "stitch_summary": {},
+    }
+
+
+def test_report_only_filters_leakage_and_excludes_legacy_rows() -> None:
+    rows = [
+        _eligible_row("53_20252026_4830466", 2, 1),
+        _eligible_row("53_20252026_4830467", 1, 1),
+        {**_eligible_row("legacy", 0, 1), "data_version": "PHASE4.23"},
+        {**_eligible_row("synthetic", 0, 1), "data_version": "PHASE4.43_SYNTHETIC"},
+    ]
+
+    report = filtered_matrix_report.build_filtered_feature_matrix_report(rows)
+
+    assert report["TASK"] == "filtered_feature_matrix_report_only"
+    assert report["mode"] == "report-only"
+    assert report["db_write"] is False
+    assert report["artifact_write"] is False
+    assert report["model_fit"] is False
+    assert report["dataset_write"] is False
+
+    matrix = report["Filtered matrix"]
+    assert matrix["filtered_matrix_rows"] == 2
+    assert matrix["excluded_legacy_or_synthetic_rows"] == 2
+    assert matrix["metadata_columns"] == 2
+    assert matrix["model_signal_feature_columns"] > 0
+    assert "golden_features._source" in matrix["excluded_metadata_names"]
+    assert "golden_features._version" in matrix["excluded_metadata_names"]
+
+    leakage = report["Leakage check"]
+    assert leakage["postmatch_leakage_remaining_count"] == 0
+    assert leakage["rating_remaining_count"] == 0
+    assert leakage["default_elo_remaining_count"] == 0
+    assert leakage["odds_fallback_remaining_count"] == 0
+    assert leakage["unknown_or_audit_only_remaining_count"] == 0
+
+    assert report["raw_group_totals"]["tactical_features"] > 0
+    assert report["filtered_group_totals"]["tactical_features"] == 0
+    assert report["filtered_group_totals"]["elo_features"] == 0
+    assert report["filtered_group_totals"]["odds_movement_features"] == 0
+
+
+def test_report_only_signal_summary_and_readiness_are_conservative() -> None:
+    rows = [
+        _eligible_row("53_20252026_4830466", 2, 1),
+        _eligible_row("53_20252026_4830467", 1, 1),
+        _eligible_row("53_20252026_4830468", 0, 2),
+    ]
+
+    report = filtered_matrix_report.build_filtered_feature_matrix_report(rows)
+
+    assert report["Label audit"]["rows_with_scores"] == 3
+    assert report["Label audit"]["home_win_count"] == 1
+    assert report["Label audit"]["draw_count"] == 1
+    assert report["Label audit"]["away_win_count"] == 1
+
+    signal = report["Signal availability"]
+    assert signal["market_value_signal_available"] is True
+    assert signal["age_signal_available"] is True
+    assert signal["injury_availability_signal_available"] is True
+    assert signal["odds_signal_available"] is False
+    assert signal["elo_signal_available"] is False
+
+    readiness = report["Readiness"]
+    assert readiness["TRAINING_READINESS_STATUS"] == "NOT_READY"
+    assert readiness["SAFE_FOR_TRAINING_DRY_RUN"] is False
+    assert readiness["SAFE_FOR_REAL_TRAINING"] is False
+    assert readiness["SAFE_FOR_REAL_PREDICTION"] is False
+    assert readiness["SAFE_FOR_BACKTEST"] is False

--- a/tests/unit/ml/test_training_no_write_guard.py
+++ b/tests/unit/ml/test_training_no_write_guard.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# ruff: noqa: ARG001, ARG002, ARG005
+"""Tests for no-write training artifact guards.
+
+lifecycle: permanent
+scope: GOLD-AUDIT-2AE training guard validation
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class ArtifactBranchEnteredError(Exception):
+    """Raised by tests when an artifact branch would start writing."""
+
+
+def _stub_module(name: str, **attrs):
+    module = sys.modules.get(name) or ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _install_training_dependency_stubs() -> None:
+    class _Frame:
+        """Minimal pandas DataFrame/Series stand-in for import-time annotations."""
+
+    class _Estimator:
+        def fit(self, *args, **kwargs):
+            raise AssertionError("fit must not run in no-write guard tests")
+
+    _stub_module("numpy", inf=float("inf"), nan=float("nan"), isfinite=lambda value: True)
+    _stub_module(
+        "pandas",
+        DataFrame=_Frame,
+        Series=_Frame,
+        get_dummies=lambda *args, **kwargs: _Frame(),
+    )
+    _stub_module("xgboost", XGBClassifier=_Estimator)
+
+    sklearn = _stub_module("sklearn")
+    sklearn.__path__ = []
+    _stub_module(
+        "sklearn.metrics",
+        accuracy_score=lambda *args, **kwargs: 0,
+        classification_report=lambda *args, **kwargs: {},
+        confusion_matrix=lambda *args, **kwargs: [],
+        f1_score=lambda *args, **kwargs: 0,
+        log_loss=lambda *args, **kwargs: 0,
+    )
+    _stub_module("sklearn.model_selection", train_test_split=lambda *args, **kwargs: ())
+    _stub_module("sklearn.preprocessing", StandardScaler=_Estimator)
+    _stub_module("sklearn.calibration", CalibratedClassifierCV=_Estimator)
+    _stub_module(
+        "joblib",
+        dump=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("joblib.dump must not run before write confirmation")
+        ),
+    )
+
+    psycopg2 = _stub_module(
+        "psycopg2",
+        connect=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("DB connections must not run in guard tests")
+        ),
+    )
+    psycopg2.__path__ = []
+    _stub_module("psycopg2.extras", RealDictCursor=object)
+
+    database = _stub_module("src.database")
+    database.__path__ = [str(PROJECT_ROOT / "src" / "database")]
+    repositories = _stub_module("src.database.repositories")
+    repositories.__path__ = [str(PROJECT_ROOT / "src" / "database" / "repositories")]
+    _stub_module(
+        "src.database.repositories.prediction_repo",
+        get_db_connection=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("DB connections must not run in guard tests")
+        ),
+        parse_jsonb=lambda value: value,
+        safe_float=lambda value, default=0.0: default if value is None else value,
+    )
+
+
+_install_training_dependency_stubs()
+src_package = _stub_module("src")
+src_package.__path__ = [str(PROJECT_ROOT / "src")]
+constants_package = _stub_module("src.constants")
+constants_package.__path__ = [str(PROJECT_ROOT / "src" / "constants")]
+
+_GUARD_SPEC = importlib.util.spec_from_file_location(
+    "training_write_guard",
+    PROJECT_ROOT / "src" / "ml" / "training_write_guard.py",
+)
+training_write_guard = importlib.util.module_from_spec(_GUARD_SPEC)
+sys.modules[_GUARD_SPEC.name] = training_write_guard
+_GUARD_SPEC.loader.exec_module(training_write_guard)
+ml_package = _stub_module("src.ml")
+ml_package.__path__ = [str(PROJECT_ROOT / "src" / "ml")]
+sys.modules["src.ml.training_write_guard"] = training_write_guard
+
+_TRAIN_MODEL_SPEC = importlib.util.spec_from_file_location(
+    "train_model",
+    PROJECT_ROOT / "scripts" / "ops" / "train_model.py",
+)
+train_model = importlib.util.module_from_spec(_TRAIN_MODEL_SPEC)
+sys.modules[_TRAIN_MODEL_SPEC.name] = train_model
+_TRAIN_MODEL_SPEC.loader.exec_module(train_model)
+
+_BASELINE_SPEC = importlib.util.spec_from_file_location(
+    "train_baseline_v1",
+    PROJECT_ROOT / "scripts" / "model_training" / "train_baseline_v1.py",
+)
+train_baseline_v1 = importlib.util.module_from_spec(_BASELINE_SPEC)
+sys.modules[_BASELINE_SPEC.name] = train_baseline_v1
+_BASELINE_SPEC.loader.exec_module(train_baseline_v1)
+
+
+def test_training_write_confirmation_requires_both_flags() -> None:
+    assert training_write_guard.training_write_confirmed({}) is False
+    assert training_write_guard.training_write_confirmed({"ALLOW_TRAINING_WRITE": "yes"}) is False
+    assert (
+        training_write_guard.training_write_confirmed(
+            {
+                "ALLOW_TRAINING_WRITE": "yes",
+                "FINAL_TRAINING_WRITE_CONFIRMATION": "yes",
+            }
+        )
+        is True
+    )
+
+
+def test_require_training_write_confirmation_fails_closed() -> None:
+    with pytest.raises(training_write_guard.TrainingWriteGuardError):
+        training_write_guard.require_training_write_confirmation({})
+
+
+def test_train_model_save_model_blocked_before_artifact_write(monkeypatch) -> None:
+    monkeypatch.delenv("ALLOW_TRAINING_WRITE", raising=False)
+    monkeypatch.delenv("FINAL_TRAINING_WRITE_CONFIRMATION", raising=False)
+
+    with pytest.raises(RuntimeError):
+        train_model.save_model(
+            model=object(),
+            scaler=object(),
+            metrics={
+                "accuracy": 0,
+                "f1_score": 0,
+                "log_loss": 0,
+                "training_samples": 0,
+                "training_time_seconds": 0,
+                "feature_importance": {},
+            },
+            output_name="blocked",
+        )
+
+
+def test_train_model_save_model_requires_double_confirmation_before_branch(monkeypatch) -> None:
+    monkeypatch.setenv("ALLOW_TRAINING_WRITE", "yes")
+    monkeypatch.setenv("FINAL_TRAINING_WRITE_CONFIRMATION", "yes")
+    joblib_stub = sys.modules["joblib"]
+    monkeypatch.setattr(
+        joblib_stub,
+        "dump",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ArtifactBranchEnteredError()),
+    )
+
+    with pytest.raises(ArtifactBranchEnteredError):
+        train_model.save_model(
+            model=object(),
+            scaler=object(),
+            metrics={
+                "accuracy": 0,
+                "f1_score": 0,
+                "log_loss": 0,
+                "training_samples": 0,
+                "training_time_seconds": 0,
+                "feature_importance": {},
+            },
+            output_name="branch_probe",
+        )
+
+
+def test_baseline_persist_outputs_blocked_before_mkdir(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("ALLOW_TRAINING_WRITE", raising=False)
+    monkeypatch.delenv("FINAL_TRAINING_WRITE_CONFIRMATION", raising=False)
+    output_dir = tmp_path / "blocked_artifacts"
+    result = train_baseline_v1.BaselineTrainingResult(
+        target="result_1x2",
+        model_path=None,
+        calibrated_model_path=None,
+        metadata_path=None,
+        samples=0,
+        features=0,
+        accuracy=None,
+        log_loss=None,
+        raw_accuracy=None,
+        raw_log_loss=None,
+        calibration_method="none",
+        calibration_cv=0,
+        class_distribution={},
+        generated_at="2026-07-06T00:00:00+00:00",
+    )
+
+    with pytest.raises(RuntimeError):
+        train_baseline_v1.persist_outputs(
+            raw_model=object(),
+            calibrated_model=object(),
+            feature_columns=[],
+            result=result,
+            output_dir=output_dir,
+        )
+
+    assert not output_dir.exists()
+
+
+def test_baseline_persist_outputs_requires_double_confirmation_before_branch(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("ALLOW_TRAINING_WRITE", "yes")
+    monkeypatch.setenv("FINAL_TRAINING_WRITE_CONFIRMATION", "yes")
+    output_dir = tmp_path / "branch_probe"
+    result = train_baseline_v1.BaselineTrainingResult(
+        target="result_1x2",
+        model_path=None,
+        calibrated_model_path=None,
+        metadata_path=None,
+        samples=0,
+        features=0,
+        accuracy=None,
+        log_loss=None,
+        raw_accuracy=None,
+        raw_log_loss=None,
+        calibration_method="none",
+        calibration_cv=0,
+        class_distribution={},
+        generated_at="2026-07-06T00:00:00+00:00",
+    )
+
+    def fail_mkdir(self, *args, **kwargs):
+        raise ArtifactBranchEnteredError
+
+    monkeypatch.setattr(Path, "mkdir", fail_mkdir)
+
+    with pytest.raises(ArtifactBranchEnteredError):
+        train_baseline_v1.persist_outputs(
+            raw_model=object(),
+            calibrated_model=object(),
+            feature_columns=[],
+            result=result,
+            output_dir=output_dir,
+        )
+
+    assert not output_dir.exists()
+
+
+def test_report_only_mode_does_not_call_training_or_save(monkeypatch) -> None:
+    expected = {
+        "TASK": "filtered_feature_matrix_report_only",
+        "mode": "report-only",
+        "model_fit": False,
+        "artifact_write": False,
+    }
+
+    def fail(*args, **kwargs):
+        raise AssertionError("training/save path must not run in report-only mode")
+
+    monkeypatch.setattr(train_model, "build_report_from_connection", lambda conn: expected)
+    monkeypatch.setattr(train_model, "train_model", fail)
+    monkeypatch.setattr(train_model, "save_model", fail)
+
+    assert train_model.run_report_only_mode(object()) == expected
+
+
+def test_setup_logging_console_only_does_not_create_log_dir(monkeypatch) -> None:
+    def fail_mkdir(self, *args, **kwargs):
+        raise AssertionError("console-only logging must not create directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_mkdir)
+
+    logger = train_model.setup_logging(write_file=False)
+
+    assert not any(isinstance(handler, logging.FileHandler) for handler in logger.handlers)


### PR DESCRIPTION
## Summary
- Added a no-write/report-only filtered feature matrix path for training readiness inspection.
- Added training artifact write guard requiring both `ALLOW_TRAINING_WRITE=yes` and `FINAL_TRAINING_WRITE_CONFIRMATION=yes` before artifact save paths can proceed.
- Added tests ensuring report-only does not train, does not call fit, does not dump artifacts, does not create directories, and filters L3 payloads through the prematch contract.

## Safety
- No DB writes from the implemented code path.
- No smelt.
- No training / fit.
- No prediction / backtest.
- No model artifacts.
- No dataset artifacts.
- No migration.

## Validation
- `docker compose -f docker-compose.dev.yml exec -T dev sh -lc 'PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider --confcutdir=tests/unit/ml tests/unit/ml/test_training_no_write_guard.py -q'` - PASS, 8 tests.
- `docker compose -f docker-compose.dev.yml exec -T dev sh -lc 'PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider --confcutdir=tests/unit/ml tests/unit/ml/test_filtered_matrix_report_only.py -q'` - PASS, 2 tests.
- Commit/push gatekeeper - PASS: ruff changed-line gate, mypy changed-line gate, ProxyProvider contract test, smoke tests, incremental JS tests, Recon coverage gate.

## Training Status
- SAFE_FOR_TRAINING_DRY_RUN: no
- SAFE_FOR_REAL_TRAINING: no
- This PR only adds guards/report-only infrastructure.

## Rollback Plan
- Revert this PR.